### PR TITLE
[v1.9.0] 트레이 아이콘 + 빠른 부팅 + 커스텀 테마 자동 생성

### DIFF
--- a/docs/superpowers/plans/2026-04-18-pre-release-polish.md
+++ b/docs/superpowers/plans/2026-04-18-pre-release-polish.md
@@ -61,9 +61,11 @@ import { app, BrowserWindow, clipboard, ipcMain, protocol, net, desktopCapturer,
 
 변경:
 ```typescript
-import { app, BrowserWindow, clipboard, ipcMain, protocol, net, desktopCapturer, screen, shell, Notification, Tray, Menu, nativeImage, dialog } from 'electron';
+import { app, BrowserWindow, clipboard, ipcMain, protocol, net, desktopCapturer, screen, shell, Notification, Tray, Menu, nativeImage } from 'electron';
 import type { MenuItemConstructorOptions } from 'electron';
 ```
+
+**주의**: `dialog`는 Chunk 2 Task 2.4에서 도입 (타임아웃 에러박스 용). Chunk 1에서는 import하지 않음.
 
 - [ ] **Step 2: 전역 변수 블록에 트레이·상태 플래그 추가**
 
@@ -96,11 +98,11 @@ git commit -m "chore(electron): 트레이/다이얼로그/스플래시용 import
 ### Task 1.2: 트레이 아이콘 경로 해석 + 1x1 폴백 이미지 유틸
 
 **Files:**
-- Modify: `electron/main.ts` (기존 `let isQuitting` 변수 직후에 신규 블록 삽입)
+- Modify: `electron/main.ts` (Task 1.1 블록 바로 다음 줄)
 
 - [ ] **Step 1: `resolveTrayIconPath()` + `EMPTY_ICON_B64` 상수 추가**
 
-`electron/main.ts`의 전역 변수 선언들 바로 아래(Task 1.1에서 추가한 변수 다음 줄)에 삽입:
+`electron/main.ts`에서 Task 1.1에서 추가한 전역 변수(`let mainLoadedOk = false;`) 바로 다음 줄에 삽입:
 
 ```typescript
 /** 아이콘 경로 해석: dev(electron/)와 prod(dist-electron/) + app.getAppPath() 순회 */
@@ -141,8 +143,18 @@ git commit -m "feat(electron): 트레이 아이콘 경로 해석 유틸 + 빈 �
 
 ### Task 1.3: `humanizeStatus` + `showMainWindow` + `toggleWidget` 헬퍼 추가
 
+> **주의**: 이 Task는 Task 1.4와 **한 덩어리**로 취급. Task 1.3 단독으로는 `rebuildTrayMenu` 미정의 에러가 발생하므로, Task 1.4 완료 전까지 STOP 하지 말 것. 중간 검증·커밋 생략.
+
 **Files:**
 - Modify: `electron/main.ts` (Task 1.2 블록 아래)
+
+**Step 0: `openWidgetPopup` 시그니처 사전 확인**
+
+```
+Grep pattern "function openWidgetPopup|openWidgetPopup\s*\(" path "electron/main.ts" output_mode content
+```
+
+기대: `function openWidgetPopup(widgetId: string, widgetTitle: string, extra?: ...)` 형태. 시그니처가 다르면 Task 1.3의 `toggleWidget` 호출을 실제 시그니처에 맞게 조정.
 
 - [ ] **Step 1: 3개 헬퍼 함수 추가**
 
@@ -270,11 +282,15 @@ git commit -m "feat(electron): 트레이 메뉴 구성 + createTray 구현 (3단
 ### Task 1.5: Supabase 상태 콜백에서 `rebuildTrayMenu` 호출
 
 **Files:**
-- Modify: `electron/main.ts:667-670` 부근 (기존 Supabase 상태 콜백)
+- Modify: `electron/main.ts` (문자열 `mainWindow.webContents.send('supabase:status'`가 포함된 콜백)
 
-- [ ] **Step 1: 기존 콜백을 찾아 `lastSupabaseStatus` 갱신 + `rebuildTrayMenu()` 호출 추가**
+- [ ] **Step 1: 해당 콜백 위치 문자열 검색으로 특정**
 
-`electron/main.ts` 안에서 `mainWindow.webContents.send('supabase:status', status)` 패턴을 포함한 콜백 위치를 찾아(현재 main.ts:667-669 부근), 콜백 진입부에서:
+```
+Grep pattern "supabase:status" path "electron/main.ts" output_mode content -n
+```
+
+매칭된 함수/콜백 내부에서 `lastSupabaseStatus` 갱신 + `rebuildTrayMenu()` 호출 추가:
 
 ```typescript
 // 기존 콜백 예시:
@@ -316,12 +332,12 @@ git commit -m "feat(electron): Supabase 상태 변화 시 트레이 메뉴/툴�
 ### Task 1.6: 위젯 open/close 시 `rebuildTrayMenu` 호출
 
 **Files:**
-- Modify: `electron/main.ts` (openWidgetPopup 내부 widgetWindows.set 직후)
-- Modify: `electron/main.ts` (popupWin.on('closed') 핸들러 내부)
+- Modify: `electron/main.ts` (`openWidgetPopup` 내부 `widgetWindows.set` 직후)
+- Modify: `electron/main.ts` (`popupWin.on('closed', ...)` 핸들러 내부)
 
 - [ ] **Step 1: `widgetWindows.set(widgetId, popupWin)` 직후에 `rebuildTrayMenu()` 호출 추가**
 
-`electron/main.ts:1141` 부근:
+문자열 `widgetWindows.set(widgetId, popupWin)` 검색하여 해당 라인 바로 다음에 삽입:
 ```typescript
 widgetWindows.set(widgetId, popupWin);
 rebuildTrayMenu(); // 트레이 체크박스 갱신
@@ -329,7 +345,7 @@ rebuildTrayMenu(); // 트레이 체크박스 갱신
 
 - [ ] **Step 2: `popupWin.on('closed')` 핸들러 내 `widgetWindows.delete` 직후에 `rebuildTrayMenu()` 호출 추가**
 
-`electron/main.ts:1156-1172` 부근:
+`popupWin.on('closed'` 문자열 검색하여 해당 블록 안에서 `widgetWindows.delete(widgetId)` 다음 줄에 삽입:
 ```typescript
 popupWin.on('closed', () => {
   widgetWindows.delete(widgetId);
@@ -358,36 +374,33 @@ git commit -m "feat(electron): 위젯 open/close 시 트레이 메뉴 갱신"
 ### Task 1.7: 위젯 캐시 삭제 로직 제거 (핵심 버그 수정)
 
 **Files:**
-- Modify: `electron/main.ts:1156-1164` (popupWin.on('closed') 핸들러)
+- Modify: `electron/main.ts` (`popupWin.on('closed', ...)` 핸들러)
 
-- [ ] **Step 1: `if (!isQuitting) { widgetPositionCache.delete(...); saveWidgetPositionsDebounced(); }` 블록 삭제**
+- [ ] **Step 1: `if (!isQuitting) { widgetPositionCache.delete(...); saveWidgetPositionsDebounced(); }` 3줄 블록을 삭제 (독 스택 제거 코드는 온전히 유지)**
 
-`electron/main.ts` 해당 핸들러에서:
-
+`popupWin.on('closed'` 블록 내 아래 3줄만 정확히 삭제:
 ```typescript
-// BEFORE:
-popupWin.on('closed', () => {
-  widgetWindows.delete(widgetId);
-  widgetOriginalBounds.delete(widgetId);
-  rebuildTrayMenu();
-  if (!isQuitting) {                           // ← 이 블록
-    widgetPositionCache.delete(widgetId);      // ← 전체를
-    saveWidgetPositionsDebounced();             // ← 삭제
-  }
-  // 독 스택에서 제거 + 나머지 재배치
-  const dockIdx = dockedWidgetIds.indexOf(widgetId);
-  // ... 이하 유지
-});
+if (!isQuitting) {
+  widgetPositionCache.delete(widgetId);
+  saveWidgetPositionsDebounced();
+}
+```
 
-// AFTER:
+주변 코드(`widgetWindows.delete`, `widgetOriginalBounds.delete`, `rebuildTrayMenu()`, `const dockIdx = dockedWidgetIds.indexOf(widgetId)` 이하 독 스택 제거/재배치 블록 전체)는 **건드리지 않음**. 삭제 대상은 정확히 위 3줄뿐.
+
+**최종 상태 예시**:
+```typescript
 popupWin.on('closed', () => {
   widgetWindows.delete(widgetId);
   widgetOriginalBounds.delete(widgetId);
-  rebuildTrayMenu();
+  rebuildTrayMenu(); // Task 1.6에서 추가
   // 캐시는 항상 유지 → 다음 실행 시 자동 복원 (spec 결정사항)
-  // 독 스택에서 제거 + 나머지 재배치
   const dockIdx = dockedWidgetIds.indexOf(widgetId);
-  // ... 이하 유지
+  if (dockIdx >= 0) {
+    dockedWidgetIds.splice(dockIdx, 1);
+    if (expandedDockWidgetId === widgetId) expandedDockWidgetId = null;
+    repositionAllDocked();
+  }
 });
 ```
 
@@ -410,17 +423,26 @@ git commit -m "fix(electron): 위젯 개별 X 닫기 시 위치 캐시 유지 (�
 
 **Files:**
 - Modify: `electron/main.ts` (전역 함수 블록, Task 1.4 `createTray` 위)
-- Modify: `electron/storage.ts` 또는 `electron/main.ts`의 기존 preferences 헬퍼 (loadPreferences/savePreferences 존재 여부 확인)
 
-- [ ] **Step 1: `loadPreferences`/`savePreferences`가 main에서 접근 가능한지 확인**
+- [ ] **Step 0: 필요한 기존 유틸 존재 여부 확인**
 
-```bash
-cd "C:\Bflow-BGonly\.claude\worktrees\ecstatic-lumiere-42f79a"
+```
+Grep pattern "function getDataPath|function ensureDir|function getAppRoot" path "electron/main.ts" output_mode content
 ```
 
-`Grep pattern "loadPreferences|savePreferences" path "electron"` 실행해 파일·함수 시그니처 확인.
+기대: `getDataPath()` / `ensureDir()` 둘 다 이미 존재 (main.ts 상단 유틸 블록). 존재 시 그대로 재사용. 부재 시 다음 폴백 작성:
 
-- [ ] **Step 2: 메인 프로세스에서 preferences.json을 읽고 쓰는 최소 헬퍼 추가 (없으면)**
+```typescript
+// 폴백 (getDataPath/ensureDir 부재 시 주입)
+function getDataPath(): string {
+  return app.getPath('userData'); // %APPDATA%/Bflow-BGonly/
+}
+function ensureDir(p: string): void {
+  if (!fs.existsSync(p)) fs.mkdirSync(p, { recursive: true });
+}
+```
+
+- [ ] **Step 1: 메인 프로세스에서 preferences.json을 읽고 쓰는 최소 헬퍼 추가**
 
 `electron/main.ts` 상단의 `getUsersFilePath` 아래 부근에 추가:
 
@@ -448,7 +470,7 @@ async function writePreferences(patch: Record<string, unknown>): Promise<void> {
 
 **주의**: 기존에 동일 기능을 하는 함수가 이미 있다면 그것을 재사용. (렌더러 쪽 `settingsService.ts`는 IPC 경유 → 메인 프로세스는 별도 파일 I/O 필요)
 
-- [ ] **Step 3: `showTrayHintOnce()` 추가**
+- [ ] **Step 2: `showTrayHintOnce()` 추가**
 
 ```typescript
 async function showTrayHintOnce(): Promise<void> {
@@ -482,13 +504,13 @@ async function showTrayHintOnce(): Promise<void> {
 }
 ```
 
-- [ ] **Step 4: tsc 검증**
+- [ ] **Step 3: tsc 검증**
 
 ```bash
 npx tsc --noEmit
 ```
 
-- [ ] **Step 5: 커밋**
+- [ ] **Step 4: 커밋**
 
 ```bash
 git add electron/main.ts
@@ -504,35 +526,22 @@ git commit -m "feat(electron): 트레이 최소화 최초 1회 안내 (Notificat
 
 - [ ] **Step 1: `mainWindow.on('closed', ...)` 위에 `mainWindow.on('close', ...)` 추가**
 
+**Chunk 1 범위에서는 `show: false` 옵션을 추가하지 않음** — Chunk 2 Task 2.3에서 스플래시 도입과 함께 변경. 여기서는 기존 `BrowserWindow` 옵션 그대로 유지하고, 핸들러 2개만 추가:
+
 ```typescript
-function createWindow(): void {
-  mainWindow = new BrowserWindow({
-    width: 1400,
-    height: 900,
-    // ... 기존 옵션
-    show: false, // ← 스플래시 표시 중엔 숨김. Task 2.4에서 show() 타이밍 변경
-  });
+// 기존 createWindow 함수의 mainWindow.on('closed', ...) 바로 위에 아래를 추가
+mainWindow.on('close', (e) => {
+  if (!isQuitting && !trayFailed) {
+    e.preventDefault();
+    mainWindow?.hide();
+    showTrayHintOnce().catch(() => {/* ignore */});
+    return;
+  }
+  // isQuitting === true || trayFailed === true인 경우 기본 동작 허용
+});
 
-  // ... 기존 loadURL/loadFile
-
-  // 창 X 버튼 → 트레이로 숨김 (트레이 실패 시 실제 종료로 폴백)
-  mainWindow.on('close', (e) => {
-    if (!isQuitting && !trayFailed) {
-      e.preventDefault();
-      mainWindow?.hide();
-      showTrayHintOnce().catch(() => {/* ignore */});
-      return;
-    }
-    // isQuitting === true || trayFailed === true인 경우 기본 동작 허용
-  });
-
-  mainWindow.on('closed', () => {
-    mainWindow = null;
-  });
-}
+// (기존 mainWindow.on('closed', () => { mainWindow = null; }); 는 유지)
 ```
-
-**주의**: `show: false`는 Task 2.4 스플래시 도입 시 함께 적용하므로, Chunk 1 작업 시엔 `show` 옵션 미지정(기본 true)으로 두고 Chunk 2에서 변경.
 
 - [ ] **Step 2: tsc 검증**
 
@@ -607,7 +616,7 @@ createTray();        // 먼저 트레이 준비 (실패해도 앱은 계속)
 createWindow();
 ```
 
-- [ ] **Step 2: tsc 검증 + Step 3: 개발 실행 검증**
+- [ ] **Step 2: tsc 검증 + Step 3: 개발 실행 정상 경로 검증**
 
 ```bash
 npx tsc --noEmit
@@ -621,7 +630,25 @@ npm run electron:dev
 - 트레이 좌클릭 or '열기' → 메인 창 복원
 - 트레이 '종료' → 앱 완전 종료, 트레이 아이콘 소거
 
-수동 검증 중 문제 발견 시 Task 1.1~1.11 해당 스텝으로 돌아가 수정.
+**증상 → 원인 Task 매트릭스** (문제 발견 시 해당 Task 재확인):
+
+| 증상 | 원인 Task |
+|---|---|
+| 트레이 아이콘 미표시 | Task 1.4 (createTray), Task 1.11 (whenReady 호출) |
+| 우클릭 메뉴 미노출 or 잘못됨 | Task 1.4 (rebuildTrayMenu) |
+| 위젯 서브메뉴 체크박스 안 맞음 | Task 1.6 (open/close 시 rebuildTrayMenu) |
+| 창 X 눌렀는데 앱이 실제로 종료됨 | Task 1.9 (close 핸들러), Task 1.10 (window-all-closed) |
+| 트레이 '종료'가 동작 안 함 | Task 1.4 (종료 메뉴 click 핸들러) |
+| 위젯 개별 X 닫았는데 재시작 시 복원 안 됨 | Task 1.7 (캐시 삭제 로직 제거 누락) |
+| Notification이 안 뜸 | Task 1.8 (showTrayHintOnce) — 다만 OS 차단 환경은 정상 |
+| Supabase 상태 툴팁 미반영 | Task 1.5 (콜백 수정) |
+
+- [ ] **Step 3.5: `trayFailed` 폴백 시나리오 검증 (좀비 방지 필수 확인)**
+
+1. `npm run electron:dev` 종료 상태에서 `public/splash/opening_image_cropped.png` 파일명을 일시 변경 (예: `.png.bak`).
+2. 다시 `npm run electron:dev` 실행 → 콘솔에 `[트레이] 생성 실패` 로그가 나오고 트레이 아이콘 없음 확인.
+3. 메인 창 X 클릭 → 실제 종료 확인 (숨어서 좀비가 되면 안 됨).
+4. 파일명 원복 후 재실행해서 정상 동작 복원 확인.
 
 - [ ] **Step 4: 커밋**
 
@@ -636,6 +663,14 @@ git commit -m "feat(electron): app.whenReady에서 트레이 초기화 수행"
 
 **Files:**
 - Modify: `electron/main.ts` (전역 스코프, `app.on('before-quit')` 근처)
+
+- [ ] **Step 0: `saveWidgetPositionsSync` 존재 확인**
+
+```
+Grep pattern "function saveWidgetPositionsSync" path "electron/main.ts" output_mode content -n
+```
+
+기대: `function saveWidgetPositionsSync(): void` 존재 (main.ts:103). 부재 시 `saveWidgetPositionsDebounced`가 내부에 timer clear + 동기 저장 흐름을 포함하는지 확인 후 대안으로 사용.
 
 - [ ] **Step 1: `process.on('exit')` 등록**
 
@@ -679,9 +714,18 @@ git commit -m "feat(electron): process exit 시 위젯 위치 최종 안전망 �
 npm run build:vite
 ```
 
-기대: tsc + vite build 성공. (electron-builder는 이후 Chunk 전체 완료 시 검증)
+기대: tsc + vite build 성공.
 
-- [ ] **Step 3: 커밋**
+- [ ] **Step 3: electron-builder --dir 모드로 파일 포함 확인 (선택)**
+
+```bash
+npx electron-builder --dir
+ls dist/win-unpacked/resources/app/public/splash/
+```
+
+기대: `opening_image_cropped.png`가 포함되어 있음. 없으면 `files` 패턴 재확인.
+
+- [ ] **Step 4: 커밋**
 
 ```bash
 git add package.json
@@ -916,7 +960,15 @@ git commit -m "feat(electron): 메인 창 show:false + did-finish-load로 스플
 ### Task 2.4: 30초 타임아웃 + `console.time` 측정 로그
 
 **Files:**
+- Modify: `electron/main.ts:1` (import에 `dialog` 추가)
 - Modify: `electron/main.ts` (`app.whenReady().then(...)` 블록)
+
+- [ ] **Step 0: `dialog` import 추가**
+
+`electron/main.ts:1`의 import 라인에 `dialog` 추가:
+```typescript
+import { app, BrowserWindow, clipboard, ipcMain, protocol, net, desktopCapturer, screen, shell, Notification, Tray, Menu, nativeImage, dialog } from 'electron';
+```
 
 - [ ] **Step 1: `app.whenReady()` 블록에서 측정 로그 시작 + 타임아웃 설정**
 

--- a/docs/superpowers/plans/2026-04-18-pre-release-polish.md
+++ b/docs/superpowers/plans/2026-04-18-pre-release-polish.md
@@ -889,58 +889,41 @@ git commit -m "feat(electron): 스플래시 윈도우 생성/종료 유틸 추�
 **Files:**
 - Modify: `electron/main.ts:262-287` (`createWindow`)
 
-- [ ] **Step 1: `BrowserWindow`에 `show: false` 추가 + `did-finish-load` 이벤트 추가**
+- [ ] **Step 1: 기존 `BrowserWindow` options 객체에 `show: false,` 한 줄만 추가 (다른 webPreferences 필드·기존 이벤트 핸들러 건드리지 않음)**
+
+`electron/main.ts:263-275`의 기존 `new BrowserWindow({...})` 블록에서 `backgroundColor` 바로 아래에 `show: false,` 한 줄 추가:
 
 ```typescript
-function createWindow(): void {
-  mainWindow = new BrowserWindow({
-    width: 1400,
-    height: 900,
-    minWidth: 800,
-    minHeight: 600,
-    title: 'B flow',
-    backgroundColor: '#0F1117',
-    show: false, // ← 스플래시 숨기기 전까진 hidden
-    webPreferences: {
-      preload: path.join(__dirname, 'preload.js'),
-      contextIsolation: true,
-      nodeIntegration: false,
-    },
-  });
-
-  if (process.env.VITE_DEV_SERVER_URL) {
-    mainWindow.loadURL(process.env.VITE_DEV_SERVER_URL);
-    mainWindow.webContents.openDevTools();
-  } else {
-    mainWindow.loadFile(path.join(__dirname, '../dist/index.html'));
-  }
-
-  // 메인 로드 완료 → 스플래시 닫고 메인 창 show
-  mainWindow.webContents.once('did-finish-load', () => {
-    mainLoadedOk = true;
-    closeSplash();
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.show();
-      mainWindow.focus();
-    }
-    try { console.timeEnd('splash-to-main'); } catch {/* 이미 종료됨 */}
-  });
-
-  // 창 X 핸들러 (Task 1.9에서 추가된 것 유지)
-  mainWindow.on('close', (e) => {
-    if (!isQuitting && !trayFailed) {
-      e.preventDefault();
-      mainWindow?.hide();
-      showTrayHintOnce().catch(() => {/* ignore */});
-      return;
-    }
-  });
-
-  mainWindow.on('closed', () => {
-    mainWindow = null;
-  });
-}
+// Edit target (precise anchor):
+//   backgroundColor: '#0F1117',
+// 의 바로 다음 줄에 삽입:
+    show: false,
 ```
+
+**주의**: `webPreferences`, `preload`, `minWidth`, `minHeight`, `title` 등 기존 옵션 전체는 수정 금지. 기존에 있는 이벤트 리스너(`did-fail-load` 등)도 그대로 둠.
+
+- [ ] **Step 2: `did-finish-load` 이벤트 핸들러 추가 (Task 2.4의 타임아웃 해제도 이 핸들러에서 처리)**
+
+`mainWindow.loadURL`/`loadFile` 호출 이후, `mainWindow.on('close', ...)` 핸들러 바로 위에 추가:
+
+```typescript
+// 메인 로드 완료 → 스플래시 닫고 메인 창 show
+mainWindow.webContents.once('did-finish-load', () => {
+  mainLoadedOk = true;
+  if (loadTimeoutId) {
+    clearTimeout(loadTimeoutId); // Task 2.4에서 설정한 타임아웃 해제
+    loadTimeoutId = null;
+  }
+  closeSplash();
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.show();
+    mainWindow.focus();
+  }
+  try { console.timeEnd('splash-to-main'); } catch {/* 이미 종료됨 */}
+});
+```
+
+**주의**: `loadTimeoutId`는 Task 2.4 Step 1에서 모듈 스코프 변수로 선언 예정 (`let loadTimeoutId: ReturnType<typeof setTimeout> | null = null;`). Task 2.3은 이 변수를 사용하는 `did-finish-load` 블록까지만 작성.
 
 - [ ] **Step 2: tsc 검증**
 
@@ -970,48 +953,44 @@ git commit -m "feat(electron): 메인 창 show:false + did-finish-load로 스플
 import { app, BrowserWindow, clipboard, ipcMain, protocol, net, desktopCapturer, screen, shell, Notification, Tray, Menu, nativeImage, dialog } from 'electron';
 ```
 
-- [ ] **Step 1: `app.whenReady()` 블록에서 측정 로그 시작 + 타임아웃 설정**
+- [ ] **Step 1: 모듈 스코프에 `loadTimeoutId` 변수 추가** (Task 1.1 전역 변수 블록 근처)
 
 ```typescript
-app.whenReady().then(() => {
-  console.time('splash-to-main'); // 측정 시작
-
-  createSplashWindow(); // 1. 가장 먼저 스플래시
-  createTray();          // 2. 트레이 (경량)
-  createWindow();        // 3. 메인 창 (숨김 상태로 로드 시작)
-
-  // 메인 로드 30초 타임아웃 (좀비 방지)
-  const MAIN_LOAD_TIMEOUT_MS = 30_000;
-  const loadTimeout = setTimeout(() => {
-    if (mainLoadedOk) return;
-    console.error('[메인 로드] 30초 타임아웃 — 에러 다이얼로그 후 종료');
-    closeSplash();
-    try {
-      dialog.showErrorBox('B flow', '앱 로드에 실패했습니다. 다시 실행해주세요.');
-    } catch {/* ignore */}
-    isQuitting = true;
-    app.quit();
-  }, MAIN_LOAD_TIMEOUT_MS);
-
-  // 로드 완료 시 타임아웃 해제
-  if (mainWindow) {
-    mainWindow.webContents.once('did-finish-load', () => {
-      clearTimeout(loadTimeout);
-    });
-  }
-
-  // Google Calendar 토큰 복원
-  gcal.restoreTokens();
-
-  // Supabase Realtime 구독 시작
-  startSupabaseRealtime();
-
-  // 기존 자동 위젯 복원 등 나머지 로직 (변경 없음, 그대로 유지)
-  // ...
-});
+let loadTimeoutId: ReturnType<typeof setTimeout> | null = null;
 ```
 
-**주의**: 기존 `app.whenReady().then(() => { ... })` 블록의 다른 내용(위젯 복원 등)은 그대로 유지. 위 코드는 블록 시작부에만 신규 호출 추가.
+- [ ] **Step 2: `app.whenReady()` 블록 시작부에 측정 로그 + 타임아웃 설정 추가**
+
+기존 `app.whenReady().then(() => { ... })` 블록의 `createWindow()` 호출 **앞**에 다음을 삽입. 기존 내용(`gcal.restoreTokens()`, `startSupabaseRealtime()`, 위젯 복원 등)은 모두 그대로 유지:
+
+```typescript
+console.time('splash-to-main'); // 측정 시작
+
+createSplashWindow(); // 1. 가장 먼저 스플래시
+// (기존) createTray();   -- Task 1.11에서 이미 추가됨
+// (기존) createWindow(); -- 아래 유지
+
+// 메인 로드 30초 타임아웃 (좀비 방지).
+// Task 2.3의 did-finish-load 핸들러에서 clearTimeout + 해제 처리.
+const MAIN_LOAD_TIMEOUT_MS = 30_000;
+loadTimeoutId = setTimeout(() => {
+  if (mainLoadedOk) {
+    loadTimeoutId = null;
+    return;
+  }
+  console.error('[메인 로드] 30초 타임아웃 — 에러 다이얼로그 후 종료');
+  closeSplash();
+  try {
+    dialog.showErrorBox('B flow', '앱 로드에 실패했습니다. 다시 실행해주세요.');
+  } catch {/* ignore */}
+  isQuitting = true;
+  app.quit();
+}, MAIN_LOAD_TIMEOUT_MS);
+```
+
+**주의**:
+1. 기존 `createTray()` (Task 1.11) 호출 앞에 `createSplashWindow()`를 두어 스플래시가 트레이보다 먼저 뜨도록 순서 유지.
+2. 타임아웃 해제는 Task 2.3의 `did-finish-load` 핸들러에서 `clearTimeout(loadTimeoutId)`로 처리 — 여기서는 별도의 `.once('did-finish-load', ...)` 등록하지 않음 (리스너 중복 방지).
 
 - [ ] **Step 2: tsc 검증**
 
@@ -1131,26 +1110,21 @@ git commit -m "perf(vite): manualChunks로 성격별 vendor 번들 분리"
 
 - [ ] **Step 1: 9개 뷰 import를 `React.lazy`로 변경**
 
-기존 `src/App.tsx:6-15`:
+기존 `src/App.tsx:6-15`의 10개 뷰 import 라인을 모두 삭제하고, 아래 lazy 선언으로 교체. **App.tsx의 non-view import(`useEffect`, `MainLayout`, `useAppStore`, `useDataStore`, 서비스·유틸 등)는 전부 그대로 보존**.
+
+기존 `src/App.tsx:1`의 react import에 `lazy`, `Suspense`를 추가:
+
 ```typescript
-import { Dashboard } from '@/views/Dashboard';
-import { ScenesView } from '@/views/ScenesView';
-import { EpisodeView } from '@/views/EpisodeView';
-import { AssigneeView } from '@/views/AssigneeView';
-import { TeamView } from '@/views/TeamView';
-import { CalendarView } from '@/views/CalendarView';
-import { ScheduleView } from '@/views/ScheduleView';
-import { VacationView } from '@/views/VacationView';
-import CompositingView from '@/views/CompositingView';
-import { SettingsView } from '@/views/SettingsView';
+// BEFORE:
+import { useEffect, useCallback, useState, useRef } from 'react';
+
+// AFTER:
+import { lazy, Suspense, useEffect, useCallback, useState, useRef } from 'react';
 ```
 
-변경 (`lazy`로 래핑. `default` vs named export 주의):
+이어서 `src/App.tsx:6-15`의 10개 뷰 import 블록만 아래로 교체. 나머지 import는 건드리지 않음:
 
 ```typescript
-import { lazy, Suspense, useEffect, useCallback, useState, useRef } from 'react';
-// ... 기타 import
-
 // 뷰 lazy 로딩 — 초기 번들에서 제외
 const Dashboard = lazy(() => import('@/views/Dashboard').then(m => ({ default: m.Dashboard })));
 const ScenesView = lazy(() => import('@/views/ScenesView').then(m => ({ default: m.ScenesView })));
@@ -1267,22 +1241,33 @@ git commit -m "perf(renderer): 인증 모달 lazy 로딩"
 
 ---
 
-### Task 2.9: 설정 섹션 lazy 로딩 (선택, 범위 조정)
+### Task 2.9: 설정 섹션 lazy 로딩 (조건부)
 
 **Files:**
-- Modify: `src/views/SettingsView.tsx` (존재 시) 또는 설정 섹션 관련 파일
+- Modify: `src/views/SettingsView.tsx` (존재/구조 확인 후 결정)
 
-- [ ] **Step 1: SettingsView 내부 구조 확인**
+- [ ] **Step 1: SettingsView 존재 및 섹션 구조 확인**
 
-```bash
-# 파일 존재 여부 및 import 구조 Read
+```
+Grep pattern "export (const|function|default) \\w*SettingsView" path "src/views" output_mode content
+Grep pattern "ThemeSection|SheetsSection|NotificationSection" path "src/views/SettingsView.tsx" output_mode content -n
 ```
 
-- [ ] **Step 2: 섹션별 `lazy` 적용**
+판단 기준:
+- **탭 기반(조건부 렌더)**: `{activeTab === 'theme' && <ThemeSection />}` 형태가 보이면 → Step 2로 진행해 lazy 적용.
+- **동시 렌더**: 모든 섹션을 한 번에 나열하는 구조 → lazy가 의미 없음. **이 Task 전체를 스킵**하고 Task 2.10으로.
+- **파일 미존재 또는 다른 구조**: 역시 스킵.
 
-`SettingsView` 안에서 각 section(`ThemeSection`, `SheetsSection`, `NotificationSection`, `StartupSection`, `ShortcutsSection`, `EffectsSection`, `ProfileSection`, `LoginSection`, `FontSizeSection`, `GuideSection`)을 `lazy` 처리하고 활성 탭만 렌더하도록 `Suspense` 추가.
+- [ ] **Step 2 (탭 기반일 때만): 섹션별 `lazy` 적용**
 
-**주의**: 현재 SettingsView가 이미 탭 기반 렌더링이면 각 탭의 섹션만 마운트하므로 lazy 적용이 쉬움. 동시에 모두 렌더하는 구조면 lazy가 의미 없으므로 스킵하고 Task 2.10으로.
+```typescript
+import { lazy, Suspense } from 'react';
+const ThemeSection = lazy(() => import('@/components/settings/ThemeSection').then(m => ({ default: m.ThemeSection })));
+const SheetsSection = lazy(() => import('@/components/settings/SheetsSection').then(m => ({ default: m.SheetsSection })));
+// ... 10개 섹션 동일 패턴
+```
+
+각 섹션 사용처를 `<Suspense fallback={null}>…</Suspense>`로 감쌈.
 
 - [ ] **Step 3: 빌드 검증 + 커밋 (변경이 있었을 때만)**
 
@@ -1307,11 +1292,16 @@ npm run build
 
 - [ ] **Step 2: portable exe 수동 실행 검증**
 
-`dist/BFLOW.exe` 더블클릭 → 다음을 확인:
+`BFLOW.exe --enable-logging` 실행 (또는 별도 터미널에서 `BFLOW.exe` 실행 후 stdout 확인):
 - 더블클릭 후 빠르게 스플래시 등장
 - 스플래시 → 메인 창 전환 부드러움
-- 콘솔 로그로 `splash-to-main` 시간 < 3000ms (이상적으로 < 1500ms)
+- 콘솔 로그로 `splash-to-main: XXXXms` 확인 (목표 < 3000ms, 이상적으로 < 1500ms)
 - 메인 창에서 뷰 전환 시 짧은 스피너 → 로드 완료
+
+**실패 시 진단 가이드**:
+- 스플래시 자체가 안 뜸 → Task 2.1(splash.html)/Task 2.2(createSplashWindow)/Task 2.4 Step 2(createSplashWindow 호출 순서) 재확인
+- 스플래시는 뜨는데 3000ms 넘어감 → `splash-to-main` 로그 확인, Task 2.6 청크 분리 / Task 2.7 lazy 적용 범위 검토
+- 스플래시 뜬 채 멈춤 (메인 창 안 뜸) → Task 2.3 `did-finish-load` 핸들러 + Task 2.4 타임아웃 경로 동작 확인 (30초 후 에러 다이얼로그 떠야 함)
 
 - [ ] **Step 3: 이상 없으면 Chunk 2 커밋 병합 확인**
 
@@ -1502,26 +1492,57 @@ const HEX_RE = /^#[0-9a-fA-F]{6}$/;
 
 /**
  * 저장된 커스텀 테마 필드들을 검증/마이그레이션.
- * - 새 포맷(hex)이 유효하면 그대로 사용
- * - 구포맷(customThemeColors triplet)만 있으면 hex 역산
- * - 둘 다 실패 시 null 반환 → 호출부는 기본 프리셋으로 폴백
+ * 부분적 유효성도 허용하여 사용자가 저장한 hex를 최대한 보존.
+ *
+ * 우선순위:
+ * 1. 두 hex 모두 유효 → 둘 다 사용
+ * 2. 한 hex만 유효 → 유효한 쪽은 유지, 나머지는 triplet에서 역산 (없으면 그 값을 sub로 복제)
+ * 3. 둘 다 hex 무효 → triplet 양쪽 모두 역산
+ * 4. triplet도 없거나 실패 → null (호출부는 DEFAULT_THEME_ID로 폴백)
  */
 export function sanitizeCustomHex(input: {
   customAccentHex?: string | null;
   customSubHex?: string | null;
   customThemeColors?: ThemeColors | null;
 }): { accent: string; sub: string } | null {
-  const a = input.customAccentHex;
-  const s = input.customSubHex;
-  if (a && HEX_RE.test(a) && s && HEX_RE.test(s)) {
-    return { accent: a, sub: s };
-  }
+  const aValid = !!(input.customAccentHex && HEX_RE.test(input.customAccentHex));
+  const sValid = !!(input.customSubHex && HEX_RE.test(input.customSubHex));
   const c = input.customThemeColors;
+
+  // Case 1: 둘 다 hex 유효
+  if (aValid && sValid) {
+    return { accent: input.customAccentHex!, sub: input.customSubHex! };
+  }
+
+  // Case 2/3: triplet으로 보강
+  let tripletAccent: string | null = null;
+  let tripletSub: string | null = null;
   if (c?.accent && c?.accentSub) {
     try {
-      return { accent: rgbToHex(c.accent), sub: rgbToHex(c.accentSub) };
+      tripletAccent = rgbToHex(c.accent);
+      tripletSub = rgbToHex(c.accentSub);
     } catch {/* triplet 파싱 실패 */}
   }
+
+  // Case 2a: accent hex만 유효
+  if (aValid) {
+    return {
+      accent: input.customAccentHex!,
+      sub: tripletSub ?? input.customAccentHex!, // sub 복구 불가 시 accent와 동일
+    };
+  }
+  // Case 2b: sub hex만 유효
+  if (sValid) {
+    return {
+      accent: tripletAccent ?? input.customSubHex!,
+      sub: input.customSubHex!,
+    };
+  }
+  // Case 3: 둘 다 hex 무효 → triplet 시도
+  if (tripletAccent && tripletSub) {
+    return { accent: tripletAccent, sub: tripletSub };
+  }
+  // Case 4: 전부 실패
   return null;
 }
 ```
@@ -1589,13 +1610,18 @@ if (savedTheme) {
       customThemeColors: savedTheme.customColors ?? null,
     });
     if (!customHex) {
-      // 손상 → 기본 프리셋으로 폴백 (조용히)
       console.warn('[테마] 커스텀 테마 데이터 손상 → 기본 프리셋으로 폴백');
     }
   }
 
+  // 실제 적용할 테마 ID (커스텀 복구 실패 시 기본 프리셋으로 강제)
+  const effectiveThemeId =
+    savedTheme.themeId === 'custom' && !customHex
+      ? DEFAULT_THEME_ID
+      : savedTheme.themeId;
+
   // CSS 적용
-  if (savedTheme.themeId === 'custom' && customHex) {
+  if (effectiveThemeId === 'custom' && customHex) {
     const colors = deriveThemeFromAccent(customHex.accent, customHex.sub, savedMode);
     applyTheme(colors, savedMode);
     themeInitRef.current = true;
@@ -1604,8 +1630,8 @@ if (savedTheme) {
     setCustomThemeColors(colors);
     useAppStore.getState().setCustomAccentHex(customHex.accent);
     useAppStore.getState().setCustomSubHex(customHex.sub);
-    // 구포맷만 있던 경우 새 포맷으로 저장
-    if (!savedTheme.customAccentHex || !savedTheme.customSubHex) {
+    // 구포맷만 있거나 sanitize로 보강된 경우 새 포맷으로 재저장
+    if (savedTheme.customAccentHex !== customHex.accent || savedTheme.customSubHex !== customHex.sub) {
       saveTheme({
         themeId: 'custom',
         customColors: colors,
@@ -1615,16 +1641,23 @@ if (savedTheme) {
       });
     }
   } else if (savedMode === 'light') {
-    applyTheme(getLightColors(savedTheme.themeId), savedMode);
+    applyTheme(getLightColors(effectiveThemeId), savedMode);
     themeInitRef.current = true;
-    setThemeId(savedTheme.themeId);
+    setThemeId(effectiveThemeId);
     setColorMode(savedMode);
   } else {
-    const preset = getPreset(savedTheme.themeId);
+    const preset = getPreset(effectiveThemeId);
     if (preset) {
       applyTheme(preset.colors, savedMode);
       themeInitRef.current = true;
-      setThemeId(savedTheme.themeId);
+      setThemeId(effectiveThemeId);
+      setColorMode(savedMode);
+    } else {
+      // 완전 손상 (프리셋 ID도 유효하지 않음) → 최종 폴백
+      const fallback = getPreset(DEFAULT_THEME_ID)!;
+      applyTheme(fallback.colors, savedMode);
+      themeInitRef.current = true;
+      setThemeId(DEFAULT_THEME_ID);
       setColorMode(savedMode);
     }
   }
@@ -1633,7 +1666,7 @@ if (savedTheme) {
 }
 ```
 
-추가 import 필요: `deriveThemeFromAccent`, `sanitizeCustomHex` from `@/themes`.
+추가 import 필요: `deriveThemeFromAccent`, `sanitizeCustomHex`, `DEFAULT_THEME_ID` from `@/themes`.
 
 - [ ] **Step 2: tsc 검증 + 커밋**
 
@@ -1645,28 +1678,52 @@ git commit -m "feat(theme): 앱 초기화 시 커스텀 테마 마이그레이�
 
 ---
 
-### Task 3.7: `App.tsx`의 테마 저장 `useEffect` 수정
+### Task 3.7: `App.tsx`의 테마 적용 `useEffect` 단일 교체
 
 **Files:**
 - Modify: `src/App.tsx:442-458` (테마 변경 시 CSS 적용 + 저장)
 
-- [ ] **Step 1: `customThemeColors`와 hex 둘 다 저장하도록 조정**
+> **주의**: 기존 플랜의 Task 3.8(colorMode 재파생)은 이 Task로 병합됨. 기존 `useEffect` 하나를 아래 버전으로 완전 교체하는 **단일 편집**으로 처리. 두 번 덮어쓰지 말 것.
+
+- [ ] **Step 1: 기존 useEffect를 다음 단일 버전으로 교체**
+
+의도: `[themeId, customThemeColors, colorMode]` 세 의존성을 모두 포함하고, 진입 시 **한 번에** 다음 분기를 타도록 함.
+- `themeId === 'custom'`이고 hex 두 개가 모두 있으면 → hex 기반 `deriveThemeFromAccent` 호출 (colorMode만 바뀐 경우도 여기서 자동 처리)
+- `themeId === 'custom'`이고 hex가 없지만 `customThemeColors`만 있으면 → 기존 colors 그대로 `applyTheme`
+- 그 외 → 프리셋 경로
 
 ```typescript
 useEffect(() => {
   if (!themeInitRef.current) return;
-  const { customAccentHex, customSubHex } = useAppStore.getState();
+  const { customAccentHex, customSubHex, setCustomThemeColors } = useAppStore.getState();
 
-  if (themeId === 'custom' && customThemeColors) {
-    applyTheme(customThemeColors, colorMode);
-    saveTheme({
-      themeId,
-      customColors: customThemeColors,
-      colorMode,
-      customAccentHex: customAccentHex ?? undefined,
-      customSubHex: customSubHex ?? undefined,
-    });
-  } else if (colorMode === 'light') {
+  if (themeId === 'custom') {
+    // Case A: hex 두 개 모두 유효 → 현재 colorMode로 재파생
+    if (customAccentHex && customSubHex) {
+      const colors = deriveThemeFromAccent(customAccentHex, customSubHex, colorMode);
+      applyTheme(colors, colorMode);
+      setCustomThemeColors(colors);
+      saveTheme({
+        themeId,
+        customColors: colors,
+        colorMode,
+        customAccentHex,
+        customSubHex,
+      });
+      return;
+    }
+    // Case B: hex 없이 customThemeColors만 (마이그레이션 과도기)
+    if (customThemeColors) {
+      applyTheme(customThemeColors, colorMode);
+      saveTheme({ themeId, customColors: customThemeColors, colorMode });
+      return;
+    }
+    // Case C: 아무것도 없음 — themeInitRef가 true면 오지 않아야 함. 안전망만.
+    return;
+  }
+
+  // 프리셋 경로
+  if (colorMode === 'light') {
     applyTheme(getLightColors(themeId), colorMode);
     saveTheme({ themeId, colorMode });
   } else {
@@ -1679,62 +1736,34 @@ useEffect(() => {
 }, [themeId, customThemeColors, colorMode]);
 ```
 
-- [ ] **Step 2: tsc 검증 + 커밋**
+**deps array 설명**:
+- `themeId`/`colorMode`: 프리셋↔커스텀 전환, 다크↔라이트 전환 시 재실행
+- `customThemeColors`: 사용자가 "적용" 버튼으로 새 customAccent를 설정한 경우 (`setCustomThemeColors`가 이 배열을 갱신 → effect 재실행 → Case A에서 최신 hex로 재파생)
+
+`customAccentHex`/`customSubHex`는 `useAppStore.getState()`로 읽어 stale closure 회피.
+
+- [ ] **Step 2: tsc 검증 + 수동 검증 + 커밋**
 
 ```bash
 npx tsc --noEmit
+npm run electron:dev
+```
+
+수동 검증:
+1. 커스텀 테마 적용 (accent #E11D48) → 전체 톤 변경 확인
+2. 다크/라이트 토글 → 배경이 accent hue 기반으로 자동 재생성되는지 확인
+3. 새 커스텀 accent(#814D41)로 재적용 → 톤 즉시 바뀜
+
+```bash
 git add src/App.tsx
-git commit -m "feat(theme): 저장 시 customAccentHex/customSubHex 함께 영속화"
+git commit -m "feat(theme): 커스텀 테마 colorMode 전환 시 hex 기반 자동 재파생 (단일 useEffect)"
 ```
 
 ---
 
-### Task 3.8: `App.tsx`의 colorMode 변경 시 커스텀 재파생
+### Task 3.8: (Task 3.7로 병합됨 — 이 Task는 스킵)
 
-**Files:**
-- Modify: `src/App.tsx` (Task 3.7과 같은 useEffect 또는 별도 hook)
-
-- [ ] **Step 1: colorMode가 바뀔 때 커스텀 테마면 hex로 재파생**
-
-Task 3.7의 useEffect 시작부에 추가:
-
-```typescript
-useEffect(() => {
-  if (!themeInitRef.current) return;
-  const { customAccentHex, customSubHex, setCustomThemeColors } = useAppStore.getState();
-
-  // 커스텀 테마에서 colorMode만 바뀐 경우: hex 기반 재파생
-  if (themeId === 'custom' && customAccentHex && customSubHex) {
-    const colors = deriveThemeFromAccent(customAccentHex, customSubHex, colorMode);
-    applyTheme(colors, colorMode);
-    setCustomThemeColors(colors);
-    saveTheme({ themeId, customColors: colors, colorMode, customAccentHex, customSubHex });
-    return;
-  }
-
-  // 기존 로직 (프리셋 테마)
-  if (colorMode === 'light') {
-    applyTheme(getLightColors(themeId), colorMode);
-    saveTheme({ themeId, colorMode });
-  } else {
-    const preset = getPreset(themeId);
-    if (preset) {
-      applyTheme(preset.colors, colorMode);
-      saveTheme({ themeId, colorMode });
-    }
-  }
-}, [themeId, colorMode]); // customThemeColors 의존성 제거 — 재파생은 여기서 담당
-```
-
-**주의**: Task 3.7의 useEffect와 합쳐야 할 수도 있음. 실제 파일 구조에 따라 의존성 배열과 분기 조정.
-
-- [ ] **Step 2: tsc 검증 + 커밋**
-
-```bash
-npx tsc --noEmit
-git add src/App.tsx
-git commit -m "feat(theme): colorMode 전환 시 커스텀 테마 hex 기반 재파생"
-```
+Task 3.7의 단일 useEffect 교체로 colorMode 재파생 로직이 통합됨. 별도의 Task 3.8 없음. 다음 Task는 Task 3.9로 바로 이어짐.
 
 ---
 

--- a/docs/superpowers/plans/2026-04-18-pre-release-polish.md
+++ b/docs/superpowers/plans/2026-04-18-pre-release-polish.md
@@ -1,0 +1,1866 @@
+# 정식 빌드 전 마감 4종 — 구현 플랜
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 정식 빌드 전에 트레이 아이콘 미구현·위젯 위치 기억 누락·빌드 실행 로딩 체감 지연·커스텀 테마 일부만 변경되는 4가지 이슈를 해결한다.
+
+**Architecture:**
+1. **Electron 메인 프로세스**에 트레이 아이콘 + 메인 창 close 차단 + 스플래시 2단계 부팅을 추가하고, 기존 `widgetPositionCache` 삭제 로직을 제거해 위젯 상태를 항상 보존한다.
+2. **렌더러 번들**은 Vite `manualChunks`로 vendor를 분리하고 `React.lazy`로 뷰/모달을 지연 로딩한다.
+3. **테마 시스템**은 `themes.ts`에 `deriveThemeFromAccent()`를 추가해 accent hex 두 개로 HSL 파생된 완전한 새 테마를 생성하고, `useAppStore`가 colorMode 변경 시 자동 재파생한다.
+
+**Tech Stack:** Electron 33, React 18, TypeScript 5, Vite 5, Zustand 4, Tailwind CSS 3. 테스트 프레임워크 없음 — 검증은 `tsc --noEmit` + `vite build` 통과 + 수동 체크리스트.
+
+**Spec:** [docs/superpowers/specs/2026-04-18-pre-release-polish-design.md](../specs/2026-04-18-pre-release-polish-design.md)
+
+---
+
+## File Structure
+
+### 변경할 파일 (수정)
+
+| 파일 | 책임 |
+|---|---|
+| [electron/main.ts](../../../electron/main.ts) | 트레이 아이콘·메뉴·상태 갱신, close 핸들러, 스플래시 2단계 부팅, 위젯 캐시 삭제 로직 제거, window-all-closed 변경, app.whenReady 재정렬, 커맨드라인 스위치 |
+| [package.json](../../../package.json) | `build.files`에 `public/splash/**` 추가 |
+| [vite.config.ts](../../../vite.config.ts) | `build.rollupOptions.output.manualChunks` 추가 |
+| [src/App.tsx](../../../src/App.tsx) | 뷰 `React.lazy` 래핑 + `Suspense`, 무거운 모달 lazy |
+| [src/themes.ts](../../../src/themes.ts) | `rgbToHsl`/`hslToRgb`/`deriveThemeFromAccent` 함수 추가 |
+| [src/stores/useAppStore.ts](../../../src/stores/useAppStore.ts) | `customAccentHex`·`customSubHex` 상태/액션, `setColorMode` 재파생 로직, `sanitizeCustomHex` 마이그레이션 |
+| [src/components/settings/ThemeSection.tsx](../../../src/components/settings/ThemeSection.tsx) | `handleCustomApply` 교체, 실시간 배경 프리뷰 |
+| [src/services/settingsService.ts](../../../src/services/settingsService.ts) | `preferences.json` 타입에 신규 필드 추가 |
+
+### 신규 파일
+
+| 파일 | 책임 |
+|---|---|
+| `public/splash/splash.html` | Electron 레벨의 즉시-표시 스플래시 (인라인 CSS, `opening_image_cropped.png` 표시) |
+
+---
+
+## Chunk 1: 트레이 아이콘 + 위젯 영속화
+
+**목표**: Electron 메인 프로세스에 Windows 시스템 트레이를 구현하고, 앱의 유일한 GUI 종료 경로를 트레이 메뉴 '종료'로 일원화. 위젯 위치 캐시 삭제 로직을 제거해 "모든 위젯은 항상 복원" 정책을 반영.
+
+**커밋 단위**: 각 Task 완료 후 독립 커밋. 중간에 `tsc --noEmit` 실패하면 즉시 수정 후 진행.
+
+---
+
+### Task 1.1: Electron import + 전역 변수 추가
+
+**Files:**
+- Modify: `electron/main.ts:1` (import 라인)
+- Modify: `electron/main.ts:49-53` (전역 변수 블록)
+
+- [ ] **Step 1: import 구문에 `Tray`, `Menu`, `nativeImage`, `dialog` 추가**
+
+기존 `electron/main.ts:1`:
+```typescript
+import { app, BrowserWindow, clipboard, ipcMain, protocol, net, desktopCapturer, screen, shell, Notification } from 'electron';
+```
+
+변경:
+```typescript
+import { app, BrowserWindow, clipboard, ipcMain, protocol, net, desktopCapturer, screen, shell, Notification, Tray, Menu, nativeImage, dialog } from 'electron';
+import type { MenuItemConstructorOptions } from 'electron';
+```
+
+- [ ] **Step 2: 전역 변수 블록에 트레이·상태 플래그 추가**
+
+기존 `electron/main.ts:49-53` 아래에 추가:
+```typescript
+let tray: Tray | null = null;
+let trayFailed = false;
+let lastSupabaseStatus = '연결 중...';
+let splashWin: BrowserWindow | null = null;
+let mainLoadedOk = false;
+```
+
+- [ ] **Step 3: tsc 검증**
+
+```bash
+cd /c/Bflow-BGonly/.claude/worktrees/ecstatic-lumiere-42f79a && npx tsc --noEmit
+```
+
+기대: 0 errors (새 import는 아직 사용 안 됨 — TS는 sideeffect 경고만. 안전)
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add electron/main.ts
+git commit -m "chore(electron): 트레이/다이얼로그/스플래시용 import 및 전역 변수 추가"
+```
+
+---
+
+### Task 1.2: 트레이 아이콘 경로 해석 + 1x1 폴백 이미지 유틸
+
+**Files:**
+- Modify: `electron/main.ts` (기존 `let isQuitting` 변수 직후에 신규 블록 삽입)
+
+- [ ] **Step 1: `resolveTrayIconPath()` + `EMPTY_ICON_B64` 상수 추가**
+
+`electron/main.ts`의 전역 변수 선언들 바로 아래(Task 1.1에서 추가한 변수 다음 줄)에 삽입:
+
+```typescript
+/** 아이콘 경로 해석: dev(electron/)와 prod(dist-electron/) + app.getAppPath() 순회 */
+function resolveTrayIconPath(): string {
+  const candidates = [
+    path.join(__dirname, '../public/splash/opening_image_cropped.png'),
+    path.join(app.getAppPath(), 'public/splash/opening_image_cropped.png'),
+  ];
+  for (const p of candidates) {
+    try {
+      if (fs.existsSync(p)) return p;
+    } catch { /* ignore */ }
+  }
+  return '';
+}
+
+/** 1x1 투명 PNG — 아이콘 로드 완전 실패 시 최후 폴백 */
+const EMPTY_ICON_B64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+```
+
+- [ ] **Step 2: tsc 검증**
+
+```bash
+npx tsc --noEmit
+```
+
+기대: 0 errors.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add electron/main.ts
+git commit -m "feat(electron): 트레이 아이콘 경로 해석 유틸 + 빈 폴백 이미지"
+```
+
+---
+
+### Task 1.3: `humanizeStatus` + `showMainWindow` + `toggleWidget` 헬퍼 추가
+
+**Files:**
+- Modify: `electron/main.ts` (Task 1.2 블록 아래)
+
+- [ ] **Step 1: 3개 헬퍼 함수 추가**
+
+```typescript
+/** Supabase 원시 상태 → 사용자에게 보여줄 한글 라벨 */
+function humanizeStatus(raw: string): string {
+  switch (raw) {
+    case 'SUBSCRIBED': return '실시간 연결됨';
+    case 'CHANNEL_ERROR': return '재연결 중';
+    case 'TIMED_OUT': return '연결 타임아웃';
+    case 'CLOSED': return '연결 끊김';
+    default: return raw || '연결 중';
+  }
+}
+
+/** 메인 창을 보이고 포커스. 숨김 상태면 복원 */
+function showMainWindow(): void {
+  if (!mainWindow || mainWindow.isDestroyed()) return;
+  if (mainWindow.isMinimized()) mainWindow.restore();
+  mainWindow.show();
+  mainWindow.focus();
+}
+
+/** 트레이 위젯 서브메뉴 토글 핸들러 */
+function toggleWidget(widgetId: string, title: string): void {
+  const existing = widgetWindows.get(widgetId);
+  if (existing && !existing.isDestroyed()) {
+    existing.close(); // closed 이벤트가 widgetWindows에서 제거
+  } else {
+    openWidgetPopup(widgetId, title);
+  }
+  // 메뉴 체크박스 상태 갱신
+  rebuildTrayMenu();
+}
+```
+
+- [ ] **Step 2: tsc 검증** (rebuildTrayMenu 아직 미정의 → 에러 예상)
+
+```bash
+npx tsc --noEmit
+```
+
+기대: `Cannot find name 'rebuildTrayMenu'` 에러 — Task 1.4에서 해결.
+
+- [ ] **Step 3: Task 1.4 완료 전까진 커밋 보류**
+
+(다음 Task로 바로 진행)
+
+---
+
+### Task 1.4: `rebuildTrayMenu` + `createTray` 구현
+
+**Files:**
+- Modify: `electron/main.ts` (Task 1.3 블록 아래)
+
+- [ ] **Step 1: `rebuildTrayMenu()` 추가**
+
+```typescript
+function rebuildTrayMenu(): void {
+  if (!tray || tray.isDestroyed()) return;
+  const widgetSubmenu: MenuItemConstructorOptions[] = Object.entries(WIDGET_TITLE_MAP).map(
+    ([id, title]) => ({
+      label: title,
+      type: 'checkbox',
+      checked: widgetWindows.has(id),
+      click: () => toggleWidget(id, title),
+    }),
+  );
+  const status = lastSupabaseStatus;
+  const menu = Menu.buildFromTemplate([
+    { label: '열기', click: showMainWindow },
+    { type: 'separator' },
+    { label: '위젯', submenu: widgetSubmenu },
+    { type: 'separator' },
+    { label: `상태: ${status}`, enabled: false },
+    { type: 'separator' },
+    { label: '종료', click: () => { isQuitting = true; app.quit(); } },
+  ]);
+  tray.setContextMenu(menu);
+  tray.setToolTip(`B flow • ${status}`);
+}
+```
+
+- [ ] **Step 2: `createTray()` 추가**
+
+```typescript
+function createTray(): void {
+  try {
+    const iconPath = resolveTrayIconPath();
+    let image = iconPath ? nativeImage.createFromPath(iconPath) : nativeImage.createEmpty();
+    if (image.isEmpty()) {
+      image = nativeImage.createFromBuffer(Buffer.from(EMPTY_ICON_B64, 'base64'));
+    }
+    image = image.resize({ width: 16, height: 16 });
+    tray = new Tray(image);
+    tray.setToolTip('B flow');
+    tray.on('click', showMainWindow);
+    tray.on('double-click', showMainWindow);
+    rebuildTrayMenu();
+  } catch (err) {
+    console.error('[트레이] 생성 실패 — 트레이 없이 실행 (창 X = 실제 종료):', err);
+    tray = null;
+    trayFailed = true;
+  }
+}
+```
+
+- [ ] **Step 3: tsc 검증**
+
+```bash
+npx tsc --noEmit
+```
+
+기대: 0 errors.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add electron/main.ts
+git commit -m "feat(electron): 트레이 메뉴 구성 + createTray 구현 (3단 폴백 포함)"
+```
+
+---
+
+### Task 1.5: Supabase 상태 콜백에서 `rebuildTrayMenu` 호출
+
+**Files:**
+- Modify: `electron/main.ts:667-670` 부근 (기존 Supabase 상태 콜백)
+
+- [ ] **Step 1: 기존 콜백을 찾아 `lastSupabaseStatus` 갱신 + `rebuildTrayMenu()` 호출 추가**
+
+`electron/main.ts` 안에서 `mainWindow.webContents.send('supabase:status', status)` 패턴을 포함한 콜백 위치를 찾아(현재 main.ts:667-669 부근), 콜백 진입부에서:
+
+```typescript
+// 기존 콜백 예시:
+(status: string) => {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send('supabase:status', status);
+  }
+}
+
+// 수정:
+(status: string) => {
+  lastSupabaseStatus = humanizeStatus(status);
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send('supabase:status', status);
+  }
+  rebuildTrayMenu();
+}
+```
+
+**주의**: `setSupabaseStatusCallback` 또는 `startSupabaseRealtime`의 인자로 넘기는 콜백 형태가 다를 수 있음. Read로 실제 구조 확인 후 동일 효과로 반영.
+
+- [ ] **Step 2: tsc 검증**
+
+```bash
+npx tsc --noEmit
+```
+
+기대: 0 errors.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add electron/main.ts
+git commit -m "feat(electron): Supabase 상태 변화 시 트레이 메뉴/툴팁 갱신"
+```
+
+---
+
+### Task 1.6: 위젯 open/close 시 `rebuildTrayMenu` 호출
+
+**Files:**
+- Modify: `electron/main.ts` (openWidgetPopup 내부 widgetWindows.set 직후)
+- Modify: `electron/main.ts` (popupWin.on('closed') 핸들러 내부)
+
+- [ ] **Step 1: `widgetWindows.set(widgetId, popupWin)` 직후에 `rebuildTrayMenu()` 호출 추가**
+
+`electron/main.ts:1141` 부근:
+```typescript
+widgetWindows.set(widgetId, popupWin);
+rebuildTrayMenu(); // 트레이 체크박스 갱신
+```
+
+- [ ] **Step 2: `popupWin.on('closed')` 핸들러 내 `widgetWindows.delete` 직후에 `rebuildTrayMenu()` 호출 추가**
+
+`electron/main.ts:1156-1172` 부근:
+```typescript
+popupWin.on('closed', () => {
+  widgetWindows.delete(widgetId);
+  widgetOriginalBounds.delete(widgetId);
+  rebuildTrayMenu(); // 트레이 체크박스 갱신 (이 줄 추가)
+  // 기존 로직: isQuitting 체크 → 캐시 삭제 (다음 Task에서 제거)
+  // 기존 로직: 독 스택 제거 + 재배치 (유지)
+});
+```
+
+- [ ] **Step 3: tsc 검증**
+
+```bash
+npx tsc --noEmit
+```
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add electron/main.ts
+git commit -m "feat(electron): 위젯 open/close 시 트레이 메뉴 갱신"
+```
+
+---
+
+### Task 1.7: 위젯 캐시 삭제 로직 제거 (핵심 버그 수정)
+
+**Files:**
+- Modify: `electron/main.ts:1156-1164` (popupWin.on('closed') 핸들러)
+
+- [ ] **Step 1: `if (!isQuitting) { widgetPositionCache.delete(...); saveWidgetPositionsDebounced(); }` 블록 삭제**
+
+`electron/main.ts` 해당 핸들러에서:
+
+```typescript
+// BEFORE:
+popupWin.on('closed', () => {
+  widgetWindows.delete(widgetId);
+  widgetOriginalBounds.delete(widgetId);
+  rebuildTrayMenu();
+  if (!isQuitting) {                           // ← 이 블록
+    widgetPositionCache.delete(widgetId);      // ← 전체를
+    saveWidgetPositionsDebounced();             // ← 삭제
+  }
+  // 독 스택에서 제거 + 나머지 재배치
+  const dockIdx = dockedWidgetIds.indexOf(widgetId);
+  // ... 이하 유지
+});
+
+// AFTER:
+popupWin.on('closed', () => {
+  widgetWindows.delete(widgetId);
+  widgetOriginalBounds.delete(widgetId);
+  rebuildTrayMenu();
+  // 캐시는 항상 유지 → 다음 실행 시 자동 복원 (spec 결정사항)
+  // 독 스택에서 제거 + 나머지 재배치
+  const dockIdx = dockedWidgetIds.indexOf(widgetId);
+  // ... 이하 유지
+});
+```
+
+- [ ] **Step 2: tsc 검증**
+
+```bash
+npx tsc --noEmit
+```
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add electron/main.ts
+git commit -m "fix(electron): 위젯 개별 X 닫기 시 위치 캐시 유지 (항상 복원 정책)"
+```
+
+---
+
+### Task 1.8: `showTrayHintOnce` + OS 차단 폴백
+
+**Files:**
+- Modify: `electron/main.ts` (전역 함수 블록, Task 1.4 `createTray` 위)
+- Modify: `electron/storage.ts` 또는 `electron/main.ts`의 기존 preferences 헬퍼 (loadPreferences/savePreferences 존재 여부 확인)
+
+- [ ] **Step 1: `loadPreferences`/`savePreferences`가 main에서 접근 가능한지 확인**
+
+```bash
+cd "C:\Bflow-BGonly\.claude\worktrees\ecstatic-lumiere-42f79a"
+```
+
+`Grep pattern "loadPreferences|savePreferences" path "electron"` 실행해 파일·함수 시그니처 확인.
+
+- [ ] **Step 2: 메인 프로세스에서 preferences.json을 읽고 쓰는 최소 헬퍼 추가 (없으면)**
+
+`electron/main.ts` 상단의 `getUsersFilePath` 아래 부근에 추가:
+
+```typescript
+function getPreferencesFilePath(): string {
+  return path.join(getDataPath(), 'preferences.json');
+}
+
+async function readPreferences(): Promise<Record<string, unknown>> {
+  try {
+    const raw = await fs.promises.readFile(getPreferencesFilePath(), 'utf-8');
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+async function writePreferences(patch: Record<string, unknown>): Promise<void> {
+  const prev = await readPreferences();
+  const next = { ...prev, ...patch };
+  ensureDir(path.dirname(getPreferencesFilePath()));
+  await fs.promises.writeFile(getPreferencesFilePath(), JSON.stringify(next, null, 2), 'utf-8');
+}
+```
+
+**주의**: 기존에 동일 기능을 하는 함수가 이미 있다면 그것을 재사용. (렌더러 쪽 `settingsService.ts`는 IPC 경유 → 메인 프로세스는 별도 파일 I/O 필요)
+
+- [ ] **Step 3: `showTrayHintOnce()` 추가**
+
+```typescript
+async function showTrayHintOnce(): Promise<void> {
+  const prefs = await readPreferences();
+  if (prefs.trayFirstMinimizeSeen) return;
+
+  let shown = false;
+  if (Notification.isSupported()) {
+    try {
+      new Notification({
+        title: 'B flow',
+        body: '트레이로 숨겨졌습니다. 트레이 아이콘 우클릭 → 종료로 완전히 닫을 수 있습니다.',
+      }).show();
+      shown = true;
+    } catch { /* ignore */ }
+  }
+
+  if (!shown && tray && !tray.isDestroyed() && process.platform === 'win32') {
+    try {
+      tray.displayBalloon({
+        title: 'B flow',
+        content: '트레이에 숨겨졌습니다. 트레이 메뉴 종료로 완전히 닫을 수 있습니다.',
+      });
+      shown = true;
+    } catch { /* ignore */ }
+  }
+
+  if (shown) {
+    await writePreferences({ trayFirstMinimizeSeen: true });
+  }
+}
+```
+
+- [ ] **Step 4: tsc 검증**
+
+```bash
+npx tsc --noEmit
+```
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add electron/main.ts
+git commit -m "feat(electron): 트레이 최소화 최초 1회 안내 (Notification + displayBalloon 폴백)"
+```
+
+---
+
+### Task 1.9: `mainWindow.on('close')` 핸들러로 창 X → 트레이 숨김
+
+**Files:**
+- Modify: `electron/main.ts:262-287` (`createWindow` 함수 내부)
+
+- [ ] **Step 1: `mainWindow.on('closed', ...)` 위에 `mainWindow.on('close', ...)` 추가**
+
+```typescript
+function createWindow(): void {
+  mainWindow = new BrowserWindow({
+    width: 1400,
+    height: 900,
+    // ... 기존 옵션
+    show: false, // ← 스플래시 표시 중엔 숨김. Task 2.4에서 show() 타이밍 변경
+  });
+
+  // ... 기존 loadURL/loadFile
+
+  // 창 X 버튼 → 트레이로 숨김 (트레이 실패 시 실제 종료로 폴백)
+  mainWindow.on('close', (e) => {
+    if (!isQuitting && !trayFailed) {
+      e.preventDefault();
+      mainWindow?.hide();
+      showTrayHintOnce().catch(() => {/* ignore */});
+      return;
+    }
+    // isQuitting === true || trayFailed === true인 경우 기본 동작 허용
+  });
+
+  mainWindow.on('closed', () => {
+    mainWindow = null;
+  });
+}
+```
+
+**주의**: `show: false`는 Task 2.4 스플래시 도입 시 함께 적용하므로, Chunk 1 작업 시엔 `show` 옵션 미지정(기본 true)으로 두고 Chunk 2에서 변경.
+
+- [ ] **Step 2: tsc 검증**
+
+```bash
+npx tsc --noEmit
+```
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add electron/main.ts
+git commit -m "feat(electron): 메인 창 X 버튼 → 트레이 숨김 (trayFailed 시 실제 종료 폴백)"
+```
+
+---
+
+### Task 1.10: `window-all-closed` 이벤트 수정
+
+**Files:**
+- Modify: `electron/main.ts:1713-1717`
+
+- [ ] **Step 1: 트레이가 살아있으면 종료하지 않도록 변경**
+
+```typescript
+// BEFORE:
+app.on('window-all-closed', () => {
+  if (!isQuitting) {
+    app.quit();
+  }
+});
+
+// AFTER:
+app.on('window-all-closed', () => {
+  // 트레이가 살아있고 사용자가 종료 의사를 표시하지 않은 경우: 백그라운드 유지
+  if (!isQuitting && tray && !tray.isDestroyed()) {
+    return;
+  }
+  // 트레이 실패 or isQuitting: 정상 종료 흐름
+  app.quit();
+});
+```
+
+- [ ] **Step 2: tsc 검증**
+
+```bash
+npx tsc --noEmit
+```
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add electron/main.ts
+git commit -m "feat(electron): window-all-closed에서 트레이 생존 시 종료 차단"
+```
+
+---
+
+### Task 1.11: `app.whenReady()` 에서 `createTray()` 호출
+
+**Files:**
+- Modify: `electron/main.ts:1620` 부근 (`createWindow()` 호출 라인)
+
+- [ ] **Step 1: `createWindow()` 호출 바로 앞에 `createTray()` 삽입**
+
+```typescript
+// app.whenReady().then(() => { ... } 내부
+// BEFORE:
+createWindow();
+
+// AFTER:
+createTray();        // 먼저 트레이 준비 (실패해도 앱은 계속)
+createWindow();
+```
+
+- [ ] **Step 2: tsc 검증 + Step 3: 개발 실행 검증**
+
+```bash
+npx tsc --noEmit
+npm run electron:dev
+```
+
+기대:
+- Windows 시스템 트레이에 B flow 아이콘 표시 (흐릿하지만 16x16로 축소된 스플래시)
+- 트레이 우클릭 → 메뉴 4항목 ('열기 / 위젯 / 상태 / 종료') 표시
+- 메인 창 X → 창 사라짐, 트레이 아이콘 유지, 최초 1회 Notification 등장
+- 트레이 좌클릭 or '열기' → 메인 창 복원
+- 트레이 '종료' → 앱 완전 종료, 트레이 아이콘 소거
+
+수동 검증 중 문제 발견 시 Task 1.1~1.11 해당 스텝으로 돌아가 수정.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add electron/main.ts
+git commit -m "feat(electron): app.whenReady에서 트레이 초기화 수행"
+```
+
+---
+
+### Task 1.12: `process.on('exit')` 위젯 위치 안전망
+
+**Files:**
+- Modify: `electron/main.ts` (전역 스코프, `app.on('before-quit')` 근처)
+
+- [ ] **Step 1: `process.on('exit')` 등록**
+
+```typescript
+// app.on('before-quit') 핸들러 정의 이후에 추가
+process.on('exit', () => {
+  try { saveWidgetPositionsSync(); } catch {/* ignore */}
+});
+```
+
+- [ ] **Step 2: tsc 검증 + Step 3: 커밋**
+
+```bash
+npx tsc --noEmit
+git add electron/main.ts
+git commit -m "feat(electron): process exit 시 위젯 위치 최종 안전망 저장"
+```
+
+---
+
+### Task 1.13: `package.json`의 `build.files`에 `public/splash/**` 추가
+
+**Files:**
+- Modify: `package.json:36-41`
+
+- [ ] **Step 1: `files` 배열에 `public/splash/**` 추가**
+
+```json
+"files": [
+  "dist/**/*",
+  "dist-electron/**/*",
+  "public/splash/**",
+  "node_modules/**/*",
+  "package.json"
+]
+```
+
+- [ ] **Step 2: 빌드 검증**
+
+```bash
+npm run build:vite
+```
+
+기대: tsc + vite build 성공. (electron-builder는 이후 Chunk 전체 완료 시 검증)
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add package.json
+git commit -m "build: public/splash/** 를 빌드 산출물에 포함"
+```
+
+---
+
+### Chunk 1 완료 검증
+
+- [ ] `npx tsc --noEmit` 통과
+- [ ] `npm run build:vite` 통과
+- [ ] `npm run electron:dev` 실행 → 스펙 체크리스트 섹션 1 9개 항목 중 수동 검증 가능한 항목(트레이 아이콘 존재/메뉴/창 X/트레이 종료/위젯 재시작 복원) 통과
+
+완료되면 Chunk 2로 진행.
+
+---
+
+## Chunk 2: 빌드 앱 로딩 속도 최적화
+
+**목표**: 스플래시 2단계 부팅(Electron BrowserWindow로 즉시 이미지 표시 → 메인 창 준비 후 전환)과 Vite `manualChunks` + `React.lazy`로 체감·실제 로딩 속도 모두 단축. `asar`·`googleapis` 구조는 건드리지 않는 안전 정책.
+
+---
+
+### Task 2.1: `public/splash/splash.html` 신규 작성
+
+**Files:**
+- Create: `public/splash/splash.html`
+
+- [ ] **Step 1: 인라인 CSS로 스플래시 HTML 작성**
+
+```html
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>B flow</title>
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+      background: transparent;
+      -webkit-app-region: drag;
+    }
+    body {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    img {
+      width: 220px;
+      height: 220px;
+      object-fit: contain;
+      animation: fadeIn 0.3s ease-out;
+      filter: drop-shadow(0 6px 16px rgba(0,0,0,0.35));
+    }
+    @keyframes fadeIn {
+      from { opacity: 0; transform: scale(0.92); }
+      to   { opacity: 1; transform: scale(1); }
+    }
+  </style>
+</head>
+<body>
+  <img src="./opening_image_cropped.png" alt="B flow">
+</body>
+</html>
+```
+
+- [ ] **Step 2: 파일 확인**
+
+```bash
+ls public/splash/
+```
+
+기대: `opening_image_cropped.png`, `splash.html`, (기존에 있던 파일들).
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add public/splash/splash.html
+git commit -m "feat: 스플래시 2단계 부팅용 HTML 신설"
+```
+
+---
+
+### Task 2.2: `createSplashWindow()` + `closeSplash()` 구현
+
+**Files:**
+- Modify: `electron/main.ts` (헬퍼 함수 블록, Task 1.4 `createTray` 근처)
+
+- [ ] **Step 1: 스플래시 윈도우 생성/종료 유틸 추가**
+
+```typescript
+function resolveSplashHtmlPath(): string {
+  const candidates = [
+    path.join(__dirname, '../public/splash/splash.html'),
+    path.join(app.getAppPath(), 'public/splash/splash.html'),
+  ];
+  for (const p of candidates) {
+    try { if (fs.existsSync(p)) return p; } catch {/* ignore */}
+  }
+  return '';
+}
+
+function createSplashWindow(): void {
+  const htmlPath = resolveSplashHtmlPath();
+  if (!htmlPath) {
+    console.warn('[스플래시] HTML 파일을 찾지 못함 — 스플래시 생략');
+    return;
+  }
+  splashWin = new BrowserWindow({
+    width: 300,
+    height: 300,
+    frame: false,
+    transparent: true,
+    alwaysOnTop: true,
+    resizable: false,
+    skipTaskbar: true,
+    closable: false, // 사용자가 닫지 못하게 (좀비 방지)
+    show: true,
+    backgroundColor: '#00000000',
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  });
+  splashWin.loadFile(htmlPath).catch((err) => {
+    console.error('[스플래시] loadFile 실패:', err);
+  });
+}
+
+function closeSplash(): void {
+  if (splashWin && !splashWin.isDestroyed()) {
+    // closable:false 창은 close() 거부 → destroy() 사용
+    splashWin.destroy();
+  }
+  splashWin = null;
+}
+```
+
+- [ ] **Step 2: tsc 검증**
+
+```bash
+npx tsc --noEmit
+```
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add electron/main.ts
+git commit -m "feat(electron): 스플래시 윈도우 생성/종료 유틸 추가"
+```
+
+---
+
+### Task 2.3: `createWindow` — `show: false` + `did-finish-load` 훅
+
+**Files:**
+- Modify: `electron/main.ts:262-287` (`createWindow`)
+
+- [ ] **Step 1: `BrowserWindow`에 `show: false` 추가 + `did-finish-load` 이벤트 추가**
+
+```typescript
+function createWindow(): void {
+  mainWindow = new BrowserWindow({
+    width: 1400,
+    height: 900,
+    minWidth: 800,
+    minHeight: 600,
+    title: 'B flow',
+    backgroundColor: '#0F1117',
+    show: false, // ← 스플래시 숨기기 전까진 hidden
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  });
+
+  if (process.env.VITE_DEV_SERVER_URL) {
+    mainWindow.loadURL(process.env.VITE_DEV_SERVER_URL);
+    mainWindow.webContents.openDevTools();
+  } else {
+    mainWindow.loadFile(path.join(__dirname, '../dist/index.html'));
+  }
+
+  // 메인 로드 완료 → 스플래시 닫고 메인 창 show
+  mainWindow.webContents.once('did-finish-load', () => {
+    mainLoadedOk = true;
+    closeSplash();
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.show();
+      mainWindow.focus();
+    }
+    try { console.timeEnd('splash-to-main'); } catch {/* 이미 종료됨 */}
+  });
+
+  // 창 X 핸들러 (Task 1.9에서 추가된 것 유지)
+  mainWindow.on('close', (e) => {
+    if (!isQuitting && !trayFailed) {
+      e.preventDefault();
+      mainWindow?.hide();
+      showTrayHintOnce().catch(() => {/* ignore */});
+      return;
+    }
+  });
+
+  mainWindow.on('closed', () => {
+    mainWindow = null;
+  });
+}
+```
+
+- [ ] **Step 2: tsc 검증**
+
+```bash
+npx tsc --noEmit
+```
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add electron/main.ts
+git commit -m "feat(electron): 메인 창 show:false + did-finish-load로 스플래시 전환"
+```
+
+---
+
+### Task 2.4: 30초 타임아웃 + `console.time` 측정 로그
+
+**Files:**
+- Modify: `electron/main.ts` (`app.whenReady().then(...)` 블록)
+
+- [ ] **Step 1: `app.whenReady()` 블록에서 측정 로그 시작 + 타임아웃 설정**
+
+```typescript
+app.whenReady().then(() => {
+  console.time('splash-to-main'); // 측정 시작
+
+  createSplashWindow(); // 1. 가장 먼저 스플래시
+  createTray();          // 2. 트레이 (경량)
+  createWindow();        // 3. 메인 창 (숨김 상태로 로드 시작)
+
+  // 메인 로드 30초 타임아웃 (좀비 방지)
+  const MAIN_LOAD_TIMEOUT_MS = 30_000;
+  const loadTimeout = setTimeout(() => {
+    if (mainLoadedOk) return;
+    console.error('[메인 로드] 30초 타임아웃 — 에러 다이얼로그 후 종료');
+    closeSplash();
+    try {
+      dialog.showErrorBox('B flow', '앱 로드에 실패했습니다. 다시 실행해주세요.');
+    } catch {/* ignore */}
+    isQuitting = true;
+    app.quit();
+  }, MAIN_LOAD_TIMEOUT_MS);
+
+  // 로드 완료 시 타임아웃 해제
+  if (mainWindow) {
+    mainWindow.webContents.once('did-finish-load', () => {
+      clearTimeout(loadTimeout);
+    });
+  }
+
+  // Google Calendar 토큰 복원
+  gcal.restoreTokens();
+
+  // Supabase Realtime 구독 시작
+  startSupabaseRealtime();
+
+  // 기존 자동 위젯 복원 등 나머지 로직 (변경 없음, 그대로 유지)
+  // ...
+});
+```
+
+**주의**: 기존 `app.whenReady().then(() => { ... })` 블록의 다른 내용(위젯 복원 등)은 그대로 유지. 위 코드는 블록 시작부에만 신규 호출 추가.
+
+- [ ] **Step 2: tsc 검증**
+
+```bash
+npx tsc --noEmit
+```
+
+- [ ] **Step 3: 개발 실행 수동 검증**
+
+```bash
+npm run electron:dev
+```
+
+기대:
+- 앱 시작 시 300x300 투명 스플래시 즉시 표시 (`opening_image_cropped.png` 중앙 정렬)
+- 약간의 시간 후 스플래시 사라지고 메인 창 등장
+- 콘솔에 `splash-to-main: XXXXms` 로그
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add electron/main.ts
+git commit -m "feat(electron): app.whenReady 재정렬 + 30초 타임아웃 + splash-to-main 측정"
+```
+
+---
+
+### Task 2.5: Chromium 커맨드라인 스위치
+
+**Files:**
+- Modify: `electron/main.ts` (파일 상단, `app.whenReady` 호출 전)
+
+- [ ] **Step 1: import 아래, 전역 변수 위에 3개 스위치 추가**
+
+```typescript
+// import 문 아래, 첫 함수 선언 전
+app.commandLine.appendSwitch('js-flags', '--nolazy');
+app.commandLine.appendSwitch('enable-gpu-rasterization');
+app.commandLine.appendSwitch('disable-renderer-backgrounding');
+```
+
+- [ ] **Step 2: tsc 검증 + 커밋**
+
+```bash
+npx tsc --noEmit
+git add electron/main.ts
+git commit -m "perf(electron): Chromium GPU/JS 최적화 스위치 3종 추가"
+```
+
+---
+
+### Task 2.6: `vite.config.ts`에 `manualChunks` 추가
+
+**Files:**
+- Modify: `vite.config.ts`
+
+- [ ] **Step 1: 렌더러 빌드 설정에 `build.rollupOptions.output.manualChunks` 추가**
+
+현재 `vite.config.ts`는 플러그인만 구성되어 있고 `build` 옵션이 없음. 최상위 `build` 블록 신설:
+
+```typescript
+export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
+  plugins: [
+    react(),
+    electron([
+      // ... 기존 설정 유지
+    ]),
+    renderer(),
+  ],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          'vendor-react': ['react', 'react-dom'],
+          'vendor-supabase': ['@supabase/supabase-js'],
+          'vendor-grid': ['react-grid-layout'],
+          'vendor-motion': ['framer-motion'],
+          'vendor-ui': ['lucide-react', 'sonner', 'clsx'],
+        },
+      },
+    },
+  },
+});
+```
+
+- [ ] **Step 2: 빌드 검증**
+
+```bash
+npm run build:vite
+ls dist/assets/
+```
+
+기대: `vendor-react-*.js`, `vendor-supabase-*.js`, `vendor-grid-*.js`, `vendor-motion-*.js`, `vendor-ui-*.js` 청크가 `dist/assets/`에 존재.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add vite.config.ts
+git commit -m "perf(vite): manualChunks로 성격별 vendor 번들 분리"
+```
+
+---
+
+### Task 2.7: `src/App.tsx` — 뷰 lazy 로딩
+
+**Files:**
+- Modify: `src/App.tsx:1-15` (import 블록)
+- Modify: `src/App.tsx:779-804` (`renderView()`)
+
+- [ ] **Step 1: 9개 뷰 import를 `React.lazy`로 변경**
+
+기존 `src/App.tsx:6-15`:
+```typescript
+import { Dashboard } from '@/views/Dashboard';
+import { ScenesView } from '@/views/ScenesView';
+import { EpisodeView } from '@/views/EpisodeView';
+import { AssigneeView } from '@/views/AssigneeView';
+import { TeamView } from '@/views/TeamView';
+import { CalendarView } from '@/views/CalendarView';
+import { ScheduleView } from '@/views/ScheduleView';
+import { VacationView } from '@/views/VacationView';
+import CompositingView from '@/views/CompositingView';
+import { SettingsView } from '@/views/SettingsView';
+```
+
+변경 (`lazy`로 래핑. `default` vs named export 주의):
+
+```typescript
+import { lazy, Suspense, useEffect, useCallback, useState, useRef } from 'react';
+// ... 기타 import
+
+// 뷰 lazy 로딩 — 초기 번들에서 제외
+const Dashboard = lazy(() => import('@/views/Dashboard').then(m => ({ default: m.Dashboard })));
+const ScenesView = lazy(() => import('@/views/ScenesView').then(m => ({ default: m.ScenesView })));
+const EpisodeView = lazy(() => import('@/views/EpisodeView').then(m => ({ default: m.EpisodeView })));
+const AssigneeView = lazy(() => import('@/views/AssigneeView').then(m => ({ default: m.AssigneeView })));
+const TeamView = lazy(() => import('@/views/TeamView').then(m => ({ default: m.TeamView })));
+const CalendarView = lazy(() => import('@/views/CalendarView').then(m => ({ default: m.CalendarView })));
+const ScheduleView = lazy(() => import('@/views/ScheduleView').then(m => ({ default: m.ScheduleView })));
+const VacationView = lazy(() => import('@/views/VacationView').then(m => ({ default: m.VacationView })));
+const CompositingView = lazy(() => import('@/views/CompositingView')); // default export
+const SettingsView = lazy(() => import('@/views/SettingsView').then(m => ({ default: m.SettingsView })));
+```
+
+- [ ] **Step 2: `renderView()` 반환을 `<Suspense>`로 감쌈**
+
+`src/App.tsx:779-804` 수정:
+
+```typescript
+const renderView = () => {
+  const view = (() => {
+    switch (currentView) {
+      case 'dashboard': return <Dashboard />;
+      case 'scenes': return <ScenesView />;
+      case 'episode': return <EpisodeView />;
+      case 'assignee': return <AssigneeView />;
+      case 'team': return <TeamView />;
+      case 'calendar': return <CalendarView />;
+      case 'schedule': return <ScheduleView />;
+      case 'vacation': return <VacationView />;
+      case 'compositing': return <CompositingView />;
+      case 'settings': return <SettingsView />;
+      default: return <Dashboard />;
+    }
+  })();
+  return (
+    <Suspense fallback={
+      <div className="flex items-center justify-center h-full w-full">
+        <div className="w-6 h-6 border-2 border-accent border-t-transparent rounded-full animate-spin" />
+      </div>
+    }>
+      {view}
+    </Suspense>
+  );
+};
+```
+
+- [ ] **Step 3: 빌드 검증**
+
+```bash
+npx tsc --noEmit
+npm run build:vite
+ls dist/assets/
+```
+
+기대: 각 뷰가 독립 청크(`Dashboard-*.js` 등)로 나옴. 초기 `index-*.js`는 viewer-*이 없음.
+
+- [ ] **Step 4: 개발 수동 검증**
+
+```bash
+npm run electron:dev
+```
+
+기대: 뷰 전환 시 잠깐 스피너 → 정상 렌더. 기존 동작 회귀 없음.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/App.tsx
+git commit -m "perf(renderer): 10개 뷰 React.lazy로 지연 로딩"
+```
+
+---
+
+### Task 2.8: 무거운 모달 lazy 로딩
+
+**Files:**
+- Modify: `src/App.tsx` (PasswordChangeModal, UserManagerModal import/렌더 부분)
+
+- [ ] **Step 1: 두 모달을 `lazy`로 변환 + `Suspense` 래핑**
+
+```typescript
+// import 상단
+const PasswordChangeModal = lazy(() => import('@/components/auth/PasswordChangeModal').then(m => ({ default: m.PasswordChangeModal })));
+const UserManagerModal = lazy(() => import('@/components/auth/UserManagerModal').then(m => ({ default: m.UserManagerModal })));
+```
+
+렌더 부분(`src/App.tsx:893-898` 부근):
+```typescript
+{showPasswordChange && (
+  <Suspense fallback={null}>
+    <PasswordChangeModal />
+  </Suspense>
+)}
+{showUserManager && (
+  <Suspense fallback={null}>
+    <UserManagerModal />
+  </Suspense>
+)}
+```
+
+- [ ] **Step 2: 빌드 검증**
+
+```bash
+npx tsc --noEmit
+npm run build:vite
+```
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/App.tsx
+git commit -m "perf(renderer): 인증 모달 lazy 로딩"
+```
+
+---
+
+### Task 2.9: 설정 섹션 lazy 로딩 (선택, 범위 조정)
+
+**Files:**
+- Modify: `src/views/SettingsView.tsx` (존재 시) 또는 설정 섹션 관련 파일
+
+- [ ] **Step 1: SettingsView 내부 구조 확인**
+
+```bash
+# 파일 존재 여부 및 import 구조 Read
+```
+
+- [ ] **Step 2: 섹션별 `lazy` 적용**
+
+`SettingsView` 안에서 각 section(`ThemeSection`, `SheetsSection`, `NotificationSection`, `StartupSection`, `ShortcutsSection`, `EffectsSection`, `ProfileSection`, `LoginSection`, `FontSizeSection`, `GuideSection`)을 `lazy` 처리하고 활성 탭만 렌더하도록 `Suspense` 추가.
+
+**주의**: 현재 SettingsView가 이미 탭 기반 렌더링이면 각 탭의 섹션만 마운트하므로 lazy 적용이 쉬움. 동시에 모두 렌더하는 구조면 lazy가 의미 없으므로 스킵하고 Task 2.10으로.
+
+- [ ] **Step 3: 빌드 검증 + 커밋 (변경이 있었을 때만)**
+
+```bash
+npx tsc --noEmit
+npm run build:vite
+git add src/views/SettingsView.tsx
+git commit -m "perf(renderer): 설정 섹션 lazy 로딩"
+```
+
+---
+
+### Task 2.10: Chunk 2 전체 검증 (electron-builder 포함)
+
+- [ ] **Step 1: 전체 빌드**
+
+```bash
+npm run build
+```
+
+기대: tsc + vite + electron-builder 모두 통과. `dist/BFLOW.exe` 생성.
+
+- [ ] **Step 2: portable exe 수동 실행 검증**
+
+`dist/BFLOW.exe` 더블클릭 → 다음을 확인:
+- 더블클릭 후 빠르게 스플래시 등장
+- 스플래시 → 메인 창 전환 부드러움
+- 콘솔 로그로 `splash-to-main` 시간 < 3000ms (이상적으로 < 1500ms)
+- 메인 창에서 뷰 전환 시 짧은 스피너 → 로드 완료
+
+- [ ] **Step 3: 이상 없으면 Chunk 2 커밋 병합 확인**
+
+```bash
+git log --oneline -15
+```
+
+Chunk 2의 10개 커밋이 순서대로 쌓여있는지 확인.
+
+---
+
+## Chunk 3: 커스텀 테마 HSL 파생
+
+**목표**: `themes.ts`에 HSL 유틸 + `deriveThemeFromAccent()` 추가. `ThemeSection`의 커스텀 적용이 accent/sub 두 hex로 완전히 새 프리셋(배경·보더·텍스트 포함)을 생성하도록 변경. colorMode 전환 시 자동 재파생.
+
+---
+
+### Task 3.1: `themes.ts`에 `rgbToHsl` + `hslToRgb` 추가
+
+**Files:**
+- Modify: `src/themes.ts:114-129` (유틸 섹션)
+
+- [ ] **Step 1: HSL 변환 유틸 2개 추가**
+
+`src/themes.ts`의 기존 `rgbToHex`/`hexToRgb` 아래에 추가:
+
+```typescript
+/** RGB triplet → HSL (h: 0-360, s/l: 0-100) */
+export function rgbToHsl(triplet: string): { h: number; s: number; l: number } {
+  const [r, g, b] = triplet.split(' ').map(Number).map(v => v / 255);
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  let h = 0;
+  let s = 0;
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r: h = ((g - b) / d + (g < b ? 6 : 0)); break;
+      case g: h = ((b - r) / d + 2); break;
+      case b: h = ((r - g) / d + 4); break;
+    }
+    h *= 60;
+  }
+  return { h: Math.round(h), s: Math.round(s * 100), l: Math.round(l * 100) };
+}
+
+/** HSL (h: 0-360, s/l: 0-100) → RGB triplet */
+export function hslToRgb(h: number, s: number, l: number): string {
+  const sN = s / 100;
+  const lN = l / 100;
+  const c = (1 - Math.abs(2 * lN - 1)) * sN;
+  const hP = h / 60;
+  const x = c * (1 - Math.abs((hP % 2) - 1));
+  let r1 = 0, g1 = 0, b1 = 0;
+  if (0 <= hP && hP < 1) [r1, g1, b1] = [c, x, 0];
+  else if (hP < 2) [r1, g1, b1] = [x, c, 0];
+  else if (hP < 3) [r1, g1, b1] = [0, c, x];
+  else if (hP < 4) [r1, g1, b1] = [0, x, c];
+  else if (hP < 5) [r1, g1, b1] = [x, 0, c];
+  else if (hP < 6) [r1, g1, b1] = [c, 0, x];
+  const m = lN - c / 2;
+  const r = Math.round((r1 + m) * 255);
+  const g = Math.round((g1 + m) * 255);
+  const b = Math.round((b1 + m) * 255);
+  return `${r} ${g} ${b}`;
+}
+```
+
+- [ ] **Step 2: 수동 sanity 검증**
+
+브라우저 콘솔(`npm run electron:dev` 실행 후)에서:
+```javascript
+// 검정 → HSL (0, 0, 0)
+rgbToHsl('0 0 0')  // { h:0, s:0, l:0 }
+// 흰색
+rgbToHsl('255 255 255')  // { h:0, s:0, l:100 }
+// 빨강
+rgbToHsl('255 0 0')  // { h:0, s:100, l:50 }
+// 역변환
+hslToRgb(0, 100, 50)  // "255 0 0"
+```
+
+**주의**: 실제로 이 함수들은 아직 import되지 않아 window 객체로는 접근 불가. 대신 TS 컴파일 통과만 확인하고 실사용 검증은 Task 3.2 이후로 미룸.
+
+```bash
+npx tsc --noEmit
+```
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/themes.ts
+git commit -m "feat(themes): rgbToHsl/hslToRgb HSL 변환 유틸 추가"
+```
+
+---
+
+### Task 3.2: `deriveThemeFromAccent` 구현
+
+**Files:**
+- Modify: `src/themes.ts` (Task 3.1 블록 아래)
+
+- [ ] **Step 1: 함수 추가**
+
+```typescript
+/**
+ * accent hex 두 개로부터 7색 ThemeColors 전체를 생성.
+ * 배경·보더·텍스트 5색은 accent hue 기반 HSL 계단 공식으로 파생.
+ */
+export function deriveThemeFromAccent(
+  accentHex: string,
+  accentSubHex: string,
+  mode: 'dark' | 'light',
+): ThemeColors {
+  const { h } = rgbToHsl(hexToRgb(accentHex));
+  const dark = mode === 'dark';
+  return {
+    bgPrimary:     dark ? hslToRgb(h, 20, 5)  : hslToRgb(h, 15, 88),
+    bgCard:        dark ? hslToRgb(h, 22, 9)  : hslToRgb(h, 10, 99),
+    bgBorder:      dark ? hslToRgb(h, 20, 16) : hslToRgb(h, 25, 70),
+    textPrimary:   dark ? hslToRgb(h, 15, 92) : hslToRgb(h, 30, 12),
+    textSecondary: dark ? hslToRgb(h, 15, 59) : hslToRgb(h, 25, 28),
+    accent:        hexToRgb(accentHex),
+    accentSub:     hexToRgb(accentSubHex),
+  };
+}
+```
+
+- [ ] **Step 2: tsc 검증 + 커밋**
+
+```bash
+npx tsc --noEmit
+git add src/themes.ts
+git commit -m "feat(themes): deriveThemeFromAccent — accent hue로 전체 테마 파생"
+```
+
+---
+
+### Task 3.3: `useAppStore`에 `customAccentHex`/`customSubHex` 상태 + 액션 추가
+
+**Files:**
+- Modify: `src/stores/useAppStore.ts`
+
+- [ ] **Step 1: 해당 store 파일에서 테마 관련 상태 블록 찾기**
+
+```bash
+# Read 전후 부분 파악
+```
+
+- [ ] **Step 2: 인터페이스/초기값/액션 추가**
+
+기존 `customThemeColors` 상태 근처에 다음 추가:
+```typescript
+// 상태 타입 (기존 타입 정의에 추가)
+customAccentHex: string | null;
+customSubHex: string | null;
+
+// 초기값 (기존 initial state 객체에 추가)
+customAccentHex: null,
+customSubHex: null,
+
+// 액션 (기존 set* 액션 근처에 추가)
+setCustomAccentHex: (hex: string | null) => set({ customAccentHex: hex }),
+setCustomSubHex: (hex: string | null) => set({ customSubHex: hex }),
+```
+
+- [ ] **Step 3: tsc 검증 + 커밋**
+
+```bash
+npx tsc --noEmit
+git add src/stores/useAppStore.ts
+git commit -m "feat(store): customAccentHex/customSubHex 상태 + 액션 추가"
+```
+
+---
+
+### Task 3.4: `sanitizeCustomHex` 마이그레이션 유틸
+
+**Files:**
+- Modify: `src/stores/useAppStore.ts` (또는 `src/themes.ts` — store에서 사용하기 편한 곳)
+
+- [ ] **Step 1: `src/themes.ts`에 `sanitizeCustomHex` 추가**
+
+```typescript
+const HEX_RE = /^#[0-9a-fA-F]{6}$/;
+
+/**
+ * 저장된 커스텀 테마 필드들을 검증/마이그레이션.
+ * - 새 포맷(hex)이 유효하면 그대로 사용
+ * - 구포맷(customThemeColors triplet)만 있으면 hex 역산
+ * - 둘 다 실패 시 null 반환 → 호출부는 기본 프리셋으로 폴백
+ */
+export function sanitizeCustomHex(input: {
+  customAccentHex?: string | null;
+  customSubHex?: string | null;
+  customThemeColors?: ThemeColors | null;
+}): { accent: string; sub: string } | null {
+  const a = input.customAccentHex;
+  const s = input.customSubHex;
+  if (a && HEX_RE.test(a) && s && HEX_RE.test(s)) {
+    return { accent: a, sub: s };
+  }
+  const c = input.customThemeColors;
+  if (c?.accent && c?.accentSub) {
+    try {
+      return { accent: rgbToHex(c.accent), sub: rgbToHex(c.accentSub) };
+    } catch {/* triplet 파싱 실패 */}
+  }
+  return null;
+}
+```
+
+- [ ] **Step 2: tsc 검증 + 커밋**
+
+```bash
+npx tsc --noEmit
+git add src/themes.ts
+git commit -m "feat(themes): sanitizeCustomHex 마이그레이션 유틸"
+```
+
+---
+
+### Task 3.5: `settingsService.ts`의 `loadTheme`/`saveTheme` 타입에 신규 필드 추가
+
+**Files:**
+- Modify: `src/services/settingsService.ts`
+
+- [ ] **Step 1: `ThemeConfig` 타입 또는 관련 인터페이스 확장**
+
+```bash
+# Read src/services/settingsService.ts to find ThemeConfig or equivalent
+```
+
+`customAccentHex?: string; customSubHex?: string;` 필드 추가. 기존 `customColors`(ThemeColors)는 유지(하위 호환).
+
+- [ ] **Step 2: tsc 검증 + 커밋**
+
+```bash
+npx tsc --noEmit
+git add src/services/settingsService.ts
+git commit -m "feat(settings): ThemeConfig에 customAccentHex/customSubHex 필드 추가"
+```
+
+---
+
+### Task 3.6: `App.tsx` 초기화 — 마이그레이션 실행 + 재파생
+
+**Files:**
+- Modify: `src/App.tsx:321-343` (테마 로드/적용 블록)
+
+- [ ] **Step 1: `sanitizeCustomHex` 사용해 저장된 상태 정규화**
+
+기존 `init()` 내부 테마 로드 블록:
+```typescript
+const savedTheme = await loadTheme();
+if (savedTheme) {
+  // ... 기존 로직
+}
+```
+
+수정:
+```typescript
+const savedTheme = await loadTheme();
+if (savedTheme) {
+  const savedMode = savedTheme.colorMode ?? 'dark';
+
+  // 커스텀 테마 마이그레이션
+  let customHex: { accent: string; sub: string } | null = null;
+  if (savedTheme.themeId === 'custom') {
+    customHex = sanitizeCustomHex({
+      customAccentHex: savedTheme.customAccentHex,
+      customSubHex: savedTheme.customSubHex,
+      customThemeColors: savedTheme.customColors ?? null,
+    });
+    if (!customHex) {
+      // 손상 → 기본 프리셋으로 폴백 (조용히)
+      console.warn('[테마] 커스텀 테마 데이터 손상 → 기본 프리셋으로 폴백');
+    }
+  }
+
+  // CSS 적용
+  if (savedTheme.themeId === 'custom' && customHex) {
+    const colors = deriveThemeFromAccent(customHex.accent, customHex.sub, savedMode);
+    applyTheme(colors, savedMode);
+    themeInitRef.current = true;
+    setThemeId('custom');
+    setColorMode(savedMode);
+    setCustomThemeColors(colors);
+    useAppStore.getState().setCustomAccentHex(customHex.accent);
+    useAppStore.getState().setCustomSubHex(customHex.sub);
+    // 구포맷만 있던 경우 새 포맷으로 저장
+    if (!savedTheme.customAccentHex || !savedTheme.customSubHex) {
+      saveTheme({
+        themeId: 'custom',
+        customColors: colors,
+        colorMode: savedMode,
+        customAccentHex: customHex.accent,
+        customSubHex: customHex.sub,
+      });
+    }
+  } else if (savedMode === 'light') {
+    applyTheme(getLightColors(savedTheme.themeId), savedMode);
+    themeInitRef.current = true;
+    setThemeId(savedTheme.themeId);
+    setColorMode(savedMode);
+  } else {
+    const preset = getPreset(savedTheme.themeId);
+    if (preset) {
+      applyTheme(preset.colors, savedMode);
+      themeInitRef.current = true;
+      setThemeId(savedTheme.themeId);
+      setColorMode(savedMode);
+    }
+  }
+} else {
+  themeInitRef.current = true;
+}
+```
+
+추가 import 필요: `deriveThemeFromAccent`, `sanitizeCustomHex` from `@/themes`.
+
+- [ ] **Step 2: tsc 검증 + 커밋**
+
+```bash
+npx tsc --noEmit
+git add src/App.tsx
+git commit -m "feat(theme): 앱 초기화 시 커스텀 테마 마이그레이션 + 구포맷 자동 변환"
+```
+
+---
+
+### Task 3.7: `App.tsx`의 테마 저장 `useEffect` 수정
+
+**Files:**
+- Modify: `src/App.tsx:442-458` (테마 변경 시 CSS 적용 + 저장)
+
+- [ ] **Step 1: `customThemeColors`와 hex 둘 다 저장하도록 조정**
+
+```typescript
+useEffect(() => {
+  if (!themeInitRef.current) return;
+  const { customAccentHex, customSubHex } = useAppStore.getState();
+
+  if (themeId === 'custom' && customThemeColors) {
+    applyTheme(customThemeColors, colorMode);
+    saveTheme({
+      themeId,
+      customColors: customThemeColors,
+      colorMode,
+      customAccentHex: customAccentHex ?? undefined,
+      customSubHex: customSubHex ?? undefined,
+    });
+  } else if (colorMode === 'light') {
+    applyTheme(getLightColors(themeId), colorMode);
+    saveTheme({ themeId, colorMode });
+  } else {
+    const preset = getPreset(themeId);
+    if (preset) {
+      applyTheme(preset.colors, colorMode);
+      saveTheme({ themeId, colorMode });
+    }
+  }
+}, [themeId, customThemeColors, colorMode]);
+```
+
+- [ ] **Step 2: tsc 검증 + 커밋**
+
+```bash
+npx tsc --noEmit
+git add src/App.tsx
+git commit -m "feat(theme): 저장 시 customAccentHex/customSubHex 함께 영속화"
+```
+
+---
+
+### Task 3.8: `App.tsx`의 colorMode 변경 시 커스텀 재파생
+
+**Files:**
+- Modify: `src/App.tsx` (Task 3.7과 같은 useEffect 또는 별도 hook)
+
+- [ ] **Step 1: colorMode가 바뀔 때 커스텀 테마면 hex로 재파생**
+
+Task 3.7의 useEffect 시작부에 추가:
+
+```typescript
+useEffect(() => {
+  if (!themeInitRef.current) return;
+  const { customAccentHex, customSubHex, setCustomThemeColors } = useAppStore.getState();
+
+  // 커스텀 테마에서 colorMode만 바뀐 경우: hex 기반 재파생
+  if (themeId === 'custom' && customAccentHex && customSubHex) {
+    const colors = deriveThemeFromAccent(customAccentHex, customSubHex, colorMode);
+    applyTheme(colors, colorMode);
+    setCustomThemeColors(colors);
+    saveTheme({ themeId, customColors: colors, colorMode, customAccentHex, customSubHex });
+    return;
+  }
+
+  // 기존 로직 (프리셋 테마)
+  if (colorMode === 'light') {
+    applyTheme(getLightColors(themeId), colorMode);
+    saveTheme({ themeId, colorMode });
+  } else {
+    const preset = getPreset(themeId);
+    if (preset) {
+      applyTheme(preset.colors, colorMode);
+      saveTheme({ themeId, colorMode });
+    }
+  }
+}, [themeId, colorMode]); // customThemeColors 의존성 제거 — 재파생은 여기서 담당
+```
+
+**주의**: Task 3.7의 useEffect와 합쳐야 할 수도 있음. 실제 파일 구조에 따라 의존성 배열과 분기 조정.
+
+- [ ] **Step 2: tsc 검증 + 커밋**
+
+```bash
+npx tsc --noEmit
+git add src/App.tsx
+git commit -m "feat(theme): colorMode 전환 시 커스텀 테마 hex 기반 재파생"
+```
+
+---
+
+### Task 3.9: `ThemeSection.tsx`의 `handleCustomApply` 교체
+
+**Files:**
+- Modify: `src/components/settings/ThemeSection.tsx:33-44`
+
+- [ ] **Step 1: 기존 구현 제거 + `deriveThemeFromAccent` 호출로 변경**
+
+```typescript
+// import 추가
+import { THEME_PRESETS, rgbToHex, hexToRgb, getPreset, getLightColors, deriveThemeFromAccent } from '@/themes';
+
+// useAppStore에서 추가 액션 가져오기
+const {
+  themeId, customThemeColors, colorMode,
+  setThemeId, setCustomThemeColors, setColorMode,
+  setCustomAccentHex, setCustomSubHex,
+} = useAppStore();
+
+// handleCustomApply 교체
+const handleCustomApply = () => {
+  const colors = deriveThemeFromAccent(customAccent, customSub, colorMode);
+  setCustomAccentHex(customAccent);
+  setCustomSubHex(customSub);
+  setThemeId('custom');
+  setCustomThemeColors(colors);
+  setEditingCustom(false);
+};
+```
+
+- [ ] **Step 2: tsc 검증 + 개발 실행 수동 검증**
+
+```bash
+npx tsc --noEmit
+npm run electron:dev
+```
+
+설정 → 테마 → 커스텀 → accent `#E11D48`, sub `#FB7185` → 적용. 기대:
+- 배경이 어두운 붉은 보라 톤으로 변경
+- 카드 배경, 보더, 텍스트 색상 모두 톤 일관
+- 공산당 레드 프리셋과 유사한 시각적 결과
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/components/settings/ThemeSection.tsx
+git commit -m "fix(theme): 커스텀 테마가 accent hue로 전체 테마 파생하도록 변경"
+```
+
+---
+
+### Task 3.10: 커스텀 편집 패널에 실시간 배경 프리뷰 추가
+
+**Files:**
+- Modify: `src/components/settings/ThemeSection.tsx:140-188` (editingCustom 블록)
+
+- [ ] **Step 1: accent 입력값에서 실시간으로 배경 3색 계산**
+
+```typescript
+// 컴포넌트 내부에 derive 메모이제이션 (useMemo로)
+const previewColors = useMemo(() => {
+  try {
+    return deriveThemeFromAccent(customAccent, customSub, colorMode);
+  } catch {
+    return null;
+  }
+}, [customAccent, customSub, colorMode]);
+```
+
+- [ ] **Step 2: 기존 그라디언트 프리뷰 아래에 배경 3색 박스 추가**
+
+```tsx
+{previewColors && (
+  <div className="flex gap-2 mt-2">
+    <div className="flex-1 flex flex-col items-center gap-1">
+      <div className="w-full h-8 rounded-md" style={{ background: `rgb(${previewColors.bgPrimary})` }} />
+      <span className="text-[10px] text-text-secondary">Primary</span>
+    </div>
+    <div className="flex-1 flex flex-col items-center gap-1">
+      <div className="w-full h-8 rounded-md" style={{ background: `rgb(${previewColors.bgCard})` }} />
+      <span className="text-[10px] text-text-secondary">Card</span>
+    </div>
+    <div className="flex-1 flex flex-col items-center gap-1">
+      <div className="w-full h-8 rounded-md" style={{ background: `rgb(${previewColors.bgBorder})` }} />
+      <span className="text-[10px] text-text-secondary">Border</span>
+    </div>
+  </div>
+)}
+```
+
+**주의**: `import { useMemo } from 'react'` 필요.
+
+- [ ] **Step 3: tsc 검증 + 수동 검증 + 커밋**
+
+```bash
+npx tsc --noEmit
+npm run electron:dev
+# 커스텀 편집 패널에서 색상 바꾸면 3색 박스가 실시간 변함
+git add src/components/settings/ThemeSection.tsx
+git commit -m "feat(theme): 커스텀 편집 패널에 실시간 배경 프리뷰 추가"
+```
+
+---
+
+### Task 3.11: 프리셋 그리드의 '커스텀' 타일 실제 그라디언트
+
+**Files:**
+- Modify: `src/components/settings/ThemeSection.tsx:117-137` (커스텀 버튼 블록)
+
+- [ ] **Step 1: `themeId === 'custom'`이고 `customThemeColors`가 있을 때 프리뷰 적용**
+
+```tsx
+<button
+  onClick={() => setEditingCustom(true)}
+  className={cn(
+    'relative flex flex-col items-center gap-2 p-3 rounded-xl border-2 transition-all cursor-pointer',
+    themeId === 'custom'
+      ? 'border-accent bg-accent/10'
+      : 'border-bg-border hover:border-accent/40 hover:bg-bg-border/30 border-dashed',
+  )}
+>
+  {themeId === 'custom' && customThemeColors ? (
+    <div
+      className="w-full h-10 rounded-lg"
+      style={{
+        background: `linear-gradient(135deg, rgb(${customThemeColors.bgCard}) 0%, rgb(${customThemeColors.accent}) 50%, rgb(${customThemeColors.accentSub}) 100%)`,
+      }}
+    />
+  ) : (
+    <div className="w-full h-10 rounded-lg flex items-center justify-center bg-bg-border/50">
+      <Palette size={20} className="text-text-secondary" />
+    </div>
+  )}
+  <span className="text-xs text-text-primary font-medium">커스텀</span>
+  <span className="text-[11px] text-text-secondary">Custom</span>
+  {themeId === 'custom' && (
+    <div className="absolute top-2 right-2 w-5 h-5 rounded-full bg-accent flex items-center justify-center">
+      <Check size={12} className="text-white" />
+    </div>
+  )}
+</button>
+```
+
+- [ ] **Step 2: tsc 검증 + 수동 검증 + 커밋**
+
+```bash
+npx tsc --noEmit
+npm run electron:dev
+git add src/components/settings/ThemeSection.tsx
+git commit -m "feat(theme): 커스텀 타일이 적용된 테마의 실제 그라디언트 표시"
+```
+
+---
+
+### Chunk 3 완료 검증
+
+- [ ] `npx tsc --noEmit` 통과
+- [ ] `npm run build:vite` 통과
+- [ ] 수동 검증:
+  - 공산당 레드 accent(#E11D48, #FB7185)를 커스텀에 넣으면 전체 톤이 공산당 레드 느낌으로 바뀜
+  - 이혜민 머쉬룸 accent(#814D41, #E0CBAF) 동일 테스트 통과
+  - 다크 ↔ 라이트 토글 시 커스텀 배경도 자동 재생성
+  - 커스텀 편집 패널의 3색 배경 프리뷰가 실시간 갱신
+  - 프리셋 그리드 '커스텀' 타일이 다른 프리셋처럼 그라디언트로 표시
+  - 앱 재시작 후 커스텀 테마 그대로 복원
+
+---
+
+## 최종 통합 검증
+
+- [ ] `npm run build` (tsc + vite + electron-builder) 전체 통과
+- [ ] `dist/BFLOW.exe` 실행 → 스펙 `검증 체크리스트` 섹션 1/2/3 전 항목 통과
+- [ ] 기존 기능 회귀 없음 (화이트보드·씬시트·캘린더·휴가·슬랙·알림·Supabase Realtime)
+- [ ] `git log --oneline -40` 으로 커밋 히스토리가 Chunk 1 13개 + Chunk 2 10개 + Chunk 3 11개 = 약 34개 커밋으로 깔끔하게 쌓여있음
+- [ ] 최종 커밋 메시지에 이 플랜 파일 링크 포함
+
+---
+
+*플랜 끝*

--- a/docs/superpowers/specs/2026-04-18-pre-release-polish-design.md
+++ b/docs/superpowers/specs/2026-04-18-pre-release-polish-design.md
@@ -249,7 +249,7 @@ async function showTrayHintOnce(): Promise<void> {
 | `createTray()` | 트레이 아이콘·툴팁·이벤트 바인딩. 앱 시작 시 1회 호출 |
 | `rebuildTrayMenu()` | 위젯 상태/Supabase 상태 변화 시 재호출되어 메뉴·툴팁 최신화 |
 | `toggleWidget(id, title)` | 트레이에서 위젯 on/off. 내부적으로 `openWidgetPopup` 또는 `widgetWindows.get(id).close()` |
-| `getSupabaseStatusLabel()` | 현재 realtime 상태를 사람이 읽을 수 있는 문자열로 |
+| `humanizeStatus(raw)` | Supabase 원시 상태 문자열(`'SUBSCRIBED'`/`'CHANNEL_ERROR'` 등)을 사람이 읽을 수 있는 한글 문자열로 변환. `lastSupabaseStatus` 갱신에만 사용 |
 | 기존 `loadWidgetPositions()` | 변경 없음. 이미 앱 시작 시 호출됨 (main.ts:1578) |
 | 기존 자동 복원 루프 (main.ts:1631) | 변경 없음. `widgetPositionCache` 내용대로 `openWidgetPopup` 호출 |
 
@@ -319,7 +319,7 @@ async function showTrayHintOnce(): Promise<void> {
 
 **구현 포인트**:
 
-- 새 파일 `public/splash.html` — 인라인 CSS, 외부 의존성 0. `opening_image_cropped.png`를 중앙 고정 표시.
+- 새 파일 `public/splash/splash.html` — 인라인 CSS, 외부 의존성 0. 같은 폴더의 `opening_image_cropped.png`를 상대 경로(`./opening_image_cropped.png`)로 참조. 경로 일원화 목적으로 `public/splash/` 하위에 배치 → `package.json` `files`의 `public/splash/**` 한 줄로 스플래시 에셋+HTML 모두 커버.
 - `electron/main.ts`에 `createSplashWindow()` 신설: `width:300, height:300, frame:false, transparent:true, alwaysOnTop:true, resizable:false, skipTaskbar:true, show:true, closable:false`. (`closable:false`로 사용자가 스플래시를 닫을 수 없게 해 좀비 상태 방지)
 - `app.whenReady()`에서 **트레이 생성 직후, createWindow 직전**에 스플래시 생성.
 - `mainWindow = new BrowserWindow({ show: false, ... })` — 기존엔 기본 show:true였음.
@@ -610,7 +610,7 @@ function sanitizeCustomHex(
 - [ ] `console.timeEnd('splash-to-main')` 로그가 스플래시 표시부터 메인 show까지의 시간을 찍는다.
 - [ ] 스플래시 → 메인 창 전환이 부드럽다 (깜빡임 없음).
 - [ ] 메인 창이 30초 안에 로드되지 않는 극단 시나리오에서 에러 다이얼로그가 뜨고 앱이 종료된다.
-- [ ] `vite build` 결과 `dist/assets/`에 `vendor-react`, `vendor-supabase`, `vendor-charts`, `vendor-ui` 번들이 분리되어 있다.
+- [ ] `vite build` 결과 `dist/assets/`에 `vendor-react`, `vendor-supabase`, `vendor-grid`, `vendor-motion`, `vendor-ui` 번들이 분리되어 있다.
 - [ ] 초기 화면이 Dashboard일 때 Schedule/Episode 뷰 번들은 로드되지 않는다 (DevTools Network).
 - [ ] Scene 상세 모달 열기 전까진 `SceneDetailModal.tsx` 번들이 요청되지 않는다.
 - [ ] 빌드 크기가 이전 대비 감소하지 않아도 무방 (파일 분할만 해도 병렬 로드 이득).
@@ -652,7 +652,7 @@ function sanitizeCustomHex(
 |---|---|
 | `electron/main.ts` | 트레이 생성/메뉴/이벤트, Supabase 상태 콜백에서 `rebuildTrayMenu` 호출, mainWindow close 차단 + `trayFailed` 폴백, 위젯 캐시 삭제 로직 제거, window-all-closed 수정, process exit 안전망, app.whenReady 재정렬, 스플래시 윈도우 + 30초 타임아웃 + 측정 로그, 커맨드라인 스위치 추가 |
 | `electron/preload.ts` | 변경 없음 (기존 IPC로 충분) |
-| `public/splash.html` | 신규 — 스플래시 2단계 부팅용 |
+| `public/splash/splash.html` | 신규 — 스플래시 2단계 부팅용. `public/splash/` 하위에 배치해 기존 이미지와 함께 `public/splash/**` files 규칙 한 줄로 커버 |
 | `package.json` | `build.files`에 `public/splash/**` 추가 |
 | `vite.config.ts` | manualChunks 설정 (성격별 vendor 분리) |
 | `src/App.tsx` | 뷰/모달 lazy 로딩 래핑 |

--- a/docs/superpowers/specs/2026-04-18-pre-release-polish-design.md
+++ b/docs/superpowers/specs/2026-04-18-pre-release-polish-design.md
@@ -1,0 +1,506 @@
+# 정식 빌드 전 마감 4종 — 디자인 문서
+
+**작성일**: 2026-04-18
+**대상 브랜치**: `claude/ecstatic-lumiere-42f79a`
+**작성자**: 한솔 × Claude
+
+---
+
+## 배경
+
+정식 빌드 배포 직전, 다음 4가지 품질 이슈를 해결해야 한다.
+
+1. **트레이 아이콘 미구현** — 앱에 트레이 아이콘이 전혀 없다.
+2. **위젯 위치/크기 기억 불완전** — 트레이로 앱을 종료한 뒤 재실행하면 플로팅 위젯이 마지막 상태를 기억하지 못한다.
+3. **빌드 앱 실행 시 로딩 체감이 느림** — 더블클릭 후 아예 아무 화면도 뜨지 않는 구간이 길다.
+4. **커스텀 테마가 '완전한 새 테마'가 아닌 '기존 테마 + 새 accent'로 생성됨** — 공산당 레드·이혜민 머쉬룸 같은 톤-온-톤 결과가 나오지 않는다.
+
+---
+
+## 결정사항 요약
+
+| 항목 | 결정 |
+|---|---|
+| 창 X 버튼 | 트레이로 최소화 (메인 창만 숨김, 위젯은 유지) |
+| 트레이 '종료' | 유일한 실제 종료 경로 (`isQuitting = true` 후 `app.quit()`) |
+| 트레이 메뉴 | 좌·더블클릭 = 창 열기 / 우클릭 = 열기·위젯 서브메뉴·현재 상태 표시·종료 |
+| 트레이 툴팁 | `'B flow • <상태>'` 실시간 갱신 (Supabase 상태 연동) |
+| 트레이 아이콘 에셋 | `public/splash/opening_image_cropped.png` 재활용 |
+| 위젯 복원 정책 | 개별 X로 닫아도 위치·크기·AOT·투명도 항상 보존, 앱 재시작 시 자동 복원 |
+| 로딩 속도 전략 | 안전 정책 (asar/googleapis 구조 미변경) + 실제 첫 페인트 단축 |
+| 커스텀 테마 슬롯 | 1개 (덮어쓰기 구조) |
+| 커스텀 테마 입력 | accent / accentSub 두 개만 사용자가 지정 |
+| 커스텀 테마 생성 | accent hue 기반 HSL로 배경·보더·텍스트 5색을 자동 파생 |
+
+---
+
+## 섹션 1: 트레이 아이콘 + 위젯 영속화 (종료 경로 재설계)
+
+### 목표
+
+- `Tray` API로 시스템 트레이 아이콘을 생성하고, 앱의 **유일한 실제 종료 경로**를 트레이 메뉴 '종료'로 일원화한다.
+- 위젯 상태는 모든 경로(개별 X, 트레이 종료, 작업관리자 강제 종료)에서 최대한 안전하게 보존한다.
+
+### 아키텍처
+
+**`electron/main.ts`에 새 전역 + 함수 추가**
+
+```typescript
+let tray: Tray | null = null;
+
+function createTray(): void {
+  const iconPath = path.join(__dirname, '../public/splash/opening_image_cropped.png');
+  const image = nativeImage.createFromPath(iconPath).resize({ width: 16, height: 16 });
+  tray = new Tray(image);
+  tray.setToolTip('B flow');
+  tray.on('click', showMainWindow);
+  tray.on('double-click', showMainWindow);
+  rebuildTrayMenu(); // 최초 메뉴 빌드
+}
+
+function rebuildTrayMenu(): void {
+  if (!tray) return;
+  const widgetSubmenu: MenuItemConstructorOptions[] = Object.entries(WIDGET_TITLE_MAP).map(
+    ([id, title]) => ({
+      label: title,
+      type: 'checkbox',
+      checked: widgetWindows.has(id),
+      click: () => toggleWidget(id, title),
+    }),
+  );
+  const status = getSupabaseStatusLabel(); // 예: "실시간 연결됨" / "재연결 중..."
+  const menu = Menu.buildFromTemplate([
+    { label: '열기', click: showMainWindow },
+    { type: 'separator' },
+    { label: '위젯', submenu: widgetSubmenu },
+    { type: 'separator' },
+    { label: `상태: ${status}`, enabled: false },
+    { type: 'separator' },
+    { label: '종료', click: () => { isQuitting = true; app.quit(); } },
+  ]);
+  tray.setContextMenu(menu);
+  tray.setToolTip(`B flow • ${status}`);
+}
+```
+
+**메인 창 닫기 차단 (`createWindow` 내부에 추가)**
+
+```typescript
+mainWindow.on('close', (e) => {
+  if (!isQuitting) {
+    e.preventDefault();
+    mainWindow?.hide();
+    // 위젯은 건드리지 않음 (요구사항 반영)
+    showTrayHintOnce(); // 최초 1회만 안내 Notification
+    return;
+  }
+  // isQuitting === true인 경우 기본 동작(닫힘) 허용
+});
+```
+
+**위젯 캐시 삭제 로직 제거 (`openWidgetPopup` 내부, `popupWin.on('closed')` 핸들러)**
+
+```typescript
+// BEFORE:
+popupWin.on('closed', () => {
+  widgetWindows.delete(widgetId);
+  widgetOriginalBounds.delete(widgetId);
+  if (!isQuitting) {
+    widgetPositionCache.delete(widgetId);    // 이 2줄을
+    saveWidgetPositionsDebounced();           // 완전 삭제
+  }
+  // ...독 스택 제거 로직 유지
+});
+
+// AFTER:
+popupWin.on('closed', () => {
+  widgetWindows.delete(widgetId);
+  widgetOriginalBounds.delete(widgetId);
+  // 캐시는 항상 유지 → 다음 실행 시 자동 복원
+  // 독 스택 제거 로직 유지
+});
+```
+
+**`window-all-closed` 동작 변경**
+
+```typescript
+app.on('window-all-closed', () => {
+  // 트레이가 있으면 백그라운드 유지. 종료는 오직 트레이 '종료' 메뉴로만.
+  if (!isQuitting) return;
+  app.quit();
+});
+```
+
+**`before-quit` 보강 — 작업관리자 강제종료 대비**
+
+```typescript
+// 기존 before-quit 핸들러는 그대로 유지. 추가 안전망:
+process.on('exit', () => {
+  // 동기 저장만 가능. debounce 제거 후 sync 저장.
+  try { saveWidgetPositionsSync(); } catch {}
+});
+```
+
+**최초 트레이 최소화 안내 (`%APPDATA%/preferences.json` 기록)**
+
+```typescript
+async function showTrayHintOnce(): Promise<void> {
+  const prefs = await loadPreferences();
+  if (prefs?.trayFirstMinimizeSeen) return;
+  new Notification({
+    title: 'B flow',
+    body: '트레이로 숨겨졌습니다. 트레이 아이콘 우클릭 → 종료로 완전히 닫을 수 있습니다.',
+  }).show();
+  await savePreferences({ ...prefs, trayFirstMinimizeSeen: true });
+}
+```
+
+### 구성요소 책임
+
+| 구성요소 | 책임 |
+|---|---|
+| `createTray()` | 트레이 아이콘·툴팁·이벤트 바인딩. 앱 시작 시 1회 호출 |
+| `rebuildTrayMenu()` | 위젯 상태/Supabase 상태 변화 시 재호출되어 메뉴·툴팁 최신화 |
+| `toggleWidget(id, title)` | 트레이에서 위젯 on/off. 내부적으로 `openWidgetPopup` 또는 `widgetWindows.get(id).close()` |
+| `getSupabaseStatusLabel()` | 현재 realtime 상태를 사람이 읽을 수 있는 문자열로 |
+| 기존 `loadWidgetPositions()` | 변경 없음. 이미 앱 시작 시 호출됨 (main.ts:1578) |
+| 기존 자동 복원 루프 (main.ts:1631) | 변경 없음. `widgetPositionCache` 내용대로 `openWidgetPopup` 호출 |
+
+### 데이터 플로우
+
+```
+[사용자 창 X 클릭]
+  → mainWindow.close()
+  → close 핸들러: isQuitting=false → preventDefault + hide()
+  → 위젯들은 그대로 유지
+
+[사용자 개별 위젯 X 클릭]
+  → popupWin closed 이벤트
+  → widgetWindows에서만 제거, widgetPositionCache는 유지
+  → saveWidgetPositionsDebounced() 호출 안 함 (변경 없으니)
+
+[사용자 트레이 '종료' 클릭]
+  → isQuitting=true; app.quit()
+  → before-quit 핸들러: saveWidgetPositionsSync() + Supabase 정리
+  → 모든 창 닫힘 허용
+  → 종료
+
+[다음 앱 실행]
+  → loadWidgetPositions() → widgetPositionCache 복원
+  → createWindow() + createTray()
+  → did-finish-load → 저장된 모든 widgetId에 대해 openWidgetPopup 호출
+  → 위젯 재등장 (마지막 위치·크기·AOT·투명도 그대로)
+```
+
+### 위험 요소 / 완화
+
+| 위험 | 완화 |
+|---|---|
+| 트레이 아이콘 16x16 변환 시 스플래시 이미지 가독성 저하 | 아이콘이 흐릿하면 Phase 후속에서 전용 `.ico` 파일로 교체 (이번 스코프 밖) |
+| macOS는 `window-all-closed` 동작 관례가 다름 | 현재 Windows 전용 빌드(`win.target: portable`)이므로 고려 불필요 |
+| 작업관리자 강제종료 시 `process.on('exit')`도 못 타는 경우 | `saveWidgetPositionsDebounced`가 500ms마다 저장하므로 마지막 저장분 보존 |
+
+---
+
+## 섹션 2: 빌드 앱 로딩 속도 — 안전 정책
+
+### 목표
+
+- 사용자 체감 로딩(더블클릭 → 첫 화면 등장) 시간을 대폭 단축.
+- `asar`, `googleapis` 구조는 건드리지 않음 (최근 수정으로 해결한 docs 모듈 누락 버그 재발 방지).
+
+### 두 축의 개선
+
+#### A. 체감 속도: 스플래시 2단계 부팅
+
+현재 흐름:
+```
+더블클릭 → Electron 초기화 → createWindow (숨김)
+  → loadFile(index.html) → Vite 번들 파싱 → React 마운트
+  → 내부 SplashScreen 컴포넌트 렌더 → 사용자가 드디어 뭔가 봄
+```
+
+개선 흐름:
+```
+더블클릭 → Electron 초기화 → createSplashWindow() (즉시 show)
+                                 ↓ (사용자는 이 시점에 스플래시 봄)
+                              백그라운드: createWindow (숨김 상태)
+                                 → loadFile(index.html) → React 준비 완료
+                                 → did-finish-load 이벤트
+                                 → splashWin.close() + mainWindow.show()
+```
+
+**구현 포인트**:
+
+- 새 파일 `public/splash.html` — 인라인 CSS, 외부 의존성 0. `opening_image_cropped.png`를 중앙 고정 표시.
+- `electron/main.ts`에 `createSplashWindow()` 신설: `width:300, height:300, frame:false, transparent:true, alwaysOnTop:true, resizable:false, skipTaskbar:true, show:true`.
+- `app.whenReady()`에서 **트레이 생성 직후, createWindow 직전**에 스플래시 생성.
+- `mainWindow = new BrowserWindow({ show: false, ... })` — 기존엔 기본 show:true였음.
+- `mainWindow.webContents.once('did-finish-load', () => { splashWin?.close(); mainWindow.show(); })`.
+
+#### B. 실제 속도: 렌더러 초기 번들 축소 + 초기화 지연
+
+**B-1. Vite 번들 분할 (`vite.config.ts`)**
+
+```typescript
+build: {
+  rollupOptions: {
+    output: {
+      manualChunks: {
+        'vendor-react': ['react', 'react-dom'],
+        'vendor-supabase': ['@supabase/supabase-js'],
+        'vendor-charts': ['react-grid-layout', 'framer-motion'],
+        'vendor-ui': ['lucide-react', 'sonner', 'clsx'],
+      },
+    },
+  },
+},
+```
+
+- 초기 HTML 파싱 시 메인 체인 번들이 작아져 첫 페인트 시간 단축.
+- 브라우저 캐시 효율↑ (vendor 번들은 앱 업데이트 후에도 동일 해시).
+
+**B-2. `React.lazy()` 적용 — 라우트/모달 단위 지연 로딩**
+
+지연 로딩 대상:
+- **뷰(라우트) 레벨**: `src/App.tsx`에서 `Dashboard`, `ScheduleView`, `EpisodeView`, `WidgetPopup`을 `React.lazy()`로 감쌈. 초기 렌더 시 현재 활성 뷰 하나만 로드.
+- **무거운 모달**: `SceneDetailModal`, `WhiteboardModal`, `UserManagerModal`, `ImageModal` — 모달이 실제로 열릴 때 번들 로드.
+- **설정 패널**: 설정 창을 처음 열 때만 각 Section 로드 (`ThemeSection`, `SheetsSection`, `NotificationSection`, `StartupSection`, `ShortcutsSection`, `EffectsSection` 등).
+
+각 `lazy` 컴포넌트는 `<Suspense fallback={기존 로딩 스피너}>`로 래핑.
+
+**B-3. 메인 프로세스 초기화 지연**
+
+`electron/main.ts`의 `app.whenReady()` 콜백 재정렬:
+
+```typescript
+app.whenReady().then(() => {
+  createSplashWindow();      // 1. 즉시 스플래시 (사용자 인지)
+  createTray();              // 2. 트레이 (경량)
+  createWindow();            // 3. 메인 창 (숨김 상태로 로드 시작)
+
+  // 4. 무거운 초기화는 메인 창 로드 완료 후로
+  mainWindow.webContents.once('did-finish-load', () => {
+    splashWin?.close();
+    mainWindow?.show();
+    gcal.restoreTokens();        // 기존엔 여기보다 위에 있었음
+    startSupabaseRealtime();     // 기존엔 여기보다 위에 있었음
+    // 기존 자동 위젯 복원 로직 그대로
+  });
+});
+```
+
+**B-4. Chromium 커맨드라인 스위치 (안전 범위)**
+
+```typescript
+app.commandLine.appendSwitch('js-flags', '--nolazy');
+app.commandLine.appendSwitch('enable-gpu-rasterization');
+app.commandLine.appendSwitch('disable-renderer-backgrounding');
+```
+
+### 기대 효과
+
+- **체감**: 더블클릭 → 수백ms 내 스플래시 표시 → 사용자가 "응답 중"임을 인지.
+- **실제**: 초기 JS 번들 크기 30~50% 축소 (vendor 분리 + lazy), React 트리 마운트 시간 단축, 첫 렌더 가능 시점(FMP) 당겨짐.
+
+### 미채택 (의도적 제외)
+
+| 항목 | 제외 이유 |
+|---|---|
+| `asar: true` 재활성화 | googleapis docs 모듈 누락 버그 회귀 위험 |
+| `googleapis` → `@googleapis/drive` + `@googleapis/calendar` 분할 | 큰 리팩터링, 회귀 위험 |
+| V8 snapshot 파일 생성 | 빌드 파이프라인 복잡도 증가 |
+| Electron 업그레이드 | 스코프 밖 |
+
+---
+
+## 섹션 3: 커스텀 테마 — accent hue 기반 HSL 파생
+
+### 목표
+
+- 커스텀 테마 슬롯(1개, 덮어쓰기)을 **완전한 새 프리셋**으로 만든다.
+- 사용자는 accent/accentSub 두 색만 고름. 나머지 5색(`bgPrimary`, `bgCard`, `bgBorder`, `textPrimary`, `textSecondary`)은 자동 파생.
+- 결과가 공산당 레드·이혜민 머쉬룸 수준의 일관된 톤을 낼 것.
+
+### 알고리즘 (기존 프리셋 역설계)
+
+**다크 모드** (L 계단: 5 / 9 / 16 / 59 / 92):
+```
+bgPrimary     = hsl(accentHue, S=20%, L=5%)
+bgCard        = hsl(accentHue, S=22%, L=9%)
+bgBorder      = hsl(accentHue, S=20%, L=16%)
+textPrimary   = hsl(accentHue, S=15%, L=92%)
+textSecondary = hsl(accentHue, S=15%, L=59%)
+```
+
+**라이트 모드**:
+```
+bgPrimary     = hsl(accentHue, S=15%, L=88%)
+bgCard        = hsl(accentHue, S=10%, L=99%)
+bgBorder      = hsl(accentHue, S=25%, L=70%)
+textPrimary   = hsl(accentHue, S=30%, L=12%)
+textSecondary = hsl(accentHue, S=25%, L=28%)
+```
+
+**검증 (예상 유사도)**: 공산당 레드 프리셋의 accent(#E11D48)를 커스텀에 넣었을 때 생성되는 배경 5색과 실제 프리셋 5색의 HSL 거리 평균 ±5% 이내로 수렴하면 합격.
+
+### 구현
+
+**`src/themes.ts` 확장**
+
+```typescript
+// 신규 유틸
+function rgbToHsl(triplet: string): { h: number; s: number; l: number }
+function hslToRgb(h: number, s: number, l: number): string  // "r g b"
+
+// 신규 함수
+export function deriveThemeFromAccent(
+  accentHex: string,
+  accentSubHex: string,
+  mode: 'dark' | 'light'
+): ThemeColors {
+  const { h } = rgbToHsl(hexToRgb(accentHex));
+  const darkMode = mode === 'dark';
+  return {
+    bgPrimary:     darkMode ? hslToRgb(h, 20, 5)  : hslToRgb(h, 15, 88),
+    bgCard:        darkMode ? hslToRgb(h, 22, 9)  : hslToRgb(h, 10, 99),
+    bgBorder:      darkMode ? hslToRgb(h, 20, 16) : hslToRgb(h, 25, 70),
+    textPrimary:   darkMode ? hslToRgb(h, 15, 92) : hslToRgb(h, 30, 12),
+    textSecondary: darkMode ? hslToRgb(h, 15, 59) : hslToRgb(h, 25, 28),
+    accent:        hexToRgb(accentHex),
+    accentSub:     hexToRgb(accentSubHex),
+  };
+}
+```
+
+**`src/components/settings/ThemeSection.tsx` — `handleCustomApply` 교체**
+
+```typescript
+// BEFORE:
+const handleCustomApply = () => {
+  const base = getPreset(themeId === 'custom' ? 'violet' : themeId)?.colors
+    ?? THEME_PRESETS[0].colors;
+  const colors: ThemeColors = {
+    ...base,
+    accent: hexToRgb(customAccent),
+    accentSub: hexToRgb(customSub),
+  };
+  setThemeId('custom');
+  setCustomThemeColors(colors);
+  setEditingCustom(false);
+};
+
+// AFTER:
+const handleCustomApply = () => {
+  const colors = deriveThemeFromAccent(customAccent, customSub, colorMode);
+  setThemeId('custom');
+  setCustomThemeColors(colors);
+  setCustomAccentHex(customAccent);       // 신규 저장 필드
+  setCustomSubHex(customSub);             // 신규 저장 필드
+  setEditingCustom(false);
+};
+```
+
+**`src/stores/useAppStore.ts` 확장**
+
+- 신규 상태: `customAccentHex: string | null`, `customSubHex: string | null`.
+- 신규 액션: `setCustomAccentHex`, `setCustomSubHex`.
+- `setColorMode(mode)` 내부에서 `themeId === 'custom'` && 두 hex 모두 있으면 `deriveThemeFromAccent(accentHex, subHex, mode)` 재호출 → `customThemeColors` 업데이트 + `applyTheme()` 재실행.
+- 저장 포맷: 기존 `customThemeColors`는 유지 (하위 호환). 신규 필드는 `preferences.json`에 추가. 기존 저장분이 두 hex 없으면 `customThemeColors.accent/accentSub`에서 역산.
+
+**커스텀 편집 패널 미리보기 (`ThemeSection.tsx`)**
+
+- 현재 프리뷰: `linear-gradient(135deg, ${customAccent}, ${customSub})` 한 줄.
+- 추가: accent 입력 변경 시 실시간으로 `deriveThemeFromAccent()` 호출 → **파생된 bgPrimary/bgCard/bgBorder 3색 박스**를 오른쪽에 나란히 표시. 사용자가 '적용' 전에 배경까지 확인 가능.
+
+**프리셋 그리드의 '커스텀' 타일**
+
+- `themeId === 'custom'`이고 `customThemeColors`가 있으면, 다른 프리셋과 동일한 그라디언트 프리뷰 표시: `linear-gradient(135deg, bgCard 0%, accent 50%, accentSub 100%)`.
+- 비어 있으면 현재의 플레이스홀더 아이콘 유지.
+
+### 구성요소 책임
+
+| 구성요소 | 책임 |
+|---|---|
+| `rgbToHsl`, `hslToRgb` | RGB triplet ↔ HSL 정확한 수학 변환 (표준 공식) |
+| `deriveThemeFromAccent` | accent/sub 두 hex + mode에서 ThemeColors 전체 생성. 순수 함수 |
+| `handleCustomApply` | UI에서 받은 두 hex를 저장 + 파생 + store 반영 |
+| `setColorMode` (수정) | 커스텀 테마일 때 mode 전환 시 재파생 |
+
+### 위험 요소 / 완화
+
+| 위험 | 완화 |
+|---|---|
+| 특정 hue(예: 순수 노랑)에서 텍스트 대비 WCAG AA 미달 | L=92% 와 L=5%는 17:1 이상 콘트라스트 → 수학적으로 AA 보장. S가 변해도 L이 지배적 |
+| 사용자가 채도 0(회색)을 accent로 고르면 파생된 배경도 완전 무채색 | 의도된 동작. 모노톤 테마는 유효한 선택 |
+| 기존 저장된 `customThemeColors`(두 hex 없음) 로드 시 colorMode 전환이 일회성으로 어색할 수 있음 | `customThemeColors.accent` triplet에서 hex 역산해 `customAccentHex`에 저장 후 정상화 |
+
+---
+
+## 검증 체크리스트
+
+### 섹션 1 (트레이 + 위젯)
+- [ ] 앱 시작 시 Windows 시스템 트레이에 B flow 아이콘이 나타난다.
+- [ ] 트레이 아이콘 좌·더블클릭 시 메인 창이 열린다 (숨겨져 있으면 복원).
+- [ ] 우클릭 메뉴에 '열기 / 위젯 서브메뉴 / 상태 / 종료'가 보인다.
+- [ ] 메인 창 X 버튼 → 창만 숨고 앱은 살아있다 (트레이 아이콘 유지, 위젯 유지).
+- [ ] 최초 1회 "트레이로 숨김" Notification이 뜬다. 두 번째부터는 안 뜬다.
+- [ ] 트레이 '종료' 클릭 → 앱이 완전히 종료된다 (트레이 아이콘 사라짐).
+- [ ] 위젯을 개별 X로 닫고 앱 재시작 → 그 위젯이 마지막 위치/크기/AOT/투명도로 자동 복원된다.
+- [ ] 트레이로 완전 종료 후 재시작 → 열려있던 모든 위젯이 복원된다.
+- [ ] Supabase 연결 상태 변화가 트레이 툴팁·메뉴에 반영된다.
+
+### 섹션 2 (로딩 속도)
+- [ ] 더블클릭 후 1초 이내에 스플래시 이미지가 화면에 나타난다 (로컬 SSD 기준).
+- [ ] 스플래시 → 메인 창 전환이 부드럽다 (깜빡임 없음).
+- [ ] `vite build` 결과 `dist/assets/`에 `vendor-react`, `vendor-supabase`, `vendor-charts`, `vendor-ui` 번들이 분리되어 있다.
+- [ ] 초기 화면이 Dashboard일 때 Schedule/Episode 뷰 번들은 로드되지 않는다 (DevTools Network).
+- [ ] Scene 상세 모달 열기 전까진 `SceneDetailModal.tsx` 번들이 요청되지 않는다.
+- [ ] 빌드 크기가 이전 대비 감소하지 않아도 무방 (파일 분할만 해도 병렬 로드 이득).
+
+### 섹션 3 (커스텀 테마)
+- [ ] 커스텀 편집 패널에서 accent·sub 색상 지정 시 배경 3색 프리뷰가 실시간으로 갱신된다.
+- [ ] '적용' 클릭 후 앱 전체(사이드바·카드·보더·텍스트)가 하나의 톤으로 자동 변경된다.
+- [ ] 공산당 레드 accent(#E11D48, #FB7185)를 커스텀에 넣은 결과가 공산당 레드 프리셋과 시각적으로 유사하다.
+- [ ] 이혜민 머쉬룸 accent(#814D41, #E0CBAF) 동일 테스트 통과.
+- [ ] 다크 ↔ 라이트 토글 시 커스텀 테마 배경도 자동으로 재생성된다.
+- [ ] 프리셋 그리드의 '커스텀' 타일이 다른 프리셋과 동일한 그라디언트 프리뷰로 표시된다.
+- [ ] 앱 재시작 후 커스텀 테마가 그대로 복원된다 (hex 저장 포맷 포함).
+
+### 회귀 방지
+- [ ] `tsc --noEmit` 통과.
+- [ ] `vite build` 통과.
+- [ ] `electron-builder`로 portable 빌드 → 실행 → 위 시나리오 수동 검증.
+- [ ] 기존 기능(화이트보드, 씬 시트뷰, 캘린더, 휴가, 슬랙 웹훅) 동작 회귀 없음.
+
+---
+
+## 비-목표 (Not in Scope)
+
+- 트레이 아이콘용 전용 `.ico` 파일 제작 (스플래시 PNG 재활용으로 충분)
+- macOS 트레이 동작 (Windows portable 빌드만 배포)
+- 여러 개 커스텀 테마 슬롯 / 테마 이름 지정 / 테마 공유
+- asar 재활성화, googleapis 의존성 재구조화
+- Electron·React 버전 업그레이드
+- 커스텀 테마에서 배경/보더/텍스트 직접 지정 (고급 모드)
+- 트레이에서의 알림 배지(미읽음 수 등)
+
+---
+
+## 파일 변경 요약
+
+| 파일 | 변경 |
+|---|---|
+| `electron/main.ts` | 트레이 생성/메뉴/이벤트, mainWindow close 차단, 위젯 캐시 삭제 로직 제거, window-all-closed 수정, process exit 안전망, app.whenReady 재정렬, 커맨드라인 스위치 추가 |
+| `electron/preload.ts` | 변경 없음 (기존 IPC로 충분) |
+| `public/splash.html` | 신규 — 스플래시 2단계 부팅용 |
+| `vite.config.ts` | manualChunks 설정 |
+| `src/App.tsx` | 뷰/모달 lazy 로딩 래핑 |
+| `src/themes.ts` | `rgbToHsl`, `hslToRgb`, `deriveThemeFromAccent` 추가 |
+| `src/stores/useAppStore.ts` | `customAccentHex`/`customSubHex` 상태, `setColorMode` 재파생 로직 |
+| `src/components/settings/ThemeSection.tsx` | `handleCustomApply` 교체, 실시간 배경 프리뷰 추가 |
+| `src/services/settingsService.ts` | preferences.json에 `trayFirstMinimizeSeen`, `customAccentHex`, `customSubHex` 필드 추가 |
+
+---
+
+*디자인 문서 끝*

--- a/docs/superpowers/specs/2026-04-18-pre-release-polish-design.md
+++ b/docs/superpowers/specs/2026-04-18-pre-release-polish-design.md
@@ -22,7 +22,7 @@
 | 항목 | 결정 |
 |---|---|
 | 창 X 버튼 | 트레이로 최소화 (메인 창만 숨김, 위젯은 유지) |
-| 트레이 '종료' | 유일한 실제 종료 경로 (`isQuitting = true` 후 `app.quit()`) |
+| 트레이 '종료' | **유일한 GUI 종료 경로** (`isQuitting = true` 후 `app.quit()`). 개발 모드의 `Ctrl+C`·작업관리자 강제 종료·트레이 생성 실패 시 fallback은 예외로 허용 |
 | 트레이 메뉴 | 좌·더블클릭 = 창 열기 / 우클릭 = 열기·위젯 서브메뉴·현재 상태 표시·종료 |
 | 트레이 툴팁 | `'B flow • <상태>'` 실시간 갱신 (Supabase 상태 연동) |
 | 트레이 아이콘 에셋 | `public/splash/opening_image_cropped.png` 재활용 |
@@ -47,16 +47,61 @@
 
 ```typescript
 let tray: Tray | null = null;
+let lastSupabaseStatus: string = '연결 중...';
+
+/** 아이콘 경로 해석: dev(electron/)와 prod(dist-electron/) 모두 커버 */
+function resolveTrayIconPath(): string {
+  // dev: __dirname = <repo>/electron → ../public
+  // prod: __dirname = resources/app/dist-electron → ../public (files 목록에 public/** 포함 필요)
+  // 추가 폴백: app.getAppPath() 기준 경로
+  const candidates = [
+    path.join(__dirname, '../public/splash/opening_image_cropped.png'),
+    path.join(app.getAppPath(), 'public/splash/opening_image_cropped.png'),
+  ];
+  for (const p of candidates) {
+    if (fs.existsSync(p)) return p;
+  }
+  return ''; // 호출부에서 빈 경로 처리
+}
+
+/** 1x1 투명 PNG (base64) — 아이콘 로드 실패 시 최후 폴백 */
+const EMPTY_ICON_B64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
 
 function createTray(): void {
-  const iconPath = path.join(__dirname, '../public/splash/opening_image_cropped.png');
-  const image = nativeImage.createFromPath(iconPath).resize({ width: 16, height: 16 });
-  tray = new Tray(image);
-  tray.setToolTip('B flow');
-  tray.on('click', showMainWindow);
-  tray.on('double-click', showMainWindow);
-  rebuildTrayMenu(); // 최초 메뉴 빌드
+  try {
+    const iconPath = resolveTrayIconPath();
+    let image = iconPath ? nativeImage.createFromPath(iconPath) : nativeImage.createEmpty();
+    if (image.isEmpty()) {
+      image = nativeImage.createFromBuffer(Buffer.from(EMPTY_ICON_B64, 'base64'));
+    }
+    image = image.resize({ width: 16, height: 16 });
+    tray = new Tray(image);
+    tray.setToolTip('B flow');
+    tray.on('click', showMainWindow);
+    tray.on('double-click', showMainWindow);
+    rebuildTrayMenu();
+  } catch (err) {
+    console.error('[트레이] 생성 실패 — 트레이 없이 실행 (창 X = 실제 종료):', err);
+    tray = null;
+    // 트레이 실패 시 창 X를 실제 종료로 폴백 (사용자가 앱을 끌 수 있도록)
+    trayFailed = true;
+  }
 }
+
+// 전역에 추가
+let trayFailed = false;
+```
+
+**`package.json`의 `files` 목록 확인**: `public/**`가 포함되어 있어야 함. 현재 목록에는 없음 → **신규 추가 필요**:
+```json
+"files": [
+  "dist/**/*",
+  "dist-electron/**/*",
+  "public/splash/**",          // 신규 추가
+  "node_modules/**/*",
+  "package.json"
+]
+```
 
 function rebuildTrayMenu(): void {
   if (!tray) return;
@@ -68,7 +113,7 @@ function rebuildTrayMenu(): void {
       click: () => toggleWidget(id, title),
     }),
   );
-  const status = getSupabaseStatusLabel(); // 예: "실시간 연결됨" / "재연결 중..."
+  const status = lastSupabaseStatus; // 아래 '상태 갱신 다리' 참고
   const menu = Menu.buildFromTemplate([
     { label: '열기', click: showMainWindow },
     { type: 'separator' },
@@ -83,18 +128,36 @@ function rebuildTrayMenu(): void {
 }
 ```
 
+**상태 갱신 다리 (Supabase realtime → 트레이)**
+
+기존 main.ts:667-670에 Supabase 상태를 렌더러로 보내는 콜백이 이미 있음 (`mainWindow.webContents.send('supabase:status', status)`). 이 콜백 내부에서 **동시에** `lastSupabaseStatus`를 갱신하고 `rebuildTrayMenu()` 호출:
+
+```typescript
+// 기존 콜백 수정
+(status: string) => {
+  lastSupabaseStatus = humanizeStatus(status); // 'SUBSCRIBED' → '실시간 연결됨' 등
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send('supabase:status', status);
+  }
+  rebuildTrayMenu(); // 트레이 메뉴/툴팁 갱신
+}
+```
+
+위젯 open/close 시점에도 `rebuildTrayMenu()` 호출 (위젯 서브메뉴 체크박스 갱신).
+```
+
 **메인 창 닫기 차단 (`createWindow` 내부에 추가)**
 
 ```typescript
 mainWindow.on('close', (e) => {
-  if (!isQuitting) {
+  if (!isQuitting && !trayFailed) {
     e.preventDefault();
     mainWindow?.hide();
     // 위젯은 건드리지 않음 (요구사항 반영)
     showTrayHintOnce(); // 최초 1회만 안내 Notification
     return;
   }
-  // isQuitting === true인 경우 기본 동작(닫힘) 허용
+  // isQuitting === true이거나 트레이 실패 상태면 기본 동작(닫힘) 허용
 });
 ```
 
@@ -143,15 +206,39 @@ process.on('exit', () => {
 
 **최초 트레이 최소화 안내 (`%APPDATA%/preferences.json` 기록)**
 
+OS가 Notification을 차단(Windows Focus Assist 등)한 경우를 고려해 다단 폴백:
+
 ```typescript
 async function showTrayHintOnce(): Promise<void> {
   const prefs = await loadPreferences();
   if (prefs?.trayFirstMinimizeSeen) return;
-  new Notification({
-    title: 'B flow',
-    body: '트레이로 숨겨졌습니다. 트레이 아이콘 우클릭 → 종료로 완전히 닫을 수 있습니다.',
-  }).show();
-  await savePreferences({ ...prefs, trayFirstMinimizeSeen: true });
+
+  let shown = false;
+  if (Notification.isSupported()) {
+    try {
+      new Notification({
+        title: 'B flow',
+        body: '트레이로 숨겨졌습니다. 트레이 아이콘 우클릭 → 종료로 완전히 닫을 수 있습니다.',
+      }).show();
+      shown = true;
+    } catch {/* ignore */}
+  }
+
+  // Windows 폴백: 트레이 balloon (전부 실패하면 그냥 조용히 진행)
+  if (!shown && tray && process.platform === 'win32') {
+    try {
+      tray.displayBalloon({
+        title: 'B flow',
+        content: '트레이에 숨겨졌습니다. 트레이 메뉴 종료로 완전히 닫을 수 있습니다.',
+      });
+      shown = true;
+    } catch {/* ignore */}
+  }
+
+  // 실제로 안내를 보여줬을 때만 "봤음"으로 기록 (차단 환경 사용자 보호)
+  if (shown) {
+    await savePreferences({ ...prefs, trayFirstMinimizeSeen: true });
+  }
 }
 ```
 
@@ -233,10 +320,41 @@ async function showTrayHintOnce(): Promise<void> {
 **구현 포인트**:
 
 - 새 파일 `public/splash.html` — 인라인 CSS, 외부 의존성 0. `opening_image_cropped.png`를 중앙 고정 표시.
-- `electron/main.ts`에 `createSplashWindow()` 신설: `width:300, height:300, frame:false, transparent:true, alwaysOnTop:true, resizable:false, skipTaskbar:true, show:true`.
+- `electron/main.ts`에 `createSplashWindow()` 신설: `width:300, height:300, frame:false, transparent:true, alwaysOnTop:true, resizable:false, skipTaskbar:true, show:true, closable:false`. (`closable:false`로 사용자가 스플래시를 닫을 수 없게 해 좀비 상태 방지)
 - `app.whenReady()`에서 **트레이 생성 직후, createWindow 직전**에 스플래시 생성.
 - `mainWindow = new BrowserWindow({ show: false, ... })` — 기존엔 기본 show:true였음.
-- `mainWindow.webContents.once('did-finish-load', () => { splashWin?.close(); mainWindow.show(); })`.
+- `mainWindow.webContents.once('did-finish-load', () => { closeSplash(); mainWindow.show(); })`.
+- `closeSplash()`는 `splashWin.destroy()` 래퍼 (`closable:false`인 창은 `close()`가 거부되므로 `destroy()` 사용).
+
+**메인 로드 타임아웃 (좀비 방지)**
+
+메인 창이 30초 내 `did-finish-load`를 내지 못하면 에러 창 띄우고 종료:
+
+```typescript
+const MAIN_LOAD_TIMEOUT_MS = 30_000;
+let mainLoadedOk = false;
+
+const timer = setTimeout(() => {
+  if (mainLoadedOk) return;
+  console.error('[메인 로드] 타임아웃 — 강제 종료');
+  closeSplash();
+  dialog.showErrorBox('B flow', '앱 로드에 실패했습니다. 다시 실행해주세요.');
+  isQuitting = true;
+  app.quit();
+}, MAIN_LOAD_TIMEOUT_MS);
+
+mainWindow.webContents.once('did-finish-load', () => {
+  mainLoadedOk = true;
+  clearTimeout(timer);
+  closeSplash();
+  mainWindow.show();
+  console.timeEnd('splash-to-main'); // 측정용 로그
+});
+
+console.time('splash-to-main'); // createSplashWindow 직후 시작
+```
+
+**측정 방법**: `console.time`/`console.timeEnd`로 스플래시 표시 시점부터 메인 show까지의 ms를 로그에 남김. 배포 portable exe에서도 `--enable-logging` 플래그로 확인 가능. 검증 체크리스트의 "1초 이내"는 이 로그 기준으로 판정.
 
 #### B. 실제 속도: 렌더러 초기 번들 축소 + 초기화 지연
 
@@ -249,13 +367,16 @@ build: {
       manualChunks: {
         'vendor-react': ['react', 'react-dom'],
         'vendor-supabase': ['@supabase/supabase-js'],
-        'vendor-charts': ['react-grid-layout', 'framer-motion'],
+        'vendor-grid': ['react-grid-layout'],
+        'vendor-motion': ['framer-motion'],
         'vendor-ui': ['lucide-react', 'sonner', 'clsx'],
       },
     },
   },
 },
 ```
+
+(공통 vendor를 성격별로 분리. `react-grid-layout`과 `framer-motion`은 서로 무관한 동적 로드 타이밍을 가지므로 분리가 캐시 효율에 유리)
 
 - 초기 HTML 파싱 시 메인 체인 번들이 작아져 첫 페인트 시간 단축.
 - 브라우저 캐시 효율↑ (vendor 번들은 앱 업데이트 후에도 동일 해시).
@@ -406,7 +527,39 @@ const handleCustomApply = () => {
 - 신규 상태: `customAccentHex: string | null`, `customSubHex: string | null`.
 - 신규 액션: `setCustomAccentHex`, `setCustomSubHex`.
 - `setColorMode(mode)` 내부에서 `themeId === 'custom'` && 두 hex 모두 있으면 `deriveThemeFromAccent(accentHex, subHex, mode)` 재호출 → `customThemeColors` 업데이트 + `applyTheme()` 재실행.
-- 저장 포맷: 기존 `customThemeColors`는 유지 (하위 호환). 신규 필드는 `preferences.json`에 추가. 기존 저장분이 두 hex 없으면 `customThemeColors.accent/accentSub`에서 역산.
+
+**마이그레이션 로직 (앱 시작 시 1회, store 초기화 단계)**
+
+```typescript
+const HEX_RE = /^#[0-9a-fA-F]{6}$/;
+
+function sanitizeCustomHex(
+  saved: Partial<{ customAccentHex: string; customSubHex: string; customThemeColors: ThemeColors }>
+): { accent: string; sub: string } | null {
+  const savedAccent = saved.customAccentHex;
+  const savedSub = saved.customSubHex;
+  // 1순위: 새 포맷 — 유효성 검증
+  if (savedAccent && HEX_RE.test(savedAccent) && savedSub && HEX_RE.test(savedSub)) {
+    return { accent: savedAccent, sub: savedSub };
+  }
+  // 2순위: 구포맷 customThemeColors.accent/accentSub에서 역산
+  if (saved.customThemeColors?.accent && saved.customThemeColors?.accentSub) {
+    try {
+      return {
+        accent: rgbToHex(saved.customThemeColors.accent),
+        sub: rgbToHex(saved.customThemeColors.accentSub),
+      };
+    } catch { /* triplet 파싱 실패 */ }
+  }
+  // 둘 다 실패 → null 반환. 호출부는 커스텀 테마를 비활성화하고 기본 프리셋으로 폴백.
+  return null;
+}
+```
+
+- 마이그레이션 타이밍: `useAppStore` 초기값 계산 단계 (앱 최초 마운트 시 1회). `preferences.json` 로드 직후.
+- 역산 성공 시: `customAccentHex`/`customSubHex`를 즉시 `savePreferences`로 기록해 다음 실행부터 새 포맷 사용.
+- 역산 실패 시: `themeId` = `DEFAULT_THEME_ID`, `customThemeColors` = `null`, 사용자에게는 침묵 (토스트 없음 — 로그만).
+- 저장 포맷: 기존 `customThemeColors`는 유지 (하위 호환). 신규 필드(`customAccentHex`/`customSubHex`)는 `preferences.json`에 추가.
 
 **커스텀 편집 패널 미리보기 (`ThemeSection.tsx`)**
 
@@ -445,14 +598,18 @@ const handleCustomApply = () => {
 - [ ] 우클릭 메뉴에 '열기 / 위젯 서브메뉴 / 상태 / 종료'가 보인다.
 - [ ] 메인 창 X 버튼 → 창만 숨고 앱은 살아있다 (트레이 아이콘 유지, 위젯 유지).
 - [ ] 최초 1회 "트레이로 숨김" Notification이 뜬다. 두 번째부터는 안 뜬다.
+- [ ] Focus Assist 등으로 Notification이 차단된 상태에서는 `trayFirstMinimizeSeen`이 `true`로 저장되지 않아 다음 실행 때 다시 안내 시도한다.
 - [ ] 트레이 '종료' 클릭 → 앱이 완전히 종료된다 (트레이 아이콘 사라짐).
+- [ ] **트레이 생성이 실패하는 시나리오** (아이콘 파일 없음 + 에셋 없음) → `trayFailed=true`로 폴백되어 창 X가 실제 종료로 동작 (앱이 좀비로 남지 않음).
 - [ ] 위젯을 개별 X로 닫고 앱 재시작 → 그 위젯이 마지막 위치/크기/AOT/투명도로 자동 복원된다.
 - [ ] 트레이로 완전 종료 후 재시작 → 열려있던 모든 위젯이 복원된다.
-- [ ] Supabase 연결 상태 변화가 트레이 툴팁·메뉴에 반영된다.
+- [ ] Supabase 연결 상태 변화가 트레이 툴팁·메뉴에 반영된다 (상태 콜백에서 `rebuildTrayMenu` 호출로 검증).
 
 ### 섹션 2 (로딩 속도)
-- [ ] 더블클릭 후 1초 이내에 스플래시 이미지가 화면에 나타난다 (로컬 SSD 기준).
+- [ ] 더블클릭 후 1초 이내에 스플래시 이미지가 화면에 나타난다 (로컬 SSD 기준, `--enable-logging` 플래그로 `console.time('splash-to-main')` 시작 시각과 `app.whenReady()` 시각 차이를 측정하여 < 1000ms 확인).
+- [ ] `console.timeEnd('splash-to-main')` 로그가 스플래시 표시부터 메인 show까지의 시간을 찍는다.
 - [ ] 스플래시 → 메인 창 전환이 부드럽다 (깜빡임 없음).
+- [ ] 메인 창이 30초 안에 로드되지 않는 극단 시나리오에서 에러 다이얼로그가 뜨고 앱이 종료된다.
 - [ ] `vite build` 결과 `dist/assets/`에 `vendor-react`, `vendor-supabase`, `vendor-charts`, `vendor-ui` 번들이 분리되어 있다.
 - [ ] 초기 화면이 Dashboard일 때 Schedule/Episode 뷰 번들은 로드되지 않는다 (DevTools Network).
 - [ ] Scene 상세 모달 열기 전까진 `SceneDetailModal.tsx` 번들이 요청되지 않는다.
@@ -466,6 +623,8 @@ const handleCustomApply = () => {
 - [ ] 다크 ↔ 라이트 토글 시 커스텀 테마 배경도 자동으로 재생성된다.
 - [ ] 프리셋 그리드의 '커스텀' 타일이 다른 프리셋과 동일한 그라디언트 프리뷰로 표시된다.
 - [ ] 앱 재시작 후 커스텀 테마가 그대로 복원된다 (hex 저장 포맷 포함).
+- [ ] **구포맷 마이그레이션**: `customAccentHex`/`customSubHex`가 없고 `customThemeColors`만 있던 기존 사용자 데이터로 시작해도 정상 복원되며, 시작 후 새 포맷으로 `preferences.json`에 기록된다.
+- [ ] **손상된 hex 방어**: `customAccentHex`가 `"garbage"` 같은 잘못된 값이면 자동으로 기본 프리셋으로 폴백하고 로그만 남긴다 (사용자 토스트 없음, 앱 크래시 없음).
 
 ### 회귀 방지
 - [ ] `tsc --noEmit` 통과.
@@ -491,13 +650,14 @@ const handleCustomApply = () => {
 
 | 파일 | 변경 |
 |---|---|
-| `electron/main.ts` | 트레이 생성/메뉴/이벤트, mainWindow close 차단, 위젯 캐시 삭제 로직 제거, window-all-closed 수정, process exit 안전망, app.whenReady 재정렬, 커맨드라인 스위치 추가 |
+| `electron/main.ts` | 트레이 생성/메뉴/이벤트, Supabase 상태 콜백에서 `rebuildTrayMenu` 호출, mainWindow close 차단 + `trayFailed` 폴백, 위젯 캐시 삭제 로직 제거, window-all-closed 수정, process exit 안전망, app.whenReady 재정렬, 스플래시 윈도우 + 30초 타임아웃 + 측정 로그, 커맨드라인 스위치 추가 |
 | `electron/preload.ts` | 변경 없음 (기존 IPC로 충분) |
 | `public/splash.html` | 신규 — 스플래시 2단계 부팅용 |
-| `vite.config.ts` | manualChunks 설정 |
+| `package.json` | `build.files`에 `public/splash/**` 추가 |
+| `vite.config.ts` | manualChunks 설정 (성격별 vendor 분리) |
 | `src/App.tsx` | 뷰/모달 lazy 로딩 래핑 |
 | `src/themes.ts` | `rgbToHsl`, `hslToRgb`, `deriveThemeFromAccent` 추가 |
-| `src/stores/useAppStore.ts` | `customAccentHex`/`customSubHex` 상태, `setColorMode` 재파생 로직 |
+| `src/stores/useAppStore.ts` | `customAccentHex`/`customSubHex` 상태, `setColorMode` 재파생 로직, `sanitizeCustomHex` 마이그레이션 |
 | `src/components/settings/ThemeSection.tsx` | `handleCustomApply` 교체, 실시간 배경 프리뷰 추가 |
 | `src/services/settingsService.ts` | preferences.json에 `trayFirstMinimizeSeen`, `customAccentHex`, `customSubHex` 필드 추가 |
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -219,7 +219,12 @@ function createSplashWindow(): void {
 function closeSplash(): void {
   if (splashWin && !splashWin.isDestroyed()) {
     // closable:false 창은 close() 거부 → destroy() 사용
-    splashWin.destroy();
+    // destroy()가 Windows 특정 엣지 케이스에서 throw 가능 → try/catch로 방어
+    try {
+      splashWin.destroy();
+    } catch (err) {
+      console.error('[스플래시] destroy 실패 — 무시하고 진행:', err);
+    }
   }
   splashWin = null;
 }
@@ -1887,12 +1892,17 @@ app.whenReady().then(() => {
   startSupabaseRealtime();
 
   // 저장된 위젯 자동 복원 (Phase 0-6) + 보류 딥링크 전달
+  // .once: 렌더러 재로드(Ctrl+Shift+R, 크래시 복구) 시 재실행 방지 — 사용자가 닫은 위젯 재등장/딥링크 재실행 차단
   if (mainWindow) {
-    mainWindow.webContents.on('did-finish-load', () => {
+    mainWindow.webContents.once('did-finish-load', () => {
       if (widgetPositionCache.size > 0) {
         for (const [widgetId, state] of widgetPositionCache) {
-          const title = state.title || WIDGET_TITLE_MAP[widgetId] || widgetId;
-          openWidgetPopup(widgetId, title);
+          try {
+            const title = state.title || WIDGET_TITLE_MAP[widgetId] || widgetId;
+            openWidgetPopup(widgetId, title);
+          } catch (err) {
+            console.error(`[위젯 자동복원] ${widgetId} 실패:`, err);
+          }
         }
       }
       // 앱 시작 시 보류된 딥링크 전달
@@ -1948,15 +1958,13 @@ app.on('before-quit', (e) => {
   const sheetsPending = getPendingOpsCount();
   const vacPending = getVacPendingOpsCount();
   const totalPending = sheetsPending + vacPending;
-  if (totalPending > 0 || watchCleanup) {
+  if (totalPending > 0) {
     e.preventDefault();
 
-    if (totalPending > 0) {
-      console.log(`[종료] ${totalPending}개 작업 대기 중 (시트: ${sheetsPending}, 휴가: ${vacPending})... 완료 후 종료합니다.`);
-    }
+    console.log(`[종료] ${totalPending}개 작업 대기 중 (시트: ${sheetsPending}, 휴가: ${vacPending})... 완료 후 종료합니다.`);
 
     // 메인 윈도우에 "저장 중" 알림
-    if (totalPending > 0 && mainWindow && !mainWindow.isDestroyed()) {
+    if (mainWindow && !mainWindow.isDestroyed()) {
       mainWindow.webContents.send('app:saving-before-quit', totalPending);
     }
 
@@ -1964,8 +1972,8 @@ app.on('before-quit', (e) => {
     const watchWithTimeout = Promise.race([watchCleanup, new Promise<void>((r) => setTimeout(r, 5000))]);
     Promise.all([
       watchWithTimeout,
-      totalPending > 0 ? waitForAllPendingOps(15000) : Promise.resolve(true),
-      totalPending > 0 ? waitForVacPendingOps(60000) : Promise.resolve(true),
+      waitForAllPendingOps(15000),
+      waitForVacPendingOps(60000),
     ]).then(([, sheetsDone, vacDone]) => {
       if (!sheetsDone || !vacDone) {
         console.warn('[종료] 타임아웃 — 일부 작업이 완료되지 않았을 수 있습니다');
@@ -1973,6 +1981,9 @@ app.on('before-quit', (e) => {
       console.log('[종료] 저장 완료, 앱을 종료합니다');
       app.quit();
     });
+  } else {
+    // 대기 중 작업 없음: Watch 정리는 fire-and-forget (종료를 지연시키지 않음)
+    Promise.race([watchCleanup, new Promise<void>((r) => setTimeout(r, 2000))]).catch(() => {});
   }
 });
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1775,6 +1775,7 @@ app.whenReady().then(() => {
     return new Response('Drive image not found', { status: 404 });
   });
 
+  createTray();        // 먼저 트레이 준비 (실패해도 앱은 계속)
   createWindow();
 
   // Google Calendar 토큰 복원

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, clipboard, ipcMain, protocol, net, desktopCapturer, screen, shell, Notification, Tray, Menu, nativeImage } from 'electron';
+import { app, BrowserWindow, clipboard, ipcMain, protocol, net, desktopCapturer, screen, shell, Notification, Tray, Menu, nativeImage, dialog } from 'electron';
 import type { MenuItemConstructorOptions } from 'electron';
 import * as gcal from './googleCalendar';
 import { pathToFileURL } from 'url';
@@ -59,6 +59,7 @@ let lastSupabaseStatus = '연결 중...';
 let splashWin: BrowserWindow | null = null;
 // Chunk 2(스플래시 2단계 부팅)에서 사용 예정
 let mainLoadedOk = false;
+let loadTimeoutId: ReturnType<typeof setTimeout> | null = null;
 let showTrayHintInFlight = false;
 
 /** 아이콘 경로 해석: dev(electron/)와 prod(dist-electron/) + app.getAppPath() 순회 */
@@ -1848,8 +1849,28 @@ app.whenReady().then(() => {
     return new Response('Drive image not found', { status: 404 });
   });
 
+  console.time('splash-to-main'); // 측정 시작
+
+  createSplashWindow(); // 1. 가장 먼저 스플래시
   createTray();        // 먼저 트레이 준비 (실패해도 앱은 계속)
   createWindow();
+
+  // 메인 로드 30초 타임아웃 (좀비 방지).
+  // Task 2.3의 did-finish-load 핸들러에서 clearTimeout + 해제 처리.
+  const MAIN_LOAD_TIMEOUT_MS = 30_000;
+  loadTimeoutId = setTimeout(() => {
+    if (mainLoadedOk) {
+      loadTimeoutId = null;
+      return;
+    }
+    console.error('[메인 로드] 30초 타임아웃 — 에러 다이얼로그 후 종료');
+    closeSplash();
+    try {
+      dialog.showErrorBox('B flow', '앱 로드에 실패했습니다. 다시 실행해주세요.');
+    } catch {/* ignore */}
+    isQuitting = true;
+    app.quit();
+  }, MAIN_LOAD_TIMEOUT_MS);
 
   // Google Calendar 토큰 복원
   gcal.restoreTokens();

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -144,8 +144,8 @@ async function showTrayHintOnce(): Promise<void> {
   if (showTrayHintInFlight) return;
   showTrayHintInFlight = true;
   try {
-    const prefs = await readPreferences();
-    if (prefs.trayFirstMinimizeSeen) return;
+    const state = await readAppState();
+    if (state.trayFirstMinimizeSeen) return;
 
     let shown = false;
     if (Notification.isSupported()) {
@@ -171,7 +171,7 @@ async function showTrayHintOnce(): Promise<void> {
     }
 
     if (shown) {
-      await writePreferences({ trayFirstMinimizeSeen: true });
+      await writeAppState({ trayFirstMinimizeSeen: true });
     }
   } finally {
     showTrayHintInFlight = false;
@@ -514,6 +514,10 @@ function getPreferencesFilePath(): string {
   return path.join(getDataPath(), 'preferences.json');
 }
 
+function getAppStateFilePath(): string {
+  return path.join(getDataPath(), 'app-state.json');
+}
+
 async function readPreferences(): Promise<Record<string, unknown>> {
   try {
     const raw = await fs.promises.readFile(getPreferencesFilePath(), 'utf-8');
@@ -528,6 +532,22 @@ async function writePreferences(patch: Record<string, unknown>): Promise<void> {
   const next = { ...prev, ...patch };
   ensureDir(path.dirname(getPreferencesFilePath()));
   await fs.promises.writeFile(getPreferencesFilePath(), JSON.stringify(next, null, 2), 'utf-8');
+}
+
+async function readAppState(): Promise<Record<string, unknown>> {
+  try {
+    const raw = await fs.promises.readFile(getAppStateFilePath(), 'utf-8');
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+async function writeAppState(patch: Record<string, unknown>): Promise<void> {
+  const prev = await readAppState();
+  const next = { ...prev, ...patch };
+  ensureDir(path.dirname(getAppStateFilePath()));
+  await fs.promises.writeFile(getAppStateFilePath(), JSON.stringify(next, null, 2), 'utf-8');
 }
 
 ipcMain.handle('users:read', () => {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1862,6 +1862,7 @@ app.whenReady().then(() => {
 
   // 메인 로드 30초 타임아웃 (좀비 방지).
   // Task 2.3의 did-finish-load 핸들러에서 clearTimeout + 해제 처리.
+  // 공유 드라이브 최초 로드/캐시 워밍 감안한 여유 타임아웃
   const MAIN_LOAD_TIMEOUT_MS = 30_000;
   loadTimeoutId = setTimeout(() => {
     if (mainLoadedOk) {
@@ -1873,6 +1874,7 @@ app.whenReady().then(() => {
     try {
       dialog.showErrorBox('B flow', '앱 로드에 실패했습니다. 다시 실행해주세요.');
     } catch {/* ignore */}
+    try { console.timeEnd('splash-to-main'); } catch {/* ignore */}
     isQuitting = true;
     app.quit();
   }, MAIN_LOAD_TIMEOUT_MS);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1869,7 +1869,10 @@ app.on('before-quit', (e) => {
 });
 
 app.on('window-all-closed', () => {
-  if (!isQuitting) {
-    app.quit();
+  // 트레이가 살아있고 사용자가 종료 의사를 표시하지 않은 경우: 백그라운드 유지
+  if (!isQuitting && tray && !tray.isDestroyed()) {
+    return;
   }
+  // 트레이 실패 or isQuitting: 정상 종료 흐름
+  app.quit();
 });

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -453,6 +453,7 @@ function createWindow(): void {
     minHeight: 600,
     title: 'B flow',
     backgroundColor: '#0F1117',
+    show: false,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
@@ -466,6 +467,21 @@ function createWindow(): void {
   } else {
     mainWindow.loadFile(path.join(__dirname, '../dist/index.html'));
   }
+
+  // 메인 로드 완료 → 스플래시 닫고 메인 창 show
+  mainWindow.webContents.once('did-finish-load', () => {
+    mainLoadedOk = true;
+    if (loadTimeoutId) {
+      clearTimeout(loadTimeoutId); // Task 2.4에서 설정한 타임아웃 해제
+      loadTimeoutId = null;
+    }
+    closeSplash();
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.show();
+      mainWindow.focus();
+    }
+    try { console.timeEnd('splash-to-main'); } catch {/* 이미 종료됨 */}
+  });
 
   mainWindow.on('close', (e) => {
     if (!isQuitting && !trayFailed) {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -506,6 +506,13 @@ function createWindow(): void {
       mainWindow.show();
       mainWindow.focus();
     }
+    // 재생성 경로 복구: 창 크래시 후 복구된 경우 보류 중인 딥링크 전달
+    // (최초 시작 시엔 app.whenReady의 .once 리스너와 중복이지만, pendingDeepLink를
+    //  null로 세팅하므로 멱등하게 동작)
+    if (pendingDeepLink) {
+      sendDeepLinkToRenderer(pendingDeepLink);
+      pendingDeepLink = null;
+    }
     try { console.timeEnd('splash-to-main'); } catch {/* 이미 종료됨 */}
   });
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1869,6 +1869,10 @@ app.on('before-quit', (e) => {
   }
 });
 
+process.on('exit', () => {
+  try { saveWidgetPositionsSync(); } catch {/* ignore */}
+});
+
 app.on('window-all-closed', () => {
   // 트레이가 살아있고 사용자가 종료 의사를 표시하지 않은 경우: 백그라운드 유지
   if (!isQuitting && tray && !tray.isDestroyed()) {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -410,6 +410,16 @@ function createWindow(): void {
     mainWindow.loadFile(path.join(__dirname, '../dist/index.html'));
   }
 
+  mainWindow.on('close', (e) => {
+    if (!isQuitting && !trayFailed) {
+      e.preventDefault();
+      mainWindow?.hide();
+      showTrayHintOnce().catch(() => {/* ignore */});
+      return;
+    }
+    // isQuitting === true || trayFailed === true인 경우 기본 동작 허용
+  });
+
   mainWindow.on('closed', () => {
     mainWindow = null;
   });

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -92,9 +92,15 @@ function humanizeStatus(raw: string): string {
   }
 }
 
-/** 메인 창을 보이고 포커스. 숨김 상태면 복원 */
+/** 메인 창을 보이고 포커스. 숨김 상태면 복원.
+ *  렌더러 크래시 등으로 창이 파괴된 상태에서도 createWindow()로 복구. */
 function showMainWindow(): void {
-  if (!mainWindow || mainWindow.isDestroyed()) return;
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    console.warn('[창] 메인 창이 없음 — 재생성');
+    mainLoadedOk = false; // 새 로드 사이클 시작
+    createWindow();        // did-finish-load 핸들러에서 자동으로 show + focus
+    return;
+  }
   if (mainWindow.isMinimized()) mainWindow.restore();
   mainWindow.show();
   mainWindow.focus();
@@ -1737,7 +1743,10 @@ function sendDeepLinkToRenderer(url: string): void {
     mainWindow.show();
     mainWindow.focus();
   } else {
+    // 메인 창이 파괴된 상태 (렌더러 크래시 등) → pendingDeepLink로 저장하고
+    // showMainWindow()로 창 복구 트리거. 새 창의 did-finish-load 시점에 처리됨.
     pendingDeepLink = url;
+    showMainWindow();
   }
 }
 
@@ -1799,13 +1808,11 @@ if (!gotTheLock) {
     console.log('[DeepLink] second-instance argv:', argv);
     const deepLinkUrl = argv.find((arg) => arg.startsWith(`${PROTOCOL}://`));
     console.log('[DeepLink] 추출된 URL:', deepLinkUrl ?? '(없음)');
-    if (deepLinkUrl) sendDeepLinkToRenderer(deepLinkUrl);
-
-    // sendDeepLinkToRenderer가 이미 show/focus하지만, URL 없는 경우에도 창 활성화
-    if (mainWindow && !deepLinkUrl) {
-      if (mainWindow.isMinimized()) mainWindow.restore();
-      mainWindow.show();
-      mainWindow.focus();
+    if (deepLinkUrl) {
+      sendDeepLinkToRenderer(deepLinkUrl);
+    } else {
+      // URL 없는 경우에도 창 활성화 (showMainWindow가 필요 시 재생성까지 책임짐)
+      showMainWindow();
     }
   });
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -172,6 +172,52 @@ async function showTrayHintOnce(): Promise<void> {
   }
 }
 
+function resolveSplashHtmlPath(): string {
+  const candidates = [
+    path.join(__dirname, '../public/splash/splash.html'),
+    path.join(app.getAppPath(), 'public/splash/splash.html'),
+  ];
+  for (const p of candidates) {
+    try { if (fs.existsSync(p)) return p; } catch {/* ignore */}
+  }
+  return '';
+}
+
+function createSplashWindow(): void {
+  const htmlPath = resolveSplashHtmlPath();
+  if (!htmlPath) {
+    console.warn('[스플래시] HTML 파일을 찾지 못함 — 스플래시 생략');
+    return;
+  }
+  splashWin = new BrowserWindow({
+    width: 300,
+    height: 300,
+    frame: false,
+    transparent: true,
+    alwaysOnTop: true,
+    resizable: false,
+    skipTaskbar: true,
+    closable: false, // 사용자가 닫지 못하게 (좀비 방지)
+    show: true,
+    backgroundColor: '#00000000',
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  });
+  splashWin.loadFile(htmlPath).catch((err) => {
+    console.error('[스플래시] loadFile 실패:', err);
+  });
+}
+
+function closeSplash(): void {
+  if (splashWin && !splashWin.isDestroyed()) {
+    // closable:false 창은 close() 거부 → destroy() 사용
+    splashWin.destroy();
+  }
+  splashWin = null;
+}
+
 function createTray(): void {
   try {
     const iconPath = resolveTrayIconPath();

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -35,6 +35,11 @@ import {
 // 앱 이름 설정 — AppData 경로에 영향
 app.name = 'Bflow-BGonly';
 
+// Chromium 성능 스위치 (app.ready 전에 호출)
+app.commandLine.appendSwitch('js-flags', '--nolazy');
+app.commandLine.appendSwitch('enable-gpu-rasterization');
+app.commandLine.appendSwitch('disable-renderer-backgrounding');
+
 // ─── 이미지 커스텀 프로토콜 등록 (app.ready 전에 호출 필수) ──
 protocol.registerSchemesAsPrivileged([
   {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -76,6 +76,81 @@ function resolveTrayIconPath(): string {
 const EMPTY_ICON_B64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
 
+/** Supabase 원시 상태 → 사용자에게 보여줄 한글 라벨 */
+function humanizeStatus(raw: string): string {
+  switch (raw) {
+    case 'SUBSCRIBED': return '실시간 연결됨';
+    case 'CHANNEL_ERROR': return '재연결 중';
+    case 'TIMED_OUT': return '연결 타임아웃';
+    case 'CLOSED': return '연결 끊김';
+    default: return raw || '연결 중';
+  }
+}
+
+/** 메인 창을 보이고 포커스. 숨김 상태면 복원 */
+function showMainWindow(): void {
+  if (!mainWindow || mainWindow.isDestroyed()) return;
+  if (mainWindow.isMinimized()) mainWindow.restore();
+  mainWindow.show();
+  mainWindow.focus();
+}
+
+/** 트레이 위젯 서브메뉴 토글 핸들러 */
+function toggleWidget(widgetId: string, title: string): void {
+  const existing = widgetWindows.get(widgetId);
+  if (existing && !existing.isDestroyed()) {
+    existing.close(); // closed 이벤트가 widgetWindows에서 제거
+  } else {
+    openWidgetPopup(widgetId, title);
+  }
+  // 메뉴 체크박스 상태 갱신
+  rebuildTrayMenu();
+}
+
+function rebuildTrayMenu(): void {
+  if (!tray || tray.isDestroyed()) return;
+  const widgetSubmenu: MenuItemConstructorOptions[] = Object.entries(WIDGET_TITLE_MAP).map(
+    ([id, title]) => ({
+      label: title,
+      type: 'checkbox',
+      checked: widgetWindows.has(id),
+      click: () => toggleWidget(id, title),
+    }),
+  );
+  const status = lastSupabaseStatus;
+  const menu = Menu.buildFromTemplate([
+    { label: '열기', click: showMainWindow },
+    { type: 'separator' },
+    { label: '위젯', submenu: widgetSubmenu },
+    { type: 'separator' },
+    { label: `상태: ${status}`, enabled: false },
+    { type: 'separator' },
+    { label: '종료', click: () => { isQuitting = true; app.quit(); } },
+  ]);
+  tray.setContextMenu(menu);
+  tray.setToolTip(`B flow • ${status}`);
+}
+
+function createTray(): void {
+  try {
+    const iconPath = resolveTrayIconPath();
+    let image = iconPath ? nativeImage.createFromPath(iconPath) : nativeImage.createEmpty();
+    if (image.isEmpty()) {
+      image = nativeImage.createFromBuffer(Buffer.from(EMPTY_ICON_B64, 'base64'));
+    }
+    image = image.resize({ width: 16, height: 16 });
+    tray = new Tray(image);
+    tray.setToolTip('B flow');
+    tray.on('click', showMainWindow);
+    tray.on('double-click', showMainWindow);
+    rebuildTrayMenu();
+  } catch (err) {
+    console.error('[트레이] 생성 실패 — 트레이 없이 실행 (창 X = 실제 종료):', err);
+    tray = null;
+    trayFailed = true;
+  }
+}
+
 // ─── 위젯 위치 영속화 (Phase 0-6) ─────────────────────────────
 const WIDGET_POS_FILE = 'widget-positions.json';
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,5 @@
-import { app, BrowserWindow, clipboard, ipcMain, protocol, net, desktopCapturer, screen, shell, Notification } from 'electron';
+import { app, BrowserWindow, clipboard, ipcMain, protocol, net, desktopCapturer, screen, shell, Notification, Tray, Menu, nativeImage } from 'electron';
+import type { MenuItemConstructorOptions } from 'electron';
 import * as gcal from './googleCalendar';
 import { pathToFileURL } from 'url';
 import path from 'path';
@@ -51,6 +52,11 @@ const widgetWindows = new Map<string, BrowserWindow>();
 const widgetOriginalBounds = new Map<string, Electron.Rectangle>();
 const animatingWidgets = new Set<string>();
 let isQuitting = false;
+let tray: Tray | null = null;
+let trayFailed = false;
+let lastSupabaseStatus = '연결 중...';
+let splashWin: BrowserWindow | null = null;
+let mainLoadedOk = false;
 
 // ─── 위젯 위치 영속화 (Phase 0-6) ─────────────────────────────
 const WIDGET_POS_FILE = 'widget-positions.json';

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -764,12 +764,14 @@ function startSupabaseRealtime() {
     onEpisodeChange: (payload) => broadcastSupabaseEvent('episodes', payload),
     onPartChange: (payload) => broadcastSupabaseEvent('parts', payload),
     onStatusChange: (status) => {
+      lastSupabaseStatus = humanizeStatus(status);
       if (mainWindow && !mainWindow.isDestroyed()) {
         mainWindow.webContents.send('supabase:status', status);
       }
       for (const win of widgetWindows.values()) {
         if (!win.isDestroyed()) win.webContents.send('supabase:status', status);
       }
+      rebuildTrayMenu();
     },
   });
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -81,10 +81,6 @@ function resolveTrayIconPath(): string {
   return '';
 }
 
-/** 1x1 투명 PNG — 아이콘 로드 완전 실패 시 최후 폴백 */
-const EMPTY_ICON_B64 =
-  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
-
 /** Supabase 원시 상태 → 사용자에게 보여줄 한글 라벨 */
 function humanizeStatus(raw: string): string {
   switch (raw) {
@@ -232,9 +228,21 @@ function closeSplash(): void {
 function createTray(): void {
   try {
     const iconPath = resolveTrayIconPath();
-    let image = iconPath ? nativeImage.createFromPath(iconPath) : nativeImage.createEmpty();
+    // 아이콘 파일을 실제로 찾지 못했으면 → 보이지 않는 트레이로 이어져
+    // "앱이 사라진 것처럼" 보일 위험. 트레이 실패로 간주해 창 X = 실제 종료로 폴백.
+    if (!iconPath) {
+      console.error('[트레이] 아이콘 파일을 찾지 못함 — 트레이 없이 실행 (창 X = 실제 종료)');
+      tray = null;
+      trayFailed = true;
+      return;
+    }
+    let image = nativeImage.createFromPath(iconPath);
     if (image.isEmpty()) {
-      image = nativeImage.createFromBuffer(Buffer.from(EMPTY_ICON_B64, 'base64'));
+      // 파일은 존재하지만 디코딩 실패 → 역시 보이지 않는 트레이 위험
+      console.error('[트레이] 아이콘 디코딩 실패 — 트레이 없이 실행 (창 X = 실제 종료):', iconPath);
+      tray = null;
+      trayFailed = true;
+      return;
     }
     image = image.resize({ width: 16, height: 16 });
     tray = new Tray(image);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1240,6 +1240,7 @@ function openWidgetPopup(widgetId: string, widgetTitle: string, extra?: Record<s
   });
 
   widgetWindows.set(widgetId, popupWin);
+  rebuildTrayMenu(); // 트레이 체크박스 갱신
 
   // 캐시에 title 저장 (자동 재오픈용)
   const existingCache = widgetPositionCache.get(widgetId);
@@ -1257,6 +1258,7 @@ function openWidgetPopup(widgetId: string, widgetTitle: string, extra?: Record<s
   popupWin.on('closed', () => {
     widgetWindows.delete(widgetId);
     widgetOriginalBounds.delete(widgetId);
+    rebuildTrayMenu(); // 트레이 체크박스 갱신
     // 사용자가 명시적으로 닫으면 캐시 삭제 (자동 복원 안 함)
     // 앱 종료 중이면 캐시 유지 (before-quit에서 이미 저장됨)
     if (!isQuitting) {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1259,12 +1259,7 @@ function openWidgetPopup(widgetId: string, widgetTitle: string, extra?: Record<s
     widgetWindows.delete(widgetId);
     widgetOriginalBounds.delete(widgetId);
     rebuildTrayMenu(); // 트레이 체크박스 갱신
-    // 사용자가 명시적으로 닫으면 캐시 삭제 (자동 복원 안 함)
-    // 앱 종료 중이면 캐시 유지 (before-quit에서 이미 저장됨)
-    if (!isQuitting) {
-      widgetPositionCache.delete(widgetId);
-      saveWidgetPositionsDebounced();
-    }
+    // 캐시는 항상 유지 → 다음 실행 시 자동 복원 (spec 결정사항)
     // 독 스택에서 제거 + 나머지 재배치
     const dockIdx = dockedWidgetIds.indexOf(widgetId);
     if (dockIdx >= 0) {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -58,6 +58,24 @@ let lastSupabaseStatus = '연결 중...';
 let splashWin: BrowserWindow | null = null;
 let mainLoadedOk = false;
 
+/** 아이콘 경로 해석: dev(electron/)와 prod(dist-electron/) + app.getAppPath() 순회 */
+function resolveTrayIconPath(): string {
+  const candidates = [
+    path.join(__dirname, '../public/splash/opening_image_cropped.png'),
+    path.join(app.getAppPath(), 'public/splash/opening_image_cropped.png'),
+  ];
+  for (const p of candidates) {
+    try {
+      if (fs.existsSync(p)) return p;
+    } catch { /* ignore */ }
+  }
+  return '';
+}
+
+/** 1x1 투명 PNG — 아이콘 로드 완전 실패 시 최후 폴백 */
+const EMPTY_ICON_B64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+
 // ─── 위젯 위치 영속화 (Phase 0-6) ─────────────────────────────
 const WIDGET_POS_FILE = 'widget-positions.json';
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -131,6 +131,36 @@ function rebuildTrayMenu(): void {
   tray.setToolTip(`B flow • ${status}`);
 }
 
+async function showTrayHintOnce(): Promise<void> {
+  const prefs = await readPreferences();
+  if (prefs.trayFirstMinimizeSeen) return;
+
+  let shown = false;
+  if (Notification.isSupported()) {
+    try {
+      new Notification({
+        title: 'B flow',
+        body: '트레이로 숨겨졌습니다. 트레이 아이콘 우클릭 → 종료로 완전히 닫을 수 있습니다.',
+      }).show();
+      shown = true;
+    } catch { /* ignore */ }
+  }
+
+  if (!shown && tray && !tray.isDestroyed() && process.platform === 'win32') {
+    try {
+      tray.displayBalloon({
+        title: 'B flow',
+        content: '트레이에 숨겨졌습니다. 트레이 메뉴 종료로 완전히 닫을 수 있습니다.',
+      });
+      shown = true;
+    } catch { /* ignore */ }
+  }
+
+  if (shown) {
+    await writePreferences({ trayFirstMinimizeSeen: true });
+  }
+}
+
 function createTray(): void {
   try {
     const iconPath = resolveTrayIconPath();
@@ -389,6 +419,26 @@ function createWindow(): void {
 
 function getUsersFilePath(): string {
   return path.join(getAppRoot(), 'users.dat');
+}
+
+function getPreferencesFilePath(): string {
+  return path.join(getDataPath(), 'preferences.json');
+}
+
+async function readPreferences(): Promise<Record<string, unknown>> {
+  try {
+    const raw = await fs.promises.readFile(getPreferencesFilePath(), 'utf-8');
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+async function writePreferences(patch: Record<string, unknown>): Promise<void> {
+  const prev = await readPreferences();
+  const next = { ...prev, ...patch };
+  ensureDir(path.dirname(getPreferencesFilePath()));
+  await fs.promises.writeFile(getPreferencesFilePath(), JSON.stringify(next, null, 2), 'utf-8');
 }
 
 ipcMain.handle('users:read', () => {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -134,7 +134,7 @@ function rebuildTrayMenu(): void {
     { type: 'separator' },
     { label: `상태: ${status}`, enabled: false },
     { type: 'separator' },
-    { label: '종료', click: () => { isQuitting = true; app.quit(); } },
+    { label: '종료', click: () => { app.quit(); } },
   ]);
   tray.setContextMenu(menu);
   tray.setToolTip(`B flow • ${status}`);
@@ -476,6 +476,7 @@ function createWindow(): void {
 
   // 메인 로드 완료 → 스플래시 닫고 메인 창 show
   mainWindow.webContents.once('did-finish-load', () => {
+    if (isQuitting) return; // 타임아웃으로 이미 종료 중
     mainLoadedOk = true;
     if (loadTimeoutId) {
       clearTimeout(loadTimeoutId); // Task 2.4에서 설정한 타임아웃 해제
@@ -510,28 +511,8 @@ function getUsersFilePath(): string {
   return path.join(getAppRoot(), 'users.dat');
 }
 
-function getPreferencesFilePath(): string {
-  return path.join(getDataPath(), 'preferences.json');
-}
-
 function getAppStateFilePath(): string {
   return path.join(getDataPath(), 'app-state.json');
-}
-
-async function readPreferences(): Promise<Record<string, unknown>> {
-  try {
-    const raw = await fs.promises.readFile(getPreferencesFilePath(), 'utf-8');
-    return JSON.parse(raw) as Record<string, unknown>;
-  } catch {
-    return {};
-  }
-}
-
-async function writePreferences(patch: Record<string, unknown>): Promise<void> {
-  const prev = await readPreferences();
-  const next = { ...prev, ...patch };
-  ensureDir(path.dirname(getPreferencesFilePath()));
-  await fs.promises.writeFile(getPreferencesFilePath(), JSON.stringify(next, null, 2), 'utf-8');
 }
 
 async function readAppState(): Promise<Record<string, unknown>> {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -55,8 +55,11 @@ let isQuitting = false;
 let tray: Tray | null = null;
 let trayFailed = false;
 let lastSupabaseStatus = '연결 중...';
+// Chunk 2(스플래시 2단계 부팅)에서 사용 예정
 let splashWin: BrowserWindow | null = null;
+// Chunk 2(스플래시 2단계 부팅)에서 사용 예정
 let mainLoadedOk = false;
+let showTrayHintInFlight = false;
 
 /** 아이콘 경로 해석: dev(electron/)와 prod(dist-electron/) + app.getAppPath() 순회 */
 function resolveTrayIconPath(): string {
@@ -83,7 +86,7 @@ function humanizeStatus(raw: string): string {
     case 'CHANNEL_ERROR': return '재연결 중';
     case 'TIMED_OUT': return '연결 타임아웃';
     case 'CLOSED': return '연결 끊김';
-    default: return raw || '연결 중';
+    default: return raw || '연결 중...';
   }
 }
 
@@ -132,32 +135,40 @@ function rebuildTrayMenu(): void {
 }
 
 async function showTrayHintOnce(): Promise<void> {
-  const prefs = await readPreferences();
-  if (prefs.trayFirstMinimizeSeen) return;
+  if (showTrayHintInFlight) return;
+  showTrayHintInFlight = true;
+  try {
+    const prefs = await readPreferences();
+    if (prefs.trayFirstMinimizeSeen) return;
 
-  let shown = false;
-  if (Notification.isSupported()) {
-    try {
-      new Notification({
-        title: 'B flow',
-        body: '트레이로 숨겨졌습니다. 트레이 아이콘 우클릭 → 종료로 완전히 닫을 수 있습니다.',
-      }).show();
-      shown = true;
-    } catch { /* ignore */ }
-  }
+    let shown = false;
+    if (Notification.isSupported()) {
+      try {
+        new Notification({
+          title: 'B flow',
+          body: '트레이로 숨겨졌습니다. 트레이 아이콘 우클릭 → 종료로 완전히 닫을 수 있습니다.',
+        }).show();
+        shown = true;
+      } catch { /* ignore */ }
+    }
 
-  if (!shown && tray && !tray.isDestroyed() && process.platform === 'win32') {
-    try {
-      tray.displayBalloon({
-        title: 'B flow',
-        content: '트레이에 숨겨졌습니다. 트레이 메뉴 종료로 완전히 닫을 수 있습니다.',
-      });
-      shown = true;
-    } catch { /* ignore */ }
-  }
+    if (!shown && tray && !tray.isDestroyed() && process.platform === 'win32') {
+      try {
+        tray.displayBalloon({
+          title: 'B flow',
+          content: '트레이에 숨겨졌습니다. 트레이 메뉴 종료로 완전히 닫을 수 있습니다.',
+        });
+        shown = true;
+      } catch (err) {
+        console.warn('[트레이] displayBalloon 실패 — 조용히 폴백 없이 진행:', err);
+      }
+    }
 
-  if (shown) {
-    await writePreferences({ trayFirstMinimizeSeen: true });
+    if (shown) {
+      await writePreferences({ trayFirstMinimizeSeen: true });
+    }
+  } finally {
+    showTrayHintInFlight = false;
   }
 }
 
@@ -413,7 +424,7 @@ function createWindow(): void {
   mainWindow.on('close', (e) => {
     if (!isQuitting && !trayFailed) {
       e.preventDefault();
-      mainWindow?.hide();
+      if (mainWindow && !mainWindow.isDestroyed()) mainWindow.hide();
       showTrayHintOnce().catch(() => {/* ignore */});
       return;
     }
@@ -1837,6 +1848,11 @@ app.on('before-quit', (e) => {
 
   // 위젯 위치 즉시 저장 (closed 이벤트보다 먼저 실행)
   saveWidgetPositionsSync();
+
+  if (tray && !tray.isDestroyed()) {
+    tray.destroy();
+    tray = null;
+  }
 
   const sheetsPending = getPendingOpsCount();
   const vacPending = getVacPendingOpsCount();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "files": [
       "dist/**/*",
       "dist-electron/**/*",
+      "public/splash/**",
       "node_modules/**/*",
       "package.json"
     ],

--- a/public/splash/splash.html
+++ b/public/splash/splash.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>B flow</title>
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+      background: transparent;
+      -webkit-app-region: drag;
+    }
+    body {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    img {
+      width: 220px;
+      height: 220px;
+      object-fit: contain;
+      animation: fadeIn 0.3s ease-out;
+      filter: drop-shadow(0 6px 16px rgba(0,0,0,0.35));
+    }
+    @keyframes fadeIn {
+      from { opacity: 0; transform: scale(0.92); }
+      to   { opacity: 1; transform: scale(1); }
+    }
+  </style>
+</head>
+<body>
+  <img src="./opening_image_cropped.png" alt="B flow">
+</body>
+</html>

--- a/public/splash/splash.html
+++ b/public/splash/splash.html
@@ -11,7 +11,7 @@
       height: 100%;
       overflow: hidden;
       background: transparent;
-      -webkit-app-region: drag;
+      -webkit-app-region: no-drag;
     }
     body {
       display: flex;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -325,6 +325,11 @@ export default function App() {
           const savedMode = savedTheme.colorMode ?? 'dark';
           themeInitRef.current = true;
 
+          // 프리셋/커스텀 모든 경로에서 hex 복원 (preferences.json 기준)
+          // → 이후 theme-save useEffect가 실행돼도 null로 덮어쓰지 않도록 보장
+          useAppStore.getState().setCustomAccentHex(savedTheme.customAccentHex ?? null);
+          useAppStore.getState().setCustomSubHex(savedTheme.customSubHex ?? null);
+
           // 커스텀 테마 마이그레이션
           let customHex: { accent: string; sub: string } | null = null;
           if (savedTheme.themeId === 'custom') {
@@ -351,8 +356,13 @@ export default function App() {
             setThemeId('custom');
             setColorMode(savedMode);
             setCustomThemeColors(colors);
-            useAppStore.getState().setCustomAccentHex(customHex.accent);
-            useAppStore.getState().setCustomSubHex(customHex.sub);
+            // sanitize로 보강된 경우 스토어도 보강된 hex로 갱신 (위 기본 복원 덮어쓰기)
+            if (customHex.accent !== (savedTheme.customAccentHex ?? null)) {
+              useAppStore.getState().setCustomAccentHex(customHex.accent);
+            }
+            if (customHex.sub !== (savedTheme.customSubHex ?? null)) {
+              useAppStore.getState().setCustomSubHex(customHex.sub);
+            }
             // 구포맷만 있거나 sanitize로 보강된 경우 새 포맷으로 재저장
             if (savedTheme.customAccentHex !== customHex.accent || savedTheme.customSubHex !== customHex.sub) {
               saveTheme({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,19 @@
-import { useEffect, useCallback, useState, useRef } from 'react';
+import { lazy, Suspense, useEffect, useCallback, useState, useRef } from 'react';
 import { MainLayout } from '@/components/layout/MainLayout';
 import { useAppStore, type ViewMode } from '@/stores/useAppStore';
 import { useDataStore } from '@/stores/useDataStore';
 import { useAuthStore } from '@/stores/useAuthStore';
-import { Dashboard } from '@/views/Dashboard';
-import { ScenesView } from '@/views/ScenesView';
-import { EpisodeView } from '@/views/EpisodeView';
-import { AssigneeView } from '@/views/AssigneeView';
-import { TeamView } from '@/views/TeamView';
-import { CalendarView } from '@/views/CalendarView';
-import { ScheduleView } from '@/views/ScheduleView';
-import { VacationView } from '@/views/VacationView';
-import CompositingView from '@/views/CompositingView';
-import { SettingsView } from '@/views/SettingsView';
+// 뷰 lazy 로딩 — 초기 번들에서 제외
+const Dashboard = lazy(() => import('@/views/Dashboard').then(m => ({ default: m.Dashboard })));
+const ScenesView = lazy(() => import('@/views/ScenesView').then(m => ({ default: m.ScenesView })));
+const EpisodeView = lazy(() => import('@/views/EpisodeView').then(m => ({ default: m.EpisodeView })));
+const AssigneeView = lazy(() => import('@/views/AssigneeView').then(m => ({ default: m.AssigneeView })));
+const TeamView = lazy(() => import('@/views/TeamView').then(m => ({ default: m.TeamView })));
+const CalendarView = lazy(() => import('@/views/CalendarView').then(m => ({ default: m.CalendarView })));
+const ScheduleView = lazy(() => import('@/views/ScheduleView').then(m => ({ default: m.ScheduleView })));
+const VacationView = lazy(() => import('@/views/VacationView').then(m => ({ default: m.VacationView })));
+const CompositingView = lazy(() => import('@/views/CompositingView')); // default export
+const SettingsView = lazy(() => import('@/views/SettingsView').then(m => ({ default: m.SettingsView })));
 import { SpotlightSearch } from '@/components/spotlight/SpotlightSearch';
 import { LoginScreen } from '@/components/auth/LoginScreen';
 import { PasswordChangeModal } from '@/components/auth/PasswordChangeModal';
@@ -777,30 +778,41 @@ export default function App() {
 
   // 뷰 렌더링
   const renderView = () => {
-    switch (currentView) {
-      case 'dashboard':
-        return <Dashboard />;
-      case 'scenes':
-        return <ScenesView />;
-      case 'episode':
-        return <EpisodeView />;
-      case 'assignee':
-        return <AssigneeView />;
-      case 'team':
-        return <TeamView />;
-      case 'calendar':
-        return <CalendarView />;
-      case 'schedule':
-        return <ScheduleView />;
-      case 'vacation':
-        return <VacationView />;
-      case 'compositing':
-        return <CompositingView />;
-      case 'settings':
-        return <SettingsView />;
-      default:
-        return <Dashboard />;
-    }
+    const view = (() => {
+      switch (currentView) {
+        case 'dashboard':
+          return <Dashboard />;
+        case 'scenes':
+          return <ScenesView />;
+        case 'episode':
+          return <EpisodeView />;
+        case 'assignee':
+          return <AssigneeView />;
+        case 'team':
+          return <TeamView />;
+        case 'calendar':
+          return <CalendarView />;
+        case 'schedule':
+          return <ScheduleView />;
+        case 'vacation':
+          return <VacationView />;
+        case 'compositing':
+          return <CompositingView />;
+        case 'settings':
+          return <SettingsView />;
+        default:
+          return <Dashboard />;
+      }
+    })();
+    return (
+      <Suspense fallback={
+        <div className="flex items-center justify-center h-full w-full">
+          <div className="w-6 h-6 border-2 border-accent border-t-transparent rounded-full animate-spin" />
+        </div>
+      }>
+        {view}
+      </Suspense>
+    );
   };
 
   // 로딩 스플래시 — authReady 후에도 유지, 클릭으로 스킵 가능

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useCallback, useState, useRef } from 'react';
+import { lazy, Suspense, useEffect, useCallback, useState, useRef, Component, type ReactNode, type ErrorInfo } from 'react';
 import { MainLayout } from '@/components/layout/MainLayout';
 import { useAppStore, type ViewMode } from '@/stores/useAppStore';
 import { useDataStore } from '@/stores/useDataStore';
@@ -39,6 +39,20 @@ import { DEFAULT_GAS_IMAGE_URL, DEFAULT_VACATION_URL } from '@/config';
 import { Toaster, toast as sonnerToast } from 'sonner';
 import { useNotificationStore } from '@/stores/useNotificationStore';
 import { dispatchNotification, type NotificationSettings } from '@/utils/notificationHelper';
+
+// Lazy chunk 로드 실패(네트워크 끊김, 빌드 artifact 누락) 시 블랭크 스크린 방지용 ErrorBoundary.
+// 이 컴포넌트 자체는 파일 외부로 분리하지 않고 로컬에 유지 — 인증 모달/메인 뷰 한정으로만 사용.
+class LazyErrorBoundary extends Component<{ children: ReactNode; name: string }, { hasError: boolean }> {
+  state = { hasError: false };
+  static getDerivedStateFromError() { return { hasError: true }; }
+  componentDidCatch(err: Error, info: ErrorInfo) {
+    console.error(`[LazyErrorBoundary] ${this.props.name} 로드 실패:`, err, info);
+  }
+  render() {
+    if (this.state.hasError) return null; // 모달/뷰가 뜨지 않는 편이 크래시보다 낫다
+    return this.props.children;
+  }
+}
 
 export default function App() {
   const { currentView, setWidgetLayout, setAllWidgetLayout, setEpisodeWidgetLayout, setChartType, setDataConnected, setGasConfig, themeId, customThemeColors, setThemeId, setCustomThemeColors, colorMode, setColorMode, setVacationConnected, setActiveDataSource } = useAppStore();
@@ -531,7 +545,10 @@ export default function App() {
         saveTheme({ themeId, customColors: customThemeColors, colorMode });
         return;
       }
-      // Case C: 아무것도 없음 — themeInitRef가 true면 오지 않아야 함. 안전망만.
+      // Case C: themeId=custom이지만 hex/customThemeColors 모두 없음 → 기본 프리셋으로 폴백
+      console.warn('[테마] themeId=custom이지만 색상 데이터 없음 → 기본 프리셋으로 폴백');
+      setThemeId(DEFAULT_THEME_ID);
+      // 이 setThemeId는 effect를 재실행시켜 프리셋 분기로 진입하므로 추가 처리 불필요
       return;
     }
 
@@ -905,13 +922,15 @@ export default function App() {
       }
     })();
     return (
-      <Suspense fallback={
-        <div className="flex items-center justify-center h-full w-full">
-          <div className="w-6 h-6 border-2 border-accent border-t-transparent rounded-full animate-spin" />
-        </div>
-      }>
-        {view}
-      </Suspense>
+      <LazyErrorBoundary name="View">
+        <Suspense fallback={
+          <div className="flex items-center justify-center h-full w-full">
+            <div className="w-6 h-6 border-2 border-accent border-t-transparent rounded-full animate-spin" />
+          </div>
+        }>
+          {view}
+        </Suspense>
+      </LazyErrorBoundary>
     );
   };
 
@@ -1005,16 +1024,20 @@ export default function App() {
 
       {/* 비밀번호 변경 모달 */}
       {showPasswordChange && (
-        <Suspense fallback={null}>
-          <PasswordChangeModal />
-        </Suspense>
+        <LazyErrorBoundary name="PasswordChangeModal">
+          <Suspense fallback={null}>
+            <PasswordChangeModal />
+          </Suspense>
+        </LazyErrorBoundary>
       )}
 
       {/* 관리자: 사용자 관리 모달 */}
       {showUserManager && (
-        <Suspense fallback={null}>
-          <UserManagerModal />
-        </Suspense>
+        <LazyErrorBoundary name="UserManagerModal">
+          <Suspense fallback={null}>
+            <UserManagerModal />
+          </Suspense>
+        </LazyErrorBoundary>
       )}
 
       {/* Sonner 토스트 — 테마 색상 연동 + 스르륵 애니메이션 + 호버 펼침 */}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,8 +16,8 @@ const CompositingView = lazy(() => import('@/views/CompositingView')); // defaul
 const SettingsView = lazy(() => import('@/views/SettingsView').then(m => ({ default: m.SettingsView })));
 import { SpotlightSearch } from '@/components/spotlight/SpotlightSearch';
 import { LoginScreen } from '@/components/auth/LoginScreen';
-import { PasswordChangeModal } from '@/components/auth/PasswordChangeModal';
-import { UserManagerModal } from '@/components/auth/UserManagerModal';
+const PasswordChangeModal = lazy(() => import('@/components/auth/PasswordChangeModal').then(m => ({ default: m.PasswordChangeModal })));
+const UserManagerModal = lazy(() => import('@/components/auth/UserManagerModal').then(m => ({ default: m.UserManagerModal })));
 import { GlobalTooltipProvider } from '@/components/ui/GlobalTooltip';
 import { loadGasConfig, connectGas, checkGasConnection } from '@/services/gasConfigService';
 import { readAll } from '@/services/supabaseService';
@@ -904,10 +904,18 @@ export default function App() {
       <GlobalTooltipProvider />
 
       {/* 비밀번호 변경 모달 */}
-      {showPasswordChange && <PasswordChangeModal />}
+      {showPasswordChange && (
+        <Suspense fallback={null}>
+          <PasswordChangeModal />
+        </Suspense>
+      )}
 
       {/* 관리자: 사용자 관리 모달 */}
-      {showUserManager && <UserManagerModal />}
+      {showUserManager && (
+        <Suspense fallback={null}>
+          <UserManagerModal />
+        </Suspense>
+      )}
 
       {/* Sonner 토스트 — 테마 색상 연동 + 스르륵 애니메이션 + 호버 펼침 */}
       <Toaster

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,7 @@ import { extractSceneDelta } from '@/utils/realtimeDelta';
 import { loadVacationConfig, connectVacation } from '@/services/vacationService';
 import { loadLayout, loadPreferences, loadTheme, saveTheme } from '@/services/settingsService';
 import { loadSession, loadUsers, setUsersSheetsMode, migrateUsersToSheets } from '@/services/userService';
-import { applyTheme, getPreset, getLightColors } from '@/themes';
+import { applyTheme, getPreset, getLightColors, deriveThemeFromAccent, sanitizeCustomHex, DEFAULT_THEME_ID } from '@/themes';
 import { applyFontSettings, DEFAULT_FONT_SCALE, DEFAULT_CATEGORY_SCALES } from '@/utils/typography';
 import type { FontScale } from '@/utils/typography';
 import { WelcomeToast } from '@/components/WelcomeToast';
@@ -323,20 +323,66 @@ export default function App() {
         const savedTheme = await loadTheme();
         if (savedTheme) {
           const savedMode = savedTheme.colorMode ?? 'dark';
-          if (savedTheme.customColors) {
-            applyTheme(savedTheme.customColors, savedMode);
-          } else if (savedMode === 'light') {
-            applyTheme(getLightColors(savedTheme.themeId), savedMode);
-          } else {
-            const preset = getPreset(savedTheme.themeId);
-            if (preset) applyTheme(preset.colors, savedMode);
+
+          // 커스텀 테마 마이그레이션
+          let customHex: { accent: string; sub: string } | null = null;
+          if (savedTheme.themeId === 'custom') {
+            customHex = sanitizeCustomHex({
+              customAccentHex: savedTheme.customAccentHex,
+              customSubHex: savedTheme.customSubHex,
+              customThemeColors: savedTheme.customColors ?? null,
+            });
+            if (!customHex) {
+              console.warn('[테마] 커스텀 테마 데이터 손상 → 기본 프리셋으로 폴백');
+            }
           }
-          // 가드를 먼저 열고 → 상태 변경 (useEffect가 실행될 때 가드가 이미 true)
-          themeInitRef.current = true;
-          setThemeId(savedTheme.themeId);
-          setColorMode(savedMode);
-          if (savedTheme.customColors) {
-            setCustomThemeColors(savedTheme.customColors);
+
+          // 실제 적용할 테마 ID (커스텀 복구 실패 시 기본 프리셋으로 강제)
+          const effectiveThemeId =
+            savedTheme.themeId === 'custom' && !customHex
+              ? DEFAULT_THEME_ID
+              : savedTheme.themeId;
+
+          // CSS 적용
+          if (effectiveThemeId === 'custom' && customHex) {
+            const colors = deriveThemeFromAccent(customHex.accent, customHex.sub, savedMode);
+            applyTheme(colors, savedMode);
+            themeInitRef.current = true;
+            setThemeId('custom');
+            setColorMode(savedMode);
+            setCustomThemeColors(colors);
+            useAppStore.getState().setCustomAccentHex(customHex.accent);
+            useAppStore.getState().setCustomSubHex(customHex.sub);
+            // 구포맷만 있거나 sanitize로 보강된 경우 새 포맷으로 재저장
+            if (savedTheme.customAccentHex !== customHex.accent || savedTheme.customSubHex !== customHex.sub) {
+              saveTheme({
+                themeId: 'custom',
+                customColors: colors,
+                colorMode: savedMode,
+                customAccentHex: customHex.accent,
+                customSubHex: customHex.sub,
+              });
+            }
+          } else if (savedMode === 'light') {
+            applyTheme(getLightColors(effectiveThemeId), savedMode);
+            themeInitRef.current = true;
+            setThemeId(effectiveThemeId);
+            setColorMode(savedMode);
+          } else {
+            const preset = getPreset(effectiveThemeId);
+            if (preset) {
+              applyTheme(preset.colors, savedMode);
+              themeInitRef.current = true;
+              setThemeId(effectiveThemeId);
+              setColorMode(savedMode);
+            } else {
+              // 완전 손상 (프리셋 ID도 유효하지 않음) → 최종 폴백
+              const fallback = getPreset(DEFAULT_THEME_ID)!;
+              applyTheme(fallback.colors, savedMode);
+              themeInitRef.current = true;
+              setThemeId(DEFAULT_THEME_ID);
+              setColorMode(savedMode);
+            }
           }
         } else {
           // 저장된 테마 없음 → 기본 테마 유지, 이후 변경부터 저장 허용

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -323,6 +323,7 @@ export default function App() {
         const savedTheme = await loadTheme();
         if (savedTheme) {
           const savedMode = savedTheme.colorMode ?? 'dark';
+          themeInitRef.current = true;
 
           // 커스텀 테마 마이그레이션
           let customHex: { accent: string; sub: string } | null = null;
@@ -347,7 +348,6 @@ export default function App() {
           if (effectiveThemeId === 'custom' && customHex) {
             const colors = deriveThemeFromAccent(customHex.accent, customHex.sub, savedMode);
             applyTheme(colors, savedMode);
-            themeInitRef.current = true;
             setThemeId('custom');
             setColorMode(savedMode);
             setCustomThemeColors(colors);
@@ -365,21 +365,18 @@ export default function App() {
             }
           } else if (savedMode === 'light') {
             applyTheme(getLightColors(effectiveThemeId), savedMode);
-            themeInitRef.current = true;
             setThemeId(effectiveThemeId);
             setColorMode(savedMode);
           } else {
             const preset = getPreset(effectiveThemeId);
             if (preset) {
               applyTheme(preset.colors, savedMode);
-              themeInitRef.current = true;
               setThemeId(effectiveThemeId);
               setColorMode(savedMode);
             } else {
               // 완전 손상 (프리셋 ID도 유효하지 않음) → 최종 폴백
               const fallback = getPreset(DEFAULT_THEME_ID)!;
               applyTheme(fallback.colors, savedMode);
-              themeInitRef.current = true;
               setThemeId(DEFAULT_THEME_ID);
               setColorMode(savedMode);
             }
@@ -496,7 +493,19 @@ export default function App() {
       if (customAccentHex && customSubHex) {
         const colors = deriveThemeFromAccent(customAccentHex, customSubHex, colorMode);
         applyTheme(colors, colorMode);
-        setCustomThemeColors(colors);
+        // 얕은 비교로 동일한 결과면 setState를 건너뛰어 effect 재실행 루프 방지
+        const same =
+          customThemeColors !== null &&
+          customThemeColors.bgPrimary === colors.bgPrimary &&
+          customThemeColors.bgCard === colors.bgCard &&
+          customThemeColors.bgBorder === colors.bgBorder &&
+          customThemeColors.textPrimary === colors.textPrimary &&
+          customThemeColors.textSecondary === colors.textSecondary &&
+          customThemeColors.accent === colors.accent &&
+          customThemeColors.accentSub === colors.accentSub;
+        if (!same) {
+          setCustomThemeColors(colors);
+        }
         saveTheme({
           themeId,
           customColors: colors,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -528,12 +528,22 @@ export default function App() {
     // 프리셋 경로
     if (colorMode === 'light') {
       applyTheme(getLightColors(themeId), colorMode);
-      saveTheme({ themeId, colorMode });
+      saveTheme({
+        themeId,
+        colorMode,
+        customAccentHex: customAccentHex ?? undefined,
+        customSubHex: customSubHex ?? undefined,
+      });
     } else {
       const preset = getPreset(themeId);
       if (preset) {
         applyTheme(preset.colors, colorMode);
-        saveTheme({ themeId, colorMode });
+        saveTheme({
+          themeId,
+          colorMode,
+          customAccentHex: customAccentHex ?? undefined,
+          customSubHex: customSubHex ?? undefined,
+        });
       }
     }
   }, [themeId, customThemeColors, colorMode]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -922,7 +922,7 @@ export default function App() {
       }
     })();
     return (
-      <LazyErrorBoundary name="View">
+      <LazyErrorBoundary key={currentView} name={`View:${currentView}`}>
         <Suspense fallback={
           <div className="flex items-center justify-center h-full w-full">
             <div className="w-6 h-6 border-2 border-accent border-t-transparent rounded-full animate-spin" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -489,10 +489,35 @@ export default function App() {
   // 테마 변경 시: CSS 적용 + appdata 저장 (초기화 완료 후에만 저장)
   useEffect(() => {
     if (!themeInitRef.current) return; // init()에서 테마 로드 전까지 저장 방지
-    if (themeId === 'custom' && customThemeColors) {
-      applyTheme(customThemeColors, colorMode);
-      saveTheme({ themeId, customColors: customThemeColors, colorMode });
-    } else if (colorMode === 'light') {
+    const { customAccentHex, customSubHex, setCustomThemeColors } = useAppStore.getState();
+
+    if (themeId === 'custom') {
+      // Case A: hex 두 개 모두 유효 → 현재 colorMode로 재파생
+      if (customAccentHex && customSubHex) {
+        const colors = deriveThemeFromAccent(customAccentHex, customSubHex, colorMode);
+        applyTheme(colors, colorMode);
+        setCustomThemeColors(colors);
+        saveTheme({
+          themeId,
+          customColors: colors,
+          colorMode,
+          customAccentHex,
+          customSubHex,
+        });
+        return;
+      }
+      // Case B: hex 없이 customThemeColors만 (마이그레이션 과도기)
+      if (customThemeColors) {
+        applyTheme(customThemeColors, colorMode);
+        saveTheme({ themeId, customColors: customThemeColors, colorMode });
+        return;
+      }
+      // Case C: 아무것도 없음 — themeInitRef가 true면 오지 않아야 함. 안전망만.
+      return;
+    }
+
+    // 프리셋 경로
+    if (colorMode === 'light') {
       applyTheme(getLightColors(themeId), colorMode);
       saveTheme({ themeId, colorMode });
     } else {

--- a/src/components/settings/ThemeSection.tsx
+++ b/src/components/settings/ThemeSection.tsx
@@ -128,9 +128,18 @@ export function ThemeSection() {
               : 'border-bg-border hover:border-accent/40 hover:bg-bg-border/30 border-dashed',
           )}
         >
-          <div className="w-full h-10 rounded-lg flex items-center justify-center bg-bg-border/50">
-            <Palette size={20} className="text-text-secondary" />
-          </div>
+          {themeId === 'custom' && customThemeColors ? (
+            <div
+              className="w-full h-10 rounded-lg"
+              style={{
+                background: `linear-gradient(135deg, rgb(${customThemeColors.bgCard}) 0%, rgb(${customThemeColors.accent}) 50%, rgb(${customThemeColors.accentSub}) 100%)`,
+              }}
+            />
+          ) : (
+            <div className="w-full h-10 rounded-lg flex items-center justify-center bg-bg-border/50">
+              <Palette size={20} className="text-text-secondary" />
+            </div>
+          )}
           <span className="text-xs text-text-primary font-medium">커스텀</span>
           <span className="text-[11px] text-text-secondary">Custom</span>
           {themeId === 'custom' && (

--- a/src/components/settings/ThemeSection.tsx
+++ b/src/components/settings/ThemeSection.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Palette, Check, Sun, Moon, Paintbrush } from 'lucide-react';
 import { useAppStore } from '@/stores/useAppStore';
-import { THEME_PRESETS, rgbToHex, getPreset, getLightColors, deriveThemeFromAccent } from '@/themes';
+import { THEME_PRESETS, rgbToHex, getPreset, getLightColors, deriveThemeFromAccent, HEX_RE } from '@/themes';
 import { cn } from '@/utils/cn';
 import { SettingsSection } from './SettingsSection';
 import { loadPreferences, savePreferences } from '@/services/settingsService';
@@ -39,13 +39,10 @@ export function ThemeSection() {
     setEditingCustom(false);
   };
 
-  // 커스텀 편집 중 실시간 배경 3색 프리뷰
+  // 커스텀 편집 중 실시간 배경 3색 프리뷰 (잘못된 hex 입력 시 null → 프리뷰 숨김)
   const previewColors = useMemo(() => {
-    try {
-      return deriveThemeFromAccent(customAccent, customSub, colorMode);
-    } catch {
-      return null;
-    }
+    if (!HEX_RE.test(customAccent) || !HEX_RE.test(customSub)) return null;
+    return deriveThemeFromAccent(customAccent, customSub, colorMode);
   }, [customAccent, customSub, colorMode]);
 
   return (

--- a/src/components/settings/ThemeSection.tsx
+++ b/src/components/settings/ThemeSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Palette, Check, Sun, Moon, Paintbrush } from 'lucide-react';
 import { useAppStore } from '@/stores/useAppStore';
 import { THEME_PRESETS, rgbToHex, getPreset, getLightColors, deriveThemeFromAccent } from '@/themes';
@@ -38,6 +38,15 @@ export function ThemeSection() {
     setCustomThemeColors(colors);
     setEditingCustom(false);
   };
+
+  // 커스텀 편집 중 실시간 배경 3색 프리뷰
+  const previewColors = useMemo(() => {
+    try {
+      return deriveThemeFromAccent(customAccent, customSub, colorMode);
+    } catch {
+      return null;
+    }
+  }, [customAccent, customSub, colorMode]);
 
   return (
     <>
@@ -166,6 +175,22 @@ export function ThemeSection() {
             className="h-8 rounded-lg"
             style={{ background: `linear-gradient(135deg, ${customAccent}, ${customSub})` }}
           />
+          {previewColors && (
+            <div className="flex gap-2 mt-2">
+              <div className="flex-1 flex flex-col items-center gap-1">
+                <div className="w-full h-8 rounded-md" style={{ background: `rgb(${previewColors.bgPrimary})` }} />
+                <span className="text-[10px] text-text-secondary">Primary</span>
+              </div>
+              <div className="flex-1 flex flex-col items-center gap-1">
+                <div className="w-full h-8 rounded-md" style={{ background: `rgb(${previewColors.bgCard})` }} />
+                <span className="text-[10px] text-text-secondary">Card</span>
+              </div>
+              <div className="flex-1 flex flex-col items-center gap-1">
+                <div className="w-full h-8 rounded-md" style={{ background: `rgb(${previewColors.bgBorder})` }} />
+                <span className="text-[10px] text-text-secondary">Border</span>
+              </div>
+            </div>
+          )}
           <div className="flex gap-2">
             <button
               onClick={handleCustomApply}

--- a/src/components/settings/ThemeSection.tsx
+++ b/src/components/settings/ThemeSection.tsx
@@ -1,8 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Palette, Check, Sun, Moon, Paintbrush } from 'lucide-react';
 import { useAppStore } from '@/stores/useAppStore';
-import { THEME_PRESETS, rgbToHex, hexToRgb, getPreset, getLightColors } from '@/themes';
-import type { ThemeColors } from '@/themes';
+import { THEME_PRESETS, rgbToHex, getPreset, getLightColors, deriveThemeFromAccent } from '@/themes';
 import { cn } from '@/utils/cn';
 import { SettingsSection } from './SettingsSection';
 import { loadPreferences, savePreferences } from '@/services/settingsService';
@@ -11,6 +10,7 @@ export function ThemeSection() {
   const {
     themeId, customThemeColors, colorMode,
     setThemeId, setCustomThemeColors, setColorMode,
+    setCustomAccentHex, setCustomSubHex,
   } = useAppStore();
 
   const [editingCustom, setEditingCustom] = useState(false);
@@ -31,13 +31,9 @@ export function ThemeSection() {
   };
 
   const handleCustomApply = () => {
-    const base = getPreset(themeId === 'custom' ? 'violet' : themeId)?.colors
-      ?? THEME_PRESETS[0].colors;
-    const colors: ThemeColors = {
-      ...base,
-      accent: hexToRgb(customAccent),
-      accentSub: hexToRgb(customSub),
-    };
+    const colors = deriveThemeFromAccent(customAccent, customSub, colorMode);
+    setCustomAccentHex(customAccent);
+    setCustomSubHex(customSub);
     setThemeId('custom');
     setCustomThemeColors(colors);
     setEditingCustom(false);

--- a/src/stores/useAppStore.ts
+++ b/src/stores/useAppStore.ts
@@ -96,9 +96,13 @@ interface AppState {
   // 테마
   themeId: string;
   customThemeColors: ThemeColors | null;
+  customAccentHex: string | null;
+  customSubHex: string | null;
   colorMode: 'dark' | 'light';
   setThemeId: (id: string) => void;
   setCustomThemeColors: (colors: ThemeColors | null) => void;
+  setCustomAccentHex: (hex: string | null) => void;
+  setCustomSubHex: (hex: string | null) => void;
   setColorMode: (mode: 'dark' | 'light') => void;
   toggleColorMode: () => void;
 
@@ -216,9 +220,13 @@ export const useAppStore = create<AppState>((set) => ({
 
   themeId: 'violet',
   customThemeColors: null,
+  customAccentHex: null,
+  customSubHex: null,
   colorMode: 'dark',
   setThemeId: (id) => set({ themeId: id }),
   setCustomThemeColors: (colors) => set({ customThemeColors: colors }),
+  setCustomAccentHex: (hex) => set({ customAccentHex: hex }),
+  setCustomSubHex: (hex) => set({ customSubHex: hex }),
   setColorMode: (mode) => set({ colorMode: mode }),
   toggleColorMode: () => set((s) => ({ colorMode: s.colorMode === 'dark' ? 'light' : 'dark' })),
 

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -162,7 +162,7 @@ export function hslToRgb(h: number, s: number, l: number): string {
   else if (hP < 3) [r1, g1, b1] = [0, c, x];
   else if (hP < 4) [r1, g1, b1] = [0, x, c];
   else if (hP < 5) [r1, g1, b1] = [x, 0, c];
-  else if (hP < 6) [r1, g1, b1] = [c, 0, x];
+  else if (hP <= 6) [r1, g1, b1] = [c, 0, x];
   const m = lN - c / 2;
   const r = Math.round((r1 + m) * 255);
   const g = Math.round((g1 + m) * 255);

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -170,6 +170,28 @@ export function hslToRgb(h: number, s: number, l: number): string {
   return `${r} ${g} ${b}`;
 }
 
+/**
+ * accent hex 두 개로부터 7색 ThemeColors 전체를 생성.
+ * 배경·보더·텍스트 5색은 accent hue 기반 HSL 계단 공식으로 파생.
+ */
+export function deriveThemeFromAccent(
+  accentHex: string,
+  accentSubHex: string,
+  mode: 'dark' | 'light',
+): ThemeColors {
+  const { h } = rgbToHsl(hexToRgb(accentHex));
+  const dark = mode === 'dark';
+  return {
+    bgPrimary:     dark ? hslToRgb(h, 20, 5)  : hslToRgb(h, 15, 88),
+    bgCard:        dark ? hslToRgb(h, 22, 9)  : hslToRgb(h, 10, 99),
+    bgBorder:      dark ? hslToRgb(h, 20, 16) : hslToRgb(h, 25, 70),
+    textPrimary:   dark ? hslToRgb(h, 15, 92) : hslToRgb(h, 30, 12),
+    textSecondary: dark ? hslToRgb(h, 15, 59) : hslToRgb(h, 25, 28),
+    accent:        hexToRgb(accentHex),
+    accentSub:     hexToRgb(accentSubHex),
+  };
+}
+
 /** 프리셋 ID로 찾기 */
 export function getPreset(id: string): ThemePreset | undefined {
   return THEME_PRESETS.find(p => p.id === id);

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -192,6 +192,64 @@ export function deriveThemeFromAccent(
   };
 }
 
+const HEX_RE = /^#[0-9a-fA-F]{6}$/;
+
+/**
+ * 저장된 커스텀 테마 필드들을 검증/마이그레이션.
+ * 부분적 유효성도 허용하여 사용자가 저장한 hex를 최대한 보존.
+ *
+ * 우선순위:
+ * 1. 두 hex 모두 유효 → 둘 다 사용
+ * 2. 한 hex만 유효 → 유효한 쪽은 유지, 나머지는 triplet에서 역산 (없으면 그 값을 sub로 복제)
+ * 3. 둘 다 hex 무효 → triplet 양쪽 모두 역산
+ * 4. triplet도 없거나 실패 → null (호출부는 DEFAULT_THEME_ID로 폴백)
+ */
+export function sanitizeCustomHex(input: {
+  customAccentHex?: string | null;
+  customSubHex?: string | null;
+  customThemeColors?: ThemeColors | null;
+}): { accent: string; sub: string } | null {
+  const aValid = !!(input.customAccentHex && HEX_RE.test(input.customAccentHex));
+  const sValid = !!(input.customSubHex && HEX_RE.test(input.customSubHex));
+  const c = input.customThemeColors;
+
+  // Case 1: 둘 다 hex 유효
+  if (aValid && sValid) {
+    return { accent: input.customAccentHex!, sub: input.customSubHex! };
+  }
+
+  // Case 2/3: triplet으로 보강
+  let tripletAccent: string | null = null;
+  let tripletSub: string | null = null;
+  if (c?.accent && c?.accentSub) {
+    try {
+      tripletAccent = rgbToHex(c.accent);
+      tripletSub = rgbToHex(c.accentSub);
+    } catch {/* triplet 파싱 실패 */}
+  }
+
+  // Case 2a: accent hex만 유효
+  if (aValid) {
+    return {
+      accent: input.customAccentHex!,
+      sub: tripletSub ?? input.customAccentHex!, // sub 복구 불가 시 accent와 동일
+    };
+  }
+  // Case 2b: sub hex만 유효
+  if (sValid) {
+    return {
+      accent: tripletAccent ?? input.customSubHex!,
+      sub: input.customSubHex!,
+    };
+  }
+  // Case 3: 둘 다 hex 무효 → triplet 시도
+  if (tripletAccent && tripletSub) {
+    return { accent: tripletAccent, sub: tripletSub };
+  }
+  // Case 4: 전부 실패
+  return null;
+}
+
 /** 프리셋 ID로 찾기 */
 export function getPreset(id: string): ThemePreset | undefined {
   return THEME_PRESETS.find(p => p.id === id);

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -128,6 +128,48 @@ export function hexToRgb(hex: string): string {
   return `${r} ${g} ${b}`;
 }
 
+/** RGB triplet → HSL (h: 0-360, s/l: 0-100) */
+export function rgbToHsl(triplet: string): { h: number; s: number; l: number } {
+  const [r, g, b] = triplet.split(' ').map(Number).map(v => v / 255);
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  let h = 0;
+  let s = 0;
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r: h = ((g - b) / d + (g < b ? 6 : 0)); break;
+      case g: h = ((b - r) / d + 2); break;
+      case b: h = ((r - g) / d + 4); break;
+    }
+    h *= 60;
+  }
+  return { h: Math.round(h), s: Math.round(s * 100), l: Math.round(l * 100) };
+}
+
+/** HSL (h: 0-360, s/l: 0-100) → RGB triplet */
+export function hslToRgb(h: number, s: number, l: number): string {
+  const sN = s / 100;
+  const lN = l / 100;
+  const c = (1 - Math.abs(2 * lN - 1)) * sN;
+  const hP = h / 60;
+  const x = c * (1 - Math.abs((hP % 2) - 1));
+  let r1 = 0, g1 = 0, b1 = 0;
+  if (0 <= hP && hP < 1) [r1, g1, b1] = [c, x, 0];
+  else if (hP < 2) [r1, g1, b1] = [x, c, 0];
+  else if (hP < 3) [r1, g1, b1] = [0, c, x];
+  else if (hP < 4) [r1, g1, b1] = [0, x, c];
+  else if (hP < 5) [r1, g1, b1] = [x, 0, c];
+  else if (hP < 6) [r1, g1, b1] = [c, 0, x];
+  const m = lN - c / 2;
+  const r = Math.round((r1 + m) * 255);
+  const g = Math.round((g1 + m) * 255);
+  const b = Math.round((b1 + m) * 255);
+  return `${r} ${g} ${b}`;
+}
+
 /** 프리셋 ID로 찾기 */
 export function getPreset(id: string): ThemePreset | undefined {
   return THEME_PRESETS.find(p => p.id === id);

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -230,6 +230,7 @@ export function sanitizeCustomHex(input: {
 
   // Case 2a: accent hex만 유효
   if (aValid) {
+    console.info('[테마] customSubHex 누락 — triplet에서 복구 또는 accent 복제');
     return {
       accent: input.customAccentHex!,
       sub: tripletSub ?? input.customAccentHex!, // sub 복구 불가 시 accent와 동일
@@ -237,6 +238,7 @@ export function sanitizeCustomHex(input: {
   }
   // Case 2b: sub hex만 유효
   if (sValid) {
+    console.info('[테마] customAccentHex 누락 — triplet에서 복구 또는 sub 복제');
     return {
       accent: tripletAccent ?? input.customSubHex!,
       sub: input.customSubHex!,
@@ -244,6 +246,7 @@ export function sanitizeCustomHex(input: {
   }
   // Case 3: 둘 다 hex 무효 → triplet 시도
   if (tripletAccent && tripletSub) {
+    console.info('[테마] 양쪽 hex 손실 — triplet에서 복구');
     return { accent: tripletAccent, sub: tripletSub };
   }
   // Case 4: 전부 실패

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -290,4 +290,6 @@ export interface ThemeConfig {
   themeId: string;
   customColors?: ThemeColors;
   colorMode?: 'dark' | 'light';
+  customAccentHex?: string;
+  customSubHex?: string;
 }

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -192,7 +192,7 @@ export function deriveThemeFromAccent(
   };
 }
 
-const HEX_RE = /^#[0-9a-fA-F]{6}$/;
+export const HEX_RE = /^#[0-9a-fA-F]{6}$/;
 
 /**
  * 저장된 커스텀 테마 필드들을 검증/마이그레이션.

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -1,15 +1,16 @@
-import { useState, useEffect } from 'react';
+import { lazy, Suspense, useState, useEffect } from 'react';
 import { SettingsSidebar, type SettingsTabId } from '@/components/settings/SettingsSidebar';
-import { ThemeSection } from '@/components/settings/ThemeSection';
-import { FontSizeSection } from '@/components/settings/FontSizeSection';
-import { SheetsSection } from '@/components/settings/SheetsSection';
-import { GuideSection } from '@/components/settings/GuideSection';
-import { StartupSection } from '@/components/settings/StartupSection';
-import { EffectsSection } from '@/components/settings/EffectsSection';
-import { LoginSection } from '@/components/settings/LoginSection';
-import { ProfileSection } from '@/components/settings/ProfileSection';
-import { NotificationSection } from '@/components/settings/NotificationSection';
-import { ShortcutsSection } from '@/components/settings/ShortcutsSection';
+// 설정 섹션 lazy 로딩 — 활성 탭 진입 시에만 로드
+const ThemeSection = lazy(() => import('@/components/settings/ThemeSection').then(m => ({ default: m.ThemeSection })));
+const FontSizeSection = lazy(() => import('@/components/settings/FontSizeSection').then(m => ({ default: m.FontSizeSection })));
+const SheetsSection = lazy(() => import('@/components/settings/SheetsSection').then(m => ({ default: m.SheetsSection })));
+const GuideSection = lazy(() => import('@/components/settings/GuideSection').then(m => ({ default: m.GuideSection })));
+const StartupSection = lazy(() => import('@/components/settings/StartupSection').then(m => ({ default: m.StartupSection })));
+const EffectsSection = lazy(() => import('@/components/settings/EffectsSection').then(m => ({ default: m.EffectsSection })));
+const LoginSection = lazy(() => import('@/components/settings/LoginSection').then(m => ({ default: m.LoginSection })));
+const ProfileSection = lazy(() => import('@/components/settings/ProfileSection').then(m => ({ default: m.ProfileSection })));
+const NotificationSection = lazy(() => import('@/components/settings/NotificationSection').then(m => ({ default: m.NotificationSection })));
+const ShortcutsSection = lazy(() => import('@/components/settings/ShortcutsSection').then(m => ({ default: m.ShortcutsSection })));
 import { loadPreferences } from '@/services/settingsService';
 import {
   type FontScale,
@@ -79,7 +80,9 @@ export function SettingsView() {
       <SettingsSidebar active={activeTab} onChange={setActiveTab} />
       <div className="flex-1 flex flex-col gap-6 min-w-0">
         <h2 className="text-xl font-bold text-text-primary">설정</h2>
-        {renderContent()}
+        <Suspense fallback={null}>
+          {renderContent()}
+        </Suspense>
       </div>
     </div>
   );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -46,11 +46,9 @@ export default defineConfig({
     rollupOptions: {
       output: {
         manualChunks: {
-          'vendor-react': ['react', 'react-dom'],
-          'vendor-supabase': ['@supabase/supabase-js'],
-          'vendor-grid': ['react-grid-layout'],
+          'vendor-grid': ['react-grid-layout', 'clsx'],
           'vendor-motion': ['framer-motion'],
-          'vendor-ui': ['lucide-react', 'sonner', 'clsx'],
+          'vendor-ui': ['lucide-react', 'sonner'],
         },
       },
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,4 +42,17 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          'vendor-react': ['react', 'react-dom'],
+          'vendor-supabase': ['@supabase/supabase-js'],
+          'vendor-grid': ['react-grid-layout'],
+          'vendor-motion': ['framer-motion'],
+          'vendor-ui': ['lucide-react', 'sonner', 'clsx'],
+        },
+      },
+    },
+  },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -45,8 +45,11 @@ export default defineConfig({
   build: {
     rollupOptions: {
       output: {
+        // vendor-react: vite-plugin-electron-renderer가 externalize 처리 → 별도 청크 무의미
+        // vendor-supabase: 렌더러에서 직접 import 없음 (메인 프로세스 IPC 경유) → 빈 청크라 제거
+        // clsx: 40+ 라우트에서 cn() 경유로 사용되므로 별도 청크로 묶지 않음 (Rollup 자동 청킹에 위임)
         manualChunks: {
-          'vendor-grid': ['react-grid-layout', 'clsx'],
+          'vendor-grid': ['react-grid-layout'],
           'vendor-motion': ['framer-motion'],
           'vendor-ui': ['lucide-react', 'sonner'],
         },


### PR DESCRIPTION
## 📋 업데이트 요약

> 이번 업데이트에서 달라진 점을 간략하게 정리했습니다.

- 🎯 **시스템 트레이 아이콘이 추가됐습니다** — 창 X를 눌러도 앱은 트레이에서 계속 실행되고, 트레이 우클릭 메뉴의 '종료'를 눌러야 완전히 닫힙니다. 마감 작업 도중 실수로 창을 닫아도 저장 중이던 데이터가 안전하게 보존돼요.
- 📌 **플로팅 위젯이 마지막 위치·크기를 기억합니다** — 위젯을 개별로 닫아도, 앱 전체를 종료해도 다음 실행 시 열려있던 모든 위젯이 마지막 상태 그대로 자동으로 복원됩니다.
- ⚡ **앱 시작이 빨라졌습니다** — 더블클릭 즉시 스플래시가 뜨고, 화면은 필요한 부분만 먼저 불러와서 초기 로딩 번들이 약 50% 줄었습니다. 공유 드라이브에서 실행해도 체감 속도가 개선됩니다.
- 🎨 **커스텀 테마가 프리셋 수준의 완성도로 바뀌었습니다** — 강조색 2개만 고르면 배경·카드·보더·텍스트까지 공산당 레드나 이혜민 머쉬룸처럼 자연스러운 톤으로 자동 생성됩니다. 다크/라이트 전환 시 배경도 함께 재구성돼요.

## 🔧 상세 기술 설명

### 1. 트레이 아이콘 + 종료 경로 일원화 (`electron/main.ts`)

- **`createTray()` 3단 폴백**: `public/splash/opening_image_cropped.png`를 후보 경로 2곳에서 탐색, 실패 시 `nativeImage.createEmpty()` → 1x1 투명 PNG base64까지. 트레이 생성 자체가 실패하면 `trayFailed = true`로 플래그하고 창 X를 실제 종료로 폴백시켜 좀비 프로세스 방지.
- **`rebuildTrayMenu()`**: `열기 / 위젯 서브메뉴 / 상태: <Supabase 상태> / 종료` 구조. `humanizeStatus(raw)`로 Supabase realtime 원시 상태(`SUBSCRIBED`, `CHANNEL_ERROR` 등)를 한글 라벨로 변환. 툴팁은 `B flow • <상태>`.
- **메인 창 `close` 차단**: `!isQuitting && !trayFailed`일 때 `e.preventDefault() + mainWindow.hide()`. 최초 1회만 `Notification.isSupported()` + Windows `tray.displayBalloon()` 폴백으로 안내. `%APPDATA%/Bflow-BGonly/app-state.json`에 `trayFirstMinimizeSeen` 기록 (렌더러의 `preferences.json`과 경합 방지 위해 별도 파일).
- **트레이 '종료' → `app.quit()`만 호출**: `before-quit` 핸들러가 `isQuitting` 전환·`waitForAllPendingOps(15s)`·`waitForVacPendingOps(60s)`·`stopAllWatches`·`tray.destroy()`까지 모두 수행하도록 단일 경로로 통일.

### 2. 위젯 위치 항상 유지 (`electron/main.ts`)

- 기존 `popupWin.on('closed')`의 캐시 삭제 3줄 (`if (!isQuitting) { widgetPositionCache.delete(...); ... }`) 제거 → 개별 X로 닫아도 위치가 보존되어 다음 실행 시 복원.
- `did-finish-load` 핸들러를 `.on` → `.once`로 교정 (렌더러 재로드 시 닫힌 위젯이 재등장하거나 argv 딥링크가 재실행되던 문제 예방).
- 자동 복원 루프에 위젯별 `try/catch + console.error` 추가 (한 위젯 실패가 나머지 복원을 중단시키지 않게).
- `process.on('exit')`에 `saveWidgetPositionsSync()` 최종 안전망 등록.

### 3. 스플래시 2단계 부팅 + 로딩 최적화

- **`public/splash/splash.html`** (신규): 인라인 CSS, 외부 의존성 0. `./opening_image_cropped.png`를 상대 경로로 참조.
- **`createSplashWindow()`**: `300x300 / frame:false / transparent:true / alwaysOnTop:true / closable:false / show:true`. 메인 창은 `show: false`로 생성되어 백그라운드 로드. `did-finish-load` 이벤트에서 `closeSplash() → mainWindow.show()` 전환.
- **30초 로드 타임아웃**: 메인 창이 완료되지 않으면 `dialog.showErrorBox` + `app.quit()` (공유 드라이브 최초 로드 지연 고려한 여유값).
- **`console.time('splash-to-main')` 측정**: `--enable-logging` 플래그로 실제 소요 시간 확인 가능.
- **Chromium 커맨드라인 스위치 3종**: `js-flags --nolazy`, `enable-gpu-rasterization`, `disable-renderer-backgrounding`.
- **Vite `manualChunks`** (`vite.config.ts`): `vendor-grid` (`react-grid-layout`), `vendor-motion` (`framer-motion`), `vendor-ui` (`lucide-react`, `sonner`). `clsx`는 `cn()` 유틸이 40+ 파일에서 쓰이므로 일부러 제외(grid 의존으로 끌려오지 않도록 Rollup 자동 청킹에 맡김). React/Supabase는 `vite-plugin-electron-renderer`가 externalize하거나 실제 import가 없어 빈 청크가 되므로 제외.
- **`React.lazy`**: 10개 뷰 (`Dashboard`, `ScenesView`, `EpisodeView` 등), 10개 설정 섹션, 2개 인증 모달. 뷰는 스피너 fallback, 모달은 `null` fallback. 모두 `LazyErrorBoundary`로 감싸서 chunk load 실패 시 블랭크 스크린 방지.
- **`package.json` `build.files`**에 `public/splash/**` 추가.

### 4. 커스텀 테마 HSL 파생 (`src/themes.ts`, `src/App.tsx`, `ThemeSection.tsx`)

- **`rgbToHsl` / `hslToRgb`**: 표준 HSL ↔ RGB 변환. `hslToRgb`는 h=360 경계를 `hP <= 6`로 수용 (원격 리뷰에서 발견한 hue drop 버그 수정).
- **`deriveThemeFromAccent(accentHex, subHex, mode)`**: accent hue 하나로 7색 테마 전체 생성. 다크 모드는 `L=5/9/16/59/92` 계단, 라이트 모드는 `L=88/99/70/12/28`. 공산당 레드(#E11D48)나 이혜민 머쉬룸(#814D41) 같은 기존 프리셋과 ±5% 오차 내 시각적으로 유사한 결과.
- **`sanitizeCustomHex()` 4-case 마이그레이션**: (a) 양쪽 hex 유효 (b) accent만 유효 + sub는 triplet 역산 또는 accent 복제 (c) sub만 유효 + 대칭 (d) 양쪽 무효 + triplet 역산. `console.info`로 부분 복구 경로 기록. 전부 실패 시 `DEFAULT_THEME_ID`로 폴백.
- **`useAppStore`에 `customAccentHex`/`customSubHex` 신규 상태** + `setCustomAccentHex`/`setCustomSubHex` 액션. `ThemeConfig`에 두 필드 추가.
- **App.tsx 초기화**: `sanitizeCustomHex`로 기존 저장 데이터 정규화 → 필요 시 새 포맷으로 자동 재저장. `effectiveThemeId`로 커스텀 복구 실패 시 기본 프리셋으로 강제.
- **App.tsx 테마 `useEffect`**: 단일 `[themeId, customThemeColors, colorMode]` deps + 7필드 얕은 비교 가드로 무한 루프 방지. colorMode 전환 시 hex 기반 자동 재파생.
- **프리셋 전환 시 hex 보존**: preset 분기에서도 `customAccentHex`/`customSubHex`를 store에서 읽어 `saveTheme` 페이로드에 포함 → custom → preset → custom 왕복해도 색상 유지.
- **ThemeSection.tsx**: `handleCustomApply`가 `deriveThemeFromAccent` 호출. 편집 패널에 실시간 배경 3색(Primary/Card/Border) 프리뷰 추가 (`HEX_RE` 검증 통과 시에만). 프리셋 그리드의 '커스텀' 타일도 저장된 커스텀 테마의 실제 그라디언트 표시.

## 🚧 개발 난항

### 리뷰 루프 24건 수정

- 자동 리뷰(스펙 준수 + 코드 품질 × 3 chunk): 9건
- 원격 bughunter 1차: 3건 (hslToRgb h=360, preset 전환 hex 소실, preferences.json 경합)
- 원격 bughunter 2차: 6건 (**트레이 종료가 `before-quit` cleanup을 bypass해 pending Google Sheets 저장이 abort되던 data loss 버그**, init preset 분기가 저장된 customHex를 store에 복원하지 않아 재시작 시 hex가 조용히 사라지던 문제 등)
- 내부 심층 리뷰 (`pr-review-toolkit:code-reviewer` + `pr-review-toolkit:silent-failure-hunter`): 6건 (`.on` → `.once`, 자동복원 루프 예외 isolation, `before-quit`의 truthy Promise 버그, React LazyErrorBoundary, theme Case C silent return, `closeSplash()` try/catch)

**교훈**:
- `app.quit()` 기반 종료 경로를 여러 곳에서 호출할 때 `isQuitting` 플래그는 `before-quit`이 소유해야 한다. 호출자가 먼저 세팅하면 guard가 cleanup 전체를 bypass한다.
- `manualChunks`에 넣은 유틸이 **그 유틸을 쓰는 모든 라우트를 해당 청크에 묶는다**. `clsx`처럼 범용 유틸은 자동 청킹에 맡기는 편이 lazy 로딩 효과를 깨지 않는다.
- `hexToRgb`/`rgbToHsl`/`hslToRgb`는 NaN을 silently 전파한다. 검증이 필요하면 `HEX_RE` 정규식을 명시적으로 돌려야 한다.
- `React.lazy` + `Suspense fallback={null}` 조합은 chunk load 실패 시 블랭크 스크린이 된다. ErrorBoundary는 선택이 아니라 필수.

### 설계-문서 한 세트로 진행

브레인스토밍 → 스펙 → 플랜 → 구현 → 리뷰 루프를 각 단계마다 독립 리뷰어(subagent)로 검증하는 방식으로 진행. 스펙·플랜 문서는 이 PR에도 포함(`docs/superpowers/specs/`, `docs/superpowers/plans/`). 향후 유사 규모 작업의 템플릿으로 활용 가능.

## ✅ 테스트 가이드

### 사용자 테스트

> 아래 시나리오를 직접 실행해서 정상 동작을 확인해주세요.

1. **트레이 아이콘 기본 동작**
   - 앱 실행 → Windows 시스템 트레이에 B flow 아이콘 표시
   - 트레이 좌클릭 or 더블클릭 → 메인 창이 열리거나 포커스됨
   - 트레이 우클릭 → `열기 / 위젯 / 상태: <연결됨/재연결중> / 종료` 메뉴 표시
   - 메인 창 X 버튼 → 창만 숨기고 앱은 계속 실행 (최초 1회 "트레이에 숨겨짐" Notification)
   - 트레이 '종료' 클릭 → 앱 완전 종료 + 트레이 아이콘 사라짐
   - ✅ 기대: 창 X로는 절대 앱이 꺼지지 않음. 종료는 트레이 메뉴를 통해서만.

2. **위젯 위치/크기 기억**
   - 전체 진행률·단계별 진행률 등 위젯 2~3개 열기 → 자유롭게 이동/리사이즈
   - 개별 위젯 X 클릭으로 1개 닫기 (나머지는 열어둠)
   - 트레이 '종료' → 앱 재실행
   - ✅ 기대: 닫혔던 위젯 포함 **모든** 위젯이 마지막 위치·크기·투명도·AOT 상태 그대로 복원

3. **빠른 부팅**
   - 포터블 `BFLOW.exe`를 새 환경에서 더블클릭
   - ✅ 기대: 1~3초 내에 스플래시 이미지 등장 → 메인 창으로 부드럽게 전환

4. **커스텀 테마**
   - 설정 → 색상 테마 → 커스텀 타일 클릭
   - 메인 액센트 `#E11D48`, 서브 `#FB7185` 선택 → 편집 패널 하단에 배경 3색 프리뷰 변화 확인
   - '적용' → 앱 전체 UI가 공산당 레드 프리셋과 유사한 톤으로 전환
   - 다크/라이트 토글 → 배경·보더·텍스트가 색상 모드에 맞춰 자동 재생성
   - 다른 프리셋(예: 에메랄드)으로 잠깐 전환 → 다시 커스텀으로 복귀 → **이전 커스텀 색상이 그대로 복원**
   - ✅ 기대: 강조색만 고르면 배경까지 포함한 완전한 테마가 자연스럽게 완성

### 개발자 테스트

```powershell
# 클린 빌드 재현
cd C:\Bflow-BGonly
Stop-Process -Name "BFLOW" -Force -ErrorAction SilentlyContinue
Remove-Item -Recurse -Force dist
npm run build

# 빌드 산출물 검증
Test-Path dist\BFLOW.exe
Test-Path dist\win-unpacked\resources\app\public\splash\splash.html
Test-Path dist\win-unpacked\resources\app\public\splash\opening_image_cropped.png

# 청크 분할 확인 (renderer)
Get-ChildItem dist\assets\vendor-*.js
# → vendor-grid-*.js, vendor-motion-*.js, vendor-ui-*.js 3개

# 뷰·섹션·모달 lazy 청크 확인
Get-ChildItem dist\assets\ | Where-Object { $_.Name -match "^(Dashboard|SceneView|Episode|Calendar|Schedule|Team|Assignee|Vacation|Compositing|Settings)" }
```

### 수동 확인 필요 (자동화 불가)

- [ ] 트레이 아이콘이 Windows 11/10 알림 영역에 정상 표시
- [ ] Focus Assist 켜진 상태에서 "트레이로 숨김" 안내가 `tray.displayBalloon` 폴백으로 표시됨
- [ ] 트레이 '종료' 클릭 시 `waitForAllPendingOps` 저장 오버레이가 잠깐 표시 후 정상 종료
- [ ] 여러 모니터 환경에서 스플래시 위치·위젯 복원 좌표 유효성
- [ ] `console.time('splash-to-main')` 측정값 (SSD 기준 목표 <1500ms)
- [ ] 화이트보드·씬 시트뷰·캘린더·휴가·슬랙 웹훅·Supabase Realtime 기존 기능 회귀 없음

---

**변경 규모**: 11개 파일 수정 + 1개 신규, +3,360줄 / -102줄 | **커밋 46개** | **설계 문서 2개**(`docs/superpowers/specs/`, `docs/superpowers/plans/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
