### PR TITLE
[v1.8.1] Electron 빌드 설정 구성 및 스플래시 리소스 경로 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,17 +31,12 @@
   "build": {
     "appId": "com.studiojbbj.bflow",
     "productName": "BFLOW",
-    "asarUnpack": [
-      "**/node_modules/googleapis/**",
-      "**/node_modules/googleapis-common/**",
-      "**/node_modules/google-auth-library/**",
-      "**/node_modules/google-logging-utils/**",
-      "**/node_modules/gaxios/**",
-      "**/node_modules/gcp-metadata/**",
-      "**/node_modules/gtoken/**",
-      "**/node_modules/jws/**",
-      "**/node_modules/jwa/**",
-      "**/node_modules/gopd/**"
+    "asar": false,
+    "files": [
+      "dist/**/*",
+      "dist-electron/**/*",
+      "node_modules/**/*",
+      "package.json"
     ],
     "win": {
       "target": "portable"

--- a/package.json
+++ b/package.json
@@ -37,8 +37,6 @@
       "dist/**/*",
       "dist-electron/**/*",
       "node_modules/**/*",
-      "!node_modules/**/{*.md,*.markdown,LICENSE*,license*,CHANGELOG*,changelog*}",
-      "!node_modules/**/{test,tests,__tests__,example,examples,docs,doc}/**",
       "package.json"
     ],
     "win": {

--- a/package.json
+++ b/package.json
@@ -32,10 +32,13 @@
     "appId": "com.studiojbbj.bflow",
     "productName": "BFLOW",
     "asar": false,
+    "npmRebuild": false,
     "files": [
       "dist/**/*",
       "dist-electron/**/*",
       "node_modules/**/*",
+      "!node_modules/**/{*.md,*.markdown,LICENSE*,license*,CHANGELOG*,changelog*}",
+      "!node_modules/**/{test,tests,__tests__,example,examples,docs,doc}/**",
       "package.json"
     ],
     "win": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,16 @@
     "sonner": "^2.0.7",
     "zustand": "^4.5.2"
   },
+  "build": {
+    "appId": "com.studiojbbj.bflow",
+    "productName": "BFLOW",
+    "win": {
+      "target": "portable"
+    },
+    "portable": {
+      "artifactName": "BFLOW.exe"
+    }
+  },
   "devDependencies": {
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,18 @@
   "build": {
     "appId": "com.studiojbbj.bflow",
     "productName": "BFLOW",
+    "asarUnpack": [
+      "**/node_modules/googleapis/**",
+      "**/node_modules/googleapis-common/**",
+      "**/node_modules/google-auth-library/**",
+      "**/node_modules/google-logging-utils/**",
+      "**/node_modules/gaxios/**",
+      "**/node_modules/gcp-metadata/**",
+      "**/node_modules/gtoken/**",
+      "**/node_modules/jws/**",
+      "**/node_modules/jwa/**",
+      "**/node_modules/gopd/**"
+    ],
     "win": {
       "target": "portable"
     },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -820,7 +820,7 @@ export default function App() {
         <div className="relative" style={{ width: 'min(420px, 75vmin)', aspectRatio: '672 / 592' }}>
           <video
             autoPlay muted playsInline preload="auto"
-            src="/splash/opening_video.mp4"
+            src="./splash/opening_video.mp4"
             className="absolute object-cover"
             style={{
               inset: '-10%', width: '120%', height: '120%',

--- a/src/components/splash/SplashScreen.tsx
+++ b/src/components/splash/SplashScreen.tsx
@@ -80,7 +80,7 @@ export function SplashScreen({ onComplete }: SplashScreenProps) {
   // 이미지 프리로드
   useEffect(() => {
     const img = new Image();
-    img.src = '/splash/opening_image_cropped.png';
+    img.src = './splash/opening_image_cropped.png';
   }, []);
 
   // ESC로 닫기
@@ -155,7 +155,7 @@ export function SplashScreen({ onComplete }: SplashScreenProps) {
             muted
             playsInline
             preload="auto"
-            src="/splash/opening_video.mp4"
+            src="./splash/opening_video.mp4"
             className="absolute object-cover"
             style={{
               inset: '-10%', width: '120%', height: '120%',
@@ -172,7 +172,7 @@ export function SplashScreen({ onComplete }: SplashScreenProps) {
 
         {/* 이미지 */}
         <img
-          src="/splash/opening_image_cropped.png"
+          src="./splash/opening_image_cropped.png"
           alt="Bflow"
           className="absolute object-cover"
           style={{

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
           build: {
             outDir: 'dist-electron',
             rollupOptions: {
-              external: ['ws', 'bufferutil', 'utf-8-validate'],
+              external: ['ws', 'bufferutil', 'utf-8-validate', 'googleapis', 'google-auth-library'],
             },
           },
         },


### PR DESCRIPTION
## 📋 업데이트 요약

> 이번 업데이트에서 달라진 점을 간략하게 정리했습니다.

- 📦 설치 없이 바로 실행되는 **`BFLOW.exe` 단일 포터블 실행파일** 빌드 설정이 추가됐습니다. 이제 한 파일만 공유하면 팀원들이 어디서든 실행할 수 있어요.
- 🐛 실행파일에서 **스플래시 영상/이미지가 표시되지 않던 문제**를 수정했습니다. 이제 앱 시작 시 정상적으로 오프닝 연출이 재생됩니다.
- ⚙️ 개발자용: Google Calendar 연동(googleapis) 모듈 때문에 빌드가 실패하던 문제를 해결해, 이제 `npm run build` 한 방으로 배포 파일이 생성됩니다.

## 🔧 상세 기술 설명

### 1. Vite 빌드 external 설정 (`vite.config.ts`)
- `electron/googleCalendar.ts`에서 import하는 `googleapis`, `google-auth-library`를 Electron 메인 빌드의 `rollupOptions.external`에 추가
- 이 모듈들은 Node.js가 런타임에 `node_modules`에서 직접 로드해야 하므로 Rollup 번들링에서 제외 필요
- 기존 external 목록(`ws`, `bufferutil`, `utf-8-validate`)에 2개 추가

### 2. electron-builder 설정 추가 (`package.json`)
새로 추가된 `build` 섹션:
- **`appId: "com.studiojbbj.bflow"`** — 앱 고유 식별자
- **`productName: "BFLOW"`** — 창 제목/실행파일 이름 베이스
- **`asar: false`** — asar 압축 비활성화 (googleapis의 동적 `require()` 안정성 확보)
- **`npmRebuild: false`** — 빌드 중 추가 npm install 단계 스킵 (모듈 누락 방지)
- **`files`** — `dist/**/*`, `dist-electron/**/*`, `node_modules/**/*`, `package.json` 명시
- **`win.target: "portable"`** + **`portable.artifactName: "BFLOW.exe"`** — NSIS 인스톨러 대신 단일 포터블 실행파일 생성

### 3. 스플래시 리소스 경로 상대화
절대 경로 `"/splash/..."` → 상대 경로 `"./splash/..."`로 변경:
- `src/App.tsx:823` — 로딩 스플래시 비디오
- `src/components/splash/SplashScreen.tsx:83,158,175` — 이스터에그 스플래시 (이미지 프리로드, 비디오, 이미지)

이유: 패키지 빌드에서 Electron이 `file://` 프로토콜로 `index.html`을 로드할 때, `/splash/...` 같은 절대 경로는 드라이브 루트(`file:///splash/...`)로 해석되어 리소스를 못 찾음. 상대 경로는 문서 위치 기준이라 dev/prod 모두 정상 동작.

## 🚧 개발 난항

빌드 관련 커밋이 5개 연속으로 발생할 만큼 시행착오가 있었습니다. 기록용으로 남깁니다.

### googleapis 패키지 처리의 연쇄 문제
- **문제**: Electron 메인에서 `googleapis`를 import했는데 Rollup이 resolve 실패 → external 처리 → 런타임 `Cannot find module 'googleapis'` → 그래도 또 실패.
- **시도 순서**:
  1. `vite.config.ts` external 목록에 추가 → 빌드는 통과, 런타임 실패
  2. `asarUnpack`으로 googleapis 관련 패키지들을 asar 외부로 추출 → 여전히 실패
  3. `asar: false`로 압축 자체 비활성화 + `files` 명시 → 여전히 실패
  4. **실제 원인 발견**: `node_modules/googleapis` 폴더가 로컬에 아예 존재하지 않았음 (npm install 누락 or 손상). `npm ci` 재실행으로 복구.
  5. 빌드 성공 후 실행하니 `Cannot find module './docs'` 발생 → 내가 `files`에 추가한 `docs` 폴더 제외 패턴이 **googleapis 내부의 Google Docs API 모듈(`build/src/apis/docs/`)까지 제외**시킨 게 원인. 제외 패턴 제거로 해결.
- **교훈**:
  - 패키지된 앱에서 모듈이 안 보이면 먼저 `Test-Path node_modules/<pkg>`로 로컬 설치 상태를 먼저 확인할 것
  - `files` 제외 패턴은 **패키지 내부 구조를 모르는 상태에서 쓰면 위험**. 특히 `docs`, `example`, `test` 같은 이름은 API 모듈 이름일 수도 있음 (googleapis처럼)
  - asar 관련 문제로 디버깅 루프에 빠지기 전에 먼저 모듈이 실제로 `node_modules`에 설치됐는지부터 확인

### 파일 잠금(EBUSY)으로 인한 재빌드 실패
- **문제**: 빌드 도중 `EBUSY: resource busy or locked, rmdir 'dist\win-unpacked'` 반복
- **원인**: 이전 빌드 결과물 `BFLOW.exe`가 백그라운드에 3개 실행 중이었음
- **해결**: `Get-Process | Where-Object { $_.Name -match "bflow|electron" }` 로 확인 후 `Stop-Process`로 종료
- **교훈**: 재빌드 전에 반드시 실행 중인 앱 프로세스를 모두 종료. `Remove-Item -ErrorAction SilentlyContinue`로 실패를 숨기면 잔재가 남아 빌드가 꼬임

### Electron 패키지 앱의 절대 경로 자산 이슈
- **문제**: 개발 모드에서는 스플래시가 잘 뜨는데 패키지 빌드에서는 표시 안 됨
- **원인**: dev는 Vite 서버가 `/splash/...`를 루트에서 서빙하지만, prod는 `file://` 프로토콜에서 `/`가 드라이브 루트로 해석됨
- **해결**: 런타임 자산 경로를 전부 `./`로 시작하는 상대 경로로 변경
- **교훈**: React 코드 내 하드코딩된 자산 경로는 항상 상대 경로 사용. Vite의 `base: './'` 설정은 번들된 asset에만 적용되고 런타임 문자열에는 영향 없음

## ✅ 테스트 가이드

### 사용자 테스트

1. **포터블 실행파일 동작 확인**
   - `C:\Bflow-BGonly\dist\BFLOW.exe`를 더블클릭하거나, USB/공유 드라이브로 옮겨서 실행
   - ✅ 기대: 잠깐 로딩 후 스플래시 영상이 재생되고 메인 화면 진입
   - ❌ 비정상: "Cannot find module ..." 다이얼로그 / 검은 화면만 표시

2. **스플래시 연출 확인**
   - 앱 실행 시 오프닝 영상이 페이드인 → 이미지로 크로스페이드 → "B flow" 텍스트 순서로 표시
   - ✅ 기대: 영상과 이미지가 모두 정상 표시
   - ❌ 비정상: 검은 박스만 나오거나 스플래시 건너뛰고 바로 로그인 화면 이동

3. **로그인 후 주요 기능 스모크 테스트**
   - 로그인 → 대시보드 진입 → 에피소드 위젯/씬 뷰 한 번씩 방문
   - 위젯에 데이터가 뜨는지, 체크박스 토글 시 즉시 반영되는지 확인

### 개발자 테스트

```powershell
# 1. 정리된 상태에서 빌드 재현
cd C:\Bflow-BGonly
Stop-Process -Name "BFLOW" -Force -ErrorAction SilentlyContinue
Remove-Item -Recurse -Force dist
npm run build

# 2. 패키지에 googleapis 및 하위 API 모듈이 모두 포함됐는지 검증
Test-Path dist\win-unpacked\resources\app\node_modules\googleapis
Test-Path dist\win-unpacked\resources\app\node_modules\googleapis\build\src\apis\docs
Test-Path dist\win-unpacked\resources\app\node_modules\google-auth-library

# 3. 스플래시 자산 포함 여부 확인
Test-Path dist\win-unpacked\resources\app\dist\splash\opening_video.mp4
Test-Path dist\win-unpacked\resources\app\dist\splash\opening_image_cropped.png