### PR TITLE
v1.4.2 화이트보드 버그 수정 및 배경색 설정 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
## 업데이트 로그 (v1.4.2)

### 버그 수정
- 공유 화이트보드 프리뷰가 Liveblocks 편집 내용을 반영하지 않던 문제 수정
- 플로팅 팝업 위젯에서 사용자 이름이 '익명'으로 표시되던 문제 수정
- 모달을 빠르게 닫을 때 마지막 그림이 저장되지 않던 문제 수정
- 로컬↔공유 탭 전환 시 이전 탭 데이터가 현재 탭을 덮어쓸 수 있던 레이스 컨디션 수정
- 디바운스 저장이 매 스트로크마다 실행되던 성능 버그 수정

### 새 기능
- 화이트보드 배경색 설정 추가 (설정 > 외관)
- 프리셋 4종 (흰색, 밝은 회색, 다크, 블랙) + 커스텀 색상 피커
- 기본 배경색을 다크(#1a1a2e) → 흰색(#FFFFFF)으로 변경

---

## 상세 설명

### 1. 공유 화이트보드 프리뷰 갱신 안됨
위젯 프리뷰는 공유 드라이브의 JSON 파일을 읽어 표시하지만, 모달 에디터는 Liveblocks로만 저장하고 공유 드라이브에는 기록하지 않았습니다.

**수정:** 공유 탭에서 모달을 닫을 때 `saveSharedWhiteboard()`로 공유 드라이브에도 저장하여 프리뷰가 최신 상태를 반영하도록 했습니다.

### 2. 플로팅 팝업에서 '익명' 표시
`RoomProvider`의 `initialPresence`는 마운트 시 한 번만 설정됩니다. 팝업 윈도우에서 auth 상태가 늦게 로드되면 `userName`이 '익명'으로 고정되어 다른 사용자에게도 '익명'으로 보였습니다.

**수정:** `LiveCanvasArea`에서 `userName` 변경을 감지하여 `updateMyPresence()`로 Liveblocks presence를 갱신하는 effect를 추가했습니다.

### 3. 모달 닫힐 때 로컬 저장 유실
500ms 디바운스 대기 중 모달을 닫으면 cleanup이 타이머만 취소하고 저장을 실행하지 않아 마지막 변경사항이 유실되었습니다.

**수정:** 별도 `useEffect([isOpen, tab])`를 추가하여 모달 닫힘/탭 전환 시에만 대기 중인 저장을 즉시 flush합니다. 기존 디바운스 cleanup은 `clearTimeout`만 수행하여 정상적인 디바운스 동작을 유지합니다.

### 4. 탭 전환 시 loadKeyRef 레이스 컨디션
`loadKeyRef` 증가가 `if (tab !== 'local') return;` 뒤에 위치하여, 로컬→공유 탭 전환 시 진행 중이던 비동기 로드가 무효화되지 않고 공유 탭 상태를 덮어쓸 수 있었습니다.

**수정:** `++loadKeyRef.current`를 탭 체크 앞으로 이동하여 모든 탭 전환 시 이전 비동기 로드를 무효화합니다.

### 5. 화이트보드 배경색 설정
캔버스 배경이 `#1a1a2e`로 하드코딩되어 있었습니다.

**수정:** 설정 > 외관 탭에 "화이트보드 배경" 섹션을 추가하고, 프리셋 4종(흰색/밝은 회색/다크/블랙) + 커스텀 색상 피커를 제공합니다. 선택한 배경색은 `preferences.json`에 저장되며, 캔버스와 위젯 프리뷰 모두에 적용됩니다. 기본값은 흰색입니다.

### 변경 파일
- `src/components/widgets/whiteboard/WhiteboardModal.tsx`
- `src/components/widgets/whiteboard/WhiteboardCanvas.tsx`
- `src/components/widgets/whiteboard/WhiteboardWidget.tsx`
- `src/components/settings/ThemeSection.tsx`
- `src/services/settingsService.ts`
- `package.json` (v1.4.1 → v1.4.2)
