### PR TITLE
[v1.10.0] 9개 UI/UX 이슈 통합 수정 + 실시간 동기화 대폭 개선

### DIFF
--- a/docs/superpowers/plans/2026-04-18-bflow-ui-fixes-plan.md
+++ b/docs/superpowers/plans/2026-04-18-bflow-ui-fixes-plan.md
@@ -1,0 +1,1644 @@
+# B flow 9개 UI/UX 이슈 통합 수정 Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 카드 라쏘 오인식, 위젯 글꼴/색상 미적용, 자동 로그인 실패, 플렉서스 파티클 색상, 대시보드 그라데이션, 휴가 pending 상태, EP 위젯 복원 등 9건을 단일 PR로 수정한다.
+
+**Architecture:** Electron 메인/렌더러 프로세스 간 IPC 브로드캐스트 채널을 추가해 "메인 창 설정 변경 → 전체 창 즉시 반영" 경로를 확립한다. CSS 변수 기반 테마 시스템을 글자 카테고리 색상까지 확장한다. 그라데이션 배경을 canvas 외부 DOM 레이어로 분리하여 파티클과 독립 토글한다. 휴가 등록은 낙관적 업데이트 + 파일 영속화 + 완료 broadcast 토스트로 개선한다.
+
+**Tech Stack:** Electron 33, React 18, TypeScript 5.5, Tailwind CSS 3, Zustand 4, sonner, Vite 5 (테스트 프레임워크 없음 — 각 Task는 `npx tsc --noEmit` + `npm run build:vite` + 수동 실행으로 검증)
+
+**Spec 참조:** [`docs/superpowers/specs/2026-04-18-bflow-ui-fixes-design.md`](../specs/2026-04-18-bflow-ui-fixes-design.md)
+
+**검증 공통 명령** (각 Task 마지막에 반복):
+```bash
+npx tsc --noEmit          # 타입 체크만
+npm run build:vite        # tsc + vite build (렌더러 번들)
+npm run electron:dev      # 실제 앱 실행(수동 스모크) — 일부 Task만 필요
+```
+
+**커밋 컨벤션 (CLAUDE.md):** 한글 메시지, prefix `fix:`/`feat:`/`refactor:`/`chore:` + 간결한 본문.
+
+---
+
+## Chunk 1: 인프라 및 버그 수정 (Task 1–4)
+
+### Task 1: 자동 로그인 실패 진단 로그 추가 (이슈 ⑥)
+
+**Files:**
+- Modify: `src/services/userService.ts:181-198` — `loadSession` 실패 구간 로그
+- Modify: `src/App.tsx:420-427` — 세션 복원 결과 로그
+- Modify: `electron/main.ts` — 이미 `app.name = 'Bflow-BGonly'` 설정됨(라인 38 확인) → 추가 변경 불필요
+
+**배경:** `app.name`은 이미 정확히 지정되어 있다(electron/main.ts:38). 빌드 앱 자동 로그인 실패의 실제 원인을 좁히려면 실패 구간을 로그로 나누어야 한다. 로그 추가 후 빌드 앱 실행 → 원인 확인 → Task 1의 **후속 커밋**으로 근본 수정.
+
+- [ ] **Step 1: `loadSession`에 구간별 로그 추가**
+
+`src/services/userService.ts`의 `loadSession` 본문을 다음과 같이 수정:
+
+```ts
+export async function loadSession(): Promise<{ session: AuthSession | null; user: AppUser | null }> {
+  let session: AuthSession | null = null;
+  try {
+    session = (await window.electronAPI.readSettings(AUTH_FILE)) as AuthSession | null;
+  } catch (err) {
+    console.warn('[auth] auth.json 읽기 실패:', err);
+    return { session: null, user: null };
+  }
+  if (!session) {
+    console.info('[auth] auth.json 미존재 — 로그인 필요');
+    return { session: null, user: null };
+  }
+  if (!session.userId) {
+    console.warn('[auth] session.userId 누락 — 세션 무효', session);
+    return { session: null, user: null };
+  }
+  const users = await loadUsers();
+  const user = users.find((u) => u.id === session!.userId) ?? null;
+  if (!user) {
+    console.warn('[auth] 세션 userId에 매칭되는 사용자 없음', { sessionUserId: session.userId, userCount: users.length });
+  } else {
+    console.info('[auth] 세션 복원 성공', { userId: user.id, name: user.name });
+  }
+  return { session, user };
+}
+```
+
+- [ ] **Step 2: `App.tsx`의 세션 복원 분기 로그 추가**
+
+[src/App.tsx:420-427] 부근 `rememberMe` 분기에 아래와 같이:
+
+```ts
+const rememberMe = savedPrefs?.rememberMe !== false;
+console.info('[auth] rememberMe =', rememberMe);
+if (rememberMe) {
+  const { user } = await loadSession();
+  if (user) {
+    setCurrentUser(user);
+    console.info('[auth] currentUser 설정 완료');
+  } else {
+    console.info('[auth] 세션 없음 — 로그인 화면 표시');
+  }
+}
+```
+
+- [ ] **Step 3: 타입 체크 + 빌드**
+
+```bash
+npx tsc --noEmit
+npm run build:vite
+```
+Expected: 에러 없음.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/services/userService.ts src/App.tsx
+git commit -m "$(cat <<'EOF'
+chore(auth): 자동 로그인 실패 진단 로그 추가
+
+auth.json 읽기/userId 매칭/사용자 검색 각 단계에서 실패 이유를 콘솔에 남긴다.
+빌드 앱에서 자동 로그인이 안 되는 실제 원인을 재현 후 구분하기 위한 선제 작업.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+**후속 예정:** 빌드 후 재현 → 실제 원인 파악 → 근본 수정 추가 커밋 (Task 1-B). 현 단계에선 근본 수정 코드는 작성하지 않는다(YAGNI — 로그 결과 확인 전에는 원인 추정만 가능).
+
+---
+
+### Task 2: IPC 브로드캐스트 인프라 (preferences/session/vacation)
+
+메인 창이 설정·세션 변경 시 모든 BrowserWindow에 push하는 공통 채널. 이후 Task들이 이를 구독한다.
+
+**Files:**
+- Modify: `electron/main.ts` — 브로드캐스트 헬퍼 + IPC 핸들러 추가
+- Modify: `electron/preload.ts` — 렌더러에서 구독/발행할 수 있도록 노출
+- Modify: `src/types/electron.d.ts` — 타입 선언
+
+- [ ] **Step 1: `electron/main.ts`에 브로드캐스트 헬퍼 추가**
+
+파일 적당한 위치(IPC 핸들러 섹션 직전)에:
+
+```ts
+/** 메인 창 + 모든 위젯 창에 동일 이벤트 push */
+function broadcastToAllWindows(channel: string, payload?: unknown): void {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send(channel, payload);
+  }
+  for (const win of widgetWindows.values()) {
+    if (!win.isDestroyed()) win.webContents.send(channel, payload);
+  }
+}
+
+// 렌더러 → 메인: "지금 설정 바꿨으니 다른 창에도 알려줘"
+ipcMain.handle('preferences:broadcast-change', (_event, payload: unknown) => {
+  broadcastToAllWindows('preferences:changed', payload);
+  return { ok: true };
+});
+
+ipcMain.handle('session:broadcast-change', (_event, payload: unknown) => {
+  broadcastToAllWindows('session:changed', payload);
+  return { ok: true };
+});
+```
+
+- [ ] **Step 2: `electron/preload.ts`에 API 노출 (라인 247 부근 `widgetOpenPopup` 근처에 추가)**
+
+```ts
+preferencesBroadcastChange: (payload?: unknown) =>
+  ipcRenderer.invoke('preferences:broadcast-change', payload),
+
+onPreferencesChanged: (callback: (payload: unknown) => void) => {
+  const listener = (_event: Electron.IpcRendererEvent, payload: unknown) => callback(payload);
+  ipcRenderer.on('preferences:changed', listener);
+  return () => ipcRenderer.removeListener('preferences:changed', listener);
+},
+
+sessionBroadcastChange: (payload?: unknown) =>
+  ipcRenderer.invoke('session:broadcast-change', payload),
+
+onSessionChanged: (callback: (payload: unknown) => void) => {
+  const listener = (_event: Electron.IpcRendererEvent, payload: unknown) => callback(payload);
+  ipcRenderer.on('session:changed', listener);
+  return () => ipcRenderer.removeListener('session:changed', listener);
+},
+```
+
+- [ ] **Step 3: `src/types/electron.d.ts`에 타입 추가**
+
+기존 `electronAPI` 인터페이스에:
+
+```ts
+preferencesBroadcastChange: (payload?: unknown) => Promise<{ ok: boolean }>;
+onPreferencesChanged: (cb: (payload: unknown) => void) => () => void;
+sessionBroadcastChange: (payload?: unknown) => Promise<{ ok: boolean }>;
+onSessionChanged: (cb: (payload: unknown) => void) => () => void;
+```
+
+- [ ] **Step 4: 타입 체크**
+
+```bash
+npx tsc --noEmit
+```
+Expected: 0 에러.
+
+- [ ] **Step 5: 빌드 확인**
+
+```bash
+npm run build:vite
+```
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add electron/main.ts electron/preload.ts src/types/electron.d.ts
+git commit -m "$(cat <<'EOF'
+feat(ipc): 설정/세션 변경 브로드캐스트 채널 추가
+
+메인 창이 설정·세션 변경 시 모든 위젯 창에 push하는 공통 IPC를 도입.
+후속 Task(위젯 글꼴 통일, 내 할일 세션 동기화)가 이 채널을 구독한다.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: 위젯 팝업 `extra` 파라미터 영속화 (이슈 ⑨)
+
+**Files:**
+- Modify: `electron/main.ts` — `WidgetPosition` 타입에 `extra` 필드, 저장/복원 로직
+- Modify: `src/types/electron.d.ts` — 관련 타입 동기화 (필요 시)
+
+**배경:** `widgetPositionCache`는 위치/크기/AOT/opacity만 저장한다. EP 위젯은 `?ep=1` query string으로 에피소드 번호를 받는데 재실행 시 `extra`가 유실되어 빈 칸이 된다.
+
+- [ ] **Step 1: `WidgetPosition` 타입에 `extra` 추가**
+
+`electron/main.ts`에서 `WidgetPosition`/`widgetPositionCache` 선언 근처에:
+
+```ts
+interface WidgetPosition {
+  x: number; y: number; width: number; height: number;
+  opacity?: number;
+  alwaysOnTop?: boolean;
+  extra?: Record<string, string>;  // 신규
+}
+```
+
+(실제 타입 위치는 grep으로 `widgetPositionCache` 선언부 찾아 적용.)
+
+- [ ] **Step 2: `openWidgetPopup`에서 `extra` 저장 + 복원**
+
+[electron/main.ts:1339] `openWidgetPopup` 본문 수정:
+
+```ts
+function openWidgetPopup(widgetId: string, widgetTitle: string, extra?: Record<string, string>): { ok: boolean } {
+  // 이미 열린 팝업이면 포커스
+  const existing = widgetWindows.get(widgetId);
+  if (existing && !existing.isDestroyed()) {
+    existing.focus();
+    return { ok: true };
+  }
+
+  const savedPos = widgetPositionCache.get(widgetId);
+  const initWidth = savedPos ? Math.max(280, savedPos.width) : 420;
+  const initHeight = savedPos ? Math.max(200, savedPos.height) : 360;
+  const initAOT = savedPos ? (savedPos.alwaysOnTop ?? true) : true;
+
+  // 신규: 호출 시 넘어온 extra가 우선. 없으면 저장된 extra 복원.
+  const effectiveExtra = extra ?? savedPos?.extra;
+
+  // ... (BrowserWindow 생성 동일)
+
+  let hash = `#widget-popup/${encodeURIComponent(widgetId)}`;
+  if (effectiveExtra && Object.keys(effectiveExtra).length > 0) {
+    const qs = new URLSearchParams(effectiveExtra).toString();
+    hash += `?${qs}`;
+  }
+  // ... (loadURL/loadFile)
+
+  // 위치 캐시 업데이트 시 extra도 포함
+  const updatePositionCache = () => {
+    if (popupWin.isDestroyed() || animatingWidgets.has(widgetId)) return;
+    const b = popupWin.getBounds();
+    widgetPositionCache.set(widgetId, {
+      x: b.x, y: b.y, width: b.width, height: b.height,
+      opacity: popupWin.getOpacity(),
+      alwaysOnTop: popupWin.isAlwaysOnTop(),
+      extra: effectiveExtra,  // 신규
+    });
+    // 파일 영속화는 기존 디바운스 경로 그대로
+  };
+  // ...
+}
+```
+
+- [ ] **Step 3: 영속 파일 로드 시 하위 호환 확인**
+
+`widget-positions.json` 로드하는 함수(grep `widgetPositionCache` 로드)에서 구버전 파일(extra 미존재) 로드가 crash 없이 처리되는지 확인. `extra?: Record<string, string>`이 optional이라 자연스럽게 호환되어야 하나 JSON.parse 후 그대로 Map에 넣는지 검증.
+
+- [ ] **Step 4: 타입 체크 + 빌드**
+
+```bash
+npx tsc --noEmit
+npm run build:vite
+```
+
+- [ ] **Step 5: 수동 스모크 — EP 위젯 재실행 복원**
+
+```bash
+npm run electron:dev
+```
+1. 메인 창에서 EP 1 → "EP 통합 진행률" 팝업 띄움
+2. 앱 종료(트레이에서 완전 종료)
+3. 재실행 → 해당 위젯이 EP 1 데이터로 복원되는지 확인 (이전엔 빈 칸)
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add electron/main.ts src/types/electron.d.ts
+git commit -m "$(cat <<'EOF'
+fix(widget): 플로팅 위젯 extra 파라미터 재시작 복원
+
+widgetPositionCache에 extra(에피소드 번호 등)를 함께 저장하여
+앱 종료 후 재실행 시 EP 위젯이 비지 않도록 한다.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: 라쏘 스크롤 보정 + 메모 영역 제외 (이슈 ①)
+
+**Files:**
+- Modify: `src/views/ScenesView.tsx:21-114` — `useLassoSelection` 훅
+- Modify: `src/components/scenes/UnifiedSceneCard.tsx:140-146` — 메모 래퍼에 `data-no-lasso`
+
+- [ ] **Step 1: 메모 래퍼에 `data-no-lasso` 속성 추가**
+
+`src/components/scenes/UnifiedSceneCard.tsx`의 메모 영역(라인 140-146)을 다음과 같이 수정:
+
+```tsx
+{primaryScene.memo && (
+  <div className="mx-4 mt-1" data-no-lasso>
+    <p className="text-[11px] text-amber-400/70 leading-relaxed line-clamp-1">
+      <HighlightText text={primaryScene.memo} query={searchQuery} />
+    </p>
+  </div>
+)}
+```
+
+- [ ] **Step 2: `useLassoSelection` 훅에 스크롤 보정 추가**
+
+`src/views/ScenesView.tsx` 라인 21-114 범위의 훅 전체 교체 (기존 형태 유지, `startScrollRef` + dx/dy 보정 + 임계값 5→8):
+
+```ts
+function useLassoSelection(
+  containerRef: React.RefObject<HTMLElement | null>,
+  cardSelector: string,
+  getSceneId: (el: Element) => string | null,
+  onSelectionChange: (ids: Set<string>) => void,
+  enabled: boolean,
+) {
+  const [lassoRect, setLassoRect] = useState<LassoRect | null>(null);
+  const startRef = useRef<{ x: number; y: number } | null>(null);
+  const startScrollRef = useRef<{ top: number; left: number } | null>(null);
+  const isDragging = useRef(false);
+  const prevIds = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!enabled) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    const onMouseDown = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (target.closest('button, input, select, textarea, a, [role="button"], [data-no-lasso], [contenteditable="true"]')) return;
+      if (target.closest('[data-no-lasso]')) return; // 중복 방지
+      if (e.button !== 0) return;
+
+      startRef.current = { x: e.clientX, y: e.clientY };
+      // 가장 가까운 스크롤 컨테이너의 초기 scrollTop/Left 기록
+      const scrollEl = findScrollParent(target) ?? container;
+      startScrollRef.current = { top: scrollEl.scrollTop, left: scrollEl.scrollLeft };
+      isDragging.current = false;
+
+      const onMouseMove = (me: MouseEvent) => {
+        if (!startRef.current || !startScrollRef.current) return;
+        const currScroll = findScrollParent(target) ?? container;
+        const scrollDx = currScroll.scrollLeft - startScrollRef.current.left;
+        const scrollDy = currScroll.scrollTop - startScrollRef.current.top;
+        const dx = (me.clientX - startRef.current.x) - scrollDx;
+        const dy = (me.clientY - startRef.current.y) - scrollDy;
+
+        // 8px 임계(기존 5 → 완화) — 스크롤 보정 이후의 실제 마우스 이동
+        if (!isDragging.current && Math.abs(dx) < 8 && Math.abs(dy) < 8) return;
+        isDragging.current = true;
+
+        const x = Math.min(startRef.current.x, me.clientX);
+        const y = Math.min(startRef.current.y, me.clientY);
+        const w = Math.abs(me.clientX - startRef.current.x);
+        const h = Math.abs(me.clientY - startRef.current.y);
+        setLassoRect({ x, y, w, h });
+
+        const cards = container.querySelectorAll(cardSelector);
+        const selected = new Set<string>();
+        cards.forEach((card) => {
+          const rect = card.getBoundingClientRect();
+          if (rect.left < x + w && rect.right > x && rect.top < y + h && rect.bottom > y) {
+            const id = getSceneId(card);
+            if (id) selected.add(id);
+          }
+        });
+        if (selected.size !== prevIds.current.size || ![...selected].every((id) => prevIds.current.has(id))) {
+          prevIds.current = selected;
+          onSelectionChange(selected);
+        }
+      };
+
+      const onMouseUp = (me: MouseEvent) => {
+        document.removeEventListener('mousemove', onMouseMove);
+        document.removeEventListener('mouseup', onMouseUp);
+        if (!isDragging.current) {
+          if (!me.ctrlKey && !me.metaKey) {
+            onSelectionChange(new Set());
+            prevIds.current = new Set();
+          }
+        }
+        startRef.current = null;
+        startScrollRef.current = null;
+        isDragging.current = false;
+        setLassoRect(null);
+      };
+
+      document.addEventListener('mousemove', onMouseMove);
+      document.addEventListener('mouseup', onMouseUp);
+    };
+
+    container.addEventListener('mousedown', onMouseDown);
+    return () => container.removeEventListener('mousedown', onMouseDown);
+  }, [enabled, containerRef, cardSelector, getSceneId, onSelectionChange]);
+
+  return { lassoRect, isSelecting: isDragging.current };
+}
+
+// 유틸: 가장 가까운 스크롤 가능 부모
+function findScrollParent(el: HTMLElement | null): HTMLElement | null {
+  let cur: HTMLElement | null = el;
+  while (cur) {
+    const style = getComputedStyle(cur);
+    const oy = style.overflowY;
+    if ((oy === 'auto' || oy === 'scroll') && cur.scrollHeight > cur.clientHeight) return cur;
+    cur = cur.parentElement;
+  }
+  return null;
+}
+```
+
+- [ ] **Step 3: 타입 체크 + 빌드**
+
+```bash
+npx tsc --noEmit
+npm run build:vite
+```
+
+- [ ] **Step 4: 수동 스모크 — 메모 클릭 / 빈 영역 드래그**
+
+```bash
+npm run electron:dev
+```
+1. 씬 뷰 → 카드 뷰로 전환
+2. 스크롤 최상단 상태에서 2번 컷 메모 영역 클릭 → 라쏘 안 뜨고 단일 클릭으로만 처리되는지 확인
+3. 카드들 사이 빈 영역에서 드래그 → 기존처럼 라쏘 선택 정상 동작
+4. 카드 빠르게 클릭(5~7px 미세 떨림 허용되는지) 확인
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/views/ScenesView.tsx src/components/scenes/UnifiedSceneCard.tsx
+git commit -m "$(cat <<'EOF'
+fix(scenes): 카드 메모 클릭 시 라쏘 오인식 방지
+
+1. 메모 래퍼에 data-no-lasso 추가, 라쏘 제외 셀렉터 확장
+2. mousedown 시점의 scrollTop/Left를 기억해 dx/dy에서 스크롤 변화를 보정
+3. 드래그 임계값 5→8px로 완화하여 미세 떨림을 클릭으로 처리
+
+스크롤 최상단에서 상단 카드 메모 클릭 → 스크롤 이동으로 인한 가짜 드래그를 방지.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Chunk 2: 글자 색상 및 위젯 통일 (Task 5–8)
+
+### Task 5: `applyTextColors` + 카테고리 CSS 변수 (이슈 ⑤ 코어)
+
+**Files:**
+- Modify: `src/utils/typography.ts` — `TextColorSettings`, `applyTextColors` 추가
+- Modify: `src/services/settingsService.ts` — `UserPreferences.fontCategoryColors`, `fontColorPreset` 필드 추가
+- Modify: `src/index.css` — 카테고리별 color CSS 규칙 추가
+
+- [ ] **Step 1: 기존 `text-text-*` 사용처 그렙 (리뷰 권고 반영)**
+
+```bash
+grep -r "text-text-primary\|text-text-secondary" src/components src/views src/App.tsx | wc -l
+```
+Expected: 수를 기록. 신규 CSS 변수 도입 시 기존 명시 클래스 컴포넌트는 영향 없음 — 확인 용도.
+
+- [ ] **Step 2: `typography.ts`에 색상 타입 + `applyTextColors` 추가**
+
+파일 끝에 추가:
+
+```ts
+// ─── 카테고리 색상 ─────────────────────────────
+
+export type FontColorPreset = 'theme' | 'high-contrast' | 'soft' | 'mono' | 'custom';
+
+export interface FontCategoryColors {
+  heading?: string;  // RGB triplet "R G B" (예: "232 232 238")
+  body?: string;
+  caption?: string;
+  micro?: string;
+}
+
+export const FONT_COLOR_PRESETS: Record<FontColorPreset, { label: string; getColors: (themePrimary: string, themeSecondary: string, themeAccentSub: string) => FontCategoryColors }> = {
+  theme: {
+    label: '테마 기본',
+    getColors: () => ({}),  // 모두 --color-text-primary 폴백
+  },
+  'high-contrast': {
+    label: '고대비',
+    getColors: (primary, secondary) => ({
+      heading: '255 255 255',
+      body: primary,
+      caption: secondary,
+      micro: secondary,
+    }),
+  },
+  soft: {
+    label: '부드러움',
+    getColors: (primary, secondary, accentSub) => ({
+      heading: accentSub,
+      body: primary,
+      caption: secondary,
+      micro: secondary,
+    }),
+  },
+  mono: {
+    label: '단색',
+    getColors: (primary) => ({
+      heading: primary,
+      body: primary,
+      caption: primary,
+      micro: primary,
+    }),
+  },
+  custom: {
+    label: '사용자 지정',
+    getColors: () => ({}),  // UI에서 직접 세팅
+  },
+};
+
+export function applyTextColors(colors: FontCategoryColors): void {
+  const root = document.documentElement;
+  const set = (key: keyof FontCategoryColors, cssVar: string) => {
+    const val = colors[key];
+    if (val) root.style.setProperty(cssVar, val);
+    else root.style.removeProperty(cssVar);
+  };
+  set('heading', '--color-text-heading');
+  set('body', '--color-text-body');
+  set('caption', '--color-text-caption');
+  set('micro', '--color-text-micro');
+}
+
+export function resetTextColors(): void {
+  applyTextColors({});
+}
+```
+
+- [ ] **Step 3: `settingsService.ts` `UserPreferences`에 필드 추가**
+
+[src/services/settingsService.ts:70-128] 인터페이스에 `fontCategoryScales` 아래에 추가:
+
+```ts
+// 글자 카테고리별 색상
+fontCategoryColors?: {
+  heading?: string;
+  body?: string;
+  caption?: string;
+  micro?: string;
+};
+fontColorPreset?: 'theme' | 'high-contrast' | 'soft' | 'mono' | 'custom';
+```
+
+- [ ] **Step 4: `src/index.css`에 카테고리 색상 CSS 규칙 추가**
+
+라인 61 부근 `:root` 블록 다음에 추가(기존 변수 유지):
+
+```css
+/* 글자 카테고리별 색상 — 미지정 시 --color-text-primary 폴백 */
+.text-xl, .text-lg, h1, h2, h3 {
+  color: rgb(var(--color-text-heading, var(--color-text-primary)));
+}
+.text-base, .text-sm {
+  color: rgb(var(--color-text-body, var(--color-text-primary)));
+}
+.text-xs {
+  color: rgb(var(--color-text-caption, var(--color-text-primary)));
+}
+.text-\[11px\], .text-\[10px\], .text-\[9px\] {
+  color: rgb(var(--color-text-micro, var(--color-text-primary)));
+}
+```
+
+**주의:** 명시적으로 `text-text-primary`/`text-text-secondary` 등 Tailwind 클래스를 지정한 요소는 Tailwind 규칙이 더 구체적이라 영향 없음 — Step 1의 그렙 결과 확인 대조.
+
+- [ ] **Step 5: 타입 체크 + 빌드**
+
+```bash
+npx tsc --noEmit
+npm run build:vite
+```
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add src/utils/typography.ts src/services/settingsService.ts src/index.css
+git commit -m "$(cat <<'EOF'
+feat(typography): 글자 카테고리별 색상 CSS 변수 기반 적용 함수
+
+applyTextColors()가 --color-text-{heading,body,caption,micro} 변수를 세팅한다.
+4개 프리셋(theme/high-contrast/soft/mono/custom) 정의.
+index.css는 카테고리별 color 규칙을 primary 폴백으로 추가 — 기존 명시 클래스는 불변.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: `FontColorSection` UI 추가 (이슈 ⑤ UI)
+
+**Files:**
+- Create: `src/components/settings/FontColorSection.tsx`
+- Modify: `src/components/settings/SettingsScreen.tsx` (또는 설정 진입점 파일) — 신규 섹션 마운트
+
+- [ ] **Step 1: 설정 진입점 파일 확인**
+
+```bash
+grep -rn "FontSizeSection" src/components/settings
+```
+→ 사용처 파일 확인 후 Step 3에서 동일한 곳에 `FontColorSection` 추가.
+
+- [ ] **Step 2: `FontColorSection.tsx` 작성**
+
+`src/components/settings/FontColorSection.tsx`:
+
+```tsx
+import { useState, useEffect } from 'react';
+import { FONT_CATEGORIES, FONT_COLOR_PRESETS, applyTextColors, type FontColorPreset, type FontCategoryColors } from '@/utils/typography';
+import { loadPreferences, savePreferences } from '@/services/settingsService';
+import { useAppStore } from '@/stores/useAppStore';
+import { getPreset, getLightColors } from '@/themes';
+
+function parseTriplet(rgb: string): [number, number, number] {
+  const [r, g, b] = rgb.split(' ').map(Number);
+  return [r || 0, g || 0, b || 0];
+}
+function toHex([r, g, b]: [number, number, number]): string {
+  return '#' + [r, g, b].map((n) => n.toString(16).padStart(2, '0')).join('');
+}
+function fromHex(hex: string): string {
+  const v = hex.replace('#', '');
+  const r = parseInt(v.slice(0, 2), 16);
+  const g = parseInt(v.slice(2, 4), 16);
+  const b = parseInt(v.slice(4, 6), 16);
+  return `${r} ${g} ${b}`;
+}
+
+export function FontColorSection() {
+  const themeId = useAppStore((s) => s.themeId);
+  const customThemeColors = useAppStore((s) => s.customThemeColors);
+  const colorMode = useAppStore((s) => s.colorMode);
+
+  const [preset, setPreset] = useState<FontColorPreset>('theme');
+  const [colors, setColors] = useState<FontCategoryColors>({});
+  const [advanced, setAdvanced] = useState(false);
+
+  // 현재 테마 색상 참조
+  const themeColors = customThemeColors ?? (colorMode === 'light' ? getLightColors(themeId) : getPreset(themeId)?.colors);
+  const primary = themeColors?.textPrimary ?? '232 232 238';
+  const secondary = themeColors?.textSecondary ?? '139 141 163';
+  const accentSub = themeColors?.accentSub ?? '162 155 254';
+
+  useEffect(() => {
+    (async () => {
+      const prefs = await loadPreferences();
+      if (prefs?.fontColorPreset) setPreset(prefs.fontColorPreset);
+      if (prefs?.fontCategoryColors) setColors(prefs.fontCategoryColors);
+    })();
+  }, []);
+
+  const handlePresetChange = async (p: FontColorPreset) => {
+    setPreset(p);
+    const nextColors = p === 'custom'
+      ? colors
+      : FONT_COLOR_PRESETS[p].getColors(primary, secondary, accentSub);
+    setColors(nextColors);
+    applyTextColors(nextColors);
+    const prev = (await loadPreferences()) ?? {};
+    await savePreferences({ ...prev, fontColorPreset: p, fontCategoryColors: nextColors });
+    window.electronAPI?.preferencesBroadcastChange?.({ fontColorPreset: p, fontCategoryColors: nextColors });
+  };
+
+  const handleCategoryColor = async (cat: keyof FontCategoryColors, hex: string) => {
+    const next = { ...colors, [cat]: fromHex(hex) };
+    setColors(next);
+    setPreset('custom');
+    applyTextColors(next);
+    const prev = (await loadPreferences()) ?? {};
+    await savePreferences({ ...prev, fontColorPreset: 'custom', fontCategoryColors: next });
+    window.electronAPI?.preferencesBroadcastChange?.({ fontColorPreset: 'custom', fontCategoryColors: next });
+  };
+
+  return (
+    <section className="space-y-4">
+      <header>
+        <h3 className="text-lg font-bold">글자 색상</h3>
+        <p className="text-xs text-text-secondary">카테고리별 색상을 프리셋 또는 사용자 지정으로 변경합니다.</p>
+      </header>
+
+      {/* 프리셋 */}
+      <div className="flex gap-2 flex-wrap">
+        {(Object.keys(FONT_COLOR_PRESETS) as FontColorPreset[]).map((p) => (
+          <button
+            key={p}
+            onClick={() => handlePresetChange(p)}
+            className={`px-3 py-1.5 rounded text-xs border ${preset === p ? 'bg-accent text-on-accent border-accent' : 'border-bg-border text-text-primary hover:bg-bg-card'}`}
+          >
+            {FONT_COLOR_PRESETS[p].label}
+          </button>
+        ))}
+      </div>
+
+      {/* 고급 모드 토글 */}
+      <label className="flex items-center gap-2 text-sm">
+        <input type="checkbox" checked={advanced} onChange={(e) => setAdvanced(e.target.checked)} />
+        고급 설정 (카테고리별 색상 개별 지정)
+      </label>
+
+      {advanced && (
+        <div className="space-y-3">
+          {FONT_CATEGORIES.map((cat) => {
+            const current = colors[cat.id]
+              ?? (preset !== 'custom' ? FONT_COLOR_PRESETS[preset].getColors(primary, secondary, accentSub)[cat.id] : undefined)
+              ?? primary;
+            return (
+              <div key={cat.id} className="flex items-center gap-3">
+                <div className="w-20 text-xs text-text-secondary">{cat.label}</div>
+                <input
+                  type="color"
+                  value={toHex(parseTriplet(current))}
+                  onChange={(e) => handleCategoryColor(cat.id, e.target.value)}
+                  className="w-10 h-8 rounded cursor-pointer"
+                />
+                <span className={`${cat.cssClass} flex-1`}>{cat.previewText}</span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}
+```
+
+- [ ] **Step 3: 설정 화면에 마운트**
+
+Step 1에서 찾은 파일에서 `FontSizeSection` 아래에 `<FontColorSection />` 추가. import 경로도 추가.
+
+- [ ] **Step 4: 타입 체크 + 빌드**
+
+```bash
+npx tsc --noEmit
+npm run build:vite
+```
+
+- [ ] **Step 5: 수동 스모크 — 프리셋 전환 / 고급 모드**
+
+```bash
+npm run electron:dev
+```
+1. 설정 → 글자 색상 섹션 진입 확인
+2. 프리셋 `high-contrast` 선택 → 제목 밝아짐 확인
+3. 고급 모드 체크 → 본문 색상 커스텀 → 즉시 반영 확인
+4. 앱 재시작 → 마지막 선택이 유지되는지 확인
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add src/components/settings/FontColorSection.tsx src/components/settings
+git commit -m "$(cat <<'EOF'
+feat(settings): 글자 카테고리별 색상 섹션 UI 추가
+
+프리셋 5종(theme/high-contrast/soft/mono/custom) + 고급 모드에서
+카테고리별 color picker. 변경 시 savePreferences + preferencesBroadcastChange.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7: `WidgetPopup` 초기화 통합 + 브로드캐스트 구독 (이슈 ②)
+
+**Files:**
+- Modify: `src/views/WidgetPopup.tsx:287-371` — 초기화 루틴에 `loadPreferences` + `applyFontSettings` + `applyTextColors` 호출, `onPreferencesChanged` 구독
+- Modify: `src/App.tsx` — 설정 저장 직후 `preferencesBroadcastChange` 호출 (이미 Task 6에서 FontColorSection이 호출하므로 FontSizeSection에도 동일 호출 추가)
+- Modify: `src/components/settings/FontSizeSection.tsx` — 변경 시 broadcast 추가
+
+- [ ] **Step 1: `WidgetPopup` 초기화에 preferences 적용 코드 추가**
+
+[src/views/WidgetPopup.tsx:287-371]의 `(async () => { ... })` 본문 `loadTheme` 직후에 추가:
+
+```ts
+// 글꼴 크기 + 색상 적용
+const prefs = await loadPreferences();
+if (prefs) {
+  applyFontSettings({
+    fontScale: (prefs.fontScale as FontScale) ?? DEFAULT_FONT_SCALE,
+    fontCategoryScales: {
+      heading: prefs.fontCategoryScales?.heading ?? 1,
+      body: prefs.fontCategoryScales?.body ?? 1,
+      caption: prefs.fontCategoryScales?.caption ?? 1,
+      micro: prefs.fontCategoryScales?.micro ?? 1,
+    },
+  });
+  applyTextColors(prefs.fontCategoryColors ?? {});
+}
+```
+
+import 추가:
+```ts
+import { loadPreferences } from '@/services/settingsService';
+import { applyFontSettings, applyTextColors, DEFAULT_FONT_SCALE, type FontScale } from '@/utils/typography';
+```
+
+- [ ] **Step 2: `onPreferencesChanged` 구독 추가**
+
+`WidgetPopup` 내 별도 `useEffect`:
+
+```ts
+useEffect(() => {
+  const cleanup = window.electronAPI?.onPreferencesChanged?.((_payload) => {
+    // 가장 단순한 방법: 재로드
+    loadPreferences().then((prefs) => {
+      if (!prefs) return;
+      applyFontSettings({
+        fontScale: (prefs.fontScale as FontScale) ?? DEFAULT_FONT_SCALE,
+        fontCategoryScales: {
+          heading: prefs.fontCategoryScales?.heading ?? 1,
+          body: prefs.fontCategoryScales?.body ?? 1,
+          caption: prefs.fontCategoryScales?.caption ?? 1,
+          micro: prefs.fontCategoryScales?.micro ?? 1,
+        },
+      });
+      applyTextColors(prefs.fontCategoryColors ?? {});
+    });
+  });
+  return () => { cleanup?.(); };
+}, []);
+```
+
+- [ ] **Step 3: 메인 앱도 동일하게 구독 (App.tsx)**
+
+`src/App.tsx`의 기존 초기화 `useEffect` 안 또는 별도 effect로:
+
+```ts
+useEffect(() => {
+  const cleanup = window.electronAPI?.onPreferencesChanged?.(() => {
+    loadPreferences().then((prefs) => {
+      if (!prefs) return;
+      applyFontSettings({ fontScale: (prefs.fontScale as FontScale) ?? 'm', fontCategoryScales: { heading: 1, body: 1, caption: 1, micro: 1, ...prefs.fontCategoryScales } });
+      applyTextColors(prefs.fontCategoryColors ?? {});
+    });
+  });
+  return () => { cleanup?.(); };
+}, []);
+```
+
+- [ ] **Step 4: `FontSizeSection`에 `preferencesBroadcastChange` 호출 추가**
+
+기존에 저장하는 곳(프리셋 변경 / 카테고리 스케일 슬라이더) 마지막에:
+
+```ts
+window.electronAPI?.preferencesBroadcastChange?.({ fontScale: ..., fontCategoryScales: ... });
+```
+
+(기존 구조에서 이미 savePreferences를 호출하는 지점 직후에 추가.)
+
+- [ ] **Step 5: 타입 체크 + 빌드**
+
+```bash
+npx tsc --noEmit
+npm run build:vite
+```
+
+- [ ] **Step 6: 수동 스모크 — 메인 변경 → 플로팅 즉시 반영**
+
+```bash
+npm run electron:dev
+```
+1. 플로팅 위젯(예: "내 할일") 띄움
+2. 메인에서 설정 → 글꼴 크기 xl로 변경
+3. 플로팅 위젯도 즉시 큰 글씨로 전환되는지 확인
+4. 글자 색상 프리셋 변경도 동일하게 플로팅에 반영되는지 확인
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add src/views/WidgetPopup.tsx src/App.tsx src/components/settings/FontSizeSection.tsx
+git commit -m "$(cat <<'EOF'
+fix(widget): 플로팅 위젯에 글꼴 크기/색상 적용 + 실시간 반영
+
+WidgetPopup 초기화에서 loadPreferences → applyFontSettings/applyTextColors 호출.
+FontSizeSection 변경 시 preferencesBroadcastChange 호출, 위젯과 메인이 구독 후 재적용.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 8: "내 할일" 플로팅 세션 동기화 (이슈 ③)
+
+**Files:**
+- Modify: `src/views/WidgetPopup.tsx` — `onSessionChanged` 구독
+- Modify: `src/App.tsx` — 로그인/로그아웃 시점에 `sessionBroadcastChange` 호출
+- Modify: `src/components/widgets/MyTasksWidget.tsx` — `currentUser` 미설정 시 로딩 상태 표시
+
+- [ ] **Step 1: 빌드 앱 재현 확인 (Task 1 로그 확인)**
+
+Task 1에서 빌드 후 자동 로그인 실패의 실제 로그를 확인했다면, 그 결과를 먼저 공유받는다. 로그가 "세션 없음"으로 나오면 이슈 ③도 "세션 자체가 안 실려서" 발생한 것이므로 Task 1 근본 수정으로 함께 해결 — 이 경우 Task 8 Step 2–3만 보험으로 추가.
+
+- [ ] **Step 2: `App.tsx`에서 로그인 성공 직후 broadcast**
+
+로그인 처리 핸들러(예: `handleLogin`) 마지막에:
+
+```ts
+window.electronAPI?.sessionBroadcastChange?.({ user });
+```
+
+로그아웃 핸들러도 동일:
+
+```ts
+window.electronAPI?.sessionBroadcastChange?.({ user: null });
+```
+
+- [ ] **Step 3: `WidgetPopup`에서 구독**
+
+```ts
+useEffect(() => {
+  const cleanup = window.electronAPI?.onSessionChanged?.((payload) => {
+    const { user } = (payload as { user: AppUser | null }) ?? {};
+    useAuthStore.getState().setCurrentUser(user ?? null);
+  });
+  return () => { cleanup?.(); };
+}, []);
+```
+
+- [ ] **Step 4: `MyTasksWidget` 로딩 상태**
+
+`activeView.type === 'assigned'` 분기 앞에 `currentUser === null && activeView.type === 'assigned'` 체크:
+
+```tsx
+if (activeView.type === 'assigned' && !currentUser) {
+  return <div className="flex items-center justify-center h-full text-xs text-text-secondary/60">사용자 정보 로딩 중...</div>;
+}
+```
+
+- [ ] **Step 5: 타입 체크 + 빌드**
+
+```bash
+npx tsc --noEmit
+npm run build:vite
+```
+
+- [ ] **Step 6: 수동 스모크 — 메인 로그인 → 플로팅 갱신**
+
+```bash
+npm run electron:dev
+```
+1. 메인 로그아웃 상태에서 "내 할일" 플로팅 띄움(가능한 경우) → 로딩 메시지 확인
+2. 메인 로그인 → 플로팅이 즉시 항목 채움
+3. 메인 로그아웃 → 플로팅이 다시 로딩 상태
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add src/views/WidgetPopup.tsx src/App.tsx src/components/widgets/MyTasksWidget.tsx
+git commit -m "$(cat <<'EOF'
+fix(widget): 플로팅 위젯 세션 동기화로 내 할일 빈 칸 해결
+
+메인 앱 로그인/로그아웃 시 sessionBroadcastChange → 모든 위젯 창의
+useAuthStore.currentUser를 동일 값으로 갱신. MyTasksWidget은 currentUser가
+아직 없을 때 로딩 상태를 표시.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Chunk 3: 시각 효과 및 휴가 (Task 9–12)
+
+### Task 9: `GradientBackdrop` 분리 + 파티클과 독립 토글 (이슈 ⑦)
+
+**사전 탐색 결과 (플랜 작성 시 확인됨):**
+- `plexusSettings` 타입: `src/stores/useAppStore.ts:110-121` (interface), 초기값: `:233-245`
+- 플렉서스 설정 UI: `src/components/settings/EffectsSection.tsx`
+- Dashboard.tsx 그라데이션 위치: 라인 127-150 (주석 `// ── 배경 그라데이션 조명` 부터 grd3의 `ctx.fillRect(0, 0, w, h);` 까지). 앞의 `ctx.clearRect`(라인 125)와 뒤의 파티클 물리 업데이트(라인 152~)는 유지.
+- LoginScreen.tsx 그라데이션 위치: 라인 205-221 (`if (!isLight) {` 블록 내의 **중앙 그라데이션 `cg`**(206-212) + **마우스 글로우 `mg`**(215-221)). 노이즈 오버레이(`ctx.drawImage(noiseRef.current, 0, 0);`, 223)는 유지.
+
+**Files:**
+- Create: `src/components/common/GradientBackdrop.tsx`
+- Modify: `src/views/Dashboard.tsx:125-150` — 그라데이션 블록만 제거
+- Modify: `src/components/auth/LoginScreen.tsx:205-222` — `cg`/`mg` 블록 제거(노이즈 유지)
+- Modify: `src/stores/useAppStore.ts:110-245` — `plexusSettings`에 gradient 플래그 추가
+- Modify: `src/services/settingsService.ts:86-96` — `UserPreferences.plexus`에 동일 필드 추가
+- Modify: `src/components/settings/EffectsSection.tsx` — 그라데이션 토글 UI
+
+- [ ] **Step 1: `GradientBackdrop` 컴포넌트 작성**
+
+`src/components/common/GradientBackdrop.tsx`:
+
+```tsx
+export function GradientBackdrop({ enabled = true }: { enabled?: boolean }) {
+  if (!enabled) return null;
+  return (
+    <div
+      className="fixed inset-0 pointer-events-none"
+      style={{
+        zIndex: -1,
+        background: `
+          radial-gradient(at 20% 10%, rgb(var(--color-accent) / 0.10) 0%, transparent 50%),
+          radial-gradient(at 80% 90%, rgb(var(--color-accent-sub) / 0.08) 0%, transparent 50%),
+          radial-gradient(at 50% 50%, rgb(var(--color-accent) / 0.04) 0%, transparent 60%)
+        `,
+      }}
+    />
+  );
+}
+```
+
+- [ ] **Step 2: `Dashboard.tsx` canvas 그라데이션 제거 + 컴포넌트 마운트**
+
+[src/views/Dashboard.tsx:127-150] 전체(`// ── 배경 그라데이션 조명 ...` 주석부터 grd3의 `ctx.fillRect(0, 0, w, h);` 까지)를 **통째로 삭제**한다. 앞 `ctx.clearRect(0, 0, w, h);`(125)와 뒤의 `const mx = mouseRef.current.x;` 이후 파티클 로직은 유지.
+
+또한 `DashboardPlexus` 컴포넌트를 렌더하는 상위 JSX(파일 내 `<DashboardPlexus />` 사용처)가 있는 블록 앞에 다음 배치:
+
+```tsx
+<GradientBackdrop enabled={plexusSettings.dashboardGradientEnabled !== false} />
+<DashboardPlexus />
+```
+
+import:
+```ts
+import { GradientBackdrop } from '@/components/common/GradientBackdrop';
+```
+
+- [ ] **Step 3: `LoginScreen.tsx` canvas 그라데이션 제거 + 컴포넌트 마운트**
+
+[src/components/auth/LoginScreen.tsx:205-222] 중 `if (!isLight) { ... }` 블록 내부의 두 영역만 삭제:
+- 중앙 그라데이션: `const cg = ctx.createRadialGradient(...)` 생성 ~ `ctx.fillRect(0, 0, w, h);` (대략 206-212)
+- 마우스 글로우: `if (mouseRef.current.x > 0 && mouseRef.current.y > 0) { const mg = ... ctx.fillRect(0, 0, w, h); }` (대략 214-221)
+
+**유지:** `ctx.drawImage(noiseRef.current, 0, 0);` (라인 223) — 노이즈 오버레이는 그라데이션이 아니므로 그대로 둔다.
+
+`PlexusBackground` 컴포넌트를 감싸는 상위 JSX(파일 내 `<PlexusBackground />` 사용처) 앞:
+
+```tsx
+<GradientBackdrop enabled={plexusSettings.loginGradientEnabled !== false} />
+<PlexusBackground />
+```
+
+- [ ] **Step 4: 스토어 + Preferences 타입 확장**
+
+`src/stores/useAppStore.ts`의 `plexusSettings` 인터페이스(라인 110-121)에 추가:
+
+```ts
+plexusSettings: {
+  loginEnabled: boolean;
+  loginGradientEnabled: boolean;        // 신규
+  loginParticleCount?: number;
+  dashboardEnabled: boolean;
+  dashboardGradientEnabled: boolean;    // 신규
+  dashboardParticleCount?: number;
+  speed?: number;
+  mouseRadius?: number;
+  mouseForce?: number;
+  glowIntensity?: number;
+  connectionDist?: number;
+};
+```
+
+초기값(라인 233-245)에 `loginGradientEnabled: true`, `dashboardGradientEnabled: true` 추가.
+
+`src/services/settingsService.ts:86-96`의 `UserPreferences.plexus`에도 동일한 두 optional 필드 추가:
+
+```ts
+plexus?: {
+  loginEnabled?: boolean;
+  loginGradientEnabled?: boolean;        // 신규
+  loginParticleCount?: number;
+  dashboardEnabled?: boolean;
+  dashboardGradientEnabled?: boolean;    // 신규
+  dashboardParticleCount?: number;
+  speed?: number;
+  mouseRadius?: number;
+  mouseForce?: number;
+  glowIntensity?: number;
+  connectionDist?: number;
+};
+```
+
+- [ ] **Step 5: 설정 UI에 그라데이션 토글 추가**
+
+`src/components/settings/EffectsSection.tsx`를 열고, 기존 파티클 토글(`dashboardEnabled`, `loginEnabled`) 근처에 동일 패턴으로 추가:
+
+```tsx
+<label className="flex items-center gap-2 text-sm">
+  <input
+    type="checkbox"
+    checked={plexusSettings.dashboardGradientEnabled !== false}
+    onChange={(e) => setPlexusSettings({ dashboardGradientEnabled: e.target.checked })}
+  />
+  대시보드 그라데이션 배경
+</label>
+<label className="flex items-center gap-2 text-sm">
+  <input
+    type="checkbox"
+    checked={plexusSettings.loginGradientEnabled !== false}
+    onChange={(e) => setPlexusSettings({ loginGradientEnabled: e.target.checked })}
+  />
+  로그인 그라데이션 배경
+</label>
+```
+
+(EffectsSection이 이미 `setPlexusSettings`로 저장/영속화 로직을 갖고 있다는 전제 — grep으로 확인 후 동일 메소드 사용. 저장 시 `savePreferences` 호출도 함께 있어야 함. 없으면 기존 토글 핸들러 패턴 그대로 복제.)
+
+- [ ] **Step 6: 타입 체크 + 빌드**
+
+```bash
+npx tsc --noEmit
+npm run build:vite
+```
+
+- [ ] **Step 7: 수동 스모크**
+
+```bash
+npm run electron:dev
+```
+1. 대시보드 파티클 OFF → 그라데이션 유지 확인(기존엔 완전 단색)
+2. 대시보드 그라데이션 OFF → 단색 배경
+3. 로그인 화면 동일 패턴 확인
+
+- [ ] **Step 8: 커밋**
+
+```bash
+git add src/components/common/GradientBackdrop.tsx src/views/Dashboard.tsx src/components/auth/LoginScreen.tsx src/services/settingsService.ts src/stores
+git commit -m "$(cat <<'EOF'
+feat(ui): 대시보드/로그인 그라데이션을 파티클과 독립 토글
+
+GradientBackdrop 컴포넌트를 canvas 외부 DOM 레이어로 분리.
+plexus.dashboardGradientEnabled / loginGradientEnabled 설정 추가.
+파티클 OFF 상태에서도 그라데이션 배경을 유지할 수 있음.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 10: 플렉서스 파티클 폴백/지연 수정 (이슈 ④)
+
+**Files:**
+- Modify: `src/components/auth/LoginScreen.tsx:48-77` — `getPlexusColors` 폴백 + 테마 로드 대기
+- Modify: `src/views/Dashboard.tsx:77-84` — `getColors` 폴백 동일
+
+- [ ] **Step 1: 폴백 배열을 accent 계열만으로 축소**
+
+`src/components/auth/LoginScreen.tsx:48-77`의 `getPlexusColors()` 중 **폴백 배열만** 교체(라인 52):
+
+```ts
+// Before (라인 52)
+if (!colors) return [[108, 92, 231], [162, 155, 254], [116, 185, 255], [0, 184, 148], [85, 239, 196]];
+
+// After
+if (!colors) return [[108, 92, 231], [162, 155, 254]];  // accent/accentSub 보라 계열만 — 파랑/청록 제거
+```
+
+**나머지 로직(HSL 기반 보색/유사색 생성, 최종 return 배열 8개)은 그대로 유지.** 테마가 로드된 정상 흐름에서는 기존과 동일하게 동작하며, 폴백 노출 시의 색상만 축소된다.
+
+`src/views/Dashboard.tsx:77-84`의 `getColors()`는 이미 `[[108, 92, 231], [162, 155, 254]]` 폴백이므로 변경 불필요.
+
+- [ ] **Step 2: 파티클 초기화를 테마 로드 후로 지연**
+
+LoginScreen의 PlexusBackground 컴포넌트에 `themeReady` 체크 추가:
+
+```tsx
+function PlexusBackground() {
+  const themeId = useAppStore((s) => s.themeId);  // 구독으로 변경 감지
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    // 테마가 한 번이라도 바뀌면(초기 로드 포함) ready
+    setReady(true);
+  }, [themeId]);
+
+  useEffect(() => {
+    if (!ready) return;
+    // ... 기존 파티클 생성/애니메이션 로직
+  }, [ready, themeId]);
+  // ...
+}
+```
+
+- [ ] **Step 3: 파티클 색을 매 프레임 최신 테마에서 resolve (LoginScreen + Dashboard 양쪽)**
+
+**LoginScreen.tsx** 수정:
+
+1. `Particle` 타입(라인 9 근처)에서 `color: [number, number, number]` → `colorIdx: number`로 교체.
+2. `createParticle` 함수(라인 89-100)에서:
+   ```ts
+   // Before
+   const cols = plexusColors ?? getPlexusColors();
+   const color = cols[Math.floor(Math.random() * cols.length)];
+   return { ..., color };
+
+   // After
+   const cols = plexusColors ?? getPlexusColors();
+   const colorIdx = Math.floor(Math.random() * cols.length);
+   return { ..., colorIdx };
+   ```
+3. 애니메이션 루프에서 `p.color` 참조를 전부 `getPlexusColors()[p.colorIdx % palette.length]`로 바꾼다. 매 프레임 상단에서 `const palette = getPlexusColors();`를 한 번 호출하고 루프에서 재사용:
+   ```ts
+   const palette = getPlexusColors();
+   for (const p of particles) {
+     const [r, g, b] = palette[p.colorIdx % palette.length];
+     // 기존 fillStyle/strokeStyle에서 p.color → [r, g, b] 사용
+   }
+   ```
+4. 연결선 렌더에서 `pts[i].color` → `palette[pts[i].colorIdx % palette.length]`.
+
+**Dashboard.tsx** 수정 (동일 패턴):
+
+1. `DashPt` 타입에서 `color` → `colorIdx`.
+2. `resize` 내 파티클 생성(라인 97-103)에서 `c` 대신 인덱스 저장:
+   ```ts
+   const cols = getColors();
+   ptsRef.current = Array.from({ length: ptCount }, () => {
+     const colorIdx = Math.floor(Math.random() * cols.length);
+     return { x: ..., y: ..., vx: ..., vy: ..., size: ..., colorIdx, alpha: ... };
+   });
+   ```
+3. 애니메이션 루프(`animate` 내부, 라인 118~)에서 매 프레임 최상단에 `const palette = getColors();` 추가. `p.color`, `pts[i].color` 참조를 `palette[p.colorIdx % palette.length]`로 교체.
+
+**주의:** 타입 호환성 — 기존에 `p.color`를 쓰는 모든 라인을 TS 컴파일러가 잡아준다. `npx tsc --noEmit`으로 누락 확인.
+
+- [ ] **Step 4: 타입 체크 + 빌드**
+
+```bash
+npx tsc --noEmit
+npm run build:vite
+```
+
+- [ ] **Step 5: 수동 스모크**
+
+```bash
+npm run electron:dev
+```
+1. 로그인 화면 진입 → 파티클 색이 현재 테마 accent 계열만 보이는지 확인 (파랑/청록 없음)
+2. 설정 → 테마 커스텀으로 accent 변경 → 대시보드 파티클이 새 색으로 전환되는지 확인
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add src/components/auth/LoginScreen.tsx src/views/Dashboard.tsx
+git commit -m "$(cat <<'EOF'
+fix(plexus): 파티클 색상이 테마 따라가도록 수정
+
+1. 폴백 팔레트에서 파랑/청록 제거 (accent/accentSub만)
+2. 파티클은 색 인덱스만 저장, draw 시 매 프레임 최신 팔레트 조회
+3. 테마 로드 전에는 파티클 초기화 지연 (폴백 색 일시 노출 방지)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 11: 휴가 pending 상태 + 브로드캐스트 토스트 (이슈 ⑧)
+
+**사전 탐색 결과:**
+- 실제 휴가 등록 함수: `submitVacation(data)` — `src/services/vacationService.ts:60`. (플랜 초안의 `registerVacation`은 없는 함수. 시그니처는 `(data: { ... })` 형태.)
+- `electron/main.ts`에 `fs`(라인 6), `path`(라인 5), `broadcastToAllWindows`(Task 2) 모두 이미 사용 가능.
+- 30초 타임아웃 주체는 **메인 창(App.tsx)만** 담당. 플로팅 위젯에서는 중복 실행 방지.
+
+**Files:**
+- Modify: `electron/main.ts` — `vacation:pending:load/save` IPC, `vacation:registered/failed` broadcast
+- Modify: `electron/preload.ts`, `src/types/electron.d.ts` — API 노출
+- Create: `src/stores/useVacationPendingStore.ts` (Zustand store)
+- Modify: `src/components/widgets/VacationWidget.tsx` — 낙관적 업데이트 + pending 렌더
+- Modify: `src/components/widgets/CalendarWidget.tsx` — pending 이벤트 노란색 렌더
+- Modify: `src/App.tsx`, `src/views/WidgetPopup.tsx` — `vacation:registered`/`failed` 구독 → sonner 토스트 (App.tsx에서만 30초 타임아웃)
+
+- [ ] **Step 1: 메인 프로세스 IPC (파일 I/O + broadcast)**
+
+`electron/main.ts`에 추가(파일 I/O와 broadcast 핸들러는 같은 섹션에 모은다). `fs`, `path`는 이미 import됨(라인 5-6).
+
+```ts
+const PENDING_VACATIONS_FILE = 'pendingVacations.json';
+
+ipcMain.handle('vacation:pending:load', () => {
+  try {
+    const file = path.join(app.getPath('userData'), PENDING_VACATIONS_FILE);
+    if (!fs.existsSync(file)) return [];
+    return JSON.parse(fs.readFileSync(file, 'utf-8'));
+  } catch (err) {
+    console.warn('[vacation] pending 로드 실패:', err);
+    return [];
+  }
+});
+
+ipcMain.handle('vacation:pending:save', (_e, list: unknown) => {
+  try {
+    const file = path.join(app.getPath('userData'), PENDING_VACATIONS_FILE);
+    fs.writeFileSync(file, JSON.stringify(list ?? []), 'utf-8');
+    return { ok: true };
+  } catch (err) {
+    console.error('[vacation] pending 저장 실패:', err);
+    return { ok: false };
+  }
+});
+
+ipcMain.handle('vacation:broadcast-registered', (_e, payload: unknown) => {
+  broadcastToAllWindows('vacation:registered', payload);
+  return { ok: true };
+});
+
+ipcMain.handle('vacation:broadcast-failed', (_e, payload: unknown) => {
+  broadcastToAllWindows('vacation:failed', payload);
+  return { ok: true };
+});
+```
+
+- [ ] **Step 2: preload.ts + 타입 완전 정의**
+
+`electron/preload.ts`에 추가(Task 2의 `onPreferencesChanged` 리스너 패턴을 동일하게 복제):
+
+```ts
+vacationPendingLoad: () =>
+  ipcRenderer.invoke('vacation:pending:load'),
+vacationPendingSave: (list: unknown) =>
+  ipcRenderer.invoke('vacation:pending:save', list),
+vacationBroadcastRegistered: (payload?: unknown) =>
+  ipcRenderer.invoke('vacation:broadcast-registered', payload),
+vacationBroadcastFailed: (payload?: unknown) =>
+  ipcRenderer.invoke('vacation:broadcast-failed', payload),
+
+onVacationRegistered: (callback: (payload: unknown) => void) => {
+  const listener = (_event: Electron.IpcRendererEvent, payload: unknown) => callback(payload);
+  ipcRenderer.on('vacation:registered', listener);
+  return () => ipcRenderer.removeListener('vacation:registered', listener);
+},
+onVacationFailed: (callback: (payload: unknown) => void) => {
+  const listener = (_event: Electron.IpcRendererEvent, payload: unknown) => callback(payload);
+  ipcRenderer.on('vacation:failed', listener);
+  return () => ipcRenderer.removeListener('vacation:failed', listener);
+},
+```
+
+`src/types/electron.d.ts`의 `electronAPI` 인터페이스에 시그니처 추가:
+
+```ts
+vacationPendingLoad: () => Promise<unknown>;
+vacationPendingSave: (list: unknown) => Promise<{ ok: boolean }>;
+vacationBroadcastRegistered: (payload?: unknown) => Promise<{ ok: boolean }>;
+vacationBroadcastFailed: (payload?: unknown) => Promise<{ ok: boolean }>;
+onVacationRegistered: (cb: (payload: unknown) => void) => () => void;
+onVacationFailed: (cb: (payload: unknown) => void) => () => void;
+```
+
+- [ ] **Step 3: `useVacationPendingStore` 작성**
+
+`src/stores/useVacationPendingStore.ts`:
+
+```ts
+import { create } from 'zustand';
+import type { VacationEvent } from '@/types';
+
+interface PendingEvent extends VacationEvent {
+  status: 'pending';
+  pendingId: string;
+  createdAt: number;
+}
+
+interface Store {
+  pending: PendingEvent[];
+  hydrated: boolean;
+  hydrate: () => Promise<void>;
+  add: (ev: PendingEvent) => Promise<void>;
+  remove: (pendingId: string) => Promise<void>;
+  clearStale: (olderThanMs: number) => Promise<void>;
+}
+
+export const useVacationPendingStore = create<Store>((set, get) => ({
+  pending: [],
+  hydrated: false,
+  hydrate: async () => {
+    const list = (await window.electronAPI?.vacationPendingLoad?.()) as PendingEvent[] | null;
+    set({ pending: list ?? [], hydrated: true });
+  },
+  add: async (ev) => {
+    const next = [...get().pending, ev];
+    set({ pending: next });
+    await window.electronAPI?.vacationPendingSave?.(next);
+  },
+  remove: async (pendingId) => {
+    const next = get().pending.filter((p) => p.pendingId !== pendingId);
+    set({ pending: next });
+    await window.electronAPI?.vacationPendingSave?.(next);
+  },
+  clearStale: async (olderThanMs) => {
+    const now = Date.now();
+    const next = get().pending.filter((p) => now - p.createdAt < olderThanMs);
+    if (next.length !== get().pending.length) {
+      set({ pending: next });
+      await window.electronAPI?.vacationPendingSave?.(next);
+    }
+  },
+}));
+```
+
+- [ ] **Step 4: `VacationWidget` 낙관적 업데이트 + pending 렌더**
+
+`src/components/widgets/VacationWidget.tsx` 기존 등록 흐름을 찾아(`submitVacation`이 실제 API — `src/services/vacationService.ts:60`) 다음 패턴으로 래핑:
+
+```ts
+import { submitVacation } from '@/services/vacationService';
+import { useVacationPendingStore } from '@/stores/useVacationPendingStore';
+
+const handleRegister = async (data: Parameters<typeof submitVacation>[0]) => {
+  const pendingId = `pending-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  // UI용 pending VacationEvent 합성 — 실제 필드는 data.dates/name 등에 맞춰 변환
+  const pendingEvent = {
+    ...data,
+    pendingId,
+    status: 'pending' as const,
+    createdAt: Date.now(),
+  };
+  await useVacationPendingStore.getState().add(pendingEvent);
+  try {
+    await submitVacation(data);
+    await useVacationPendingStore.getState().remove(pendingId);
+    await window.electronAPI?.vacationBroadcastRegistered?.({ name: data.name });
+    await load();  // 기존 위젯의 데이터 리로드
+  } catch (err) {
+    await useVacationPendingStore.getState().remove(pendingId);
+    await window.electronAPI?.vacationBroadcastFailed?.({ error: String(err) });
+  }
+};
+```
+
+**주의:** `submitVacation` 실제 인자 형태는 `src/services/vacationService.ts:60-71`를 열어 복사. `VacationEvent` 타입은 `src/types`에서 import. pending 이벤트의 `pendingId`는 기존 키(`rowIndex`, `date+name` 등)와 충돌하지 않도록 `'pending-...'` prefix를 문자열로 보장.
+
+pending 이벤트는 기존 이벤트 렌더 로직에 합류시키되 `className="bg-amber-400/20 border border-amber-400/60 text-amber-200"` 같은 노란 계열로 분기.
+
+- [ ] **Step 5: `CalendarWidget`에도 pending 이벤트 병합 표시**
+
+`src/components/widgets/CalendarWidget.tsx`에서:
+
+```ts
+import { useVacationPendingStore } from '@/stores/useVacationPendingStore';
+const pending = useVacationPendingStore((s) => s.pending);
+```
+
+기존 이벤트 렌더 배열에 `pending`을 **concat**해서 함께 표시. pending 이벤트는 `pendingId`로 구분해 노란 스타일을 분기(`event.status === 'pending'` 또는 `'pendingId' in event` 체크). key로 `event.pendingId ?? event.id ?? \`${date}-${name}\``를 사용하여 기존 정상 이벤트 key와 충돌 없도록 한다.
+
+- [ ] **Step 6: 토스트 구독 (App.tsx + WidgetPopup.tsx)**
+
+```ts
+import { toast } from 'sonner';
+
+useEffect(() => {
+  const cleanup = window.electronAPI?.onVacationRegistered?.(() => {
+    toast.success('휴가 등록 완료');
+  });
+  return () => { cleanup?.(); };
+}, []);
+useEffect(() => {
+  const cleanup = window.electronAPI?.onVacationFailed?.((payload) => {
+    toast.error(`휴가 등록 실패: ${(payload as { error?: string })?.error ?? '알 수 없는 오류'}`);
+  });
+  return () => { cleanup?.(); };
+}, []);
+```
+
+- [ ] **Step 7: 30초 타임아웃 (메인 창 전용)**
+
+**App.tsx에서만** 실행(플로팅 위젯에서는 실행 금지 — 중복 방지):
+
+```ts
+useEffect(() => {
+  // 초기 1회 + 이후 15초마다 오래된 pending 정리
+  useVacationPendingStore.getState().hydrate();
+  const timer = setInterval(() => {
+    useVacationPendingStore.getState().clearStale(30_000);
+  }, 15_000);
+  return () => clearInterval(timer);
+}, []);
+```
+
+`WidgetPopup.tsx`에서는 `hydrate()`만 호출하고 setInterval은 추가하지 않는다. 여러 플로팅 창이 동시에 setInterval을 돌릴 때 같은 파일을 동시에 여러 번 쓰는 경쟁 상태 방지.
+
+`clearStale`에서 제거된 pending 각각에 대해 `sonner.toast.error('휴가 등록 타임아웃 (30초 경과) — 다시 시도해주세요')` 를 메인 창에서만 호출(Store 내부에서 broadcast 호출은 하지 않음 — 메인 창이 직접 처리).
+
+- [ ] **Step 8: 타입 체크 + 빌드**
+
+```bash
+npx tsc --noEmit
+npm run build:vite
+```
+
+- [ ] **Step 9: 수동 스모크**
+
+```bash
+npm run electron:dev
+```
+1. 휴가 등록 → 즉시 노란색 pending 표시
+2. 대기 중 다른 탭 이동 후 돌아옴 → 여전히 노란색
+3. 등록 완료 → 어느 화면이든 "휴가 등록 완료" 토스트
+4. 네트워크 끊은 채 등록 → 30초 뒤 자동 실패 토스트
+
+- [ ] **Step 10: 커밋**
+
+```bash
+git add electron/main.ts electron/preload.ts src/types/electron.d.ts src/stores/useVacationPendingStore.ts src/components/widgets/VacationWidget.tsx src/components/widgets/CalendarWidget.tsx src/services/vacationService.ts src/App.tsx src/views/WidgetPopup.tsx
+git commit -m "$(cat <<'EOF'
+feat(vacation): 등록 중 pending 상태 + 완료 브로드캐스트 토스트
+
+1. 낙관적 업데이트: 등록 요청 즉시 노란색 pending 이벤트 추가
+2. pending 목록을 pendingVacations.json에 영속화 (화면 전환/재시작 유지)
+3. 완료/실패 시 broadcastToAllWindows → 어느 창이든 sonner 토스트
+4. 30초 타임아웃으로 무한 pending 방지
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 12: 최종 빌드 검증 + 스모크 테스트
+
+**Files:** 없음(검증만)
+
+- [ ] **Step 1: 전체 타입 체크**
+
+```bash
+npx tsc --noEmit
+```
+Expected: 0 에러.
+
+- [ ] **Step 2: 렌더러 빌드**
+
+```bash
+npm run build:vite
+```
+Expected: 번들 생성 성공.
+
+- [ ] **Step 3: 개발 모드 스모크 (먼저)**
+
+```bash
+npm run electron:dev
+```
+
+아래 체크리스트 중 빌드가 필요 없는 항목을 개발 모드에서 먼저 확인. 이 단계에서 찾은 버그는 각 Task로 돌아가 수정.
+
+- 카드 뷰 스크롤 최상단에서 메모 클릭 → 라쏘 안 생김 (이슈 ①)
+- 설정 프리셋 xl 변경 → 모든 위젯 즉시 반영 (이슈 ②)
+- "내 할일" 플로팅이 메인과 동일 항목 수 노출 (이슈 ③)
+- 로그인/대시보드 파티클이 테마 색만 사용 (이슈 ④)
+- 글자 카테고리 색상 프리셋 5종 + 고급 모드 동작 (이슈 ⑤)
+- 파티클 OFF 시 그라데이션 유지 (이슈 ⑦)
+- 휴가 등록 pending + 완료 토스트 전역 (이슈 ⑧)
+- EP 위젯 재시작 후 데이터 복원 (이슈 ⑨, 개발 모드에서도 재현 가능)
+
+- [ ] **Step 4: Electron 실제 빌드 (검증용 포터블 exe)**
+
+```bash
+npm run build
+```
+Expected: `release/BFLOW.exe` (또는 `dist-electron/` 하위 포터블 파일) 생성 성공.
+
+- [ ] **Step 5: 빌드 앱 수동 스모크 — 이슈 ⑥ 중점**
+
+빌드된 `BFLOW.exe`를 실행:
+
+- [ ] 빌드 앱 최초 실행 → 로그인 → 앱 종료 → 재실행 → **자동 로그인 성공** (이슈 ⑥ 근본 수정 확인)
+- [ ] Task 1에서 추가한 진단 로그 확인 (DevTools 콘솔) — 실패 시 로그로 원인 파악 후 Task 1-B로 근본 수정 추가
+- [ ] `%APPDATA%\Bflow-BGonly\auth.json`이 실제 생성·읽기 가능한지 확인
+
+- [ ] **Step 6: 기타 빌드 앱 스모크**
+
+Step 3에서 개발 모드로 통과한 항목도 빌드 앱에서 재확인:
+
+- [ ] 이슈 ①~⑨ 전부 빌드 앱에서도 동일하게 동작
+
+**실패 시**: 해당 Task로 돌아가 수정 → 재빌드 → 재확인.
+
+- [ ] **Step 7: 하위 호환 스모크**
+
+1. 구버전 `widget-positions.json` 파일 그대로 둔 채 새 빌드 실행 → crash 없이 동작, 이후 extra 저장되어 새 포맷 반영
+2. 구버전 `preferences.json` (fontCategoryColors 없는 상태) 로드 → 기본 색상 정상 동작
+
+- [ ] **Step 8: 최종 커밋 (필요 시 lessons.md 업데이트)**
+
+```bash
+git add tasks/lessons.md  # 실행 중 얻은 교훈이 있으면
+git commit -m "chore: Phase 마무리 검증 완료 + lessons 갱신"
+```
+
+---
+
+## 체크리스트 — PR 올리기 전
+
+- [ ] 모든 Task의 커밋이 브랜치에 쌓였는가
+- [ ] `npm run build` 성공
+- [ ] 수동 스모크 9건 모두 통과
+- [ ] `ROADMAP.md` 해당 Phase 상태 갱신 (필요 시)
+- [ ] 버전 범프 (`package.json` `1.9.0` → `1.10.0` — 기능 추가이므로 minor)
+
+## 리스크 메모
+
+- **Task 1 근본 수정**이 Task 1-A(로그 추가)만으로는 완결되지 않는다. 빌드 앱 재현 후 추가 커밋 필요. 해당 시점에 Task 1-B를 본 플랜에 추가로 기재.
+- **Task 5의 CSS 선택자**가 전역에 적용된다. 기존 명시 클래스 사용처가 많다면 일부 UI에서 색이 바뀔 수 있음 — Step 1 그렙 결과로 사전 평가.
+- **Task 11 파일 I/O** 경로가 한글 포함(드라이브 경로)일 가능성. `app.getPath('userData')`를 사용하므로 문제없어야 하나, 저장 실패 로그 확인.

--- a/docs/superpowers/specs/2026-04-18-bflow-ui-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-18-bflow-ui-fixes-design.md
@@ -159,6 +159,9 @@ if (prefs) {
 - `mono` — 전부 primary
 - `custom` — 고급 모드 사용자 지정
 
+**기존 사용처 영향 범위**  
+- 구현 플랜 1단계에서 `text-text-primary`, `text-text-secondary`, `text-[11px]`, `text-[10px]`, `text-xs`, `text-sm`, `text-base`, `text-lg`, `text-xl` 등 Tailwind 텍스트 클래스의 현재 사용처를 `grep`으로 집계. 명시적으로 `text-text-*`를 지정한 컴포넌트는 **기존 색 유지**, 미지정 컴포넌트만 신규 CSS 변수 폴백으로 색상이 바뀐다. 회귀 영향을 미리 추정하고 필요 시 명시 클래스를 일부 제거.
+
 **설정 UI**  
 - `FontColorSection.tsx` 신규. `FontSizeSection`과 동일 UX:
   - 프리셋 셀렉터 5종(프리셋 선택 시 개별 색상 자동 적용·잠금).
@@ -178,7 +181,7 @@ if (prefs) {
 `app.setName('Bflow-BGonly')`가 main process 초기화에 명시되지 않으면 userData 경로가 `package.json`의 `productName` 등으로 결정되어 **개발과 빌드 경로가 달라질 수 있다**. 결과적으로 빌드 앱이 `auth.json`을 찾지 못해 세션 복원 실패.
 
 **수정**  
-1. `electron/main.ts` 최상단에 `app.setName('Bflow-BGonly')` 또는 `app.setPath('userData', ...)` 명시(CLAUDE.md 경로 요건 `%APPDATA%\Bflow-BGonly\`).
+1. **선행 체크**: `electron/main.ts`에 이미 `app.setName(...)` 또는 `app.setPath('userData', ...)`가 있는지 먼저 grep. 있으면 이름·경로가 `Bflow-BGonly`와 정확히 일치하는지만 확인. 없으면 `app.setName('Bflow-BGonly')` 추가(CLAUDE.md 경로 요건 `%APPDATA%\Bflow-BGonly\`).
 2. `loadSession` 실패 구간별 로그 추가:
    - auth.json 미존재
    - JSON 파싱 실패
@@ -226,8 +229,9 @@ if (prefs) {
 1. 낙관적 업데이트 — 등록 요청 순간 `useVacationStore`(신규 또는 기존 vacation store)에 `pendingEvents: VacationEvent[]` 추가. `status: 'pending'` 필드로 구분.
 2. `VacationWidget`과 `CalendarWidget` 렌더링 시 pending 이벤트는 **노란색(예: amber-400 배경 + amber 테두리)** 으로 표시.
 3. 영속성 — pending 목록을 `%APPDATA%\Bflow-BGonly\pendingVacations.json`에 저장. 다른 화면 전환/재시작 시에도 유지.
+   - 신규 IPC: `vacation:pending:load` (읽기), `vacation:pending:save` (쓰기). `electron/main.ts`에 파일 I/O 핸들러 추가, `electron/preload.ts`에 `vacationPendingLoad/Save` 노출.
 4. 메인 프로세스에 `vacation:registered` broadcast 채널 추가. API 응답 성공 시 모든 창에 push → 각 창이 `sonner.toast.success('휴가 등록 완료')` 표시 + pending 제거.
-5. 실패 시 `vacation:failed` broadcast → 에러 토스트 + pending을 사용자 수동 재시도 또는 자동 롤백.
+5. 실패 시 `vacation:failed` broadcast → 에러 토스트 + pending을 사용자 수동 재시도 또는 자동 롤백. 30초 타임아웃으로 무한 pending 방지.
 
 **테스트**  
 - 휴가 등록 버튼 클릭 → 즉시 노란색 pending으로 표시.
@@ -313,3 +317,5 @@ if (prefs) {
 - [ ] 글자 카테고리별 색상 프리셋 5종 + 고급 모드 동작
 - [ ] 휴가 등록 pending 상태 + 완료 토스트 전역 전파
 - [ ] EP 위젯 재시작 복원 성공(EP 번호 유지)
+- [ ] 구버전 `widget-positions.json` 로드 시 `extra` 없어도 crash 없음, 이후 저장하면 새 포맷 반영
+- [ ] 구버전 `preferences.json`(fontCategoryColors 미존재)에서도 기본 색상 정상 동작

--- a/docs/superpowers/specs/2026-04-18-bflow-ui-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-18-bflow-ui-fixes-design.md
@@ -1,0 +1,315 @@
+# B flow 9개 UI/UX 이슈 통합 수정 — 설계 문서
+
+- 작성일: 2026-04-18
+- 브랜치: `claude/quirky-keller-3422fd`
+- 대상 범위: Electron 메인 앱, 플로팅 위젯(BrowserWindow), 대시보드 내 위젯, 로그인 화면
+- PR 단위: **단일 PR**(사용자 결정)
+
+## 배경
+
+사용자 리포트로 파악된 9건의 이슈를 한 PR에 통합 반영한다. 구성은 다음과 같다.
+
+1. 씬 뷰 카드 메모 영역 클릭이 라쏘 드래그로 오인식되어 다수 카드가 선택됨
+2. 설정의 글꼴 크기(프리셋·카테고리별 스케일)가 플로팅 위젯/대시보드 위젯에 반영되지 않음
+3. "내 할일" 위젯을 플로팅으로 띄우면 항목이 빈 칸으로 표시됨
+4. 로그인 화면 플렉서스 파티클 색상이 현재 테마와 다르게 보임(초기 프레임 폴백 색상 노출 추정)
+5. 글자 카테고리별 **색상** 개별 조절 기능 신규 추가(크기와 동일 구조) — 메인·플로팅·대시보드 전부
+6. 빌드된 앱에서 자동 로그인이 작동하지 않음
+7. 대시보드 파티클을 끄면 그라데이션 배경도 함께 사라짐 → 그라데이션만 유지하는 **옵션** 제공. **로그인 화면까지 포함**(사용자 결정)
+8. 휴가 등록 중에는 캘린더/휴가 위젯에 "등록 대기중" 상태(노란색)로 표시, 등록 완료 시 어느 화면에서든 토스트 알림
+9. 에피소드 위젯을 플로팅으로 띄운 상태에서 앱 재시작 시 위젯이 빈 칸으로 뜸(에피소드 번호 파라미터 미복원)
+
+## 용어 및 참고
+
+- **플로팅 위젯**: `WidgetPopup`이 진입점인 별도 BrowserWindow. `#widget-popup/<id>?ep=...` URL hash로 메타 전달.
+- **대시보드 위젯**: 메인 앱 대시보드에서 `react-grid-layout`으로 배치되는 카드.
+- **공유 경로**
+  - 글꼴 설정: `src/services/settingsService.ts`(loadPreferences/savePreferences), `src/utils/typography.ts`(applyFontSettings), `preferences.json`
+  - 테마 색상: `src/themes.ts`(applyTheme), `src/index.css` 전역 CSS 변수
+  - 위젯 팝업 창 생성: `electron/main.ts` `openWidgetPopup()`, 위치 캐시 `widgetPositionCache`
+  - 세션: `src/services/userService.ts`(loadSession), `src/stores/useAuthStore.ts`, `auth.json`
+
+## 설계 — 이슈별
+
+### ① 카드 메모 클릭 → 라쏘 오인식
+
+**현상 (사용자 보고)**  
+`스크롤 맨 위` 상태에서 2번 컷의 메모 영역을 클릭하면 스크롤이 내려가며 6번 컷이 선택되어 2–6번 다중 선택이 되는 것처럼 보임. 마우스는 움직이지 않았음.
+
+**원인**  
+- `useLassoSelection`([src/views/ScenesView.tsx:41-113])의 라쏘 제외 셀렉터(`button, input, select, textarea, a, [role="button"]`)에 메모 영역이 포함되지 않음. 메모는 `<div><p>`([src/components/scenes/UnifiedSceneCard.tsx:140-146]).
+- mousedown 직후 카드에 포커스/레이아웃 변화로 스크롤 컨테이너가 움직이면 `getBoundingClientRect()` 기반 교차 판정에서 라쏘 드래그가 사실상 시작된 효과가 난다.
+- 5px 임계값은 `clientX/Y`만 기준이라 "스크롤 발생 후 실제 마우스 이동 없음" 케이스를 거르지 못함.
+
+**수정**  
+1. `UnifiedSceneCard.tsx` 메모 래퍼 div에 `data-no-lasso` 속성 추가.
+2. `useLassoSelection` 제외 조건에 `[data-no-lasso]`, `[contenteditable="true"]`도 포함(이미 지원 — 확인 후 보강).
+3. mousedown 당시 `container.scrollTop/scrollLeft`를 `startScrollRef`에 저장. mousemove에서 실제 스크롤 변화분을 dx/dy에서 **차감**하여 스크롤로 인한 가짜 이동을 무효화한다.
+
+```ts
+// mousedown
+startScrollRef.current = { top: container.scrollTop, left: container.scrollLeft };
+// mousemove
+const scrollDx = container.scrollLeft - startScrollRef.current.left;
+const scrollDy = container.scrollTop - startScrollRef.current.top;
+const dx = me.clientX - startRef.current.x - scrollDx;
+const dy = me.clientY - startRef.current.y - scrollDy;
+if (!isDragging.current && Math.abs(dx) < 8 && Math.abs(dy) < 8) return;
+```
+
+4. 임계값 5 → 8px(클릭 허용 범위 완화).
+
+**테스트**  
+- 카드 뷰 스크롤 최상단에서 상단 카드 메모 클릭 → 라쏘 안 뜨고 단일 클릭으로만 처리.
+- 빈 영역에서 실제 드래그 시 라쏘 선택 정상 동작 확인.
+
+---
+
+### ② 글꼴 크기 플로팅/대시보드 위젯 미적용
+
+**원인**  
+`WidgetPopup`의 초기화([src/views/WidgetPopup.tsx:287-371])에서 `loadTheme()`만 호출하고 `loadPreferences()` + `applyFontSettings()`가 빠져 있음. 플로팅 BrowserWindow는 별도 렌더러 프로세스라 메인 앱의 `document.documentElement.style`을 공유하지 않음.
+
+**수정**  
+1. `WidgetPopup` 초기화 루틴에 아래 추가(theme 적용 직후).
+
+```ts
+const prefs = await loadPreferences();
+if (prefs) {
+  applyFontSettings({
+    scale: prefs.fontScale ?? 'm',
+    categoryScales: prefs.fontCategoryScales,
+  });
+}
+```
+
+2. **실시간 반영**: 메인 앱의 `FontSizeSection`/`FontColorSection`에서 저장 시, `window.electronAPI.preferencesBroadcast()`(신규 IPC) 호출 → 메인 프로세스가 모든 위젯 창에 `preferences:changed` 전송 → 각 위젯이 리스너에서 `loadPreferences` + `applyFontSettings` + `applyTextColors`(신규) 재호출.
+3. 메인 창도 동일 브로드캐스트에 반응(자기 자신 포함).
+
+**테스트**  
+- 설정에서 프리셋 xl로 변경 → 메인·플로팅·대시보드 모든 위젯 글자 크기 즉시 변경.
+- 앱 재시작 후에도 유지.
+
+---
+
+### ③ "내 할일" 플로팅 빈 칸
+
+**원인 가설**  
+- `WidgetPopup`의 `loadSession()`([src/views/WidgetPopup.tsx:362-365])은 호출되지만 실패 조건(auth.json 파싱 문제, 사용자 배열 불일치)에서 `currentUser`가 null.
+- 또는 `currentUser.name`은 설정되더라도, 씬 `assignee` 이름 매칭 로직과 `readTaskViews(userId)`의 assignedSceneKeys 로드가 플로팅 컨텍스트에서 async 경합.
+- 이슈 ⑥(자동 로그인)와 동일 근본 원인일 가능성. **먼저 ⑥을 고치면 해결되는지 확인** 후 남은 케이스만 추가 패치.
+
+**수정**  
+1. `loadSession` 실패/사용자 없음 시 로그를 명시적으로 남김(`console.warn('[WidgetPopup] session load failed', reason)`).
+2. `MyTasksWidget`의 `activeView.type === 'assigned'` 분기에서 `currentUser`가 아직 없을 때 스켈레톤/로딩 상태로 렌더링(현재는 `name=''`이면 빈 배열 반환).
+3. `readTaskViews` 호출도 `currentUser?.id`가 준비된 뒤에 trigger. 현재 이미 userId 기반이면 확인.
+4. 이슈 ⑥ 수정 후 재현 없으면 여기서 마무리. 재현 시 `useAuthStore`를 플로팅 창에서 메인 창과 동기화하는 IPC(`session:broadcast`) 추가 — 메인이 로그인 성공/로그아웃 시 모든 창에 push.
+
+**테스트**  
+- 메인에서 로그인한 사용자로 "내 할일" 플로팅 띄우기 → 메인과 동일 개수의 씬 노출.
+- 메인에서 로그아웃 후 플로팅도 빈 상태로 전환.
+
+---
+
+### ④ 플렉서스 파티클에 테마와 다른 색이 껴 보임
+
+**원인**  
+- `PlexusBackground` / `DashboardPlexus`의 `getPlexusColors`/`getColors`([src/components/auth/LoginScreen.tsx:48-77], [src/views/Dashboard.tsx:77-84])는 테마 로드 실패 시 하드코딩 RGB 폴백을 사용: `[[108,92,231], [162,155,254], [116,185,255], [0,184,148], [85,239,196]]` — 파랑/청록이 섞여 있음.
+- 로그인 화면은 테마 로드 전에 canvas 첫 프레임이 렌더될 수 있음. 파티클 색은 생성 시 고정되어, 이후 테마가 적용돼도 이미 칠해진 파티클은 폴백 색상을 유지.
+
+**수정**  
+1. 파티클 생성 루프를 "테마 로드 확정 후"로 지연. `PlexusBackground` 내부에서 `themeReady` 플래그가 true가 될 때까지 canvas 비우고 대기.
+2. 폴백 배열은 **테마 accent/accentSub만** 남기고 파랑/청록 제거(`[[108,92,231], [162,155,254]]`). 필요한 variation은 HSL 이동으로 생성하되 채도 너무 튀지 않게 clamp.
+3. 파티클마다 색 레퍼런스를 "인덱스 → 현재 getPlexusColors() 반환의 인덱스"로 매 프레임 resolve하도록 바꿔, 테마 변경이 실시간 반영되게 한다(현재는 초기화 시 한 번 고정).
+
+**테스트**  
+- 로그인 화면 최초 진입 → 파티클이 현재 테마 accent 계열로 통일되어 보임(파랑/청록 없음).
+- 설정에서 테마 색 변경(커스텀) → 대시보드/로그인 파티클 색이 즉시 따라감.
+
+---
+
+### ⑤ 글자 카테고리별 색상 개별 조절 (신기능)
+
+**구조**  
+- `UserPreferences`([src/services/settingsService.ts])에 추가:
+  ```ts
+  fontCategoryColors?: {
+    heading?: string;  // "R G B" RGB triplet (theme와 동일 포맷)
+    body?: string;
+    caption?: string;
+    micro?: string;
+  };
+  fontColorPreset?: 'theme' | 'high-contrast' | 'soft' | 'mono' | 'custom';
+  ```
+- `applyFontSettings`와 별개로 `applyTextColors(colors)` 함수를 `typography.ts`에 추가. `document.documentElement`에 CSS 변수를 설정:
+  - `--color-text-heading`, `--color-text-body`, `--color-text-caption`, `--color-text-micro` (미지정 시 `--color-text-primary`로 폴백).
+- `src/index.css`에 카테고리 클래스 매핑:
+  ```css
+  .text-xl, .text-lg, h1, h2, h3 { color: rgb(var(--color-text-heading, var(--color-text-primary))); }
+  .text-base, .text-sm { color: rgb(var(--color-text-body, var(--color-text-primary))); }
+  .text-xs { color: rgb(var(--color-text-caption, var(--color-text-primary))); }
+  .text-\[11px\], .text-\[10px\], .text-\[9px\] { color: rgb(var(--color-text-micro, var(--color-text-primary))); }
+  ```
+  (Tailwind `text-text-primary` 등 명시 클래스를 이미 사용하는 곳은 유지 — 계층 색상은 "기본값 override" 레이어로 동작.)
+
+**프리셋 (사용자 결정: 포함)**  
+- `theme` (기본) — 모두 `--color-text-primary`
+- `high-contrast` — 제목 100% 흰, 본문 primary, 캡션/마이크로 secondary
+- `soft` — 제목 accent-sub, 본문 primary, 캡션/마이크로 secondary(낮은 밝기)
+- `mono` — 전부 primary
+- `custom` — 고급 모드 사용자 지정
+
+**설정 UI**  
+- `FontColorSection.tsx` 신규. `FontSizeSection`과 동일 UX:
+  - 프리셋 셀렉터 5종(프리셋 선택 시 개별 색상 자동 적용·잠금).
+  - 고급 토글 ON 시 카테고리별 color picker + 현재 미리보기.
+  - 설정 저장 → `savePreferences` → `applyTextColors` 즉시 호출 → 이슈 ②의 브로드캐스트 채널로 다른 창도 반영.
+
+**테스트**  
+- 프리셋 high-contrast 선택 → 제목 대비 증가 확인.
+- 고급에서 본문 색만 변경 → 메인·플로팅·대시보드 모두 즉시 반영.
+- 테마 변경 시 프리셋 `theme`이면 새 테마 색을 따라감.
+
+---
+
+### ⑥ 빌드 앱 자동 로그인 실패
+
+**원인 가설**  
+`app.setName('Bflow-BGonly')`가 main process 초기화에 명시되지 않으면 userData 경로가 `package.json`의 `productName` 등으로 결정되어 **개발과 빌드 경로가 달라질 수 있다**. 결과적으로 빌드 앱이 `auth.json`을 찾지 못해 세션 복원 실패.
+
+**수정**  
+1. `electron/main.ts` 최상단에 `app.setName('Bflow-BGonly')` 또는 `app.setPath('userData', ...)` 명시(CLAUDE.md 경로 요건 `%APPDATA%\Bflow-BGonly\`).
+2. `loadSession` 실패 구간별 로그 추가:
+   - auth.json 미존재
+   - JSON 파싱 실패
+   - `users.find(...)`가 undefined
+3. 빌드 후 `%APPDATA%\Bflow-BGonly\` 실제 존재/파일 확인.
+4. `rememberMe`가 false로 저장되어 있는 케이스도 방어: 기본값 true 유지 확인.
+
+**테스트**  
+- 빌드 설치 후 최초 로그인 → 앱 재실행 → 자동 로그인 성공.
+- `%APPDATA%\Bflow-BGonly\auth.json` 존재 및 읽기 가능.
+
+---
+
+### ⑦ 파티클 OFF 시 그라데이션 유지 옵션 (로그인 화면 포함)
+
+**원인**  
+그라데이션이 canvas 내부(`ctx.createRadialGradient`)에 그려져 파티클과 묶여 있음([src/views/Dashboard.tsx:127-150], [src/components/auth/LoginScreen.tsx:PlexusBackground 내부]).
+
+**수정**  
+1. 그라데이션을 canvas 밖 DOM 배경으로 분리:
+   ```tsx
+   <div className="fixed inset-0 -z-10" style={{
+     background: `radial-gradient(at 20% 10%, rgb(var(--color-accent) / 0.10) 0%, transparent 50%),
+                  radial-gradient(at 80% 90%, rgb(var(--color-accent-sub) / 0.08) 0%, transparent 50%)`,
+   }} />
+   ```
+   - 색은 이미 존재하는 테마 변수 사용 → 테마 바뀌면 자동 갱신.
+2. `useAppStore.plexusSettings`에 `gradientEnabled` 추가(기본 true). 파티클 설정 UI에 "그라데이션 배경" 토글 추가.
+3. 파티클 `enabled=false`여도 `gradientEnabled=true`면 그라데이션 레이어만 렌더.
+4. **적용 범위** — Dashboard + LoginScreen (사용자 결정). 각 컴포넌트가 동일 `GradientBackdrop` 재사용 가능한 컴포넌트로 분리.
+
+**테스트**  
+- 대시보드에서 파티클 off → 어두운 단색 대신 그라데이션 유지.
+- 설정에서 그라데이션 off → 완전 단색.
+- 로그인 화면도 동일 동작.
+
+---
+
+### ⑧ 휴가 등록 대기 상태 + 완료 토스트
+
+**현상**  
+현재 휴가 등록은 GAS API 호출 후 응답이 와야 반영. 등록 요청 후 다른 화면으로 나갔다 돌아오면 대기 상태가 사라짐. 완료 알림 없음.
+
+**수정**  
+1. 낙관적 업데이트 — 등록 요청 순간 `useVacationStore`(신규 또는 기존 vacation store)에 `pendingEvents: VacationEvent[]` 추가. `status: 'pending'` 필드로 구분.
+2. `VacationWidget`과 `CalendarWidget` 렌더링 시 pending 이벤트는 **노란색(예: amber-400 배경 + amber 테두리)** 으로 표시.
+3. 영속성 — pending 목록을 `%APPDATA%\Bflow-BGonly\pendingVacations.json`에 저장. 다른 화면 전환/재시작 시에도 유지.
+4. 메인 프로세스에 `vacation:registered` broadcast 채널 추가. API 응답 성공 시 모든 창에 push → 각 창이 `sonner.toast.success('휴가 등록 완료')` 표시 + pending 제거.
+5. 실패 시 `vacation:failed` broadcast → 에러 토스트 + pending을 사용자 수동 재시도 또는 자동 롤백.
+
+**테스트**  
+- 휴가 등록 버튼 클릭 → 즉시 노란색 pending으로 표시.
+- 대기 중 다른 탭 이동 후 복귀 → 여전히 노란색.
+- 등록 완료 시 어느 화면이든 토스트 알림.
+- 실패 시 에러 토스트 + 상태 롤백.
+
+---
+
+### ⑨ 에피소드 위젯 재시작 시 빈 칸
+
+**원인**  
+`widgetPositionCache`([electron/main.ts 1340-1500 근처])는 위치/크기/AOT/opacity만 저장. `openWidgetPopup(widgetId, title, extra)`의 `extra` (예: `{ ep: '1' }`)가 저장되지 않아 재실행 시 `#widget-popup/ep-overall-progress` 로만 로드됨 → `extraParams.ep === undefined` → `episodeDashboardEp` 복원 안 됨 → 렌더 대상 에피소드 없음 → 빈 칸.
+
+**수정**  
+1. `WidgetPosition` 타입에 `extra?: Record<string, string>` 추가.
+2. `openWidgetPopup` 호출 시점에 `widgetPositionCache.set(widgetId, { ...existing, extra })`로 저장.
+3. 창 생성 시 `savedPos.extra`가 있으면 URL hash의 query string에 자동 주입.
+4. 저장 대상은 `ep-*` 위젯 공통(특정 prefix 필터 불필요, 모든 extra 저장).
+5. 기존 포지션 저장 파일(`widget-positions.json` 등) 하위 호환성 유지 — `extra` 미존재 시 `undefined`로 로드.
+
+**테스트**  
+- EP 1의 "EP 통합 진행률" 플로팅 띄움 → 앱 종료 → 재시작 → 동일 위치·크기에 EP 1 데이터로 복원.
+- EP 2의 "EP 부서별 비교"도 동일 시나리오로 확인.
+
+---
+
+## 변경 파일 요약
+
+| 영역 | 파일 | 변경 |
+|------|------|------|
+| 라쏘 수정 | `src/views/ScenesView.tsx`, `src/components/scenes/UnifiedSceneCard.tsx` | 제외 셀렉터 + 스크롤 보정 + `data-no-lasso` |
+| 위젯 공통 초기화 | `src/views/WidgetPopup.tsx` | `loadPreferences` + `applyFontSettings` + `applyTextColors` + 브로드캐스트 리스너 |
+| 폰트 색상 (신규) | `src/utils/typography.ts`, `src/services/settingsService.ts`, `src/index.css`, `src/components/settings/FontColorSection.tsx`, `src/components/settings/SettingsScreen.tsx` 진입점 | 카테고리별 색상 + 프리셋 |
+| 브로드캐스트 IPC | `electron/main.ts`, `electron/preload.ts`, `src/types/electron.d.ts` | `preferences:changed`, `vacation:registered`, `session:broadcast` |
+| 플렉서스 | `src/components/auth/LoginScreen.tsx`, `src/views/Dashboard.tsx` | 테마 로드 전 파티클 지연 + 폴백 색 정리 + 그라데이션 분리 |
+| 그라데이션 분리 | `src/components/common/GradientBackdrop.tsx` (신규), `LoginScreen.tsx`, `Dashboard.tsx` | 공통 배경 컴포넌트 |
+| 자동 로그인 | `electron/main.ts`, `src/App.tsx`, `src/services/userService.ts` | `setName` 명시 + 로그 |
+| 휴가 | `src/components/widgets/VacationWidget.tsx`, `src/components/widgets/CalendarWidget.tsx`, `src/services/vacationService.ts`, `src/stores/useVacationStore.ts` (신규 가능), `electron/main.ts` | pending 상태 + 영속 + 브로드캐스트 토스트 |
+| 위젯 복원 | `electron/main.ts` (`widgetPositionCache`), `electron/preload.ts` | `extra` 영속화 |
+
+## 작업 순서 (단일 PR 내부 순서)
+
+1. `electron/main.ts` `app.setName` + 로그(이슈 ⑥)
+2. IPC 브로드캐스트 인프라 추가(`preferences:changed`, `vacation:*`, `session:broadcast`)
+3. 위젯 창 `extra` 영속화(이슈 ⑨)
+4. 라쏘 제외/스크롤 보정(이슈 ①)
+5. `applyTextColors` + CSS 변수 기반 카테고리 색(이슈 ⑤ 코어)
+6. `FontColorSection` + 프리셋 UI(이슈 ⑤ UI)
+7. `WidgetPopup` 초기화 루틴에 preferences/텍스트 색 적용(이슈 ②)
+8. MyTasks 플로팅 세션 문제 재확인 및 패치(이슈 ③)
+9. `GradientBackdrop` 분리 + 설정 토글(이슈 ⑦)
+10. 플렉서스 폴백/지연 수정(이슈 ④)
+11. 휴가 pending 흐름(이슈 ⑧)
+12. 단계마다 `tsc --noEmit` + `vite build`
+
+## 호환성 및 리스크
+
+- **기존 preferences.json**: 신규 필드는 전부 optional. 구버전 파일도 그대로 로드.
+- **widgetPositionCache 포맷 변경**: `extra` 필드 추가는 하위 호환(미존재 시 undefined).
+- **CSS 변수 추가**: `--color-text-heading` 등은 폴백(`var(... , --color-text-primary)`)으로 기본값 유지. 기존 컴포넌트 색상 깨짐 없음.
+- **IPC 브로드캐스트 누적**: 리스너 정리(return cleanup) 누락 시 메모리 누수. `useEffect` 구독은 반드시 cleanup 반환.
+- **플렉서스 지연**: 테마 로드가 지연되면 로그인 화면이 잠시 비어 보일 수 있음 → 빈 배경 대신 `GradientBackdrop`이 이미 깔려 있어 위화감 최소.
+- **휴가 pending**: 네트워크 장애로 무한 pending 방지 위해 30초 후 자동 실패 처리(타이머).
+- **단일 PR 규모**: 파일 약 12–15개 변경. 각 이슈가 독립적이라 리뷰 청크별 검토 가능.
+
+## 미결 사항
+
+- 플로팅 위젯용 `session:broadcast`가 필요한지는 이슈 ⑥ 수정 후 재현 테스트로 결정.
+- 프리셋 `high-contrast` 등의 실제 색상값은 디자인 토큰(`themes.ts`)의 현재 accent/secondary와 맞춰 구현 시 최종 확정.
+- 휴가 pending의 UI 구체 스타일(노란색 배경 농도)은 기존 VacationWidget 색상 체계에 맞춰 구현 시 조정.
+
+## 검증 체크리스트
+
+- [ ] tsc --noEmit 통과
+- [ ] vite build 통과
+- [ ] 메인 앱 로그인 → 재실행 → 자동 로그인 성공
+- [ ] 카드 뷰 스크롤 최상단에서 메모 클릭 시 라쏘 안 생김
+- [ ] 설정 프리셋 변경 시 모든 위젯에 즉시 반영
+- [ ] "내 할일" 플로팅이 메인과 동일 항목 수 노출
+- [ ] 로그인/대시보드 파티클이 테마 색만 사용
+- [ ] 파티클 off 시 그라데이션 유지 가능
+- [ ] 글자 카테고리별 색상 프리셋 5종 + 고급 모드 동작
+- [ ] 휴가 등록 pending 상태 + 완료 토스트 전역 전파
+- [ ] EP 위젯 재시작 복원 성공(EP 번호 유지)

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -66,6 +66,9 @@ let splashWin: BrowserWindow | null = null;
 let mainLoadedOk = false;
 let loadTimeoutId: ReturnType<typeof setTimeout> | null = null;
 let showTrayHintInFlight = false;
+// 최근 브로드캐스트된 세션 정보 캐시 → 새로 열리는 플로팅 위젯 창에 즉시 전달
+// (메인 프로세스 재시작 시 null로 초기화됨 — 메인 창이 첫 로그인 broadcast를 쏘면 다시 캐싱)
+let lastKnownSession: unknown = null;
 
 /** 아이콘 경로 해석: dev(electron/)와 prod(dist-electron/) + app.getAppPath() 순회 */
 function resolveTrayIconPath(): string {
@@ -1115,6 +1118,7 @@ ipcMain.handle('preferences:broadcast-change', (_event, payload: unknown) => {
 });
 
 ipcMain.handle('session:broadcast-change', (_event, payload: unknown) => {
+  lastKnownSession = payload;
   broadcastToAllWindows('session:changed', payload);
   return { ok: true };
 });
@@ -1473,8 +1477,13 @@ function openWidgetPopup(widgetId: string, widgetTitle: string, extra?: Record<s
   // Acrylic DWM 버그 우회: 생성자의 alwaysOnTop:true는 기본 레벨이라 Acrylic에서 무효.
   // 윈도우 준비 후 'normal' 레벨로 명시적 재설정 (Acrylic에서 'normal'이 실제 topmost)
   popupWin.once('ready-to-show', () => {
-    if (!popupWin.isDestroyed() && initAOT) {
+    if (popupWin.isDestroyed()) return;
+    if (initAOT) {
       popupWin.setAlwaysOnTop(true, 'normal');
+    }
+    // 마지막으로 알려진 세션을 즉시 전달 → 위젯 초기 "사용자 정보 로딩 중..." 상태 해결
+    if (lastKnownSession) {
+      popupWin.webContents.send('session:changed', lastKnownSession);
     }
   });
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1194,13 +1194,16 @@ ipcMain.handle('vacation:pending:save', (_e, list: unknown) => {
   return pendingSaveChain;
 });
 
-ipcMain.handle('vacation:broadcast-registered', (_e, payload: unknown) => {
-  broadcastToAllWindows('vacation:registered', payload);
+// 송신자 제외(excludeSenderId): 현재 창은 VacationRegisterModal에서 로컬 setToast로
+// 즉시 피드백하므로, 자기 자신이 broadcast를 받아 Sonner 토스트를 중복 표시하는 것을 방지.
+// dev/test 모드에서도 로컬 setToast가 동작하여 사용자 피드백 보장.
+ipcMain.handle('vacation:broadcast-registered', (event, payload: unknown) => {
+  broadcastToAllWindows('vacation:registered', payload, event.sender.id);
   return { ok: true };
 });
 
-ipcMain.handle('vacation:broadcast-failed', (_e, payload: unknown) => {
-  broadcastToAllWindows('vacation:failed', payload);
+ipcMain.handle('vacation:broadcast-failed', (event, payload: unknown) => {
+  broadcastToAllWindows('vacation:failed', payload, event.sender.id);
   return { ok: true };
 });
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1119,6 +1119,42 @@ ipcMain.handle('session:broadcast-change', (_event, payload: unknown) => {
   return { ok: true };
 });
 
+// ─── IPC 핸들러: 휴가 pending 상태 파일 I/O + 브로드캐스트 ─────
+
+const PENDING_VACATIONS_FILE = 'pendingVacations.json';
+
+ipcMain.handle('vacation:pending:load', () => {
+  try {
+    const file = path.join(app.getPath('userData'), PENDING_VACATIONS_FILE);
+    if (!fs.existsSync(file)) return [];
+    return JSON.parse(fs.readFileSync(file, 'utf-8'));
+  } catch (err) {
+    console.warn('[vacation] pending 로드 실패:', err);
+    return [];
+  }
+});
+
+ipcMain.handle('vacation:pending:save', (_e, list: unknown) => {
+  try {
+    const file = path.join(app.getPath('userData'), PENDING_VACATIONS_FILE);
+    fs.writeFileSync(file, JSON.stringify(list ?? []), 'utf-8');
+    return { ok: true };
+  } catch (err) {
+    console.error('[vacation] pending 저장 실패:', err);
+    return { ok: false };
+  }
+});
+
+ipcMain.handle('vacation:broadcast-registered', (_e, payload: unknown) => {
+  broadcastToAllWindows('vacation:registered', payload);
+  return { ok: true };
+});
+
+ipcMain.handle('vacation:broadcast-failed', (_e, payload: unknown) => {
+  broadcastToAllWindows('vacation:failed', payload);
+  return { ok: true };
+});
+
 // ─── IPC 핸들러: 휴가 관리 (vacation-repo WebApi) ────────────
 
 ipcMain.handle('vacation:connect', async (_event, webAppUrl: string) => {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1189,6 +1189,13 @@ ipcMain.handle('vacation:broadcast-failed', (_e, payload: unknown) => {
   return { ok: true };
 });
 
+// pending 상태 변경(add/remove/clearStale) 브로드캐스트 — 다른 창이 hydrate하여 노란색 동기화
+// 송신자 제외(excludeSenderId): 자기 상태를 덮어쓰지 않도록 (이미 set으로 최신)
+ipcMain.handle('vacation:broadcast-pending-changed', (event, payload: unknown) => {
+  broadcastToAllWindows('vacation:pending-changed', payload, event.sender.id);
+  return { ok: true };
+});
+
 // ─── IPC 핸들러: 휴가 관리 (vacation-repo WebApi) ────────────
 
 ipcMain.handle('vacation:connect', async (_event, webAppUrl: string) => {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1122,10 +1122,15 @@ ipcMain.handle('session:broadcast-change', (_event, payload: unknown) => {
 // ─── IPC 핸들러: 휴가 pending 상태 파일 I/O + 브로드캐스트 ─────
 
 const PENDING_VACATIONS_FILE = 'pendingVacations.json';
+let pendingSaveChain: Promise<{ ok: boolean }> = Promise.resolve({ ok: true });
+
+function getPendingVacationsPath(): string {
+  return path.join(app.getPath('userData'), PENDING_VACATIONS_FILE);
+}
 
 ipcMain.handle('vacation:pending:load', () => {
   try {
-    const file = path.join(app.getPath('userData'), PENDING_VACATIONS_FILE);
+    const file = getPendingVacationsPath();
     if (!fs.existsSync(file)) return [];
     return JSON.parse(fs.readFileSync(file, 'utf-8'));
   } catch (err) {
@@ -1135,14 +1140,18 @@ ipcMain.handle('vacation:pending:load', () => {
 });
 
 ipcMain.handle('vacation:pending:save', (_e, list: unknown) => {
-  try {
-    const file = path.join(app.getPath('userData'), PENDING_VACATIONS_FILE);
-    fs.writeFileSync(file, JSON.stringify(list ?? []), 'utf-8');
-    return { ok: true };
-  } catch (err) {
-    console.error('[vacation] pending 저장 실패:', err);
-    return { ok: false };
-  }
+  // 저장은 체인으로 직렬화 — 동시 호출 경합 방지
+  pendingSaveChain = pendingSaveChain.then(async () => {
+    try {
+      const file = getPendingVacationsPath();
+      await fs.promises.writeFile(file, JSON.stringify(list ?? []), 'utf-8');
+      return { ok: true };
+    } catch (err) {
+      console.error('[vacation] pending 저장 실패:', err);
+      return { ok: false };
+    }
+  });
+  return pendingSaveChain;
 });
 
 ipcMain.handle('vacation:broadcast-registered', (_e, payload: unknown) => {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -447,6 +447,16 @@ function broadcastSnapshotRelay(excludeWebContentsId: number, data: unknown): vo
   }
 }
 
+/** 메인 창 + 모든 위젯 창에 동일 이벤트 push */
+function broadcastToAllWindows(channel: string, payload?: unknown): void {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send(channel, payload);
+  }
+  for (const win of widgetWindows.values()) {
+    if (!win.isDestroyed()) win.webContents.send(channel, payload);
+  }
+}
+
 // ─── 유틸리티 ─────────────────────────────────────────────────
 
 function getDataPath(): string {
@@ -1092,6 +1102,17 @@ ipcMain.handle('data:notify-change', (event, delta?: unknown) => {
 // 스냅샷 릴레이: 구조적 변경 후 최신 데이터를 다른 창에 직접 전달
 ipcMain.handle('sheets:relay-snapshot', (event, data: unknown) => {
   broadcastSnapshotRelay(event.sender.id, data);
+  return { ok: true };
+});
+
+// 렌더러 → 메인: "지금 설정 바꿨으니 다른 창에도 알려줘"
+ipcMain.handle('preferences:broadcast-change', (_event, payload: unknown) => {
+  broadcastToAllWindows('preferences:changed', payload);
+  return { ok: true };
+});
+
+ipcMain.handle('session:broadcast-change', (_event, payload: unknown) => {
+  broadcastToAllWindows('session:changed', payload);
   return { ok: true };
 });
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1123,6 +1123,11 @@ ipcMain.handle('session:broadcast-change', (_event, payload: unknown) => {
   return { ok: true };
 });
 
+ipcMain.handle('theme:broadcast-change', (_event, payload: unknown) => {
+  broadcastToAllWindows('theme:changed', payload);
+  return { ok: true };
+});
+
 // ─── IPC 핸들러: 휴가 pending 상태 파일 I/O + 브로드캐스트 ─────
 
 const PENDING_VACATIONS_FILE = 'pendingVacations.json';

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -270,6 +270,9 @@ interface SavedWidgetState {
   x: number; y: number; width: number; height: number;
   opacity: number; alwaysOnTop: boolean;
   title?: string;
+  // 위젯 query string용 부가 파라미터 (예: EP 위젯의 ?ep=1).
+  // 재실행 시 유실 방지를 위해 함께 영속화. optional이라 구버전 파일과 호환.
+  extra?: Record<string, string>;
 }
 
 // 위젯 ID → 제목 매핑 (자동 복원 시 title 미저장 파일 호환용)
@@ -1371,6 +1374,10 @@ function openWidgetPopup(widgetId: string, widgetTitle: string, extra?: Record<s
   const initHeight = savedPos ? Math.max(200, savedPos.height) : 360;
   const initAOT = savedPos ? savedPos.alwaysOnTop : true;
 
+  // 호출 시점 extra가 우선. 없으면 이전에 저장된 extra 복원.
+  // (EP 위젯 `?ep=1` 등의 query string 파라미터 영속화 — 이슈 ⑨)
+  const effectiveExtra = extra ?? savedPos?.extra;
+
   const popupWin = new BrowserWindow({
     width: initWidth,
     height: initHeight,
@@ -1408,8 +1415,8 @@ function openWidgetPopup(widgetId: string, widgetTitle: string, extra?: Record<s
 
   // 같은 앱을 로드하되, 해시로 팝업 모드 + 위젯 ID 전달
   let hash = `#widget-popup/${encodeURIComponent(widgetId)}`;
-  if (extra && Object.keys(extra).length > 0) {
-    const qs = new URLSearchParams(extra).toString();
+  if (effectiveExtra && Object.keys(effectiveExtra).length > 0) {
+    const qs = new URLSearchParams(effectiveExtra).toString();
     hash += `?${qs}`;
   }
   if (process.env.VITE_DEV_SERVER_URL) {
@@ -1433,11 +1440,14 @@ function openWidgetPopup(widgetId: string, widgetTitle: string, extra?: Record<s
   const existingCache = widgetPositionCache.get(widgetId);
   if (existingCache) {
     existingCache.title = widgetTitle;
+    // 명시적 extra가 새로 들어온 경우만 덮어씀 (복원 경로에서는 savedPos?.extra를 유지)
+    if (extra) existingCache.extra = extra;
   } else {
     const b = popupWin.getBounds();
     widgetPositionCache.set(widgetId, {
       x: b.x, y: b.y, width: b.width, height: b.height,
       opacity: 1.0, alwaysOnTop: initAOT, title: widgetTitle,
+      extra: effectiveExtra,
     });
   }
   saveWidgetPositionsDebounced();
@@ -1511,6 +1521,7 @@ function openWidgetPopup(widgetId: string, widgetTitle: string, extra?: Record<s
       opacity: prev?.opacity ?? 0.92,
       alwaysOnTop: prev?.alwaysOnTop ?? true,
       title: prev?.title ?? widgetTitle,
+      extra: prev?.extra ?? effectiveExtra,
     });
     saveWidgetPositionsDebounced();
   };
@@ -1536,6 +1547,7 @@ ipcMain.handle('widget:set-opacity', (_event, widgetId: string, opacity: number)
       widgetPositionCache.set(widgetId, cached);
     } else {
       cached.opacity = clamped;
+      // extra는 기존 값 유지 (별도 변경 없음)
     }
     saveWidgetPositionsDebounced();
   }
@@ -1942,7 +1954,9 @@ app.whenReady().then(() => {
         for (const [widgetId, state] of widgetPositionCache) {
           try {
             const title = state.title || WIDGET_TITLE_MAP[widgetId] || widgetId;
-            openWidgetPopup(widgetId, title);
+            // state.extra를 명시적으로 넘기지 않아도 openWidgetPopup 내부에서
+            // savedPos.extra를 자동 복원(effectiveExtra)하지만, 명시 전달로 의도를 분명히 한다.
+            openWidgetPopup(widgetId, title, state.extra);
           } catch (err) {
             console.error(`[위젯 자동복원] ${widgetId} 실패:`, err);
           }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1133,6 +1133,15 @@ ipcMain.handle('session:broadcast-change', (_event, payload: unknown) => {
   return { ok: true };
 });
 
+// 팝업이 onSessionChanged 구독 등록 후 명시적으로 재전송을 요청 — ready-to-show 타이밍 miss 방어.
+// event.sender.send로 요청한 창에만 전송 (broadcast 아님). lastKnownSession이 null이면 무응답.
+ipcMain.handle('session:request-current', (event) => {
+  if (lastKnownSession !== null) {
+    event.sender.send('session:changed', lastKnownSession);
+  }
+  return { ok: true };
+});
+
 ipcMain.handle('theme:broadcast-change', (_event, payload: unknown) => {
   broadcastToAllWindows('theme:changed', payload);
   return { ok: true };

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1166,7 +1166,13 @@ ipcMain.handle('vacation:pending:load', () => {
   try {
     const file = getPendingVacationsPath();
     if (!fs.existsSync(file)) return [];
-    return JSON.parse(fs.readFileSync(file, 'utf-8'));
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    // 파일이 유효 JSON이지만 배열이 아닌 경우(파손 후 수동 편집 등) downstream crash 방어
+    if (!Array.isArray(parsed)) {
+      console.warn('[vacation] pending 파일이 배열 형태가 아님 — 빈 배열로 fallback');
+      return [];
+    }
+    return parsed;
   } catch (err) {
     console.warn('[vacation] pending 로드 실패:', err);
     return [];

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -453,13 +453,23 @@ function broadcastSnapshotRelay(excludeWebContentsId: number, data: unknown): vo
   }
 }
 
-/** 메인 창 + 모든 위젯 창에 동일 이벤트 push */
-function broadcastToAllWindows(channel: string, payload?: unknown): void {
-  if (mainWindow && !mainWindow.isDestroyed()) {
+/** 메인 창 + 모든 위젯 창에 동일 이벤트 push (optional: 송신자 제외) */
+function broadcastToAllWindows(
+  channel: string,
+  payload?: unknown,
+  excludeSenderId?: number,
+): void {
+  if (
+    mainWindow &&
+    !mainWindow.isDestroyed() &&
+    mainWindow.webContents.id !== excludeSenderId
+  ) {
     mainWindow.webContents.send(channel, payload);
   }
   for (const win of widgetWindows.values()) {
-    if (!win.isDestroyed()) win.webContents.send(channel, payload);
+    if (!win.isDestroyed() && win.webContents.id !== excludeSenderId) {
+      win.webContents.send(channel, payload);
+    }
   }
 }
 
@@ -1125,6 +1135,12 @@ ipcMain.handle('session:broadcast-change', (_event, payload: unknown) => {
 
 ipcMain.handle('theme:broadcast-change', (_event, payload: unknown) => {
   broadcastToAllWindows('theme:changed', payload);
+  return { ok: true };
+});
+
+// 캘린더 변경 브로드캐스트 — 송신자 제외(자기 프로세스 window event 중복 방지)
+ipcMain.handle('calendar:broadcast-change', (event, payload: unknown) => {
+  broadcastToAllWindows('calendar:changed', payload, event.sender.id);
   return { ok: true };
 });
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -285,4 +285,23 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('widget:dock-change', handler);
     return () => { ipcRenderer.removeListener('widget:dock-change', handler); };
   },
+
+  // ─── 설정/세션 변경 브로드캐스트 ─────────────────
+  preferencesBroadcastChange: (payload?: unknown) =>
+    ipcRenderer.invoke('preferences:broadcast-change', payload),
+
+  onPreferencesChanged: (callback: (payload: unknown) => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, payload: unknown) => callback(payload);
+    ipcRenderer.on('preferences:changed', listener);
+    return () => ipcRenderer.removeListener('preferences:changed', listener);
+  },
+
+  sessionBroadcastChange: (payload?: unknown) =>
+    ipcRenderer.invoke('session:broadcast-change', payload),
+
+  onSessionChanged: (callback: (payload: unknown) => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, payload: unknown) => callback(payload);
+    ipcRenderer.on('session:changed', listener);
+    return () => ipcRenderer.removeListener('session:changed', listener);
+  },
 });

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -333,6 +333,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('vacation:broadcast-registered', payload),
   vacationBroadcastFailed: (payload?: unknown) =>
     ipcRenderer.invoke('vacation:broadcast-failed', payload),
+  vacationBroadcastPendingChanged: (payload?: unknown) =>
+    ipcRenderer.invoke('vacation:broadcast-pending-changed', payload),
 
   onVacationRegistered: (callback: (payload: unknown) => void) => {
     const listener = (_event: Electron.IpcRendererEvent, payload: unknown) => callback(payload);
@@ -343,5 +345,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     const listener = (_event: Electron.IpcRendererEvent, payload: unknown) => callback(payload);
     ipcRenderer.on('vacation:failed', listener);
     return () => ipcRenderer.removeListener('vacation:failed', listener);
+  },
+  onVacationPendingChanged: (callback: (payload: unknown) => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, payload: unknown) => callback(payload);
+    ipcRenderer.on('vacation:pending-changed', listener);
+    return () => ipcRenderer.removeListener('vacation:pending-changed', listener);
   },
 });

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -304,4 +304,25 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('session:changed', listener);
     return () => ipcRenderer.removeListener('session:changed', listener);
   },
+
+  // ─── 휴가 pending 상태 + 브로드캐스트 ─────────────
+  vacationPendingLoad: () =>
+    ipcRenderer.invoke('vacation:pending:load'),
+  vacationPendingSave: (list: unknown) =>
+    ipcRenderer.invoke('vacation:pending:save', list),
+  vacationBroadcastRegistered: (payload?: unknown) =>
+    ipcRenderer.invoke('vacation:broadcast-registered', payload),
+  vacationBroadcastFailed: (payload?: unknown) =>
+    ipcRenderer.invoke('vacation:broadcast-failed', payload),
+
+  onVacationRegistered: (callback: (payload: unknown) => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, payload: unknown) => callback(payload);
+    ipcRenderer.on('vacation:registered', listener);
+    return () => ipcRenderer.removeListener('vacation:registered', listener);
+  },
+  onVacationFailed: (callback: (payload: unknown) => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, payload: unknown) => callback(payload);
+    ipcRenderer.on('vacation:failed', listener);
+    return () => ipcRenderer.removeListener('vacation:failed', listener);
+  },
 });

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -299,6 +299,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   sessionBroadcastChange: (payload?: unknown) =>
     ipcRenderer.invoke('session:broadcast-change', payload),
 
+  // 구독 등록 후 메인에 현재 세션 재전송 요청 (ready-to-show 타이밍 miss 방어)
+  sessionRequestCurrent: () =>
+    ipcRenderer.invoke('session:request-current'),
+
   onSessionChanged: (callback: (payload: unknown) => void) => {
     const listener = (_event: Electron.IpcRendererEvent, payload: unknown) => callback(payload);
     ipcRenderer.on('session:changed', listener);

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -305,6 +305,15 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return () => ipcRenderer.removeListener('session:changed', listener);
   },
 
+  themeBroadcastChange: (payload?: unknown) =>
+    ipcRenderer.invoke('theme:broadcast-change', payload),
+
+  onThemeChanged: (callback: (payload: unknown) => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, payload: unknown) => callback(payload);
+    ipcRenderer.on('theme:changed', listener);
+    return () => ipcRenderer.removeListener('theme:changed', listener);
+  },
+
   // ─── 휴가 pending 상태 + 브로드캐스트 ─────────────
   vacationPendingLoad: () =>
     ipcRenderer.invoke('vacation:pending:load'),

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -314,6 +314,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return () => ipcRenderer.removeListener('theme:changed', listener);
   },
 
+  // ─── 캘린더 변경 브로드캐스트 ─────────────────────
+  calendarBroadcastChange: (payload?: unknown) =>
+    ipcRenderer.invoke('calendar:broadcast-change', payload),
+
+  onCalendarChanged: (callback: (payload: unknown) => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, payload: unknown) => callback(payload);
+    ipcRenderer.on('calendar:changed', listener);
+    return () => ipcRenderer.removeListener('calendar:changed', listener);
+  },
+
   // ─── 휴가 pending 상태 + 브로드캐스트 ─────────────
   vacationPendingLoad: () =>
     ipcRenderer.invoke('vacation:pending:load'),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -525,8 +525,16 @@ export default function App() {
       return;
     }
 
-    // 동일 사용자면 스킵 (ID 비교)
-    if (prev?.id === currentUser?.id) return;
+    // 동일 사용자 + 동일 필드면 스킵.
+    // id만 비교하면 같은 유저의 필드 변경(비밀번호 변경, isInitialPassword, role, name 등)이 전파되지 않아
+    // 팝업/위젯 창이 stale currentUser를 유지하게 됨. AppUser는 평탄 data 구조(types/index.ts:114)라
+    // JSON.stringify 동등성으로 안전하게 비교 가능.
+    const isSameUser =
+      (prev === null && currentUser === null) ||
+      (prev != null &&
+        currentUser != null &&
+        JSON.stringify(prev) === JSON.stringify(currentUser));
+    if (isSameUser) return;
 
     window.electronAPI?.sessionBroadcastChange?.({ user: currentUser ?? null });
   }, [currentUser]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -498,6 +498,24 @@ export default function App() {
     }
   }, [currentUser, authReady]);
 
+  // 세션 변경 브로드캐스트: currentUser 변화를 모든 위젯 창에 전파
+  // (로그인/세션 복원/로그아웃/비밀번호 변경 등 모든 setCurrentUser 경로 공통)
+  // 로그인: user truthy → { user } 브로드캐스트
+  // 로그아웃: null → { user: null } 명시적 브로드캐스트 (위젯 창이 currentUser를 null로 재설정)
+  const prevBroadcastUserRef = useRef<typeof currentUser | undefined>(undefined);
+  useEffect(() => {
+    // 첫 렌더는 스킵 — 초기값 전파는 위젯 창이 자체적으로 loadSession으로 복원
+    if (prevBroadcastUserRef.current === undefined) {
+      prevBroadcastUserRef.current = currentUser;
+      return;
+    }
+    // 동일 사용자면 스킵 (ID 비교)
+    const prev = prevBroadcastUserRef.current;
+    if (prev?.id === currentUser?.id && !!prev === !!currentUser) return;
+    prevBroadcastUserRef.current = currentUser;
+    window.electronAPI?.sessionBroadcastChange?.({ user: currentUser ?? null });
+  }, [currentUser]);
+
   // 사용자 변경 시 목록 리로드
   useEffect(() => {
     if (currentUser) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -604,8 +604,13 @@ export default function App() {
         });
       }
     }
+  }, [themeId, customThemeColors, colorMode]);
 
-    // 다른 창(플로팅 위젯)에도 테마 변경 전파 — loadTheme으로 재적용 유도
+  // 테마 broadcast — themeId/colorMode/customThemeColors 중 어느 것이라도 바뀌면 전파
+  // 별도 effect로 분리한 이유: 위 effect의 early return(custom 경로 Case A/B/C)을 우회하여
+  // 커스텀 accent/sub 변경 시에도 플로팅 위젯에 전파되도록 보장
+  useEffect(() => {
+    if (!themeInitRef.current) return; // 초기 로드는 제외
     window.electronAPI?.themeBroadcastChange?.({ themeId, colorMode });
   }, [themeId, customThemeColors, colorMode]);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -604,6 +604,9 @@ export default function App() {
         });
       }
     }
+
+    // 다른 창(플로팅 위젯)에도 테마 변경 전파 — loadTheme으로 재적용 유도
+    window.electronAPI?.themeBroadcastChange?.({ themeId, colorMode });
   }, [themeId, customThemeColors, colorMode]);
 
   // 초기화 완료 후 데이터 로드

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -502,17 +502,24 @@ export default function App() {
   // (로그인/세션 복원/로그아웃/비밀번호 변경 등 모든 setCurrentUser 경로 공통)
   // 로그인: user truthy → { user } 브로드캐스트
   // 로그아웃: null → { user: null } 명시적 브로드캐스트 (위젯 창이 currentUser를 null로 재설정)
+  // 첫 실행 시 이미 로그인된 사용자(loadSession 복원 등)가 있으면 broadcast —
+  // 플로팅 위젯이 이미 열려 있는 경우 초기 사용자 상태를 전파하기 위함.
   const prevBroadcastUserRef = useRef<typeof currentUser | undefined>(undefined);
   useEffect(() => {
-    // 첫 렌더는 스킵 — 초기값 전파는 위젯 창이 자체적으로 loadSession으로 복원
-    if (prevBroadcastUserRef.current === undefined) {
-      prevBroadcastUserRef.current = currentUser;
+    const prev = prevBroadcastUserRef.current;
+    prevBroadcastUserRef.current = currentUser;
+
+    // 첫 실행: currentUser가 이미 있다면 broadcast (플로팅 위젯이 이미 열려 있을 수 있음)
+    if (prev === undefined) {
+      if (currentUser) {
+        window.electronAPI?.sessionBroadcastChange?.({ user: currentUser });
+      }
       return;
     }
+
     // 동일 사용자면 스킵 (ID 비교)
-    const prev = prevBroadcastUserRef.current;
-    if (prev?.id === currentUser?.id && !!prev === !!currentUser) return;
-    prevBroadcastUserRef.current = currentUser;
+    if (prev?.id === currentUser?.id) return;
+
     window.electronAPI?.sessionBroadcastChange?.({ user: currentUser ?? null });
   }, [currentUser]);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -285,8 +285,10 @@ export default function App() {
           const p = savedPrefs.plexus;
           useAppStore.getState().setPlexusSettings({
             loginEnabled: p.loginEnabled ?? true,
+            loginGradientEnabled: p.loginGradientEnabled ?? true,
             loginParticleCount: p.loginParticleCount ?? 666,
             dashboardEnabled: p.dashboardEnabled ?? true,
+            dashboardGradientEnabled: p.dashboardGradientEnabled ?? true,
             dashboardParticleCount: p.dashboardParticleCount ?? 120,
             speed: p.speed ?? 1.0,
             mouseRadius: p.mouseRadius ?? 250,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -870,6 +870,17 @@ export default function App() {
     return () => { cleanup?.(); };
   }, []);
 
+  // ─── 캘린더 변경 IPC 브로드캐스트 구독 ───────────
+  // 다른 창(플로팅 위젯 등)에서 발생한 캘린더 변경을 IPC로 받아
+  // 자기 프로세스 window event로 재발행 → 기존 구독자(CalendarWidget/MyTasksWidget/ScheduleView)가 자동 반응
+  // 무한 루프 방지: 송신자 제외는 메인 프로세스에서 처리됨
+  useEffect(() => {
+    const cleanup = window.electronAPI?.onCalendarChanged?.((payload) => {
+      window.dispatchEvent(new CustomEvent('bflow:calendar-changed', { detail: payload }));
+    });
+    return () => { cleanup?.(); };
+  }, []);
+
   // ─── 휴가 등록 완료 브로드캐스트 구독 → Sonner 토스트 ─────
   useEffect(() => {
     const cleanup = window.electronAPI?.onVacationRegistered?.((payload) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,8 +30,7 @@ import { loadVacationConfig, connectVacation } from '@/services/vacationService'
 import { loadLayout, loadPreferences, loadTheme, saveTheme } from '@/services/settingsService';
 import { loadSession, loadUsers, setUsersSheetsMode, migrateUsersToSheets } from '@/services/userService';
 import { applyTheme, getPreset, getLightColors, deriveThemeFromAccent, sanitizeCustomHex, DEFAULT_THEME_ID } from '@/themes';
-import { applyFontSettings, applyTextColors, DEFAULT_FONT_SCALE, DEFAULT_CATEGORY_SCALES } from '@/utils/typography';
-import type { FontScale } from '@/utils/typography';
+import { applyPreferencesToDOM } from '@/utils/typography';
 import { WelcomeToast } from '@/components/WelcomeToast';
 import { getGreeting, isFirstLogin, markFirstLoginShown } from '@/utils/greetings';
 import { useGlobalShortcuts } from '@/hooks/useGlobalShortcuts';
@@ -274,13 +273,8 @@ export default function App() {
           }
         }
 
-        // 글꼴 크기 적용 (FOUC 방지: 테마보다 먼저 적용)
-        applyFontSettings({
-          fontScale: (savedPrefs?.fontScale as FontScale) ?? DEFAULT_FONT_SCALE,
-          fontCategoryScales: savedPrefs?.fontCategoryScales
-            ? { ...DEFAULT_CATEGORY_SCALES, ...savedPrefs.fontCategoryScales }
-            : undefined,
-        });
+        // 글꼴 크기/색상 적용 (FOUC 방지: 테마보다 먼저 적용)
+        if (savedPrefs) applyPreferencesToDOM(savedPrefs);
 
         // Phase 8-4: 스플래시 건너뛰기
         if (savedPrefs?.skipLoadingSplash) setLoadingSplashDone(true);
@@ -833,19 +827,9 @@ export default function App() {
   //    여러 창(메인 + 플로팅 위젯 N개) 간 일관성이 유지됨
   useEffect(() => {
     const cleanup = window.electronAPI?.onPreferencesChanged?.(() => {
-      loadPreferences().then((prefs) => {
-        if (!prefs) return;
-        applyFontSettings({
-          fontScale: (prefs.fontScale as FontScale) ?? DEFAULT_FONT_SCALE,
-          fontCategoryScales: {
-            heading: prefs.fontCategoryScales?.heading ?? 1,
-            body: prefs.fontCategoryScales?.body ?? 1,
-            caption: prefs.fontCategoryScales?.caption ?? 1,
-            micro: prefs.fontCategoryScales?.micro ?? 1,
-          },
-        });
-        applyTextColors(prefs.fontCategoryColors ?? {});
-      });
+      loadPreferences()
+        .then((prefs) => { if (prefs) applyPreferencesToDOM(prefs); })
+        .catch((err) => console.warn('[설정] 브로드캐스트 재적용 실패', err));
     });
     return () => { cleanup?.(); };
   }, []);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import { LoginScreen } from '@/components/auth/LoginScreen';
 const PasswordChangeModal = lazy(() => import('@/components/auth/PasswordChangeModal').then(m => ({ default: m.PasswordChangeModal })));
 const UserManagerModal = lazy(() => import('@/components/auth/UserManagerModal').then(m => ({ default: m.UserManagerModal })));
 import { GlobalTooltipProvider } from '@/components/ui/GlobalTooltip';
+import { GradientBackdrop } from '@/components/common/GradientBackdrop';
 import { loadGasConfig, connectGas, checkGasConnection } from '@/services/gasConfigService';
 import { readAll } from '@/services/supabaseService';
 import { readAllFromSupabase, testSupabaseConnection, readAllMetadataFromSupabase, onSupabaseRealtimeEvent, onSupabaseStatusChange } from '@/services/supabaseService';
@@ -68,6 +69,9 @@ export default function App() {
   // Sonner 토스트 브릿지: 기존 setToast 호출을 Sonner로 전달
   const setStoreToast = useAppStore((s) => s.setToast);
   const storeToast = useAppStore((s) => s.toast);
+
+  // 전역 그라데이션 배경 토글 (모든 뷰 뒤에 표시, 로그인/스플래시 포함)
+  const globalGradientEnabled = useAppStore((s) => s.plexusSettings.globalGradientEnabled !== false);
 
   // 글로벌 스토어 토스트 → Sonner 자동 전달
   useEffect(() => {
@@ -291,6 +295,7 @@ export default function App() {
             dashboardEnabled: p.dashboardEnabled ?? true,
             dashboardGradientEnabled: p.dashboardGradientEnabled ?? true,
             dashboardParticleCount: p.dashboardParticleCount ?? 120,
+            globalGradientEnabled: p.globalGradientEnabled ?? true,
             speed: p.speed ?? 1.0,
             mouseRadius: p.mouseRadius ?? 250,
             mouseForce: p.mouseForce ?? 0.06,
@@ -1084,16 +1089,27 @@ export default function App() {
 
   // 로그인 화면 (비로그인 상태)
   if (!currentUser) {
-    return <LoginScreen />;
+    return (
+      <>
+        <GradientBackdrop intensity="normal" enabled={globalGradientEnabled} />
+        <LoginScreen />
+      </>
+    );
   }
 
   // 스플래시 랜딩 (로그인 상태에서도 앱 시작 시 표시)
   if (showSplash) {
-    return <LoginScreen mode="splash" onComplete={() => setShowSplash(false)} />;
+    return (
+      <>
+        <GradientBackdrop intensity="normal" enabled={globalGradientEnabled} />
+        <LoginScreen mode="splash" onComplete={() => setShowSplash(false)} />
+      </>
+    );
   }
 
   return (
     <>
+      <GradientBackdrop intensity="normal" enabled={globalGradientEnabled} />
       <MainLayout onRefresh={loadData}>{renderView()}</MainLayout>
       <SpotlightSearch />
       <GlobalTooltipProvider />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import { useGlobalShortcuts } from '@/hooks/useGlobalShortcuts';
 import { DEFAULT_GAS_IMAGE_URL, DEFAULT_VACATION_URL } from '@/config';
 import { Toaster, toast as sonnerToast } from 'sonner';
 import { useNotificationStore } from '@/stores/useNotificationStore';
+import { useVacationPendingStore } from '@/stores/useVacationPendingStore';
 import { dispatchNotification, type NotificationSettings } from '@/utils/notificationHelper';
 
 // Lazy chunk 로드 실패(네트워크 끊김, 빌드 artifact 누락) 시 블랭크 스크린 방지용 ErrorBoundary.
@@ -859,6 +860,44 @@ export default function App() {
         .catch((err) => console.warn('[설정] 브로드캐스트 재적용 실패', err));
     });
     return () => { cleanup?.(); };
+  }, []);
+
+  // ─── 휴가 등록 완료 브로드캐스트 구독 → Sonner 토스트 ─────
+  useEffect(() => {
+    const cleanup = window.electronAPI?.onVacationRegistered?.((payload) => {
+      const p = payload as { name?: string; type?: string } | undefined;
+      const who = p?.name ? `${p.name} ` : '';
+      const what = p?.type ? ` (${p.type})` : '';
+      sonnerToast.success(`${who}휴가 등록 완료${what}`);
+    });
+    return () => { cleanup?.(); };
+  }, []);
+
+  // ─── 휴가 등록 실패 브로드캐스트 구독 ─────────────
+  useEffect(() => {
+    const cleanup = window.electronAPI?.onVacationFailed?.((payload) => {
+      const p = payload as { name?: string; error?: string } | undefined;
+      const who = p?.name ? `${p.name} ` : '';
+      const err = p?.error ?? '알 수 없는 오류';
+      sonnerToast.error(`${who}휴가 등록 실패: ${err}`, { duration: 10000 });
+    });
+    return () => { cleanup?.(); };
+  }, []);
+
+  // ─── pending 휴가: hydrate + 30초 타임아웃 (메인 창 전용) ────
+  useEffect(() => {
+    useVacationPendingStore.getState().hydrate();
+    const timer = setInterval(async () => {
+      try {
+        const stale = await useVacationPendingStore.getState().clearStale(30_000);
+        for (const p of stale) {
+          sonnerToast.error(`휴가 등록 타임아웃: ${p.name ?? '알 수 없음'} (30초 경과)`, { duration: 10000 });
+        }
+      } catch (err) {
+        console.warn('[vacation:pending] 타임아웃 검사 실패', err);
+      }
+    }, 15_000);
+    return () => clearInterval(timer);
   }, []);
 
   // 주기적 폴링: Realtime 이벤트 누락 방지용 안전망 (5초 간격)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -419,10 +419,14 @@ export default function App() {
 
         // 세션 복원 (Phase 8-5: rememberMe 설정 확인)
         const rememberMe = savedPrefs?.rememberMe !== false; // 기본 true (하위 호환)
+        console.info('[auth] rememberMe =', rememberMe);
         if (rememberMe) {
           const { user } = await loadSession();
           if (user) {
             setCurrentUser(user);
+            console.info('[auth] currentUser 설정 완료');
+          } else {
+            console.info('[auth] 세션 없음 — 로그인 화면 표시');
           }
         }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,10 +28,10 @@ import { invalidatePartCache } from '@/services/commentService';
 import { invalidateRevisionsCache } from '@/services/revisionService';
 import { extractSceneDelta } from '@/utils/realtimeDelta';
 import { loadVacationConfig, connectVacation } from '@/services/vacationService';
-import { loadLayout, loadPreferences, loadTheme, saveTheme } from '@/services/settingsService';
+import { loadLayout, loadPreferences, savePreferences, loadTheme, saveTheme } from '@/services/settingsService';
 import { loadSession, loadUsers, setUsersSheetsMode, migrateUsersToSheets } from '@/services/userService';
 import { applyTheme, getPreset, getLightColors, deriveThemeFromAccent, sanitizeCustomHex, DEFAULT_THEME_ID } from '@/themes';
-import { applyPreferencesToDOM } from '@/utils/typography';
+import { applyPreferencesToDOM, FONT_COLOR_PRESETS, applyTextColors } from '@/utils/typography';
 import { WelcomeToast } from '@/components/WelcomeToast';
 import { getGreeting, isFirstLogin, markFirstLoginShown } from '@/utils/greetings';
 import { useGlobalShortcuts } from '@/hooks/useGlobalShortcuts';
@@ -628,6 +628,40 @@ export default function App() {
       customColors: customThemeColors ?? null,
     });
   }, [themeId, customThemeColors, colorMode]);
+
+  // 비-custom 폰트 색상 프리셋 사용 시: 테마/모드/커스텀색 변경에 따라 카테고리 색상 재계산·저장·broadcast
+  // FontColorSection은 settings 'font' 탭이 열렸을 때만 마운트되므로,
+  // 사용자가 다른 탭에서 테마를 바꾸면 stale fontCategoryColors가 디스크에 남는 문제 해결.
+  useEffect(() => {
+    if (!themeInitRef.current) return; // 초기 로드는 skip
+    (async () => {
+      try {
+        const prefs = await loadPreferences();
+        const preset = prefs?.fontColorPreset;
+        if (!preset || preset === 'custom') return; // custom은 사용자 지정값 유지
+        const themeColors =
+          customThemeColors
+            ?? (colorMode === 'light' ? getLightColors(themeId) : getPreset(themeId)?.colors);
+        if (!themeColors) return;
+        const primary = themeColors.textPrimary;
+        const secondary = themeColors.textSecondary;
+        const accentSub = themeColors.accentSub;
+        const nextColors = FONT_COLOR_PRESETS[preset].getColors(primary, secondary, accentSub);
+        applyTextColors(nextColors);
+        await savePreferences({
+          ...(prefs ?? {}),
+          fontColorPreset: preset,
+          fontCategoryColors: nextColors,
+        });
+        window.electronAPI?.preferencesBroadcastChange?.({
+          fontColorPreset: preset,
+          fontCategoryColors: nextColors,
+        });
+      } catch (err) {
+        console.warn('[font-color] 테마 변경에 따른 재계산 실패:', err);
+      }
+    })();
+  }, [themeId, colorMode, customThemeColors]);
 
   // 초기화 완료 후 데이터 로드
   // authReady 가드: init 완료 전까지 데이터 로딩 방지 (플래시 제거)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -609,9 +609,16 @@ export default function App() {
   // 테마 broadcast — themeId/colorMode/customThemeColors 중 어느 것이라도 바뀌면 전파
   // 별도 effect로 분리한 이유: 위 effect의 early return(custom 경로 Case A/B/C)을 우회하여
   // 커스텀 accent/sub 변경 시에도 플로팅 위젯에 전파되도록 보장
+  //
+  // payload에 customColors 포함: 팝업이 파일 재로드 없이 즉시 적용 → race 제거
+  // (saveTheme 쓰기 완료 전에 broadcast가 발행될 수 있어, 팝업이 stale 파일을 읽는 문제 방지)
   useEffect(() => {
     if (!themeInitRef.current) return; // 초기 로드는 제외
-    window.electronAPI?.themeBroadcastChange?.({ themeId, colorMode });
+    window.electronAPI?.themeBroadcastChange?.({
+      themeId,
+      colorMode,
+      customColors: customThemeColors ?? null,
+    });
   }, [themeId, customThemeColors, colorMode]);
 
   // 초기화 완료 후 데이터 로드
@@ -904,6 +911,15 @@ export default function App() {
       const who = p?.name ? `${p.name} ` : '';
       const err = p?.error ?? '알 수 없는 오류';
       sonnerToast.error(`${who}휴가 등록 실패: ${err}`, { duration: 10000 });
+    });
+    return () => { cleanup?.(); };
+  }, []);
+
+  // ─── pending 변경 브로드캐스트 구독 → hydrate (다른 창에서 add/remove/clearStale 시 동기화) ──
+  // 송신자는 메인에서 excludeSenderId로 제외되므로 자기 상태를 덮어쓰지 않음
+  useEffect(() => {
+    const cleanup = window.electronAPI?.onVacationPendingChanged?.(() => {
+      useVacationPendingStore.getState().hydrate();
     });
     return () => { cleanup?.(); };
   }, []);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,7 @@ import { loadVacationConfig, connectVacation } from '@/services/vacationService'
 import { loadLayout, loadPreferences, loadTheme, saveTheme } from '@/services/settingsService';
 import { loadSession, loadUsers, setUsersSheetsMode, migrateUsersToSheets } from '@/services/userService';
 import { applyTheme, getPreset, getLightColors, deriveThemeFromAccent, sanitizeCustomHex, DEFAULT_THEME_ID } from '@/themes';
-import { applyFontSettings, DEFAULT_FONT_SCALE, DEFAULT_CATEGORY_SCALES } from '@/utils/typography';
+import { applyFontSettings, applyTextColors, DEFAULT_FONT_SCALE, DEFAULT_CATEGORY_SCALES } from '@/utils/typography';
 import type { FontScale } from '@/utils/typography';
 import { WelcomeToast } from '@/components/WelcomeToast';
 import { getGreeting, isFirstLogin, markFirstLoginShown } from '@/utils/greetings';
@@ -827,6 +827,28 @@ export default function App() {
       if (reloadTimer) clearTimeout(reloadTimer);
     };
   }, [loadData]);
+
+  // 환경설정(글꼴 크기/색상) 변경 브로드캐스트 구독
+  // — 설정 창이 메인 창과 동일하지만, 메인도 자기 자신의 브로드캐스트에 반응해 재적용해야
+  //    여러 창(메인 + 플로팅 위젯 N개) 간 일관성이 유지됨
+  useEffect(() => {
+    const cleanup = window.electronAPI?.onPreferencesChanged?.(() => {
+      loadPreferences().then((prefs) => {
+        if (!prefs) return;
+        applyFontSettings({
+          fontScale: (prefs.fontScale as FontScale) ?? DEFAULT_FONT_SCALE,
+          fontCategoryScales: {
+            heading: prefs.fontCategoryScales?.heading ?? 1,
+            body: prefs.fontCategoryScales?.body ?? 1,
+            caption: prefs.fontCategoryScales?.caption ?? 1,
+            micro: prefs.fontCategoryScales?.micro ?? 1,
+          },
+        });
+        applyTextColors(prefs.fontCategoryColors ?? {});
+      });
+    });
+    return () => { cleanup?.(); };
+  }, []);
 
   // 주기적 폴링: Realtime 이벤트 누락 방지용 안전망 (5초 간격)
   useEffect(() => {

--- a/src/components/auth/LoginScreen.tsx
+++ b/src/components/auth/LoginScreen.tsx
@@ -4,6 +4,7 @@ import { LogIn, ChevronRight } from 'lucide-react';
 import { login } from '@/services/userService';
 import { useAuthStore } from '@/stores/useAuthStore';
 import { useAppStore } from '@/stores/useAppStore';
+import { GradientBackdrop } from '@/components/common/GradientBackdrop';
 import { getPreset } from '@/themes';
 import { cn } from '@/utils/cn';
 
@@ -198,28 +199,8 @@ function PlexusBackground() {
       ctx.fillStyle = isLight ? '#ECEDF2' : '#12141C';
       ctx.fillRect(0, 0, w, h);
 
-      const tc = getPlexusColors()[0];
-      const ts = getPlexusColors()[2] ?? getPlexusColors()[1];
-
-      // 다크모드에서만 중앙 그라데이션 + 마우스 글로우 + 노이즈 오버레이 적용
+      // 다크모드에서만 노이즈 오버레이 적용 (중앙 그라데이션/마우스 글로우는 GradientBackdrop으로 분리됨)
       if (!isLight) {
-        const cg = ctx.createRadialGradient(w * 0.5, h * 0.45, 0, w * 0.5, h * 0.45, w * 0.7);
-        cg.addColorStop(0, `rgba(${tc[0]}, ${tc[1]}, ${tc[2]}, 0.06)`);
-        cg.addColorStop(0.3, `rgba(${tc[0]}, ${tc[1]}, ${tc[2]}, 0.03)`);
-        cg.addColorStop(0.6, `rgba(${ts[0]}, ${ts[1]}, ${ts[2]}, 0.015)`);
-        cg.addColorStop(1, 'rgba(0, 0, 0, 0)');
-        ctx.fillStyle = cg;
-        ctx.fillRect(0, 0, w, h);
-
-        if (mouseRef.current.x > 0 && mouseRef.current.y > 0) {
-          const mg = ctx.createRadialGradient(mouseRef.current.x, mouseRef.current.y, 0, mouseRef.current.x, mouseRef.current.y, 250);
-          mg.addColorStop(0, `rgba(${tc[0]}, ${tc[1]}, ${tc[2]}, 0.08)`);
-          mg.addColorStop(0.4, `rgba(${tc[0]}, ${tc[1]}, ${tc[2]}, 0.03)`);
-          mg.addColorStop(1, 'rgba(0, 0, 0, 0)');
-          ctx.fillStyle = mg;
-          ctx.fillRect(0, 0, w, h);
-        }
-
         if (noiseRef.current) ctx.drawImage(noiseRef.current, 0, 0);
       }
 
@@ -745,6 +726,7 @@ type Phase = 'landing' | 'ready' | 'transition' | 'login' | 'done';
 export function LoginScreen({ mode = 'login', onComplete }: LoginScreenProps) {
   const { setCurrentUser } = useAuthStore();
   const [phase, setPhase] = useState<Phase>('landing');
+  const plexusSettings = useAppStore((s) => s.plexusSettings);
 
   // 텍스트 애니메이션 완료 콜백
   const handleAnimationDone = useCallback(() => {
@@ -797,6 +779,7 @@ export function LoginScreen({ mode = 'login', onComplete }: LoginScreenProps) {
       onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') handleClick(); }}
       tabIndex={-1}
     >
+      <GradientBackdrop enabled={plexusSettings.loginGradientEnabled !== false} />
       <PlexusBackground />
 
       <AnimatePresence mode="wait">

--- a/src/components/auth/LoginScreen.tsx
+++ b/src/components/auth/LoginScreen.tsx
@@ -779,7 +779,7 @@ export function LoginScreen({ mode = 'login', onComplete }: LoginScreenProps) {
       onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') handleClick(); }}
       tabIndex={-1}
     >
-      <GradientBackdrop enabled={plexusSettings.loginGradientEnabled !== false} />
+      <GradientBackdrop enabled={plexusSettings.loginGradientEnabled !== false} intensity="subtle" />
       <PlexusBackground />
 
       <AnimatePresence mode="wait">

--- a/src/components/auth/LoginScreen.tsx
+++ b/src/components/auth/LoginScreen.tsx
@@ -4,7 +4,6 @@ import { LogIn, ChevronRight } from 'lucide-react';
 import { login } from '@/services/userService';
 import { useAuthStore } from '@/stores/useAuthStore';
 import { useAppStore } from '@/stores/useAppStore';
-import { GradientBackdrop } from '@/components/common/GradientBackdrop';
 import { getPreset } from '@/themes';
 import { cn } from '@/utils/cn';
 
@@ -731,7 +730,6 @@ type Phase = 'landing' | 'ready' | 'transition' | 'login' | 'done';
 export function LoginScreen({ mode = 'login', onComplete }: LoginScreenProps) {
   const { setCurrentUser } = useAuthStore();
   const [phase, setPhase] = useState<Phase>('landing');
-  const plexusSettings = useAppStore((s) => s.plexusSettings);
 
   // 텍스트 애니메이션 완료 콜백
   const handleAnimationDone = useCallback(() => {
@@ -779,12 +777,13 @@ export function LoginScreen({ mode = 'login', onComplete }: LoginScreenProps) {
   return (
     <div
       className="fixed inset-0 flex flex-col items-center justify-center overflow-hidden select-none z-[9998] cursor-pointer"
-      style={{ background: 'rgb(var(--color-bg-primary))' }}
+      // 배경: body의 --color-bg-primary가 깔려있고, 전역 GradientBackdrop이 그 위에 그라데이션을 렌더.
+      // 플렉서스 canvas(PlexusBackground)가 ON일 때는 canvas가 불투명으로 덮음.
       onClick={handleClick}
       onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') handleClick(); }}
       tabIndex={-1}
     >
-      <GradientBackdrop enabled={plexusSettings.loginGradientEnabled !== false} intensity="subtle" />
+      {/* 그라데이션 배경은 App.tsx의 전역 GradientBackdrop이 담당 */}
       <PlexusBackground />
 
       <AnimatePresence mode="wait">

--- a/src/components/auth/LoginScreen.tsx
+++ b/src/components/auth/LoginScreen.tsx
@@ -1,11 +1,12 @@
 import { useState, useCallback, useEffect, useRef, useLayoutEffect, useMemo } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { LogIn, ChevronRight } from 'lucide-react';
+import { LogIn, ChevronRight, AlertTriangle } from 'lucide-react';
 import { login } from '@/services/userService';
 import { useAuthStore } from '@/stores/useAuthStore';
 import { useAppStore } from '@/stores/useAppStore';
 import { getPreset } from '@/themes';
 import { cn } from '@/utils/cn';
+import { useCapsLockWarning } from '@/hooks/useCapsLockWarning';
 
 // ─── 플렉서스 배경 (Canvas 2D, Z축 깊이감, 마우스 인터랙션) ─────
 
@@ -570,6 +571,7 @@ function LoginForm({ onLogin }: { onLogin: (name: string, pw: string, rememberMe
   const nameRef = useRef<HTMLInputElement>(null);
   const colorMode = useAppStore((s) => s.colorMode);
   const isLight = colorMode === 'light';
+  const capsLock = useCapsLockWarning();
 
   useEffect(() => {
     const timer = setTimeout(() => nameRef.current?.focus(), 400);
@@ -649,6 +651,8 @@ function LoginForm({ onLogin }: { onLogin: (name: string, pw: string, rememberMe
           type="password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
+          onKeyDown={capsLock.onKeyDown}
+          onKeyUp={capsLock.onKeyUp}
           placeholder="비밀번호 입력"
           className={cn(
             'rounded-xl px-3.5 py-2.5 text-sm text-text-primary placeholder:text-text-secondary/50 focus:outline-none focus:border-accent/50 transition-all duration-200',
@@ -657,6 +661,12 @@ function LoginForm({ onLogin }: { onLogin: (name: string, pw: string, rememberMe
               : 'bg-white/[0.04] border border-white/[0.08] focus:bg-white/[0.06]',
           )}
         />
+        {capsLock.isCapsLockOn && (
+          <div className="mt-1 text-[11px] text-amber-400 flex items-center gap-1">
+            <AlertTriangle size={12} />
+            Caps Lock이 켜져 있습니다
+          </div>
+        )}
         <p className="text-[11px] text-text-secondary/60 leading-relaxed">
           최초 비밀번호는 1234<br />
           모르겠으면 배씨에게 문의

--- a/src/components/auth/LoginScreen.tsx
+++ b/src/components/auth/LoginScreen.tsx
@@ -132,7 +132,9 @@ function PlexusBackground() {
     if (!loginEnabled) return;
     const canvas = canvasRef.current;
     if (!canvas) return;
-    const ctx = canvas.getContext('2d', { alpha: false });
+    // alpha: true — canvas 뒤의 <GradientBackdrop />이 비치도록 투명 배경 사용.
+    // (이전 alpha: false + fillRect는 solid fill이라 전역 그라데이션을 가렸음)
+    const ctx = canvas.getContext('2d', { alpha: true });
     if (!ctx) return;
 
     const resize = () => {
@@ -198,11 +200,12 @@ function PlexusBackground() {
       const mx = mouseRef.current.x + ox;
       const my = mouseRef.current.y + oy;
 
-      const isLight = useAppStore.getState().colorMode === 'light';
-      ctx.fillStyle = isLight ? '#ECEDF2' : '#12141C';
-      ctx.fillRect(0, 0, w, h);
+      // 투명하게 clear — 전역 <GradientBackdrop />이 캔버스 뒤로 비치도록.
+      // (이전에는 solid fillRect로 테마 배경색을 칠해 그라데이션을 가렸음)
+      ctx.clearRect(0, 0, w, h);
 
       // 다크모드에서만 노이즈 오버레이 적용 (중앙 그라데이션/마우스 글로우는 GradientBackdrop으로 분리됨)
+      const isLight = useAppStore.getState().colorMode === 'light';
       if (!isLight) {
         if (noiseRef.current) ctx.drawImage(noiseRef.current, 0, 0);
       }

--- a/src/components/auth/LoginScreen.tsx
+++ b/src/components/auth/LoginScreen.tsx
@@ -18,7 +18,7 @@ interface Particle {
   vy: number;
   baseSpeed: number;
   size: number;
-  color: [number, number, number];
+  colorIdx: number;
 }
 
 // RGB ↔ HSL 변환 유틸
@@ -50,7 +50,7 @@ function getPlexusColors(): [number, number, number][] {
   const themeId = useAppStore.getState().themeId;
   const custom = useAppStore.getState().customThemeColors;
   const colors = custom ?? getPreset(themeId)?.colors;
-  if (!colors) return [[108, 92, 231], [162, 155, 254], [116, 185, 255], [0, 184, 148], [85, 239, 196]];
+  if (!colors) return [[108, 92, 231], [162, 155, 254]];
   const parse = (s: string): [number, number, number] => {
     const [r, g, b] = s.split(' ').map(Number);
     return [r, g, b];
@@ -90,13 +90,13 @@ const VIRTUAL_H = 1800;
 function createParticle(_w: number, _h: number, plexusColors?: [number, number, number][]): Particle {
   const z = 0.1 + Math.random() * 0.9;
   const cols = plexusColors ?? getPlexusColors();
-  const color = cols[Math.floor(Math.random() * cols.length)];
+  const colorIdx = Math.floor(Math.random() * cols.length);
   const baseSpeed = 0.12 + Math.random() * 0.35;
   return {
     x: Math.random() * VIRTUAL_W, y: Math.random() * VIRTUAL_H, z,
     vx: (Math.random() - 0.5) * baseSpeed * z,
     vy: (Math.random() - 0.5) * baseSpeed * z,
-    baseSpeed, size: 1.2 + z * 3, color,
+    baseSpeed, size: 1.2 + z * 3, colorIdx,
   };
 }
 
@@ -185,6 +185,9 @@ function PlexusBackground() {
       lastTime = timestamp;
       const dtFactor = Math.min(delta / TARGET_FRAME_MS, 3); // cap at 3x (최소 ~20fps)
 
+      // 매 프레임 최신 팔레트 조회 → 테마 변경 시 즉시 색 반영
+      const palette = getPlexusColors();
+
       const { w, h } = sizeRef.current;
       const particles = particlesRef.current;
 
@@ -261,9 +264,11 @@ function PlexusBackground() {
             const midY = (a.y + b.y) * 0.5;
             const dMid = Math.sqrt((midX - mx) ** 2 + (midY - my) ** 2);
             const glowBoost = dMid < cfgMouseR ? (1 - dMid / cfgMouseR) * 0.4 : 0;
-            const r = Math.round((a.color[0] + b.color[0]) * 0.5);
-            const g = Math.round((a.color[1] + b.color[1]) * 0.5);
-            const bl = Math.round((a.color[2] + b.color[2]) * 0.5);
+            const aCol = palette[a.colorIdx % palette.length];
+            const bCol = palette[b.colorIdx % palette.length];
+            const r = Math.round((aCol[0] + bCol[0]) * 0.5);
+            const g = Math.round((aCol[1] + bCol[1]) * 0.5);
+            const bl = Math.round((aCol[2] + bCol[2]) * 0.5);
             ctx.beginPath();
             ctx.moveTo(a.x - ox, a.y - oy); ctx.lineTo(b.x - ox, b.y - oy);
             ctx.strokeStyle = `rgba(${r}, ${g}, ${bl}, ${Math.min(lineAlpha + glowBoost, 0.75)})`;
@@ -277,7 +282,7 @@ function PlexusBackground() {
       const cfgGlow = cfg.glowIntensity;
       for (const p of sorted) {
         const alpha = 0.35 + p.z * 0.6;
-        const [r, g, b] = p.color;
+        const [r, g, b] = palette[p.colorIdx % palette.length];
         const sx = p.x - ox; // 화면 x
         const sy = p.y - oy; // 화면 y
         const dmx2 = p.x - mx; const dmy2 = p.y - my;

--- a/src/components/auth/PasswordChangeModal.tsx
+++ b/src/components/auth/PasswordChangeModal.tsx
@@ -1,7 +1,8 @@
 import { useState, useCallback } from 'react';
-import { X, Check } from 'lucide-react';
+import { X, Check, AlertTriangle } from 'lucide-react';
 import { changePassword, loadUsers } from '@/services/userService';
 import { useAuthStore } from '@/stores/useAuthStore';
+import { useCapsLockWarning } from '@/hooks/useCapsLockWarning';
 
 export function PasswordChangeModal() {
   const { currentUser, setCurrentUser, setShowPasswordChange, setUsers } = useAuthStore();
@@ -10,6 +11,7 @@ export function PasswordChangeModal() {
   const [confirmPw, setConfirmPw] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const capsLock = useCapsLockWarning();
 
   const passwordsMatch = newPw.length > 0 && newPw === confirmPw;
 
@@ -54,6 +56,12 @@ export function PasswordChangeModal() {
           </button>
         </div>
 
+        {capsLock.isCapsLockOn && (
+          <div className="p-2 rounded bg-amber-500/10 border border-amber-500/30 text-[11px] text-amber-400 flex items-center gap-1.5">
+            <AlertTriangle size={12} /> Caps Lock이 켜져 있습니다
+          </div>
+        )}
+
         {/* 현재 비밀번호 */}
         <div className="flex flex-col gap-1">
           <label className="text-xs text-text-secondary">현재 비밀번호</label>
@@ -61,6 +69,8 @@ export function PasswordChangeModal() {
             type="password"
             value={currentPw}
             onChange={(e) => setCurrentPw(e.target.value)}
+            onKeyDown={capsLock.onKeyDown}
+            onKeyUp={capsLock.onKeyUp}
             autoFocus
             className="bg-bg-primary border border-bg-border rounded-lg px-3 py-2 text-sm text-text-primary focus:outline-none focus:border-accent transition-colors"
           />
@@ -73,6 +83,8 @@ export function PasswordChangeModal() {
             type="password"
             value={newPw}
             onChange={(e) => setNewPw(e.target.value)}
+            onKeyDown={capsLock.onKeyDown}
+            onKeyUp={capsLock.onKeyUp}
             className="bg-bg-primary border border-bg-border rounded-lg px-3 py-2 text-sm text-text-primary focus:outline-none focus:border-accent transition-colors"
           />
         </div>
@@ -84,6 +96,8 @@ export function PasswordChangeModal() {
             type="password"
             value={confirmPw}
             onChange={(e) => setConfirmPw(e.target.value)}
+            onKeyDown={capsLock.onKeyDown}
+            onKeyUp={capsLock.onKeyUp}
             className="bg-bg-primary border border-bg-border rounded-lg px-3 py-2 text-sm text-text-primary focus:outline-none focus:border-accent transition-colors"
           />
           {passwordsMatch && (

--- a/src/components/common/GradientBackdrop.tsx
+++ b/src/components/common/GradientBackdrop.tsx
@@ -1,22 +1,43 @@
 /**
+ * 파티클 canvas 뒤, 앱 콘텐츠 뒤에 깔리는 그라데이션 배경.
+ * z-index: -1 — 부모가 stacking context를 만들어야 올바르게 보임.
+ *
  * 대시보드/로그인 배경 그라데이션 조명을 canvas 외부 DOM 레이어로 분리.
  * 파티클(플렉서스)과 독립적으로 토글할 수 있어, 파티클 OFF 상태에서도
  * 배경 조명을 유지할 수 있음.
  *
  * CSS 변수(--color-accent, --color-accent-sub)를 사용하므로
  * 테마 변경 시 자동으로 갱신됨.
+ *
+ * intensity:
+ *  - subtle: 로그인 화면 (원본 canvas 그라데이션 0.06/0.03/0.015보다 약간 밝음)
+ *  - normal: 대시보드 (위젯 글래스모피즘을 위한 충분한 밝기, 원본 0.18/0.15/0.08)
  */
-export function GradientBackdrop({ enabled = true }: { enabled?: boolean }) {
+export type BackdropIntensity = 'subtle' | 'normal';
+
+export function GradientBackdrop({
+  enabled = true,
+  intensity = 'normal',
+}: {
+  enabled?: boolean;
+  intensity?: BackdropIntensity;
+}) {
   if (!enabled) return null;
+
+  const alphas =
+    intensity === 'subtle'
+      ? { a: 0.08, b: 0.06, c: 0.03 }
+      : { a: 0.18, b: 0.15, c: 0.08 };
+
   return (
     <div
       className="fixed inset-0 pointer-events-none"
       style={{
         zIndex: -1,
         background: `
-          radial-gradient(at 20% 10%, rgb(var(--color-accent) / 0.10) 0%, transparent 50%),
-          radial-gradient(at 80% 90%, rgb(var(--color-accent-sub) / 0.08) 0%, transparent 50%),
-          radial-gradient(at 50% 50%, rgb(var(--color-accent) / 0.04) 0%, transparent 60%)
+          radial-gradient(at 20% 10%, rgb(var(--color-accent) / ${alphas.a}) 0%, transparent 50%),
+          radial-gradient(at 80% 90%, rgb(var(--color-accent-sub) / ${alphas.b}) 0%, transparent 50%),
+          radial-gradient(at 50% 50%, rgb(var(--color-accent) / ${alphas.c}) 0%, transparent 60%)
         `,
       }}
     />

--- a/src/components/common/GradientBackdrop.tsx
+++ b/src/components/common/GradientBackdrop.tsx
@@ -1,0 +1,24 @@
+/**
+ * 대시보드/로그인 배경 그라데이션 조명을 canvas 외부 DOM 레이어로 분리.
+ * 파티클(플렉서스)과 독립적으로 토글할 수 있어, 파티클 OFF 상태에서도
+ * 배경 조명을 유지할 수 있음.
+ *
+ * CSS 변수(--color-accent, --color-accent-sub)를 사용하므로
+ * 테마 변경 시 자동으로 갱신됨.
+ */
+export function GradientBackdrop({ enabled = true }: { enabled?: boolean }) {
+  if (!enabled) return null;
+  return (
+    <div
+      className="fixed inset-0 pointer-events-none"
+      style={{
+        zIndex: -1,
+        background: `
+          radial-gradient(at 20% 10%, rgb(var(--color-accent) / 0.10) 0%, transparent 50%),
+          radial-gradient(at 80% 90%, rgb(var(--color-accent-sub) / 0.08) 0%, transparent 50%),
+          radial-gradient(at 50% 50%, rgb(var(--color-accent) / 0.04) 0%, transparent 60%)
+        `,
+      }}
+    />
+  );
+}

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -8,7 +8,7 @@ interface MainLayoutProps {
 
 export function MainLayout({ children, onRefresh }: MainLayoutProps) {
   return (
-    <div className="flex h-screen w-screen overflow-hidden bg-bg-primary">
+    <div className="flex h-screen w-screen overflow-hidden">
       <Sidebar />
       <div className="flex flex-col flex-1 overflow-hidden">
         <Header onRefresh={onRefresh} />

--- a/src/components/scenes/UnifiedSceneCard.tsx
+++ b/src/components/scenes/UnifiedSceneCard.tsx
@@ -138,7 +138,7 @@ export function UnifiedSceneCard({
 
         {/* ── 메모 ── */}
         {primaryScene.memo && (
-          <div className="mx-4 mt-1">
+          <div className="mx-4 mt-1" data-no-lasso>
             <p className="text-[11px] text-amber-400/70 leading-relaxed line-clamp-1">
               <HighlightText text={primaryScene.memo} query={searchQuery} />
             </p>

--- a/src/components/scenes/UnifiedSceneCard.tsx
+++ b/src/components/scenes/UnifiedSceneCard.tsx
@@ -45,7 +45,7 @@ export function UnifiedSceneCard({
   const primaryScene = bgScene ?? actScene;
 
   const cardRootRef = useRef<HTMLDivElement>(null);
-  const prevHighlightedRef = useRef(isHighlighted);
+  const prevHighlightedRef = useRef(false);
 
   useEffect(() => {
     if (isHighlighted && !prevHighlightedRef.current) {

--- a/src/components/scenes/UnifiedSceneCard.tsx
+++ b/src/components/scenes/UnifiedSceneCard.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { motion } from 'framer-motion';
 import { MessageCircle } from 'lucide-react';
 import { cn } from '@/utils/cn';
@@ -42,6 +43,17 @@ export function UnifiedSceneCard({
 }: UnifiedSceneCardProps) {
   const { sceneId, bgScene, actScene, bgSceneIndex, actSceneIndex } = merged;
   const primaryScene = bgScene ?? actScene;
+
+  const cardRootRef = useRef<HTMLDivElement>(null);
+  const prevHighlightedRef = useRef(isHighlighted);
+
+  useEffect(() => {
+    if (isHighlighted && !prevHighlightedRef.current) {
+      cardRootRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+    prevHighlightedRef.current = isHighlighted;
+  }, [isHighlighted]);
+
   if (!primaryScene) return null;
 
   const bgPct = bgScene ? sceneProgress(bgScene) : 0;
@@ -81,7 +93,7 @@ export function UnifiedSceneCard({
       }}
       onClick={handleClick}
       onDoubleClick={handleDoubleClick}
-      ref={isHighlighted ? (el) => el?.scrollIntoView({ behavior: 'smooth', block: 'center' }) : undefined}
+      ref={cardRootRef}
       {...(isHighlighted ? {
         initial: { scale: 1.06 },
         animate: { scale: 1 },

--- a/src/components/scenes/UnifiedSceneSheetView.tsx
+++ b/src/components/scenes/UnifiedSceneSheetView.tsx
@@ -384,7 +384,7 @@ export function UnifiedSceneSheetView({
       setRangeEnd(null);
       setIsDragging(true);
     }
-    tableRef.current?.focus();
+    tableRef.current?.focus({ preventScroll: true });
   }, [anchor]);
 
   const handleCellMouseEnter = useCallback((row: number, col: number) => {
@@ -401,7 +401,7 @@ export function UnifiedSceneSheetView({
   const handleStopEditing = useCallback(() => {
     setEditingCell(null);
     setInitialEditChar(null);
-    tableRef.current?.focus();
+    tableRef.current?.focus({ preventScroll: true });
   }, []);
 
   // 필드 저장 헬퍼: col에 따라 올바른 sheetName/sceneIndex 결정

--- a/src/components/settings/EffectsSection.tsx
+++ b/src/components/settings/EffectsSection.tsx
@@ -297,6 +297,8 @@ function Slider({ label, value, min, max, step, defaultVal, onChange }: {
 async function persistPlexus(plexus: typeof DEFAULTS) {
   const existing = await loadPreferences() ?? {};
   await savePreferences({ ...existing, plexus });
+  // 다른 창(플로팅 위젯 포함)에 실시간 전파
+  window.electronAPI?.preferencesBroadcastChange?.({ plexus });
 }
 
 /* ── 메인 섹션 ── */

--- a/src/components/settings/EffectsSection.tsx
+++ b/src/components/settings/EffectsSection.tsx
@@ -12,6 +12,7 @@ const DEFAULTS = {
   dashboardEnabled: true,
   dashboardGradientEnabled: true,
   dashboardParticleCount: 120,
+  globalGradientEnabled: true,
   speed: 1.0,
   mouseRadius: 250,
   mouseForce: 0.06,
@@ -329,6 +330,33 @@ export function EffectsSection() {
         </button>
       }
     >
+      {/* 전체 화면 그라데이션 배경 (모든 뷰 공통) */}
+      <div className="mb-5 pb-4 border-b border-bg-border/30">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <p className="text-sm font-medium text-text-primary">전체 화면 그라데이션 배경</p>
+            <p className="text-[11px] text-text-secondary/60 mt-0.5">
+              메인 앱, 로그인 화면, 플로팅 위젯 뒤에 부드러운 조명 배경을 표시합니다.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            {(plexusSettings.globalGradientEnabled !== false) !== DEFAULTS.globalGradientEnabled && (
+              <button
+                onClick={() => update({ globalGradientEnabled: DEFAULTS.globalGradientEnabled })}
+                className="text-text-secondary/40 hover:text-accent transition-colors cursor-pointer"
+                title={`기본값 (${DEFAULTS.globalGradientEnabled ? 'ON' : 'OFF'})`}
+              >
+                <RotateCcw size={11} />
+              </button>
+            )}
+            <Toggle
+              checked={plexusSettings.globalGradientEnabled !== false}
+              onChange={(v) => update({ globalGradientEnabled: v })}
+            />
+          </div>
+        </div>
+      </div>
+
       {/* 로그인 플렉서스 */}
       <div className="mb-5">
         <div className="flex items-center justify-between gap-4 mb-1">
@@ -347,28 +375,6 @@ export function EffectsSection() {
               </button>
             )}
             <Toggle checked={plexusSettings.loginEnabled} onChange={(v) => update({ loginEnabled: v })} />
-          </div>
-        </div>
-
-        <div className="flex items-center justify-between gap-4 mb-1 mt-2">
-          <div>
-            <p className="text-xs font-medium text-text-primary/80">그라데이션 배경</p>
-            <p className="text-[11px] text-text-secondary/60 mt-0.5">파티클과 독립적인 부드러운 조명</p>
-          </div>
-          <div className="flex items-center gap-2">
-            {(plexusSettings.loginGradientEnabled !== false) !== DEFAULTS.loginGradientEnabled && (
-              <button
-                onClick={() => update({ loginGradientEnabled: DEFAULTS.loginGradientEnabled })}
-                className="text-text-secondary/40 hover:text-accent transition-colors cursor-pointer"
-                title={`기본값 (${DEFAULTS.loginGradientEnabled ? 'ON' : 'OFF'})`}
-              >
-                <RotateCcw size={11} />
-              </button>
-            )}
-            <Toggle
-              checked={plexusSettings.loginGradientEnabled !== false}
-              onChange={(v) => update({ loginGradientEnabled: v })}
-            />
           </div>
         </div>
 
@@ -410,28 +416,6 @@ export function EffectsSection() {
               </button>
             )}
             <Toggle checked={plexusSettings.dashboardEnabled} onChange={(v) => update({ dashboardEnabled: v })} />
-          </div>
-        </div>
-
-        <div className="flex items-center justify-between gap-4 mb-1 mt-2">
-          <div>
-            <p className="text-xs font-medium text-text-primary/80">그라데이션 배경</p>
-            <p className="text-[11px] text-text-secondary/60 mt-0.5">파티클과 독립적인 부드러운 조명</p>
-          </div>
-          <div className="flex items-center gap-2">
-            {(plexusSettings.dashboardGradientEnabled !== false) !== DEFAULTS.dashboardGradientEnabled && (
-              <button
-                onClick={() => update({ dashboardGradientEnabled: DEFAULTS.dashboardGradientEnabled })}
-                className="text-text-secondary/40 hover:text-accent transition-colors cursor-pointer"
-                title={`기본값 (${DEFAULTS.dashboardGradientEnabled ? 'ON' : 'OFF'})`}
-              >
-                <RotateCcw size={11} />
-              </button>
-            )}
-            <Toggle
-              checked={plexusSettings.dashboardGradientEnabled !== false}
-              onChange={(v) => update({ dashboardGradientEnabled: v })}
-            />
           </div>
         </div>
 

--- a/src/components/settings/EffectsSection.tsx
+++ b/src/components/settings/EffectsSection.tsx
@@ -7,8 +7,10 @@ import { cn } from '@/utils/cn';
 
 const DEFAULTS = {
   loginEnabled: true,
+  loginGradientEnabled: true,
   loginParticleCount: 666,
   dashboardEnabled: true,
+  dashboardGradientEnabled: true,
   dashboardParticleCount: 120,
   speed: 1.0,
   mouseRadius: 250,
@@ -348,6 +350,28 @@ export function EffectsSection() {
           </div>
         </div>
 
+        <div className="flex items-center justify-between gap-4 mb-1 mt-2">
+          <div>
+            <p className="text-xs font-medium text-text-primary/80">그라데이션 배경</p>
+            <p className="text-[11px] text-text-secondary/60 mt-0.5">파티클과 독립적인 부드러운 조명</p>
+          </div>
+          <div className="flex items-center gap-2">
+            {(plexusSettings.loginGradientEnabled !== false) !== DEFAULTS.loginGradientEnabled && (
+              <button
+                onClick={() => update({ loginGradientEnabled: DEFAULTS.loginGradientEnabled })}
+                className="text-text-secondary/40 hover:text-accent transition-colors cursor-pointer"
+                title={`기본값 (${DEFAULTS.loginGradientEnabled ? 'ON' : 'OFF'})`}
+              >
+                <RotateCcw size={11} />
+              </button>
+            )}
+            <Toggle
+              checked={plexusSettings.loginGradientEnabled !== false}
+              onChange={(v) => update({ loginGradientEnabled: v })}
+            />
+          </div>
+        </div>
+
         <MiniPlexusPreview
           particleCount={plexusSettings.loginParticleCount}
           enabled={plexusSettings.loginEnabled}
@@ -386,6 +410,28 @@ export function EffectsSection() {
               </button>
             )}
             <Toggle checked={plexusSettings.dashboardEnabled} onChange={(v) => update({ dashboardEnabled: v })} />
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between gap-4 mb-1 mt-2">
+          <div>
+            <p className="text-xs font-medium text-text-primary/80">그라데이션 배경</p>
+            <p className="text-[11px] text-text-secondary/60 mt-0.5">파티클과 독립적인 부드러운 조명</p>
+          </div>
+          <div className="flex items-center gap-2">
+            {(plexusSettings.dashboardGradientEnabled !== false) !== DEFAULTS.dashboardGradientEnabled && (
+              <button
+                onClick={() => update({ dashboardGradientEnabled: DEFAULTS.dashboardGradientEnabled })}
+                className="text-text-secondary/40 hover:text-accent transition-colors cursor-pointer"
+                title={`기본값 (${DEFAULTS.dashboardGradientEnabled ? 'ON' : 'OFF'})`}
+              >
+                <RotateCcw size={11} />
+              </button>
+            )}
+            <Toggle
+              checked={plexusSettings.dashboardGradientEnabled !== false}
+              onChange={(v) => update({ dashboardGradientEnabled: v })}
+            />
           </div>
         </div>
 

--- a/src/components/settings/FontColorSection.tsx
+++ b/src/components/settings/FontColorSection.tsx
@@ -60,6 +60,15 @@ export function FontColorSection() {
     })();
   }, []);
 
+  // 테마/컬러모드/커스텀 색상이 변경되면 현재 preset 기준으로 카테고리 색 재계산·적용
+  useEffect(() => {
+    if (preset === 'custom') return; // custom은 사용자가 직접 지정한 값 유지
+    const nextColors = FONT_COLOR_PRESETS[preset].getColors(primary, secondary, accentSub);
+    setColors(nextColors);
+    applyTextColors(nextColors);
+    // preferences 저장은 하지 않음 — 테마 변경은 별도 저장 트리거이고, 여기서는 UI 반영만.
+  }, [preset, primary, secondary, accentSub]);
+
   // 프리셋 변경
   const handlePresetChange = async (p: FontColorPreset) => {
     setPreset(p);

--- a/src/components/settings/FontColorSection.tsx
+++ b/src/components/settings/FontColorSection.tsx
@@ -64,30 +64,17 @@ export function FontColorSection() {
 
   // 테마/컬러모드/커스텀 색상이 변경되면 현재 preset 기준으로 카테고리 색 재계산·적용
   // loadPreferences 완료 전에는 skip → 저장된 custom 색이 기본값으로 플래시되는 것 방지
+  //
+  // 저장(savePreferences) 및 broadcast(preferencesBroadcastChange)는 App.tsx의 전역 effect가
+  // 담당. 이 컴포넌트는 'font' 탭이 열렸을 때만 마운트되므로, 여기서 저장하면 다른 탭에서
+  // 테마를 바꿨을 때 stale fontCategoryColors가 디스크에 남는 문제 발생.
+  // 여기서는 로컬 state(colors) 동기화 + 즉시 DOM 반영(applyTextColors)만 담당.
   useEffect(() => {
     if (!hasLoaded) return;
     if (preset === 'custom') return; // custom은 사용자가 직접 지정한 값 유지
     const nextColors = FONT_COLOR_PRESETS[preset].getColors(primary, secondary, accentSub);
     setColors(nextColors);
     applyTextColors(nextColors);
-    // 재계산된 색상을 디스크에 영속화 — 앱 재시작 후에도 현재 테마 기준 색상 유지
-    // (이전에는 session-only 였기 때문에 재시작 시 stale 색상으로 되돌아감)
-    (async () => {
-      try {
-        const prev = (await loadPreferences()) ?? {};
-        await savePreferences({
-          ...prev,
-          fontColorPreset: preset,
-          fontCategoryColors: nextColors,
-        });
-        window.electronAPI?.preferencesBroadcastChange?.({
-          fontColorPreset: preset,
-          fontCategoryColors: nextColors,
-        });
-      } catch (err) {
-        console.warn('[font-color] 재계산 색상 저장 실패:', err);
-      }
-    })();
   }, [hasLoaded, preset, primary, secondary, accentSub]);
 
   // 프리셋 변경

--- a/src/components/settings/FontColorSection.tsx
+++ b/src/components/settings/FontColorSection.tsx
@@ -1,0 +1,179 @@
+import { useState, useEffect } from 'react';
+import { Palette, ChevronDown, ChevronUp } from 'lucide-react';
+import { cn } from '@/utils/cn';
+import { SettingsSection } from './SettingsSection';
+import {
+  FONT_CATEGORIES,
+  FONT_COLOR_PRESETS,
+  applyTextColors,
+  type FontColorPreset,
+  type FontCategoryColors,
+} from '@/utils/typography';
+import { loadPreferences, savePreferences } from '@/services/settingsService';
+import { useAppStore } from '@/stores/useAppStore';
+import { getPreset, getLightColors } from '@/themes';
+
+// ─── 헬퍼 ──────────────────────────────────────
+
+function parseTriplet(rgb: string): [number, number, number] {
+  const [r, g, b] = rgb.split(' ').map(Number);
+  return [r || 0, g || 0, b || 0];
+}
+
+function toHex([r, g, b]: [number, number, number]): string {
+  return '#' + [r, g, b].map((n) => n.toString(16).padStart(2, '0')).join('');
+}
+
+function fromHex(hex: string): string {
+  const v = hex.replace('#', '');
+  const r = parseInt(v.slice(0, 2), 16);
+  const g = parseInt(v.slice(2, 4), 16);
+  const b = parseInt(v.slice(4, 6), 16);
+  return `${r} ${g} ${b}`;
+}
+
+// ─── 컴포넌트 ──────────────────────────────────
+
+export function FontColorSection() {
+  const themeId = useAppStore((s) => s.themeId);
+  const customThemeColors = useAppStore((s) => s.customThemeColors);
+  const colorMode = useAppStore((s) => s.colorMode);
+
+  const [preset, setPreset] = useState<FontColorPreset>('theme');
+  const [colors, setColors] = useState<FontCategoryColors>({});
+  const [showAdvanced, setShowAdvanced] = useState(false);
+
+  // 테마 기반 폴백 색상 (사용자 커스텀 > 라이트 > 다크 프리셋 > 기본값)
+  const themeColors =
+    customThemeColors ??
+    (colorMode === 'light' ? getLightColors(themeId) : getPreset(themeId)?.colors);
+  const primary = themeColors?.textPrimary ?? '232 232 238';
+  const secondary = themeColors?.textSecondary ?? '139 141 163';
+  const accentSub = themeColors?.accentSub ?? '162 155 254';
+
+  // 저장된 설정 로드
+  useEffect(() => {
+    (async () => {
+      const prefs = await loadPreferences();
+      if (prefs?.fontColorPreset) setPreset(prefs.fontColorPreset);
+      if (prefs?.fontCategoryColors) setColors(prefs.fontCategoryColors);
+    })();
+  }, []);
+
+  // 프리셋 변경
+  const handlePresetChange = async (p: FontColorPreset) => {
+    setPreset(p);
+    const nextColors =
+      p === 'custom'
+        ? colors
+        : FONT_COLOR_PRESETS[p].getColors(primary, secondary, accentSub);
+    setColors(nextColors);
+    applyTextColors(nextColors);
+    try {
+      const prev = (await loadPreferences()) ?? {};
+      await savePreferences({
+        ...prev,
+        fontColorPreset: p,
+        fontCategoryColors: nextColors,
+      });
+      window.electronAPI?.preferencesBroadcastChange?.({
+        fontColorPreset: p,
+        fontCategoryColors: nextColors,
+      });
+    } catch (err) {
+      console.error('[설정] 글자 색상 프리셋 저장 실패:', err);
+    }
+  };
+
+  // 카테고리별 색상 변경
+  const handleCategoryColor = async (cat: keyof FontCategoryColors, hex: string) => {
+    const next: FontCategoryColors = { ...colors, [cat]: fromHex(hex) };
+    setColors(next);
+    setPreset('custom');
+    applyTextColors(next);
+    try {
+      const prev = (await loadPreferences()) ?? {};
+      await savePreferences({
+        ...prev,
+        fontColorPreset: 'custom',
+        fontCategoryColors: next,
+      });
+      window.electronAPI?.preferencesBroadcastChange?.({
+        fontColorPreset: 'custom',
+        fontCategoryColors: next,
+      });
+    } catch (err) {
+      console.error('[설정] 글자 카테고리 색상 저장 실패:', err);
+    }
+  };
+
+  return (
+    <SettingsSection
+      icon={<Palette size={18} className="text-accent" />}
+      title="글자 색상"
+    >
+      <p className="text-xs text-text-secondary mb-3">
+        카테고리별 색상을 프리셋 또는 사용자 지정으로 변경합니다.
+      </p>
+
+      {/* 프리셋 버튼 */}
+      <div className="flex gap-2 flex-wrap mb-4">
+        {(Object.keys(FONT_COLOR_PRESETS) as FontColorPreset[]).map((p) => (
+          <button
+            key={p}
+            onClick={() => handlePresetChange(p)}
+            className={cn(
+              'px-3 py-1.5 rounded-md text-xs font-medium border transition-all cursor-pointer',
+              preset === p
+                ? 'bg-accent text-on-accent border-accent'
+                : 'border-bg-border text-text-primary hover:bg-bg-border/30',
+            )}
+          >
+            {FONT_COLOR_PRESETS[p].label}
+          </button>
+        ))}
+      </div>
+
+      {/* 고급 설정 토글 */}
+      <button
+        onClick={() => setShowAdvanced(!showAdvanced)}
+        className="flex items-center gap-1.5 text-xs text-text-secondary hover:text-text-primary transition-colors cursor-pointer mb-3"
+      >
+        {showAdvanced ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+        고급 설정
+        <span className="text-[10px] text-text-secondary/40">카테고리별 색상 개별 지정</span>
+      </button>
+
+      {showAdvanced && (
+        <div className="space-y-3">
+          {FONT_CATEGORIES.map((cat) => {
+            const current =
+              colors[cat.id] ??
+              (preset !== 'custom'
+                ? FONT_COLOR_PRESETS[preset].getColors(primary, secondary, accentSub)[cat.id]
+                : undefined) ??
+              primary;
+            return (
+              <div key={cat.id} className="flex items-center gap-3">
+                <div className="w-20 shrink-0">
+                  <span className="text-xs font-medium text-text-primary">{cat.label}</span>
+                  <p className="text-[10px] text-text-secondary/50">{cat.description}</p>
+                </div>
+                <input
+                  type="color"
+                  value={toHex(parseTriplet(current))}
+                  onChange={(e) => handleCategoryColor(cat.id, e.target.value)}
+                  className="w-10 h-8 rounded cursor-pointer bg-transparent"
+                />
+                <span className={cn(cat.cssClass, 'flex-1 truncate')}>{cat.previewText}</span>
+              </div>
+            );
+          })}
+          <p className="text-[10px] text-text-secondary/40 mt-2">
+            * 고급 설정을 변경하면 프리셋이 &apos;사용자 지정&apos;으로 전환됩니다
+          </p>
+        </div>
+      )}
+    </SettingsSection>
+  );
+}

--- a/src/components/settings/FontColorSection.tsx
+++ b/src/components/settings/FontColorSection.tsx
@@ -70,7 +70,24 @@ export function FontColorSection() {
     const nextColors = FONT_COLOR_PRESETS[preset].getColors(primary, secondary, accentSub);
     setColors(nextColors);
     applyTextColors(nextColors);
-    // preferences 저장은 하지 않음 — 테마 변경은 별도 저장 트리거이고, 여기서는 UI 반영만.
+    // 재계산된 색상을 디스크에 영속화 — 앱 재시작 후에도 현재 테마 기준 색상 유지
+    // (이전에는 session-only 였기 때문에 재시작 시 stale 색상으로 되돌아감)
+    (async () => {
+      try {
+        const prev = (await loadPreferences()) ?? {};
+        await savePreferences({
+          ...prev,
+          fontColorPreset: preset,
+          fontCategoryColors: nextColors,
+        });
+        window.electronAPI?.preferencesBroadcastChange?.({
+          fontColorPreset: preset,
+          fontCategoryColors: nextColors,
+        });
+      } catch (err) {
+        console.warn('[font-color] 재계산 색상 저장 실패:', err);
+      }
+    })();
   }, [hasLoaded, preset, primary, secondary, accentSub]);
 
   // 프리셋 변경

--- a/src/components/settings/FontColorSection.tsx
+++ b/src/components/settings/FontColorSection.tsx
@@ -42,6 +42,7 @@ export function FontColorSection() {
   const [preset, setPreset] = useState<FontColorPreset>('theme');
   const [colors, setColors] = useState<FontCategoryColors>({});
   const [showAdvanced, setShowAdvanced] = useState(false);
+  const [hasLoaded, setHasLoaded] = useState(false);
 
   // 테마 기반 폴백 색상 (사용자 커스텀 > 라이트 > 다크 프리셋 > 기본값)
   const themeColors =
@@ -57,17 +58,20 @@ export function FontColorSection() {
       const prefs = await loadPreferences();
       if (prefs?.fontColorPreset) setPreset(prefs.fontColorPreset);
       if (prefs?.fontCategoryColors) setColors(prefs.fontCategoryColors);
+      setHasLoaded(true);
     })();
   }, []);
 
   // 테마/컬러모드/커스텀 색상이 변경되면 현재 preset 기준으로 카테고리 색 재계산·적용
+  // loadPreferences 완료 전에는 skip → 저장된 custom 색이 기본값으로 플래시되는 것 방지
   useEffect(() => {
+    if (!hasLoaded) return;
     if (preset === 'custom') return; // custom은 사용자가 직접 지정한 값 유지
     const nextColors = FONT_COLOR_PRESETS[preset].getColors(primary, secondary, accentSub);
     setColors(nextColors);
     applyTextColors(nextColors);
     // preferences 저장은 하지 않음 — 테마 변경은 별도 저장 트리거이고, 여기서는 UI 반영만.
-  }, [preset, primary, secondary, accentSub]);
+  }, [hasLoaded, preset, primary, secondary, accentSub]);
 
   // 프리셋 변경
   const handlePresetChange = async (p: FontColorPreset) => {

--- a/src/components/settings/FontSizeSection.tsx
+++ b/src/components/settings/FontSizeSection.tsx
@@ -209,6 +209,8 @@ async function persistSettings(
       fontScale,
       fontCategoryScales,
     });
+    // 다른 창(플로팅 위젯 등)에도 즉시 반영
+    window.electronAPI?.preferencesBroadcastChange?.({ fontScale, fontCategoryScales });
   } catch (err) {
     console.error('[설정] 글꼴 설정 저장 실패:', err);
   }

--- a/src/components/vacation/VacationRegisterModal.tsx
+++ b/src/components/vacation/VacationRegisterModal.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/utils/cn';
 import { useAppStore } from '@/stores/useAppStore';
 import { submitVacation } from '@/services/vacationService';
 import { VACATION_TYPES, type VacationType } from '@/types/vacation';
+import { useVacationPendingStore } from '@/stores/useVacationPendingStore';
 
 interface VacationRegisterModalProps {
   open: boolean;
@@ -87,6 +88,19 @@ export function VacationRegisterModal({
     setToast({ message: '휴가 등록 요청 중...', type: 'info' });
     onClose();
 
+    // 낙관적 pending 이벤트 추가 (위젯/캘린더에 노란색으로 즉시 표시)
+    const pendingId = `pending-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    await useVacationPendingStore.getState().add({
+      name: userName,
+      type,
+      startDate,
+      endDate,
+      reason,
+      status: 'pending',
+      pendingId,
+      createdAt: Date.now(),
+    });
+
     try {
       const result = await submitVacation({
         name: userName,
@@ -97,7 +111,9 @@ export function VacationRegisterModal({
       });
 
       if (result.ok && result.success) {
-        setToast({ message: '휴가가 등록되었습니다', type: 'success' });
+        // pending 제거 → 모든 창에 완료 브로드캐스트
+        await useVacationPendingStore.getState().remove(pendingId);
+        await window.electronAPI?.vacationBroadcastRegistered?.({ name: userName, type });
         invalidateVacationCache();
         // GAS 파이프라인 완전 완료 후 데이터 갱신 (8초 후)
         setTimeout(() => {
@@ -106,11 +122,15 @@ export function VacationRegisterModal({
         }, 8000);
       } else {
         // D3: 등록 실패 상세 알림 — critical 토스트로 강조
-        setToast({ message: '휴가 등록 실패: ' + (result.error || result.state || '알 수 없는 오류'), type: 'critical' });
+        const errorMsg = result.error || result.state || '알 수 없는 오류';
+        await useVacationPendingStore.getState().remove(pendingId);
+        await window.electronAPI?.vacationBroadcastFailed?.({ name: userName, error: errorMsg });
         onSubmitEnd?.();
       }
     } catch (err) {
-      setToast({ message: '휴가 등록 실패: ' + (err instanceof Error ? err.message : String(err)), type: 'critical' });
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      await useVacationPendingStore.getState().remove(pendingId);
+      await window.electronAPI?.vacationBroadcastFailed?.({ name: userName, error: errorMsg });
       onSubmitEnd?.();
     }
   };

--- a/src/components/vacation/VacationRegisterModal.tsx
+++ b/src/components/vacation/VacationRegisterModal.tsx
@@ -89,7 +89,9 @@ export function VacationRegisterModal({
     onClose();
 
     // 낙관적 pending 이벤트 추가 (위젯/캘린더에 노란색으로 즉시 표시)
+    // pending 저장 실패는 optimistic UI 문제일 뿐 — 실제 등록 API는 계속 진행해야 함
     const pendingId = `pending-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    let pendingAdded = true;
     try {
       await useVacationPendingStore.getState().add({
         name: userName,
@@ -102,20 +104,20 @@ export function VacationRegisterModal({
         createdAt: Date.now(),
       });
     } catch (addErr) {
-      // pending 저장 자체가 실패 (IPC/디스크 쓰기 등) — 사용자에게 피드백 필수
-      const errorMsg = addErr instanceof Error ? addErr.message : String(addErr);
-      console.error('[vacation] pending 저장 실패:', addErr);
+      // pending 저장 실패 — optimistic 표시만 생략, 실제 등록은 계속 진행
+      pendingAdded = false;
+      console.warn('[vacation] pending 저장 실패 — 등록은 계속 진행:', addErr);
       setToast({
-        message: `휴가 등록 준비 중 오류: ${errorMsg}`,
-        type: 'critical',
+        message: '로컬 캐시 저장 실패 — 등록은 계속 진행됩니다.',
+        type: 'warning',
       });
-      onSubmitEnd?.();
-      return;
     }
 
     // pending 제거 헬퍼: 실패해도 후속 broadcast/onSubmitEnd 실행을 막지 않음
     // (pending-store 쓰기 자체가 실패한 경우 두 번째 remove도 throw할 수 있어 가드 필수)
+    // add 성공 시에만 호출 — add 실패 시 remove할 항목 자체가 없음
     const safeRemovePending = async (label: string) => {
+      if (!pendingAdded) return;
       try {
         await useVacationPendingStore.getState().remove(pendingId);
       } catch (e) {

--- a/src/components/vacation/VacationRegisterModal.tsx
+++ b/src/components/vacation/VacationRegisterModal.tsx
@@ -135,8 +135,11 @@ export function VacationRegisterModal({
       });
 
       if (result.ok && result.success) {
-        // pending 제거 → 모든 창에 완료 브로드캐스트
+        // pending 제거 → 로컬 즉시 피드백 + 다른 창에 완료 브로드캐스트
+        // 로컬 setToast: 현재 창 즉시 피드백 (dev/test 모드 포함).
+        // broadcast는 `excludeSenderId` 적용으로 다른 창만 수신 → 중복 토스트 없음.
         await safeRemovePending('성공 후');
+        setToast({ message: `${userName} 휴가 등록 완료 (${type})`, type: 'success' });
         await window.electronAPI?.vacationBroadcastRegistered?.({ name: userName, type });
         invalidateVacationCache();
         // GAS 파이프라인 완전 완료 후 데이터 갱신 (8초 후)
@@ -148,12 +151,14 @@ export function VacationRegisterModal({
         // D3: 등록 실패 상세 알림 — critical 토스트로 강조
         const errorMsg = result.error || result.state || '알 수 없는 오류';
         await safeRemovePending('실패 응답 후');
+        setToast({ message: `휴가 등록 실패: ${errorMsg}`, type: 'critical' });
         await window.electronAPI?.vacationBroadcastFailed?.({ name: userName, error: errorMsg });
         onSubmitEnd?.();
       }
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err);
       await safeRemovePending('예외 후');
+      setToast({ message: `휴가 등록 실패: ${errorMsg}`, type: 'critical' });
       await window.electronAPI?.vacationBroadcastFailed?.({ name: userName, error: errorMsg });
       onSubmitEnd?.();
     }

--- a/src/components/vacation/VacationRegisterModal.tsx
+++ b/src/components/vacation/VacationRegisterModal.tsx
@@ -90,16 +90,28 @@ export function VacationRegisterModal({
 
     // 낙관적 pending 이벤트 추가 (위젯/캘린더에 노란색으로 즉시 표시)
     const pendingId = `pending-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-    await useVacationPendingStore.getState().add({
-      name: userName,
-      type,
-      startDate,
-      endDate,
-      reason,
-      status: 'pending',
-      pendingId,
-      createdAt: Date.now(),
-    });
+    try {
+      await useVacationPendingStore.getState().add({
+        name: userName,
+        type,
+        startDate,
+        endDate,
+        reason,
+        status: 'pending',
+        pendingId,
+        createdAt: Date.now(),
+      });
+    } catch (addErr) {
+      // pending 저장 자체가 실패 (IPC/디스크 쓰기 등) — 사용자에게 피드백 필수
+      const errorMsg = addErr instanceof Error ? addErr.message : String(addErr);
+      console.error('[vacation] pending 저장 실패:', addErr);
+      setToast({
+        message: `휴가 등록 준비 중 오류: ${errorMsg}`,
+        type: 'critical',
+      });
+      onSubmitEnd?.();
+      return;
+    }
 
     try {
       const result = await submitVacation({

--- a/src/components/vacation/VacationRegisterModal.tsx
+++ b/src/components/vacation/VacationRegisterModal.tsx
@@ -113,6 +113,16 @@ export function VacationRegisterModal({
       return;
     }
 
+    // pending 제거 헬퍼: 실패해도 후속 broadcast/onSubmitEnd 실행을 막지 않음
+    // (pending-store 쓰기 자체가 실패한 경우 두 번째 remove도 throw할 수 있어 가드 필수)
+    const safeRemovePending = async (label: string) => {
+      try {
+        await useVacationPendingStore.getState().remove(pendingId);
+      } catch (e) {
+        console.warn(`[vacation] ${label} pending 제거 실패:`, e);
+      }
+    };
+
     try {
       const result = await submitVacation({
         name: userName,
@@ -124,7 +134,7 @@ export function VacationRegisterModal({
 
       if (result.ok && result.success) {
         // pending 제거 → 모든 창에 완료 브로드캐스트
-        await useVacationPendingStore.getState().remove(pendingId);
+        await safeRemovePending('성공 후');
         await window.electronAPI?.vacationBroadcastRegistered?.({ name: userName, type });
         invalidateVacationCache();
         // GAS 파이프라인 완전 완료 후 데이터 갱신 (8초 후)
@@ -135,13 +145,13 @@ export function VacationRegisterModal({
       } else {
         // D3: 등록 실패 상세 알림 — critical 토스트로 강조
         const errorMsg = result.error || result.state || '알 수 없는 오류';
-        await useVacationPendingStore.getState().remove(pendingId);
+        await safeRemovePending('실패 응답 후');
         await window.electronAPI?.vacationBroadcastFailed?.({ name: userName, error: errorMsg });
         onSubmitEnd?.();
       }
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err);
-      await useVacationPendingStore.getState().remove(pendingId);
+      await safeRemovePending('예외 후');
       await window.electronAPI?.vacationBroadcastFailed?.({ name: userName, error: errorMsg });
       onSubmitEnd?.();
     }

--- a/src/components/widgets/CalendarWidget.tsx
+++ b/src/components/widgets/CalendarWidget.tsx
@@ -8,7 +8,11 @@ import * as gcalService from '@/services/googleCalendarService';
 import { fetchAllVacationEvents } from '@/services/vacationService';
 import type { CalendarEvent, CalendarFilter } from '@/types/calendar';
 import { VACATION_COLOR } from '@/types/vacation';
+import { useVacationPendingStore } from '@/stores/useVacationPendingStore';
 import { Widget } from './Widget';
+
+// pending 휴가용 노란색 (amber-400)
+const PENDING_VACATION_COLOR = '#FBBF24';
 
 const WEEKDAYS_SHORT = ['일', '월', '화', '수', '목', '금', '토'];
 
@@ -76,6 +80,9 @@ export function CalendarWidget() {
   const vacationConnected = useAppStore((s) => s.vacationConnected);
   const [events, setEvents] = useState<CalendarEvent[]>([]);
   const [vacationEvts, setVacationEvts] = useState<CalendarEvent[]>([]);
+  const pendingVacations = useVacationPendingStore((s) => s.pending);
+  const pendingHydrated = useVacationPendingStore((s) => s.hydrated);
+  const hydratePending = useVacationPendingStore((s) => s.hydrate);
   const [year, setYear] = useState(() => new Date().getFullYear());
   const [month, setMonth] = useState(() => new Date().getMonth());
   const [viewMode, setViewMode] = useState<WidgetViewMode>('month');
@@ -139,8 +146,31 @@ export function CalendarWidget() {
       .catch(() => setVacationEvts([]));
   }, [vacationConnected]);
 
-  // 통합 이벤트
-  const allEvents = useMemo(() => [...events, ...vacationEvts], [events, vacationEvts]);
+  // pending 휴가를 CalendarEvent 형태로 변환
+  const pendingEvts = useMemo<CalendarEvent[]>(() => {
+    return pendingVacations.map((p) => ({
+      id: `wvac-pending-${p.pendingId}`,
+      title: `${p.name} ${p.type} (등록 중)`,
+      memo: '',
+      color: PENDING_VACATION_COLOR,
+      type: 'vacation' as const,
+      startDate: p.startDate,
+      endDate: p.endDate,
+      createdBy: p.name,
+      createdAt: new Date(p.createdAt).toISOString(),
+      vacationType: p.type,
+      vacationUserName: p.name,
+      isReadOnly: true,
+    }));
+  }, [pendingVacations]);
+
+  // pending 스토어 하이드레이트
+  useEffect(() => {
+    if (!pendingHydrated) { hydratePending(); }
+  }, [pendingHydrated, hydratePending]);
+
+  // 통합 이벤트 (pending 포함)
+  const allEvents = useMemo(() => [...events, ...vacationEvts, ...pendingEvts], [events, vacationEvts, pendingEvts]);
 
   // Wheel scroll navigation for all view modes
   const handleWheel = useCallback((e: WheelEvent) => {

--- a/src/components/widgets/CalendarWidget.tsx
+++ b/src/components/widgets/CalendarWidget.tsx
@@ -278,7 +278,7 @@ export function CalendarWidget() {
               onClick={() => { setViewMode(m); setSelectedDate(null); setWeekOffset(0); setDayOffset(0); }}
               className={cn(
                 'px-1.5 py-0.5 text-[9px] rounded font-medium cursor-pointer transition-colors',
-                viewMode === m ? 'bg-accent/20 text-accent' : 'text-text-secondary/40 hover:text-text-primary',
+                viewMode === m ? 'bg-accent/20 text-accent' : 'opacity-50 hover:opacity-100',
               )}
             >
               {m === 'month' ? '월' : m === '2week' ? '2주' : m === 'week' ? '주' : '오늘'}

--- a/src/components/widgets/MyTasksWidget.tsx
+++ b/src/components/widgets/MyTasksWidget.tsx
@@ -1002,6 +1002,9 @@ export function MyTasksWidget() {
   // assigned 뷰에서 수동으로 추가한 씬 키
   const [assignedSceneKeys, setAssignedSceneKeys] = useState<SceneKey[]>([]);
 
+  // 플로팅 위젯에서 메인 세션 수신 실패 시 안내 메시지 표시 (10초 타임아웃)
+  const [loadTimedOut, setLoadTimedOut] = useState(false);
+
   // Supabase 초기화 완료 여부 (save effect에서 초기화 전 저장 방지)
   const _supabaseInitialized = useRef(false);
 
@@ -1026,6 +1029,17 @@ export function MyTasksWidget() {
       window.electronAPI?.dataNotifyChange?.({ type: 'todo' } as import('@/types').SheetDeltaTodo);
     }
   }, [isPopup]);
+
+  // 플로팅 위젯에서 currentUser가 10초 내에 수신되지 않으면 안내 메시지로 전환
+  useEffect(() => {
+    if (currentUser) {
+      setLoadTimedOut(false);
+      return;
+    }
+    if (activeView.type !== 'assigned') return;
+    const timer = setTimeout(() => setLoadTimedOut(true), 10_000);
+    return () => clearTimeout(timer);
+  }, [currentUser, activeView.type]);
 
   // Supabase 초기화: 마이그레이션 후 데이터 로드
   useEffect(() => {
@@ -1761,10 +1775,18 @@ export function MyTasksWidget() {
 
   // 플로팅 위젯 창에서 메인 앱 로그인 전 → currentUser가 null인 상태로 렌더될 수 있음
   // (assigned 뷰는 currentUser.name과 assignee 매칭 → 빈 결과 방지 위해 로딩 표시)
+  // 10초 이상 로딩되면 메인 앱 로그인 확인 안내로 전환
   if (activeView.type === 'assigned' && !currentUser) {
     return (
-      <div className="flex items-center justify-center h-full text-xs text-text-secondary/60">
-        사용자 정보 로딩 중...
+      <div className="flex flex-col items-center justify-center h-full gap-2 text-xs text-text-secondary/60 px-4 text-center">
+        {loadTimedOut ? (
+          <>
+            <div>사용자 정보를 불러오지 못했습니다.</div>
+            <div className="text-[10px] text-text-secondary/40">메인 앱의 로그인 상태를 확인해주세요.</div>
+          </>
+        ) : (
+          '사용자 정보 로딩 중...'
+        )}
       </div>
     );
   }

--- a/src/components/widgets/MyTasksWidget.tsx
+++ b/src/components/widgets/MyTasksWidget.tsx
@@ -1759,6 +1759,16 @@ export function MyTasksWidget() {
     );
   };
 
+  // 플로팅 위젯 창에서 메인 앱 로그인 전 → currentUser가 null인 상태로 렌더될 수 있음
+  // (assigned 뷰는 currentUser.name과 assignee 매칭 → 빈 결과 방지 위해 로딩 표시)
+  if (activeView.type === 'assigned' && !currentUser) {
+    return (
+      <div className="flex items-center justify-center h-full text-xs text-text-secondary/60">
+        사용자 정보 로딩 중...
+      </div>
+    );
+  }
+
   return (
     <Widget
       title="내 할일"

--- a/src/components/widgets/VacationWidget.tsx
+++ b/src/components/widgets/VacationWidget.tsx
@@ -4,7 +4,14 @@ import { Widget } from './Widget';
 import { useAppStore } from '@/stores/useAppStore';
 import { fetchAllVacationEvents } from '@/services/vacationService';
 import type { VacationEvent } from '@/types/vacation';
+import { useVacationPendingStore, type PendingVacationEvent } from '@/stores/useVacationPendingStore';
 import { cn } from '@/utils/cn';
+
+type DisplayEvent = VacationEvent | PendingVacationEvent;
+
+function isPending(ev: DisplayEvent): ev is PendingVacationEvent {
+  return (ev as PendingVacationEvent).status === 'pending';
+}
 
 type ViewMode = 'today' | 'week';
 
@@ -30,6 +37,9 @@ export function VacationWidget() {
   const [mode, setMode] = useState<ViewMode>('today');
   const [events, setEvents] = useState<VacationEvent[]>([]);
   const [loading, setLoading] = useState(false);
+  const pending = useVacationPendingStore((s) => s.pending);
+  const pendingHydrated = useVacationPendingStore((s) => s.hydrated);
+  const hydratePending = useVacationPendingStore((s) => s.hydrate);
 
   const load = useCallback(async () => {
     if (!vacationConnected) return;
@@ -46,20 +56,32 @@ export function VacationWidget() {
 
   useEffect(() => { load(); }, [load]);
 
+  // pending 스토어 하이드레이트 (팝업/메인 둘 다 안전하게)
+  useEffect(() => {
+    if (!pendingHydrated) { hydratePending(); }
+  }, [pendingHydrated, hydratePending]);
+
   const today = fmtDate(new Date());
   const weekRange = getWeekRange();
 
-  const filtered = events.filter((ev) => {
+  // pending + 실제 이벤트 병합
+  const combined: DisplayEvent[] = [...events, ...pending];
+
+  const filtered = combined.filter((ev) => {
     if (mode === 'today') {
       return ev.startDate <= today && ev.endDate >= today;
     }
     return ev.startDate <= weekRange.end && ev.endDate >= weekRange.start;
   });
 
-  // 중복 제거 (같은 이름 + 같은 타입 + 같은 기간)
-  const unique = filtered.reduce<VacationEvent[]>((acc, ev) => {
-    if (!acc.some((e) => e.name === ev.name && e.type === ev.type && e.startDate === ev.startDate && e.endDate === ev.endDate)) {
+  // 중복 제거 (같은 이름 + 같은 타입 + 같은 기간) — pending 우선 유지
+  const unique = filtered.reduce<DisplayEvent[]>((acc, ev) => {
+    const dupIdx = acc.findIndex((e) => e.name === ev.name && e.type === ev.type && e.startDate === ev.startDate && e.endDate === ev.endDate);
+    if (dupIdx === -1) {
       acc.push(ev);
+    } else if (isPending(ev) && !isPending(acc[dupIdx])) {
+      // 같은 항목이 pending + 서버 둘 다 있으면 pending 쪽을 유지 (등록 중 표시 우선)
+      acc[dupIdx] = ev;
     }
     return acc;
   }, []);
@@ -100,16 +122,37 @@ export function VacationWidget() {
         </div>
       ) : (
         <div className="space-y-1 px-1 overflow-auto">
-          {unique.map((ev, i) => (
-            <div
-              key={`${ev.name}-${ev.startDate}-${i}`}
-              className="flex items-center gap-2 px-2 py-1.5 rounded-lg hover:bg-bg-border/10 transition-colors"
-            >
-              <div className="w-1.5 h-1.5 rounded-full bg-emerald-400 shrink-0" />
-              <span className="text-[12px] text-text-primary font-medium">{ev.name}</span>
-              <span className="text-[11px] text-text-secondary/50">{ev.type}</span>
-            </div>
-          ))}
+          {unique.map((ev, i) => {
+            const isP = isPending(ev);
+            const key = isP ? ev.pendingId : `${ev.name}-${ev.startDate}-${i}`;
+            return (
+              <div
+                key={key}
+                className={cn(
+                  'flex items-center gap-2 px-2 py-1.5 rounded-lg transition-colors',
+                  isP
+                    ? 'bg-amber-400/20 border border-amber-400/60'
+                    : 'hover:bg-bg-border/10',
+                )}
+              >
+                <div className={cn(
+                  'w-1.5 h-1.5 rounded-full shrink-0',
+                  isP ? 'bg-amber-400 animate-pulse' : 'bg-emerald-400',
+                )} />
+                <span className={cn(
+                  'text-[12px] font-medium',
+                  isP ? 'text-amber-200' : 'text-text-primary',
+                )}>{ev.name}</span>
+                <span className={cn(
+                  'text-[11px]',
+                  isP ? 'text-amber-200/70' : 'text-text-secondary/50',
+                )}>{ev.type}</span>
+                {isP && (
+                  <span className="ml-auto text-[9px] text-amber-300/80 font-semibold">등록 중...</span>
+                )}
+              </div>
+            );
+          })}
         </div>
       )}
     </Widget>

--- a/src/hooks/useCapsLockWarning.ts
+++ b/src/hooks/useCapsLockWarning.ts
@@ -1,0 +1,11 @@
+import { useState, useCallback } from 'react';
+
+/** Caps Lock 감지 — 비밀번호 입력에 사용. input의 onKeyDown/onKeyUp에 연결 */
+export function useCapsLockWarning() {
+  const [isCapsLockOn, setCapsLockOn] = useState(false);
+  const onKey = useCallback((e: React.KeyboardEvent) => {
+    // getModifierState는 keydown/keyup에서 모두 현재 상태를 반환
+    setCapsLockOn(e.getModifierState('CapsLock'));
+  }, []);
+  return { isCapsLockOn, onKeyDown: onKey, onKeyUp: onKey };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -29,6 +29,20 @@
 [class*="text-\[8px\]"]  { font-size: calc(8px * var(--text-scale) * var(--text-micro-scale)) !important; }
 [class*="text-\[7px\]"]  { font-size: calc(7px * var(--text-scale) * var(--text-micro-scale)) !important; }
 
+/* 글자 카테고리별 색상 — 미지정 시 --color-text-primary 폴백 */
+.text-xl, .text-lg, h1, h2, h3 {
+  color: rgb(var(--color-text-heading, var(--color-text-primary)));
+}
+.text-base, .text-sm {
+  color: rgb(var(--color-text-body, var(--color-text-primary)));
+}
+.text-xs {
+  color: rgb(var(--color-text-caption, var(--color-text-primary)));
+}
+.text-\[11px\], .text-\[10px\], .text-\[9px\] {
+  color: rgb(var(--color-text-micro, var(--color-text-primary)));
+}
+
 /* ─── Liveblocks SDK 자동 삽입 배지 숨기기 ─── */
 #liveblocks-badge { display: none !important; }
 

--- a/src/index.css
+++ b/src/index.css
@@ -29,18 +29,21 @@
 [class*="text-\[8px\]"]  { font-size: calc(8px * var(--text-scale) * var(--text-micro-scale)) !important; }
 [class*="text-\[7px\]"]  { font-size: calc(7px * var(--text-scale) * var(--text-micro-scale)) !important; }
 
-/* 글자 카테고리별 색상 — 미지정 시 --color-text-primary 폴백 */
-.text-xl, .text-lg, h1, h2, h3 {
-  color: rgb(var(--color-text-heading, var(--color-text-primary)));
-}
-.text-base, .text-sm {
-  color: rgb(var(--color-text-body, var(--color-text-primary)));
-}
-.text-xs {
-  color: rgb(var(--color-text-caption, var(--color-text-primary)));
-}
-.text-\[11px\], .text-\[10px\], .text-\[9px\] {
-  color: rgb(var(--color-text-micro, var(--color-text-primary)));
+/* 글자 카테고리별 색상 — 미지정 시 --color-text-primary 폴백
+   @layer base 안에 배치 → Tailwind utilities가 언제나 우선 */
+@layer base {
+  .text-xl, .text-lg, h1, h2, h3 {
+    color: rgb(var(--color-text-heading, var(--color-text-primary)));
+  }
+  .text-base, .text-sm {
+    color: rgb(var(--color-text-body, var(--color-text-primary)));
+  }
+  .text-xs {
+    color: rgb(var(--color-text-caption, var(--color-text-primary)));
+  }
+  .text-\[11px\], .text-\[10px\], .text-\[9px\] {
+    color: rgb(var(--color-text-micro, var(--color-text-primary)));
+  }
 }
 
 /* ─── Liveblocks SDK 자동 삽입 배지 숨기기 ─── */

--- a/src/index.css
+++ b/src/index.css
@@ -32,6 +32,12 @@
 /* 글자 카테고리별 색상 — 미지정 시 --color-text-primary 폴백
    @layer base 안에 배치 → Tailwind utilities가 언제나 우선 */
 @layer base {
+  /* 전역 배경/텍스트: GradientBackdrop(z:-1)이 그 위에 얹혀 그라데이션 노출됨.
+     MainLayout 등 콘텐츠 컨테이너는 자체 bg를 깔지 말 것. */
+  html, body {
+    background: rgb(var(--color-bg-primary));
+    color: rgb(var(--color-text-primary));
+  }
   .text-xl, .text-lg, h1, h2, h3 {
     color: rgb(var(--color-text-heading, var(--color-text-primary)));
   }

--- a/src/mocks/devElectronAPI.ts
+++ b/src/mocks/devElectronAPI.ts
@@ -161,6 +161,7 @@ export function installDevElectronAPI(): void {
     preferencesBroadcastChange: async () => ({ ok: true }),
     onPreferencesChanged: noop,
     sessionBroadcastChange: async () => ({ ok: true }),
+    sessionRequestCurrent: async () => ({ ok: true }),
     onSessionChanged: noop,
     themeBroadcastChange: async () => ({ ok: true }),
     onThemeChanged: noop,

--- a/src/mocks/devElectronAPI.ts
+++ b/src/mocks/devElectronAPI.ts
@@ -156,6 +156,12 @@ export function installDevElectronAPI(): void {
     gcalUpdateEvent: async () => {},
     gcalDeleteEvent: async () => {},
     gcalEnsureWatch: async () => {},
+
+    // 설정/세션 변경 브로드캐스트 (mock은 no-op)
+    preferencesBroadcastChange: async () => ({ ok: true }),
+    onPreferencesChanged: noop,
+    sessionBroadcastChange: async () => ({ ok: true }),
+    onSessionChanged: noop,
   };
 
   (window as Window & typeof globalThis).electronAPI = mockAPI;

--- a/src/mocks/devElectronAPI.ts
+++ b/src/mocks/devElectronAPI.ts
@@ -162,6 +162,8 @@ export function installDevElectronAPI(): void {
     onPreferencesChanged: noop,
     sessionBroadcastChange: async () => ({ ok: true }),
     onSessionChanged: noop,
+    themeBroadcastChange: async () => ({ ok: true }),
+    onThemeChanged: noop,
 
     // ─── 휴가 pending 상태 + 브로드캐스트 (mock은 no-op) ───
     vacationPendingLoad: async () => [],

--- a/src/mocks/devElectronAPI.ts
+++ b/src/mocks/devElectronAPI.ts
@@ -162,6 +162,14 @@ export function installDevElectronAPI(): void {
     onPreferencesChanged: noop,
     sessionBroadcastChange: async () => ({ ok: true }),
     onSessionChanged: noop,
+
+    // ─── 휴가 pending 상태 + 브로드캐스트 (mock은 no-op) ───
+    vacationPendingLoad: async () => [],
+    vacationPendingSave: async () => ({ ok: true }),
+    vacationBroadcastRegistered: async () => ({ ok: true }),
+    vacationBroadcastFailed: async () => ({ ok: true }),
+    onVacationRegistered: noop,
+    onVacationFailed: noop,
   };
 
   (window as Window & typeof globalThis).electronAPI = mockAPI;

--- a/src/mocks/devElectronAPI.ts
+++ b/src/mocks/devElectronAPI.ts
@@ -164,6 +164,8 @@ export function installDevElectronAPI(): void {
     onSessionChanged: noop,
     themeBroadcastChange: async () => ({ ok: true }),
     onThemeChanged: noop,
+    calendarBroadcastChange: async () => ({ ok: true }),
+    onCalendarChanged: noop,
 
     // ─── 휴가 pending 상태 + 브로드캐스트 (mock은 no-op) ───
     vacationPendingLoad: async () => [],

--- a/src/mocks/devElectronAPI.ts
+++ b/src/mocks/devElectronAPI.ts
@@ -172,8 +172,10 @@ export function installDevElectronAPI(): void {
     vacationPendingSave: async () => ({ ok: true }),
     vacationBroadcastRegistered: async () => ({ ok: true }),
     vacationBroadcastFailed: async () => ({ ok: true }),
+    vacationBroadcastPendingChanged: async () => ({ ok: true }),
     onVacationRegistered: noop,
     onVacationFailed: noop,
+    onVacationPendingChanged: noop,
   };
 
   (window as Window & typeof globalThis).electronAPI = mockAPI;

--- a/src/services/calendarService.ts
+++ b/src/services/calendarService.ts
@@ -174,20 +174,9 @@ let legacyLoaded = false;
 
 /** 기존 calendar-events.json에서 로컬 이벤트 로드 (GCal 전환 전 데이터 보존) */
 async function loadLegacyEvents(): Promise<void> {
-  if (legacyLoaded) return;
+  // 기존 calendar-events.json legacy 이벤트는 더 이상 로드하지 않음
+  // (GCal 전환 완료 — 로컬 전용 이벤트는 이제 지원 안 함)
   legacyLoaded = true;
-  try {
-    const data = await window.electronAPI.readSettings('calendar-events.json');
-    if (Array.isArray(data) && data.length > 0) {
-      // GCal sync로 채워진 이벤트와 중복되지 않도록 ID 기반 머지
-      const existingIds = new Set(eventCache.map((e) => e.id));
-      const legacy = (data as CalendarEvent[]).filter((e) => !existingIds.has(e.id));
-      if (legacy.length > 0) {
-        eventCache = [...eventCache, ...legacy];
-        console.log(`[Calendar] 기존 로컬 이벤트 ${legacy.length}개 로드`);
-      }
-    }
-  } catch { /* 파일 없거나 읽기 실패 — 무시 */ }
 }
 
 export async function loadAllEvents(): Promise<CalendarEvent[]> {
@@ -225,10 +214,8 @@ export async function syncAll(): Promise<CalendarEvent[]> {
     }
   }
 
-  // legacy 로컬 이벤트 보존: GCal에 없는 로컬 전용 이벤트는 유지
-  // (sourceCalendarId가 없는 이벤트 = 기존 calendar-events.json에서 온 것)
-  const legacyEvents = eventCache.filter((e) => !e.sourceCalendarId && !seen.has(e.id));
-  eventCache = [...events, ...legacyEvents];
+  // GCal에 없는 이벤트는 캐시에서도 제거 (legacy 로컬 이벤트 미지원)
+  eventCache = [...events];
   broadcastCalendarChange();
 
   // Watch 채널 등록 (실시간 동기화용)

--- a/src/services/calendarService.ts
+++ b/src/services/calendarService.ts
@@ -416,7 +416,16 @@ export async function deleteEvent(eventId: string): Promise<void> {
 }
 
 function broadcastCalendarChange(detail?: { eventId?: string; action?: 'add' | 'update' | 'delete' }) {
+  // 1) 자기 프로세스 구독자에게 즉시 전파 (즉각적 UX 반응)
   window.dispatchEvent(new CustomEvent('bflow:calendar-changed', { detail }));
+  // 2) 다른 BrowserWindow(플로팅 위젯 등)에도 IPC로 전파
+  //    무한 루프 방지: 메인 프로세스가 송신자(event.sender.id)를 제외하므로
+  //    자기 창은 IPC로 되돌아온 이벤트를 수신하지 않음.
+  try {
+    window.electronAPI?.calendarBroadcastChange?.(detail);
+  } catch {
+    // 브라우저/개발 환경에서 electronAPI 미제공 시 무시
+  }
 }
 
 export function filterEventsByRange(events: CalendarEvent[], rangeStart: string, rangeEnd: string): CalendarEvent[] {

--- a/src/services/calendarService.ts
+++ b/src/services/calendarService.ts
@@ -384,6 +384,17 @@ export async function deleteEvent(eventId: string): Promise<void> {
   if (!existing) return;
   const actualId = existing.id; // GCal ID
 
+  // 로컬 전용 이벤트(GCal에 저장되지 않은 legacy 이벤트)는 캐시에서만 제거
+  // sourceCalendarId 부재 = GCal과 연동되지 않은 이벤트 (calendarService.ts:229 참고)
+  // cal_ prefix ID도 GCal 저장 전이거나 GCal 동기화가 실패한 로컬 전용 상태
+  const isLocalOnly = !existing.sourceCalendarId || actualId.startsWith('cal_');
+  if (isLocalOnly) {
+    eventCache = eventCache.filter((e) => e.id !== actualId);
+    localToGcalId.delete(eventId);
+    broadcastCalendarChange({ eventId: actualId, action: 'delete' });
+    return;
+  }
+
   // 원본 캘린더 ID 우선 사용
   const calId = existing.sourceCalendarId || await getTargetCalendar(existing.type);
   if (!calId) return;

--- a/src/services/calendarService.ts
+++ b/src/services/calendarService.ts
@@ -373,8 +373,10 @@ export async function deleteEvent(eventId: string): Promise<void> {
 
   // 로컬 전용 이벤트(GCal에 저장되지 않은 legacy 이벤트)는 캐시에서만 제거
   // sourceCalendarId 부재 = GCal과 연동되지 않은 이벤트 (calendarService.ts:229 참고)
-  // cal_ prefix ID도 GCal 저장 전이거나 GCal 동기화가 실패한 로컬 전용 상태
-  const isLocalOnly = !existing.sourceCalendarId || actualId.startsWith('cal_');
+  // 주의: cal_ prefix 가드는 제거됨. in-flight insert 상태(actualId=cal_*, sourceCalendarId=실제)도
+  // GCal 삭제 경로로 진입해야 함. insert가 성공하면 GCal에 고스트 이벤트가 남기 때문.
+  // 404 등 실패 시 catch에서 롤백 처리.
+  const isLocalOnly = !existing.sourceCalendarId;
   if (isLocalOnly) {
     eventCache = eventCache.filter((e) => e.id !== actualId);
     localToGcalId.delete(eventId);

--- a/src/services/settingsService.ts
+++ b/src/services/settingsService.ts
@@ -99,6 +99,7 @@ export interface UserPreferences {
     dashboardEnabled?: boolean;
     dashboardGradientEnabled?: boolean;
     dashboardParticleCount?: number;
+    globalGradientEnabled?: boolean;
     speed?: number;
     mouseRadius?: number;
     mouseForce?: number;

--- a/src/services/settingsService.ts
+++ b/src/services/settingsService.ts
@@ -94,8 +94,10 @@ export interface UserPreferences {
   // Phase 8-3: 플렉서스 애니메이션
   plexus?: {
     loginEnabled?: boolean;
+    loginGradientEnabled?: boolean;
     loginParticleCount?: number;
     dashboardEnabled?: boolean;
+    dashboardGradientEnabled?: boolean;
     dashboardParticleCount?: number;
     speed?: number;
     mouseRadius?: number;

--- a/src/services/settingsService.ts
+++ b/src/services/settingsService.ts
@@ -82,6 +82,15 @@ export interface UserPreferences {
     micro?: number;
   };
 
+  // 글자 카테고리별 색상
+  fontCategoryColors?: {
+    heading?: string;
+    body?: string;
+    caption?: string;
+    micro?: string;
+  };
+  fontColorPreset?: 'theme' | 'high-contrast' | 'soft' | 'mono' | 'custom';
+
   // Phase 8-3: 플렉서스 애니메이션
   plexus?: {
     loginEnabled?: boolean;

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -194,7 +194,14 @@ export async function loadSession(): Promise<{ session: AuthSession | null; user
     console.warn('[auth] session.userId 누락 — 세션 무효', session);
     return { session: null, user: null };
   }
-  const users = await loadUsers();
+  let users: AppUser[];
+  try {
+    users = await loadUsers();
+  } catch (err) {
+    // loadUsers 실패도 복구 가능한 시나리오로 취급 → 앱 초기화 전체 실패 방지
+    console.warn('[auth] 사용자 목록 로드 실패 — 세션 복원 불가:', err);
+    return { session: null, user: null };
+  }
   const user = users.find((u) => u.id === session!.userId) ?? null;
   if (!user) {
     console.warn('[auth] 세션 userId에 매칭되는 사용자 없음', { sessionUserId: session.userId, userCount: users.length });

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -179,22 +179,31 @@ export async function logout(): Promise<void> {
 }
 
 export async function loadSession(): Promise<{ session: AuthSession | null; user: AppUser | null }> {
+  let session: AuthSession | null = null;
   try {
-    const session = (await window.electronAPI.readSettings(AUTH_FILE)) as AuthSession | null;
-    if (!session?.userId) return { session: null, user: null };
-
-    // 사용자 파일에서 해당 유저가 아직 존재하는지 확인
-    const users = await loadUsers();
-    const user = users.find((u) => u.id === session.userId) ?? null;
-    if (!user) {
-      // 삭제된 사용자 → 세션 클리어
-      await logout();
-      return { session: null, user: null };
-    }
-    return { session, user };
-  } catch {
+    session = (await window.electronAPI.readSettings(AUTH_FILE)) as AuthSession | null;
+  } catch (err) {
+    console.warn('[auth] auth.json 읽기 실패:', err);
     return { session: null, user: null };
   }
+  if (!session) {
+    console.info('[auth] auth.json 미존재 — 로그인 필요');
+    return { session: null, user: null };
+  }
+  if (!session.userId) {
+    console.warn('[auth] session.userId 누락 — 세션 무효', session);
+    return { session: null, user: null };
+  }
+  const users = await loadUsers();
+  const user = users.find((u) => u.id === session!.userId) ?? null;
+  if (!user) {
+    console.warn('[auth] 세션 userId에 매칭되는 사용자 없음', { sessionUserId: session.userId, userCount: users.length });
+    // 삭제된 사용자 → 세션 클리어
+    await logout();
+    return { session: null, user: null };
+  }
+  console.info('[auth] 세션 복원 성공', { userId: user.id, name: user.name });
+  return { session, user };
 }
 
 export function isInitialPassword(user: AppUser): boolean {

--- a/src/stores/useAppStore.ts
+++ b/src/stores/useAppStore.ts
@@ -114,6 +114,7 @@ interface AppState {
     dashboardEnabled: boolean;
     dashboardGradientEnabled: boolean;
     dashboardParticleCount: number;
+    globalGradientEnabled: boolean;  // 전역 그라데이션 배경 (모든 뷰 뒤)
     speed: number;           // 0.5-2.0, default 1.0
     mouseRadius: number;     // 100-400, default 250
     mouseForce: number;      // 0.02-0.15, default 0.06
@@ -239,6 +240,7 @@ export const useAppStore = create<AppState>((set) => ({
     dashboardEnabled: true,
     dashboardGradientEnabled: true,
     dashboardParticleCount: 120,
+    globalGradientEnabled: true,
     speed: 1.0,
     mouseRadius: 250,
     mouseForce: 0.06,

--- a/src/stores/useAppStore.ts
+++ b/src/stores/useAppStore.ts
@@ -109,8 +109,10 @@ interface AppState {
   // 플렉서스 설정
   plexusSettings: {
     loginEnabled: boolean;
+    loginGradientEnabled: boolean;
     loginParticleCount: number;
     dashboardEnabled: boolean;
+    dashboardGradientEnabled: boolean;
     dashboardParticleCount: number;
     speed: number;           // 0.5-2.0, default 1.0
     mouseRadius: number;     // 100-400, default 250
@@ -232,8 +234,10 @@ export const useAppStore = create<AppState>((set) => ({
 
   plexusSettings: {
     loginEnabled: true,
+    loginGradientEnabled: true,
     loginParticleCount: 666,
     dashboardEnabled: true,
+    dashboardGradientEnabled: true,
     dashboardParticleCount: 120,
     speed: 1.0,
     mouseRadius: 250,

--- a/src/stores/useVacationPendingStore.ts
+++ b/src/stores/useVacationPendingStore.ts
@@ -1,0 +1,66 @@
+/**
+ * 휴가 등록 pending 상태 스토어
+ *
+ * 휴가 등록 요청을 낙관적으로 UI에 반영하기 위한 임시 pending 이벤트 저장소.
+ * - 등록 버튼 누르는 즉시 pending 이벤트 추가 → 노란색으로 위젯/캘린더에 표시
+ * - API 성공 시 제거 + 완료 브로드캐스트 → 전 창 토스트
+ * - API 실패 시 제거 + 실패 브로드캐스트
+ * - 30초 타임아웃: 메인 창(App.tsx) 전용 주기적 clearStale 호출
+ * - 영속화: pendingVacations.json (AppData) — 화면 전환/재시작에도 유지
+ */
+
+import { create } from 'zustand';
+import type { VacationEvent } from '@/types/vacation';
+
+export interface PendingVacationEvent extends VacationEvent {
+  status: 'pending';
+  pendingId: string;
+  createdAt: number;
+  reason?: string;
+}
+
+interface Store {
+  pending: PendingVacationEvent[];
+  hydrated: boolean;
+  hydrate: () => Promise<void>;
+  add: (ev: PendingVacationEvent) => Promise<void>;
+  remove: (pendingId: string) => Promise<void>;
+  /** 제한 시간 경과 항목을 제거하고 제거된 항목을 반환 */
+  clearStale: (olderThanMs: number) => Promise<PendingVacationEvent[]>;
+}
+
+export const useVacationPendingStore = create<Store>((set, get) => ({
+  pending: [],
+  hydrated: false,
+  hydrate: async () => {
+    try {
+      const list = (await window.electronAPI?.vacationPendingLoad?.()) as
+        | PendingVacationEvent[]
+        | null
+        | undefined;
+      set({ pending: list ?? [], hydrated: true });
+    } catch (err) {
+      console.warn('[vacation:pending] hydrate 실패', err);
+      set({ pending: [], hydrated: true });
+    }
+  },
+  add: async (ev) => {
+    const next = [...get().pending, ev];
+    set({ pending: next });
+    await window.electronAPI?.vacationPendingSave?.(next);
+  },
+  remove: async (pendingId) => {
+    const next = get().pending.filter((p) => p.pendingId !== pendingId);
+    set({ pending: next });
+    await window.electronAPI?.vacationPendingSave?.(next);
+  },
+  clearStale: async (olderThanMs) => {
+    const now = Date.now();
+    const stale = get().pending.filter((p) => now - p.createdAt >= olderThanMs);
+    if (stale.length === 0) return [];
+    const next = get().pending.filter((p) => now - p.createdAt < olderThanMs);
+    set({ pending: next });
+    await window.electronAPI?.vacationPendingSave?.(next);
+    return stale;
+  },
+}));

--- a/src/stores/useVacationPendingStore.ts
+++ b/src/stores/useVacationPendingStore.ts
@@ -45,25 +45,42 @@ export const useVacationPendingStore = create<Store>((set, get) => ({
     }
   },
   add: async (ev) => {
-    const next = [...get().pending, ev];
+    const prev = get().pending;
+    const next = [...prev, ev];
     set({ pending: next });
-    await window.electronAPI?.vacationPendingSave?.(next);
+    const result = await window.electronAPI?.vacationPendingSave?.(next);
+    // 디스크 쓰기 실패(권한/용량/손상 등) — 메모리 rollback 후 throw.
+    // window.electronAPI 자체가 없는 dev 환경에서는 result === undefined → skip.
+    if (result && (result as { ok: boolean }).ok === false) {
+      set({ pending: prev });
+      throw new Error('pending 저장 실패: 디스크 쓰기 실패');
+    }
     // 다른 창(팝업 등)이 hydrate하여 노란 pending 상태 동기화 — 송신자는 excludeSenderId로 제외
     await window.electronAPI?.vacationBroadcastPendingChanged?.();
   },
   remove: async (pendingId) => {
-    const next = get().pending.filter((p) => p.pendingId !== pendingId);
+    const prev = get().pending;
+    const next = prev.filter((p) => p.pendingId !== pendingId);
     set({ pending: next });
-    await window.electronAPI?.vacationPendingSave?.(next);
+    const result = await window.electronAPI?.vacationPendingSave?.(next);
+    if (result && (result as { ok: boolean }).ok === false) {
+      set({ pending: prev });
+      throw new Error('pending 저장 실패: 디스크 쓰기 실패');
+    }
     await window.electronAPI?.vacationBroadcastPendingChanged?.();
   },
   clearStale: async (olderThanMs) => {
     const now = Date.now();
-    const stale = get().pending.filter((p) => now - p.createdAt >= olderThanMs);
+    const prev = get().pending;
+    const stale = prev.filter((p) => now - p.createdAt >= olderThanMs);
     if (stale.length === 0) return [];
-    const next = get().pending.filter((p) => now - p.createdAt < olderThanMs);
+    const next = prev.filter((p) => now - p.createdAt < olderThanMs);
     set({ pending: next });
-    await window.electronAPI?.vacationPendingSave?.(next);
+    const result = await window.electronAPI?.vacationPendingSave?.(next);
+    if (result && (result as { ok: boolean }).ok === false) {
+      set({ pending: prev });
+      throw new Error('pending 저장 실패: 디스크 쓰기 실패');
+    }
     await window.electronAPI?.vacationBroadcastPendingChanged?.();
     return stale;
   },

--- a/src/stores/useVacationPendingStore.ts
+++ b/src/stores/useVacationPendingStore.ts
@@ -48,11 +48,14 @@ export const useVacationPendingStore = create<Store>((set, get) => ({
     const next = [...get().pending, ev];
     set({ pending: next });
     await window.electronAPI?.vacationPendingSave?.(next);
+    // 다른 창(팝업 등)이 hydrate하여 노란 pending 상태 동기화 — 송신자는 excludeSenderId로 제외
+    await window.electronAPI?.vacationBroadcastPendingChanged?.();
   },
   remove: async (pendingId) => {
     const next = get().pending.filter((p) => p.pendingId !== pendingId);
     set({ pending: next });
     await window.electronAPI?.vacationPendingSave?.(next);
+    await window.electronAPI?.vacationBroadcastPendingChanged?.();
   },
   clearStale: async (olderThanMs) => {
     const now = Date.now();
@@ -61,6 +64,7 @@ export const useVacationPendingStore = create<Store>((set, get) => ({
     const next = get().pending.filter((p) => now - p.createdAt < olderThanMs);
     set({ pending: next });
     await window.electronAPI?.vacationPendingSave?.(next);
+    await window.electronAPI?.vacationBroadcastPendingChanged?.();
     return stale;
   },
 }));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -466,6 +466,7 @@ export interface ElectronAPI {
   preferencesBroadcastChange: (payload?: unknown) => Promise<{ ok: boolean }>;
   onPreferencesChanged: (cb: (payload: unknown) => void) => () => void;
   sessionBroadcastChange: (payload?: unknown) => Promise<{ ok: boolean }>;
+  sessionRequestCurrent: () => Promise<{ ok: boolean }>;
   onSessionChanged: (cb: (payload: unknown) => void) => () => void;
   themeBroadcastChange: (payload?: unknown) => Promise<{ ok: boolean }>;
   onThemeChanged: (cb: (payload: unknown) => void) => () => void;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -468,6 +468,14 @@ export interface ElectronAPI {
   sessionBroadcastChange: (payload?: unknown) => Promise<{ ok: boolean }>;
   onSessionChanged: (cb: (payload: unknown) => void) => () => void;
 
+  // ─── 휴가 pending 상태 + 브로드캐스트 ─────────────
+  vacationPendingLoad: () => Promise<unknown>;
+  vacationPendingSave: (list: unknown) => Promise<{ ok: boolean }>;
+  vacationBroadcastRegistered: (payload?: unknown) => Promise<{ ok: boolean }>;
+  vacationBroadcastFailed: (payload?: unknown) => Promise<{ ok: boolean }>;
+  onVacationRegistered: (cb: (payload: unknown) => void) => () => void;
+  onVacationFailed: (cb: (payload: unknown) => void) => () => void;
+
   // ─── Google Calendar ──────────────────────────────
   gcalIsAuthenticated: () => Promise<boolean>;
   gcalStartAuth: () => Promise<void>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -467,6 +467,8 @@ export interface ElectronAPI {
   onPreferencesChanged: (cb: (payload: unknown) => void) => () => void;
   sessionBroadcastChange: (payload?: unknown) => Promise<{ ok: boolean }>;
   onSessionChanged: (cb: (payload: unknown) => void) => () => void;
+  themeBroadcastChange: (payload?: unknown) => Promise<{ ok: boolean }>;
+  onThemeChanged: (cb: (payload: unknown) => void) => () => void;
 
   // ─── 휴가 pending 상태 + 브로드캐스트 ─────────────
   vacationPendingLoad: () => Promise<unknown>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -462,6 +462,12 @@ export interface ElectronAPI {
   supabaseUpsertMemo: (userId: string, widgetId: string, data: unknown) => Promise<void>;
   supabaseReadAllMemos: (userId: string) => Promise<any[]>;
 
+  // ─── 설정/세션 변경 브로드캐스트 ─────────────────
+  preferencesBroadcastChange: (payload?: unknown) => Promise<{ ok: boolean }>;
+  onPreferencesChanged: (cb: (payload: unknown) => void) => () => void;
+  sessionBroadcastChange: (payload?: unknown) => Promise<{ ok: boolean }>;
+  onSessionChanged: (cb: (payload: unknown) => void) => () => void;
+
   // ─── Google Calendar ──────────────────────────────
   gcalIsAuthenticated: () => Promise<boolean>;
   gcalStartAuth: () => Promise<void>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -469,6 +469,8 @@ export interface ElectronAPI {
   onSessionChanged: (cb: (payload: unknown) => void) => () => void;
   themeBroadcastChange: (payload?: unknown) => Promise<{ ok: boolean }>;
   onThemeChanged: (cb: (payload: unknown) => void) => () => void;
+  calendarBroadcastChange: (payload?: unknown) => Promise<{ ok: boolean }>;
+  onCalendarChanged: (cb: (payload: unknown) => void) => () => void;
 
   // ─── 휴가 pending 상태 + 브로드캐스트 ─────────────
   vacationPendingLoad: () => Promise<unknown>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -477,8 +477,10 @@ export interface ElectronAPI {
   vacationPendingSave: (list: unknown) => Promise<{ ok: boolean }>;
   vacationBroadcastRegistered: (payload?: unknown) => Promise<{ ok: boolean }>;
   vacationBroadcastFailed: (payload?: unknown) => Promise<{ ok: boolean }>;
+  vacationBroadcastPendingChanged: (payload?: unknown) => Promise<{ ok: boolean }>;
   onVacationRegistered: (cb: (payload: unknown) => void) => () => void;
   onVacationFailed: (cb: (payload: unknown) => void) => () => void;
+  onVacationPendingChanged: (cb: (payload: unknown) => void) => () => void;
 
   // ─── Google Calendar ──────────────────────────────
   gcalIsAuthenticated: () => Promise<boolean>;

--- a/src/utils/typography.ts
+++ b/src/utils/typography.ts
@@ -112,3 +112,69 @@ export function resetFontSettings(): void {
     fontCategoryScales: { ...DEFAULT_CATEGORY_SCALES },
   });
 }
+
+// ─── 카테고리 색상 ─────────────────────────────
+
+export type FontColorPreset = 'theme' | 'high-contrast' | 'soft' | 'mono' | 'custom';
+
+export interface FontCategoryColors {
+  heading?: string;  // RGB triplet "R G B" (예: "232 232 238")
+  body?: string;
+  caption?: string;
+  micro?: string;
+}
+
+export const FONT_COLOR_PRESETS: Record<FontColorPreset, { label: string; getColors: (themePrimary: string, themeSecondary: string, themeAccentSub: string) => FontCategoryColors }> = {
+  theme: {
+    label: '테마 기본',
+    getColors: () => ({}),  // 모두 --color-text-primary 폴백
+  },
+  'high-contrast': {
+    label: '고대비',
+    getColors: (primary, secondary) => ({
+      heading: '255 255 255',
+      body: primary,
+      caption: secondary,
+      micro: secondary,
+    }),
+  },
+  soft: {
+    label: '부드러움',
+    getColors: (primary, secondary, accentSub) => ({
+      heading: accentSub,
+      body: primary,
+      caption: secondary,
+      micro: secondary,
+    }),
+  },
+  mono: {
+    label: '단색',
+    getColors: (primary) => ({
+      heading: primary,
+      body: primary,
+      caption: primary,
+      micro: primary,
+    }),
+  },
+  custom: {
+    label: '사용자 지정',
+    getColors: () => ({}),  // UI에서 직접 세팅
+  },
+};
+
+export function applyTextColors(colors: FontCategoryColors): void {
+  const root = document.documentElement;
+  const set = (key: keyof FontCategoryColors, cssVar: string) => {
+    const val = colors[key];
+    if (val) root.style.setProperty(cssVar, val);
+    else root.style.removeProperty(cssVar);
+  };
+  set('heading', '--color-text-heading');
+  set('body', '--color-text-body');
+  set('caption', '--color-text-caption');
+  set('micro', '--color-text-micro');
+}
+
+export function resetTextColors(): void {
+  applyTextColors({});
+}

--- a/src/utils/typography.ts
+++ b/src/utils/typography.ts
@@ -178,3 +178,30 @@ export function applyTextColors(colors: FontCategoryColors): void {
 export function resetTextColors(): void {
   applyTextColors({});
 }
+
+// ─── 저장된 환경설정을 런타임에 적용 ──────────
+
+const VALID_FONT_SCALES: readonly FontScale[] = ['xs', 's', 'm', 'l', 'xl'];
+
+export function isFontScale(v: unknown): v is FontScale {
+  return typeof v === 'string' && (VALID_FONT_SCALES as readonly string[]).includes(v);
+}
+
+/** UserPreferences의 글자 크기/색상 관련 필드를 CSS 변수에 적용 */
+export function applyPreferencesToDOM(prefs: {
+  fontScale?: string;
+  fontCategoryScales?: Partial<FontCategoryScales>;
+  fontCategoryColors?: FontCategoryColors;
+}): void {
+  const scale: FontScale = isFontScale(prefs.fontScale) ? prefs.fontScale : DEFAULT_FONT_SCALE;
+  applyFontSettings({
+    fontScale: scale,
+    fontCategoryScales: {
+      heading: prefs.fontCategoryScales?.heading ?? 1,
+      body: prefs.fontCategoryScales?.body ?? 1,
+      caption: prefs.fontCategoryScales?.caption ?? 1,
+      micro: prefs.fontCategoryScales?.micro ?? 1,
+    },
+  });
+  applyTextColors(prefs.fontCategoryColors ?? {});
+}

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -826,7 +826,7 @@ export function Dashboard() {
   return (
     <div className="relative flex flex-col gap-4 h-full overflow-y-auto overflow-x-hidden z-0">
       {/* 그라데이션 배경 (파티클과 독립 토글) */}
-      <GradientBackdrop enabled={plexusSettings.dashboardGradientEnabled !== false} />
+      <GradientBackdrop enabled={plexusSettings.dashboardGradientEnabled !== false} intensity="normal" />
       {/* 경량 플렉서스 배경 (fixed로 뷰포트 전체 커버) */}
       <DashboardPlexus />
 

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -38,7 +38,7 @@ import '@/styles/widget-animations.css';
 const ResponsiveGridLayout = WidthProvider(Responsive);
 
 /* ── 대시보드 플렉서스 배경 (연결선 + 그라데이션 조명 + 마우스 반응) ── */
-interface DashPt { x: number; y: number; vx: number; vy: number; size: number; color: [number, number, number]; alpha: number }
+interface DashPt { x: number; y: number; vx: number; vy: number; size: number; colorIdx: number; alpha: number }
 const DEFAULT_DASH_PT_COUNT = 120;
 const DASH_CONNECT_DIST = 140;
 
@@ -96,11 +96,11 @@ function DashboardPlexus() {
       if (ptsRef.current.length === 0 || ptsRef.current.length !== ptCount) {
         const cols = getColors();
         ptsRef.current = Array.from({ length: ptCount }, () => {
-          const c = cols[Math.floor(Math.random() * cols.length)];
+          const colorIdx = Math.floor(Math.random() * cols.length);
           return {
             x: Math.random() * w, y: Math.random() * h,
             vx: (Math.random() - 0.5) * 0.4, vy: (Math.random() - 0.5) * 0.4,
-            size: 1.2 + Math.random() * 2.5, color: c, alpha: 0.25 + Math.random() * 0.35,
+            size: 1.2 + Math.random() * 2.5, colorIdx, alpha: 0.25 + Math.random() * 0.35,
           };
         });
       }
@@ -121,6 +121,9 @@ function DashboardPlexus() {
       const delta = lastTime ? timestamp - lastTime : TARGET_FRAME_MS;
       lastTime = timestamp;
       const dtFactor = Math.min(delta / TARGET_FRAME_MS, 3);
+
+      // 매 프레임 최신 팔레트 조회 → 테마 변경 시 즉시 색 반영
+      const palette = getColors();
 
       const { w, h } = sizeRef.current;
       ctx.clearRect(0, 0, w, h);
@@ -154,7 +157,7 @@ function DashboardPlexus() {
           const dist = Math.sqrt(dx * dx + dy * dy);
           if (dist < cDist) {
             const alpha = (1 - dist / cDist) * 0.28;
-            const [r, g, b] = pts[i].color;
+            const [r, g, b] = palette[pts[i].colorIdx % palette.length];
             ctx.strokeStyle = `rgba(${r},${g},${b},${alpha})`;
             ctx.lineWidth = (1 - dist / cDist) * 1.2;
             ctx.beginPath();
@@ -172,7 +175,7 @@ function DashboardPlexus() {
         const dist = Math.sqrt(dx * dx + dy * dy);
         const nearMouse = dist < dc.mouseRadius;
         const glowAlpha = nearMouse ? p.alpha + (1 - dist / dc.mouseRadius) * 0.25 : p.alpha;
-        const [r, g, b] = p.color;
+        const [r, g, b] = palette[p.colorIdx % palette.length];
         // 소프트 글로우
         if (dcGlow > 0.2) {
           const glR = p.size * 5 * dcGlow;

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -25,6 +25,7 @@ import { EpDeptComparisonWidget } from '@/components/widgets/episode/EpDeptCompa
 import { EpSinglePartWidget, parsePartWidgetId } from '@/components/widgets/episode/EpSinglePartWidget';
 import { EpFullDeptProgressWidget } from '@/components/widgets/episode/EpFullDeptProgressWidget';
 import { ChartTypeContextMenu, getWidgetSupportedCharts, useChartContextMenu } from '@/components/widgets/ChartTypeContextMenu';
+import { GradientBackdrop } from '@/components/common/GradientBackdrop';
 import { saveLayout } from '@/services/settingsService';
 import { DEPARTMENTS, DEPARTMENT_CONFIGS } from '@/types';
 import { cn } from '@/utils/cn';
@@ -123,31 +124,6 @@ function DashboardPlexus() {
 
       const { w, h } = sizeRef.current;
       ctx.clearRect(0, 0, w, h);
-
-      // ── 배경 그라데이션 조명 (위젯 글래스모피즘을 위한 충분한 밝기) ──
-      const cols = getColors();
-      const [ar, ag, ab] = cols[0];
-      const [sr, sg, sb] = cols[1] ?? cols[0];
-      // 좌상단 글로우 (강)
-      const grd1 = ctx.createRadialGradient(w * 0.12, h * 0.15, 0, w * 0.12, h * 0.15, w * 0.55);
-      grd1.addColorStop(0, `rgba(${ar},${ag},${ab},0.18)`);
-      grd1.addColorStop(0.5, `rgba(${ar},${ag},${ab},0.06)`);
-      grd1.addColorStop(1, `rgba(${ar},${ag},${ab},0)`);
-      ctx.fillStyle = grd1;
-      ctx.fillRect(0, 0, w, h);
-      // 우하단 글로우 (강)
-      const grd2 = ctx.createRadialGradient(w * 0.88, h * 0.85, 0, w * 0.88, h * 0.85, w * 0.55);
-      grd2.addColorStop(0, `rgba(${sr},${sg},${sb},0.15)`);
-      grd2.addColorStop(0.5, `rgba(${sr},${sg},${sb},0.05)`);
-      grd2.addColorStop(1, `rgba(${sr},${sg},${sb},0)`);
-      ctx.fillStyle = grd2;
-      ctx.fillRect(0, 0, w, h);
-      // 중앙 소프트 글로우 (위젯 뒤로 비치는 조명)
-      const grd3 = ctx.createRadialGradient(w * 0.5, h * 0.45, 0, w * 0.5, h * 0.45, w * 0.4);
-      grd3.addColorStop(0, `rgba(${(ar + sr) >> 1},${(ag + sg) >> 1},${(ab + sb) >> 1},0.08)`);
-      grd3.addColorStop(1, 'rgba(0,0,0,0)');
-      ctx.fillStyle = grd3;
-      ctx.fillRect(0, 0, w, h);
 
       const mx = mouseRef.current.x;
       const my = mouseRef.current.y;
@@ -625,6 +601,7 @@ export function Dashboard() {
   const isEpMode = episodeDashboardEp !== null;
   const episodes = useDataStore((s) => s.episodes);
   const currentUser = useAuthStore((s) => s.currentUser);
+  const plexusSettings = useAppStore((s) => s.plexusSettings);
 
   // 현재 에피소드의 파트 ID 목록 (위젯 피커 2단계용)
   const epPartIds = useMemo(() => {
@@ -848,6 +825,8 @@ export function Dashboard() {
 
   return (
     <div className="relative flex flex-col gap-4 h-full overflow-y-auto overflow-x-hidden z-0">
+      {/* 그라데이션 배경 (파티클과 독립 토글) */}
+      <GradientBackdrop enabled={plexusSettings.dashboardGradientEnabled !== false} />
       {/* 경량 플렉서스 배경 (fixed로 뷰포트 전체 커버) */}
       <DashboardPlexus />
 

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -25,7 +25,6 @@ import { EpDeptComparisonWidget } from '@/components/widgets/episode/EpDeptCompa
 import { EpSinglePartWidget, parsePartWidgetId } from '@/components/widgets/episode/EpSinglePartWidget';
 import { EpFullDeptProgressWidget } from '@/components/widgets/episode/EpFullDeptProgressWidget';
 import { ChartTypeContextMenu, getWidgetSupportedCharts, useChartContextMenu } from '@/components/widgets/ChartTypeContextMenu';
-import { GradientBackdrop } from '@/components/common/GradientBackdrop';
 import { saveLayout } from '@/services/settingsService';
 import { DEPARTMENTS, DEPARTMENT_CONFIGS } from '@/types';
 import { cn } from '@/utils/cn';
@@ -828,9 +827,7 @@ export function Dashboard() {
 
   return (
     <div className="relative flex flex-col gap-4 h-full overflow-y-auto overflow-x-hidden z-0">
-      {/* 그라데이션 배경 (파티클과 독립 토글) */}
-      <GradientBackdrop enabled={plexusSettings.dashboardGradientEnabled !== false} intensity="normal" />
-      {/* 경량 플렉서스 배경 (fixed로 뷰포트 전체 커버) */}
+      {/* 경량 플렉서스 배경 (fixed로 뷰포트 전체 커버) — 그라데이션은 App.tsx의 전역 GradientBackdrop이 담당 */}
       <DashboardPlexus />
 
       {/* 부서 탭 + 편집 버튼 */}

--- a/src/views/ScenesView.tsx
+++ b/src/views/ScenesView.tsx
@@ -51,9 +51,8 @@ function useLassoSelection(
 
       const onMouseMove = (me: MouseEvent) => {
         if (!startRef.current || !startScrollRef.current) return;
-        const currScroll = findScrollParent(target) ?? container;
-        const scrollDx = currScroll.scrollLeft - startScrollRef.current.left;
-        const scrollDy = currScroll.scrollTop - startScrollRef.current.top;
+        const scrollDx = scrollEl.scrollLeft - startScrollRef.current.left;
+        const scrollDy = scrollEl.scrollTop - startScrollRef.current.top;
         const dx = (me.clientX - startRef.current.x) - scrollDx;
         const dy = (me.clientY - startRef.current.y) - scrollDy;
 

--- a/src/views/ScenesView.tsx
+++ b/src/views/ScenesView.tsx
@@ -30,6 +30,7 @@ function useLassoSelection(
 ) {
   const [lassoRect, setLassoRect] = useState<LassoRect | null>(null);
   const startRef = useRef<{ x: number; y: number } | null>(null);
+  const startScrollRef = useRef<{ top: number; left: number } | null>(null);
   const isDragging = useRef(false);
   const prevIds = useRef<Set<string>>(new Set());
 
@@ -39,48 +40,41 @@ function useLassoSelection(
     if (!container) return;
 
     const onMouseDown = (e: MouseEvent) => {
-      // 버튼/인풋/select/체크박스 위에서는 라쏘 시작 안 함
       const target = e.target as HTMLElement;
-      if (target.closest('button, input, select, textarea, a, [role="button"]')) return;
-      // 사이드바 트리뷰 내부에서는 라쏘 시작 안 함 (사이드바 아래 잉여 공간은 허용)
-      if (target.closest('[data-no-lasso]')) return;
-      // 좌클릭만
+      if (target.closest('button, input, select, textarea, a, [role="button"], [data-no-lasso], [contenteditable="true"]')) return;
       if (e.button !== 0) return;
 
       startRef.current = { x: e.clientX, y: e.clientY };
+      const scrollEl = findScrollParent(target) ?? container;
+      startScrollRef.current = { top: scrollEl.scrollTop, left: scrollEl.scrollLeft };
       isDragging.current = false;
 
       const onMouseMove = (me: MouseEvent) => {
-        if (!startRef.current) return;
-        const dx = me.clientX - startRef.current.x;
-        const dy = me.clientY - startRef.current.y;
-        // 5px 이상 이동해야 라쏘 시작 (클릭과 구분)
-        if (!isDragging.current && Math.abs(dx) < 5 && Math.abs(dy) < 5) return;
+        if (!startRef.current || !startScrollRef.current) return;
+        const currScroll = findScrollParent(target) ?? container;
+        const scrollDx = currScroll.scrollLeft - startScrollRef.current.left;
+        const scrollDy = currScroll.scrollTop - startScrollRef.current.top;
+        const dx = (me.clientX - startRef.current.x) - scrollDx;
+        const dy = (me.clientY - startRef.current.y) - scrollDy;
+
+        if (!isDragging.current && Math.abs(dx) < 8 && Math.abs(dy) < 8) return;
         isDragging.current = true;
 
         const x = Math.min(startRef.current.x, me.clientX);
         const y = Math.min(startRef.current.y, me.clientY);
-        const w = Math.abs(dx);
-        const h = Math.abs(dy);
+        const w = Math.abs(me.clientX - startRef.current.x);
+        const h = Math.abs(me.clientY - startRef.current.y);
         setLassoRect({ x, y, w, h });
 
-        // 실시간으로 겹치는 카드 계산
         const cards = container.querySelectorAll(cardSelector);
         const selected = new Set<string>();
         cards.forEach((card) => {
           const rect = card.getBoundingClientRect();
-          // 교차 판정
-          if (
-            rect.left < x + w &&
-            rect.right > x &&
-            rect.top < y + h &&
-            rect.bottom > y
-          ) {
+          if (rect.left < x + w && rect.right > x && rect.top < y + h && rect.bottom > y) {
             const id = getSceneId(card);
             if (id) selected.add(id);
           }
         });
-        // 변경 시에만 콜백
         if (selected.size !== prevIds.current.size || ![...selected].every((id) => prevIds.current.has(id))) {
           prevIds.current = selected;
           onSelectionChange(selected);
@@ -91,13 +85,13 @@ function useLassoSelection(
         document.removeEventListener('mousemove', onMouseMove);
         document.removeEventListener('mouseup', onMouseUp);
         if (!isDragging.current) {
-          // 단순 클릭이면 선택 해제 (Ctrl 없으면)
           if (!me.ctrlKey && !me.metaKey) {
             onSelectionChange(new Set());
             prevIds.current = new Set();
           }
         }
         startRef.current = null;
+        startScrollRef.current = null;
         isDragging.current = false;
         setLassoRect(null);
       };
@@ -111,6 +105,18 @@ function useLassoSelection(
   }, [enabled, containerRef, cardSelector, getSceneId, onSelectionChange]);
 
   return { lassoRect, isSelecting: isDragging.current };
+}
+
+// 유틸: 가장 가까운 스크롤 가능 부모
+function findScrollParent(el: HTMLElement | null): HTMLElement | null {
+  let cur: HTMLElement | null = el;
+  while (cur) {
+    const style = getComputedStyle(cur);
+    const oy = style.overflowY;
+    if ((oy === 'auto' || oy === 'scroll') && cur.scrollHeight > cur.clientHeight) return cur;
+    cur = cur.parentElement;
+  }
+  return null;
 }
 
 /* ── 글로우 하이라이트 CSS 주입 (스포트라이트/인원별 뷰에서 이동 시) ── */

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -3,6 +3,7 @@ import { SettingsSidebar, type SettingsTabId } from '@/components/settings/Setti
 // 설정 섹션 lazy 로딩 — 활성 탭 진입 시에만 로드
 const ThemeSection = lazy(() => import('@/components/settings/ThemeSection').then(m => ({ default: m.ThemeSection })));
 const FontSizeSection = lazy(() => import('@/components/settings/FontSizeSection').then(m => ({ default: m.FontSizeSection })));
+const FontColorSection = lazy(() => import('@/components/settings/FontColorSection').then(m => ({ default: m.FontColorSection })));
 const SheetsSection = lazy(() => import('@/components/settings/SheetsSection').then(m => ({ default: m.SheetsSection })));
 const GuideSection = lazy(() => import('@/components/settings/GuideSection').then(m => ({ default: m.GuideSection })));
 const StartupSection = lazy(() => import('@/components/settings/StartupSection').then(m => ({ default: m.StartupSection })));
@@ -51,12 +52,15 @@ export function SettingsView() {
         return <ThemeSection />;
       case 'font':
         return (
-          <FontSizeSection
-            fontScale={fontScale}
-            categoryScales={categoryScales}
-            onFontScaleChange={setFontScale}
-            onCategoryScalesChange={setCategoryScales}
-          />
+          <div className="flex flex-col gap-6">
+            <FontSizeSection
+              fontScale={fontScale}
+              categoryScales={categoryScales}
+              onFontScaleChange={setFontScale}
+              onCategoryScalesChange={setCategoryScales}
+            />
+            <FontColorSection />
+          </div>
         );
       case 'sheets':
         return <SheetsSection />;

--- a/src/views/WidgetPopup.tsx
+++ b/src/views/WidgetPopup.tsx
@@ -21,6 +21,7 @@ import { EpDeptComparisonWidget } from '@/components/widgets/episode/EpDeptCompa
 import { EpFullDeptProgressWidget } from '@/components/widgets/episode/EpFullDeptProgressWidget';
 import { EpSinglePartWidget } from '@/components/widgets/episode/EpSinglePartWidget';
 import { WidgetIdContext, IsPopupContext } from '@/components/widgets/Widget';
+import { GradientBackdrop } from '@/components/common/GradientBackdrop';
 import { loadPreferences, loadTheme } from '@/services/settingsService';
 import { loadSession, loadUsers } from '@/services/userService';
 import { applyPreferencesToDOM } from '@/utils/typography';
@@ -70,7 +71,26 @@ const WIDGET_REGISTRY: Record<string, { label: string; component: React.ReactNod
  * 위젯 팝업 윈도우 전용 렌더러
  * Windows Acrylic 네이티브 블러 + CSS 글래스 틴트 + AOT 핀 + 독 모드
  */
+/**
+ * preferences.plexus → useAppStore.setPlexusSettings 병합 헬퍼.
+ * App.tsx의 동일 로직과 일치시켜 "전체 화면 그라데이션" 토글이 팝업에도 반영되도록 함.
+ */
+function applyPlexusFromPrefs(prefs: Awaited<ReturnType<typeof loadPreferences>> | null): void {
+  if (!prefs?.plexus) return;
+  const p = prefs.plexus;
+  useAppStore.getState().setPlexusSettings({
+    ...(p.loginEnabled !== undefined ? { loginEnabled: p.loginEnabled } : {}),
+    ...(p.loginGradientEnabled !== undefined ? { loginGradientEnabled: p.loginGradientEnabled } : {}),
+    ...(p.dashboardEnabled !== undefined ? { dashboardEnabled: p.dashboardEnabled } : {}),
+    ...(p.dashboardGradientEnabled !== undefined ? { dashboardGradientEnabled: p.dashboardGradientEnabled } : {}),
+    globalGradientEnabled: p.globalGradientEnabled ?? true,
+  });
+}
+
 export function WidgetPopup({ widgetId, extraParams }: { widgetId: string; extraParams?: Record<string, string> }) {
+  // 전역 그라데이션 배경 토글 (설정의 "전체 화면 그라데이션"이 플로팅 위젯에도 반영되도록)
+  const globalGradientEnabled = useAppStore((s) => s.plexusSettings.globalGradientEnabled !== false);
+
   const [appOpacity, setAppOpacity] = useState(1);
   const [glassIntensity, setGlassIntensity] = useState(0.7);
   const [showControls, setShowControls] = useState(false);
@@ -147,11 +167,18 @@ export function WidgetPopup({ widgetId, extraParams }: { widgetId: string; extra
     return () => { cleanup?.(); };
   }, []);
 
-  // 환경설정(글꼴 크기/색상) 변경 브로드캐스트 구독 — 메인 창에서 저장되면 즉시 재적용
+  // 환경설정(글꼴 크기/색상 + 플렉서스) 변경 브로드캐스트 구독 — 메인 창에서 저장되면 즉시 재적용
+  // plexus(globalGradientEnabled 등)는 현재 EffectsSection이 broadcast하지 않지만, 향후 추가 시
+  // WidgetPopup도 자동 반영되도록 미리 재적용 경로 포함.
   useEffect(() => {
     const cleanup = window.electronAPI?.onPreferencesChanged?.(() => {
       loadPreferences()
-        .then((prefs) => { if (prefs) applyPreferencesToDOM(prefs); })
+        .then((prefs) => {
+          if (prefs) {
+            applyPreferencesToDOM(prefs);
+            applyPlexusFromPrefs(prefs);
+          }
+        })
         .catch((err) => console.warn('[설정] 브로드캐스트 재적용 실패', err));
     });
     return () => { cleanup?.(); };
@@ -404,9 +431,12 @@ export function WidgetPopup({ widgetId, extraParams }: { widgetId: string; extra
           if (colors) applyTheme(colors, savedMode);
         }
 
-        // 글꼴 크기/색상 적용 (FOUC 방지: 초기 렌더 전에 CSS 변수 세팅)
+        // 글꼴 크기/색상 + 플렉서스 설정 적용 (FOUC 방지: 초기 렌더 전에 CSS 변수 세팅)
         const prefs = await loadPreferences();
-        if (prefs) applyPreferencesToDOM(prefs);
+        if (prefs) {
+          applyPreferencesToDOM(prefs);
+          applyPlexusFromPrefs(prefs);
+        }
 
         const api = window.electronAPI;
         if (!api) { setReady(true); return; }
@@ -655,7 +685,7 @@ export function WidgetPopup({ widgetId, extraParams }: { widgetId: string; extra
   const isRestoring = morphState === 'restoring';
   return (
     <div
-      className="h-screen w-screen flex flex-col overflow-hidden"
+      className="h-screen w-screen flex flex-col overflow-hidden relative"
       style={{
         background: `rgb(var(--color-bg-primary) / ${tintAlpha})`,
         transition: 'background 0.3s ease, opacity 0.35s ease, transform 0.35s cubic-bezier(0.4, 0, 0.2, 1)',
@@ -670,6 +700,8 @@ export function WidgetPopup({ widgetId, extraParams }: { widgetId: string; extra
       onMouseMove={handleMouseMove}
       onMouseLeave={handleMouseLeave}
     >
+      {/* 전역 그라데이션 배경 (App.tsx와 동일한 intensity="normal"로 일관성 유지) */}
+      <GradientBackdrop enabled={globalGradientEnabled} intensity="normal" />
       {/* ── 유리 반사 하이라이트 (상단) ── */}
       <div
         className="absolute inset-x-0 top-0 pointer-events-none"

--- a/src/views/WidgetPopup.tsx
+++ b/src/views/WidgetPopup.tsx
@@ -203,6 +203,8 @@ export function WidgetPopup({ widgetId, extraParams }: { widgetId: string; extra
       const { user } = (payload as { user: AppUser | null }) ?? {};
       useAuthStore.getState().setCurrentUser(user ?? null);
     });
+    // 구독 등록 직후 메인에 현재 세션 재전송 요청 — ready-to-show 타이밍 miss 방어 (이중 안전망)
+    window.electronAPI?.sessionRequestCurrent?.();
     return () => { cleanup?.(); };
   }, []);
 

--- a/src/views/WidgetPopup.tsx
+++ b/src/views/WidgetPopup.tsx
@@ -193,6 +193,28 @@ export function WidgetPopup({ widgetId, extraParams }: { widgetId: string; extra
     return () => { cleanup?.(); };
   }, []);
 
+  // 테마 변경 브로드캐스트 구독 — 메인 창에서 테마 바뀌면 즉시 재적용
+  useEffect(() => {
+    const cleanup = window.electronAPI?.onThemeChanged?.(() => {
+      (async () => {
+        try {
+          const saved = await loadTheme();
+          if (!saved) return;
+          const savedMode = saved.colorMode ?? 'dark';
+          useAppStore.getState().setThemeId(saved.themeId);
+          useAppStore.getState().setColorMode(savedMode);
+          if (saved.customColors) useAppStore.getState().setCustomThemeColors(saved.customColors);
+          const colors = saved.customColors
+            ?? (savedMode === 'light' ? getLightColors(saved.themeId) : getPreset(saved.themeId)?.colors);
+          if (colors) applyTheme(colors, savedMode);
+        } catch (err) {
+          console.warn('[theme] 재적용 실패:', err);
+        }
+      })();
+    });
+    return () => { cleanup?.(); };
+  }, []);
+
   // 저장된 opacity/AOT 복원 (Phase 0-6)
   useEffect(() => {
     window.electronAPI?.widgetGetSavedState?.(widgetId).then((saved) => {

--- a/src/views/WidgetPopup.tsx
+++ b/src/views/WidgetPopup.tsx
@@ -32,7 +32,7 @@ import { loadVacationConfig, connectVacation } from '@/services/vacationService'
 import { useVacationPendingStore } from '@/stores/useVacationPendingStore';
 import { Toaster, toast as sonnerToast } from 'sonner';
 import type { Episode, AppUser } from '@/types';
-import { getPreset, getLightColors, applyTheme } from '@/themes';
+import { getPreset, getLightColors, applyTheme, type ThemeColors } from '@/themes';
 import { DEFAULT_GAS_IMAGE_URL } from '@/config';
 
 // 모듈 레벨 쿨다운: dataNotifyChange 호출 시 자체 변경 감지
@@ -188,6 +188,15 @@ export function WidgetPopup({ widgetId, extraParams }: { widgetId: string; extra
     return () => { cleanup?.(); };
   }, []);
 
+  // pending 변경 브로드캐스트 구독 → hydrate (다른 창에서 add/remove/clearStale 시 동기화)
+  // 송신자는 메인에서 excludeSenderId로 제외 (자기 상태 덮어쓰기 방지)
+  useEffect(() => {
+    const cleanup = window.electronAPI?.onVacationPendingChanged?.(() => {
+      useVacationPendingStore.getState().hydrate();
+    });
+    return () => { cleanup?.(); };
+  }, []);
+
   // 세션 변경 브로드캐스트 구독 — 메인 창 로그인/로그아웃 시 currentUser 즉시 동기화
   useEffect(() => {
     const cleanup = window.electronAPI?.onSessionChanged?.((payload) => {
@@ -198,23 +207,31 @@ export function WidgetPopup({ widgetId, extraParams }: { widgetId: string; extra
   }, []);
 
   // 테마 변경 브로드캐스트 구독 — 메인 창에서 테마 바뀌면 즉시 재적용
+  // payload를 직접 적용 (파일 재로드 X) — saveTheme 완료 전 broadcast 수신 시 stale 파일 읽는 race 방지
   useEffect(() => {
-    const cleanup = window.electronAPI?.onThemeChanged?.(() => {
-      (async () => {
-        try {
-          const saved = await loadTheme();
-          if (!saved) return;
-          const savedMode = saved.colorMode ?? 'dark';
-          useAppStore.getState().setThemeId(saved.themeId);
-          useAppStore.getState().setColorMode(savedMode);
-          if (saved.customColors) useAppStore.getState().setCustomThemeColors(saved.customColors);
-          const colors = saved.customColors
-            ?? (savedMode === 'light' ? getLightColors(saved.themeId) : getPreset(saved.themeId)?.colors);
-          if (colors) applyTheme(colors, savedMode);
-        } catch (err) {
-          console.warn('[theme] 재적용 실패:', err);
-        }
-      })();
+    const cleanup = window.electronAPI?.onThemeChanged?.((payload) => {
+      try {
+        const data = payload as {
+          themeId?: string;
+          colorMode?: 'dark' | 'light';
+          customColors?: ThemeColors | null;
+        } | null;
+        if (!data) return;
+        const nextThemeId = data.themeId;
+        const nextMode = data.colorMode ?? 'dark';
+        const nextCustom = data.customColors ?? null;
+        if (!nextThemeId) return;
+
+        useAppStore.getState().setThemeId(nextThemeId);
+        useAppStore.getState().setColorMode(nextMode);
+        useAppStore.getState().setCustomThemeColors(nextCustom);
+
+        const colors = nextCustom
+          ?? (nextMode === 'light' ? getLightColors(nextThemeId) : getPreset(nextThemeId)?.colors);
+        if (colors) applyTheme(colors, nextMode);
+      } catch (err) {
+        console.warn('[theme] broadcast 적용 실패:', err);
+      }
     });
     return () => { cleanup?.(); };
   }, []);

--- a/src/views/WidgetPopup.tsx
+++ b/src/views/WidgetPopup.tsx
@@ -29,7 +29,7 @@ import { connectGas, loadGasConfig } from '@/services/gasConfigService';
 import { invalidatePartCache } from '@/services/commentService';
 import { extractSceneDelta } from '@/utils/realtimeDelta';
 import { loadVacationConfig, connectVacation } from '@/services/vacationService';
-import type { Episode } from '@/types';
+import type { Episode, AppUser } from '@/types';
 import { getPreset, getLightColors, applyTheme } from '@/themes';
 import { DEFAULT_GAS_IMAGE_URL } from '@/config';
 
@@ -151,6 +151,15 @@ export function WidgetPopup({ widgetId, extraParams }: { widgetId: string; extra
       loadPreferences()
         .then((prefs) => { if (prefs) applyPreferencesToDOM(prefs); })
         .catch((err) => console.warn('[설정] 브로드캐스트 재적용 실패', err));
+    });
+    return () => { cleanup?.(); };
+  }, []);
+
+  // 세션 변경 브로드캐스트 구독 — 메인 창 로그인/로그아웃 시 currentUser 즉시 동기화
+  useEffect(() => {
+    const cleanup = window.electronAPI?.onSessionChanged?.((payload) => {
+      const { user } = (payload as { user: AppUser | null }) ?? {};
+      useAuthStore.getState().setCurrentUser(user ?? null);
     });
     return () => { cleanup?.(); };
   }, []);

--- a/src/views/WidgetPopup.tsx
+++ b/src/views/WidgetPopup.tsx
@@ -215,6 +215,15 @@ export function WidgetPopup({ widgetId, extraParams }: { widgetId: string; extra
     return () => { cleanup?.(); };
   }, []);
 
+  // 캘린더 변경 IPC 브로드캐스트 구독 — 다른 창(메인/다른 위젯)에서 변경되면 window event 재발행
+  // 무한 루프 방지: 송신자 제외는 메인 프로세스에서 처리됨
+  useEffect(() => {
+    const cleanup = window.electronAPI?.onCalendarChanged?.((payload) => {
+      window.dispatchEvent(new CustomEvent('bflow:calendar-changed', { detail: payload }));
+    });
+    return () => { cleanup?.(); };
+  }, []);
+
   // 저장된 opacity/AOT 복원 (Phase 0-6)
   useEffect(() => {
     window.electronAPI?.widgetGetSavedState?.(widgetId).then((saved) => {

--- a/src/views/WidgetPopup.tsx
+++ b/src/views/WidgetPopup.tsx
@@ -29,6 +29,8 @@ import { connectGas, loadGasConfig } from '@/services/gasConfigService';
 import { invalidatePartCache } from '@/services/commentService';
 import { extractSceneDelta } from '@/utils/realtimeDelta';
 import { loadVacationConfig, connectVacation } from '@/services/vacationService';
+import { useVacationPendingStore } from '@/stores/useVacationPendingStore';
+import { Toaster, toast as sonnerToast } from 'sonner';
 import type { Episode, AppUser } from '@/types';
 import { getPreset, getLightColors, applyTheme } from '@/themes';
 import { DEFAULT_GAS_IMAGE_URL } from '@/config';
@@ -151,6 +153,33 @@ export function WidgetPopup({ widgetId, extraParams }: { widgetId: string; extra
       loadPreferences()
         .then((prefs) => { if (prefs) applyPreferencesToDOM(prefs); })
         .catch((err) => console.warn('[설정] 브로드캐스트 재적용 실패', err));
+    });
+    return () => { cleanup?.(); };
+  }, []);
+
+  // ─── 휴가 pending hydrate (팝업에서도 필요) — 30초 타임아웃은 메인 창 전용 ───
+  useEffect(() => {
+    useVacationPendingStore.getState().hydrate();
+  }, []);
+
+  // ─── 휴가 등록 완료 브로드캐스트 구독 → Sonner 토스트 ─────
+  useEffect(() => {
+    const cleanup = window.electronAPI?.onVacationRegistered?.((payload) => {
+      const p = payload as { name?: string; type?: string } | undefined;
+      const who = p?.name ? `${p.name} ` : '';
+      const what = p?.type ? ` (${p.type})` : '';
+      sonnerToast.success(`${who}휴가 등록 완료${what}`);
+    });
+    return () => { cleanup?.(); };
+  }, []);
+
+  // ─── 휴가 등록 실패 브로드캐스트 구독 ─────────────
+  useEffect(() => {
+    const cleanup = window.electronAPI?.onVacationFailed?.((payload) => {
+      const p = payload as { name?: string; error?: string } | undefined;
+      const who = p?.name ? `${p.name} ` : '';
+      const err = p?.error ?? '알 수 없는 오류';
+      sonnerToast.error(`${who}휴가 등록 실패: ${err}`, { duration: 10000 });
     });
     return () => { cleanup?.(); };
   }, []);
@@ -733,6 +762,19 @@ export function WidgetPopup({ widgetId, extraParams }: { widgetId: string; extra
         </WidgetIdContext.Provider>
         </IsPopupContext.Provider>
       </div>
+
+      {/* Sonner 토스트 (휴가 등록 완료/실패 브로드캐스트 표시용) */}
+      <Toaster
+        theme="dark"
+        position="bottom-right"
+        duration={4000}
+        toastOptions={{
+          className: 'bflow-toast',
+          style: { fontSize: '12px' },
+        }}
+        visibleToasts={3}
+        closeButton
+      />
     </div>
   );
 }

--- a/src/views/WidgetPopup.tsx
+++ b/src/views/WidgetPopup.tsx
@@ -163,23 +163,27 @@ export function WidgetPopup({ widgetId, extraParams }: { widgetId: string; extra
   }, []);
 
   // ─── 휴가 등록 완료 브로드캐스트 구독 → Sonner 토스트 ─────
+  // hydrate() 재호출: 메인 창이 pending을 제거했을 수 있으므로 디스크에서 최신 목록 재로드
   useEffect(() => {
     const cleanup = window.electronAPI?.onVacationRegistered?.((payload) => {
       const p = payload as { name?: string; type?: string } | undefined;
       const who = p?.name ? `${p.name} ` : '';
       const what = p?.type ? ` (${p.type})` : '';
       sonnerToast.success(`${who}휴가 등록 완료${what}`);
+      useVacationPendingStore.getState().hydrate();
     });
     return () => { cleanup?.(); };
   }, []);
 
   // ─── 휴가 등록 실패 브로드캐스트 구독 ─────────────
+  // hydrate() 재호출: 실패 시에도 메인 창이 pending을 제거했을 수 있음
   useEffect(() => {
     const cleanup = window.electronAPI?.onVacationFailed?.((payload) => {
       const p = payload as { name?: string; error?: string } | undefined;
       const who = p?.name ? `${p.name} ` : '';
       const err = p?.error ?? '알 수 없는 오류';
       sonnerToast.error(`${who}휴가 등록 실패: ${err}`, { duration: 10000 });
+      useVacationPendingStore.getState().hydrate();
     });
     return () => { cleanup?.(); };
   }, []);

--- a/src/views/WidgetPopup.tsx
+++ b/src/views/WidgetPopup.tsx
@@ -23,7 +23,7 @@ import { EpSinglePartWidget } from '@/components/widgets/episode/EpSinglePartWid
 import { WidgetIdContext, IsPopupContext } from '@/components/widgets/Widget';
 import { loadPreferences, loadTheme } from '@/services/settingsService';
 import { loadSession, loadUsers } from '@/services/userService';
-import { applyFontSettings, applyTextColors, DEFAULT_FONT_SCALE, type FontScale } from '@/utils/typography';
+import { applyPreferencesToDOM } from '@/utils/typography';
 import { readAll, checkConnection, readMetadata } from '@/services/supabaseService';
 import { connectGas, loadGasConfig } from '@/services/gasConfigService';
 import { invalidatePartCache } from '@/services/commentService';
@@ -148,19 +148,9 @@ export function WidgetPopup({ widgetId, extraParams }: { widgetId: string; extra
   // 환경설정(글꼴 크기/색상) 변경 브로드캐스트 구독 — 메인 창에서 저장되면 즉시 재적용
   useEffect(() => {
     const cleanup = window.electronAPI?.onPreferencesChanged?.(() => {
-      loadPreferences().then((prefs) => {
-        if (!prefs) return;
-        applyFontSettings({
-          fontScale: (prefs.fontScale as FontScale) ?? DEFAULT_FONT_SCALE,
-          fontCategoryScales: {
-            heading: prefs.fontCategoryScales?.heading ?? 1,
-            body: prefs.fontCategoryScales?.body ?? 1,
-            caption: prefs.fontCategoryScales?.caption ?? 1,
-            micro: prefs.fontCategoryScales?.micro ?? 1,
-          },
-        });
-        applyTextColors(prefs.fontCategoryColors ?? {});
-      });
+      loadPreferences()
+        .then((prefs) => { if (prefs) applyPreferencesToDOM(prefs); })
+        .catch((err) => console.warn('[설정] 브로드캐스트 재적용 실패', err));
     });
     return () => { cleanup?.(); };
   }, []);
@@ -324,18 +314,7 @@ export function WidgetPopup({ widgetId, extraParams }: { widgetId: string; extra
 
         // 글꼴 크기/색상 적용 (FOUC 방지: 초기 렌더 전에 CSS 변수 세팅)
         const prefs = await loadPreferences();
-        if (prefs) {
-          applyFontSettings({
-            fontScale: (prefs.fontScale as FontScale) ?? DEFAULT_FONT_SCALE,
-            fontCategoryScales: {
-              heading: prefs.fontCategoryScales?.heading ?? 1,
-              body: prefs.fontCategoryScales?.body ?? 1,
-              caption: prefs.fontCategoryScales?.caption ?? 1,
-              micro: prefs.fontCategoryScales?.micro ?? 1,
-            },
-          });
-          applyTextColors(prefs.fontCategoryColors ?? {});
-        }
+        if (prefs) applyPreferencesToDOM(prefs);
 
         const api = window.electronAPI;
         if (!api) { setReady(true); return; }

--- a/src/views/WidgetPopup.tsx
+++ b/src/views/WidgetPopup.tsx
@@ -21,8 +21,9 @@ import { EpDeptComparisonWidget } from '@/components/widgets/episode/EpDeptCompa
 import { EpFullDeptProgressWidget } from '@/components/widgets/episode/EpFullDeptProgressWidget';
 import { EpSinglePartWidget } from '@/components/widgets/episode/EpSinglePartWidget';
 import { WidgetIdContext, IsPopupContext } from '@/components/widgets/Widget';
-import { loadTheme } from '@/services/settingsService';
+import { loadPreferences, loadTheme } from '@/services/settingsService';
 import { loadSession, loadUsers } from '@/services/userService';
+import { applyFontSettings, applyTextColors, DEFAULT_FONT_SCALE, type FontScale } from '@/utils/typography';
 import { readAll, checkConnection, readMetadata } from '@/services/supabaseService';
 import { connectGas, loadGasConfig } from '@/services/gasConfigService';
 import { invalidatePartCache } from '@/services/commentService';
@@ -140,6 +141,26 @@ export function WidgetPopup({ widgetId, extraParams }: { widgetId: string; extra
     const cleanup = window.electronAPI?.onWidgetDockChange?.((docked) => {
       setIsDocked(docked);
       if (!docked) setIsDockHover(false);
+    });
+    return () => { cleanup?.(); };
+  }, []);
+
+  // 환경설정(글꼴 크기/색상) 변경 브로드캐스트 구독 — 메인 창에서 저장되면 즉시 재적용
+  useEffect(() => {
+    const cleanup = window.electronAPI?.onPreferencesChanged?.(() => {
+      loadPreferences().then((prefs) => {
+        if (!prefs) return;
+        applyFontSettings({
+          fontScale: (prefs.fontScale as FontScale) ?? DEFAULT_FONT_SCALE,
+          fontCategoryScales: {
+            heading: prefs.fontCategoryScales?.heading ?? 1,
+            body: prefs.fontCategoryScales?.body ?? 1,
+            caption: prefs.fontCategoryScales?.caption ?? 1,
+            micro: prefs.fontCategoryScales?.micro ?? 1,
+          },
+        });
+        applyTextColors(prefs.fontCategoryColors ?? {});
+      });
     });
     return () => { cleanup?.(); };
   }, []);
@@ -299,6 +320,21 @@ export function WidgetPopup({ widgetId, extraParams }: { widgetId: string; extra
           if (saved.customColors) useAppStore.getState().setCustomThemeColors(saved.customColors);
           let colors = saved.customColors ?? (savedMode === 'light' ? getLightColors(saved.themeId) : getPreset(saved.themeId)?.colors);
           if (colors) applyTheme(colors, savedMode);
+        }
+
+        // 글꼴 크기/색상 적용 (FOUC 방지: 초기 렌더 전에 CSS 변수 세팅)
+        const prefs = await loadPreferences();
+        if (prefs) {
+          applyFontSettings({
+            fontScale: (prefs.fontScale as FontScale) ?? DEFAULT_FONT_SCALE,
+            fontCategoryScales: {
+              heading: prefs.fontCategoryScales?.heading ?? 1,
+              body: prefs.fontCategoryScales?.body ?? 1,
+              caption: prefs.fontCategoryScales?.caption ?? 1,
+              micro: prefs.fontCategoryScales?.micro ?? 1,
+            },
+          });
+          applyTextColors(prefs.fontCategoryColors ?? {});
         }
 
         const api = window.electronAPI;


### PR DESCRIPTION
## 📋 업데이트 요약

> 이번 업데이트에서 달라진 점을 간략하게 정리했습니다. 실사용 관점의 주요 변경 사항입니다.

### ✨ 새 기능
- **글자 색상도 개별 조절 가능**: 설정 → "글자 색상" 섹션 신규. 제목/본문/캡션/마이크로 카테고리별로 색상을 바꿀 수 있고, `테마 기본/고대비/부드러움/단색/사용자 지정` 5가지 프리셋 제공.
- **전체 화면에 그라데이션 배경**: 기존에는 대시보드·로그인 화면에만 있던 은은한 그라데이션을 앱 전 영역(씬 뷰, 에피소드, 휴가, 캘린더 등)에 깔았습니다. 설정에서 끌 수 있습니다.
- **휴가 등록 대기 상태**: 휴가 등록 요청 순간 캘린더·휴가 위젯에 **노란색 "등록 중..."** 으로 즉시 표시. 다른 화면으로 나갔다 돌아와도 유지되며, 등록이 완료되면 현재 열려 있는 모든 창에 "휴가 등록 완료" 알림.
- **비밀번호 Caps Lock 경고**: 로그인 화면과 비밀번호 변경 창에서 Caps Lock이 켜져 있으면 "⚠️ Caps Lock이 켜져 있습니다" 경고를 표시.
- **설정 변경이 플로팅 위젯에도 즉시 반영**: 글꼴 크기·색상·테마를 바꾸면 띄워져 있는 모든 플로팅 위젯이 바로 따라서 변경됩니다(재시작 불필요).
- **캘린더 변경이 위젯에도 즉시 반영**: 일정 추가/수정/삭제 시 대시보드·플로팅의 캘린더 위젯이 실시간으로 동기화.

### 🐛 버그 수정
- **카드 뷰 메모 클릭 시 라쏘 오인식**: 스크롤 최상단에서 상단 카드의 메모를 클릭하면 스크롤이 내려가면서 2~6번 컷이 통째로 선택되던 문제 해결.
- **시트 뷰 셀 클릭 시 스크롤 점프**: 셀을 선택할 때마다 스크롤이 쑥 내려가던 문제 해결.
- **카드 하이라이트 반복 스크롤**: 카드 선택 시 화면 중앙으로 반복 스크롤되던 현상 제거 (스포트라이트 이동은 그대로 동작).
- **"내 할일" 플로팅 빈 칸**: 플로팅으로 띄우면 항목이 안 나오던 문제 해결. 세션 동기화 개선 + 10초 타임아웃 안내.
- **EP 위젯 빈 칸**: 에피소드별 위젯을 띄운 채 앱을 종료하고 다시 켜면 위젯이 비어 나오던 문제 해결. 에피소드 번호가 재시작 후에도 유지됩니다.
- **로그인 파티클 색상**: 로그인 화면 플렉서스 파티클에 테마와 다른 파랑/청록이 섞여 보이던 문제 수정.
- **캘린더 로컬 이벤트 삭제 오류**: 로컬로 추가한 캘린더 이벤트를 삭제하려 하면 `invalid_request` 오류로 삭제되지 않던 문제 수정.
- **캘린더 월/2주/주/오늘 버튼 색상**: 글자 카테고리 색상 설정이 캘린더 상단 뷰모드 버튼에는 적용되지 않던 문제 수정.

### ⚡ 개선 / 기타
- 플렉서스 파티클 색상이 테마 변경 시 실시간으로 따라갑니다.
- 대시보드 파티클을 꺼도 그라데이션 배경은 유지할 수 있습니다(두 토글 분리).
- 자동 로그인 실패 시 원인을 찾을 수 있도록 진단 로그 추가(이슈 재현 시 DevTools 콘솔에서 `[auth]` 로그 확인 가능).
- 기존 로컬 캘린더 이벤트 로드 중단 — Google Calendar 전환 완료에 따른 후속 조치. `%APPDATA%/Bflow-BGonly/calendar-events.json` 파일은 그대로 두지만 더 이상 읽지 않습니다.

---

## 🔧 상세 기술 설명

### IPC 브로드캐스트 인프라 신설
메인 창과 모든 플로팅 위젯(각기 별도 BrowserWindow/렌더러 프로세스)을 실시간 동기화하기 위한 공통 채널을 도입했습니다.

- `electron/main.ts`: `broadcastToAllWindows(channel, payload, excludeSenderId?)` 헬퍼. mainWindow + widgetWindows 순회, 각 `isDestroyed()` 체크 + 선택적 송신자 제외.
- IPC 채널 5종: `preferences:broadcast-change`, `session:broadcast-change`, `theme:broadcast-change`, `calendar:broadcast-change`, `vacation:broadcast-registered/failed`.
- `electron/preload.ts`, `src/types/index.ts`, `src/mocks/devElectronAPI.ts`에 대응 API 10종 노출(브라우저 dev 모드 mock 포함).
- 메인 프로세스에 `lastKnownSession` 캐시 — 새 플로팅 창 `ready-to-show` 시점에 자동 주입해 늦게 열린 위젯도 세션을 받을 수 있게 함.
- 캘린더는 `excludeSenderId`로 자기 창 수신 방지 → 무한 루프 차단.

### 글자 카테고리별 색상 시스템
- `src/utils/typography.ts`: `FontColorPreset`, `FontCategoryColors`, `FONT_COLOR_PRESETS`(5 프리셋), `applyTextColors()`, `applyPreferencesToDOM()` 통합 헬퍼, `isFontScale()` 런타임 가드.
- `src/index.css`: `.text-xl/.text-lg/h1-h3`, `.text-base/.text-sm`, `.text-xs`, `.text-[11px]/[10px]/[9px]` 에 카테고리 CSS 변수(`--color-text-heading/body/caption/micro`) 매핑. `@layer base` 래핑으로 Tailwind utility override 보장.
- `src/components/settings/FontColorSection.tsx`: 프리셋 버튼 + 고급 모드(카테고리별 color picker) + 테마/모드 변경 시 자동 재계산 effect(load race guard 포함).
- `src/services/settingsService.ts` `UserPreferences`에 `fontCategoryColors?`, `fontColorPreset?` 필드 추가.

### 그라데이션 백드롭 전역화
- `src/components/common/GradientBackdrop.tsx` 신규: `enabled` + `intensity: 'subtle' | 'normal'` props. CSS 변수 기반 3-layer radial gradient로 테마 변경에 자동 반응.
- `src/App.tsx` 최상단에 단일 마운트 → 모든 뷰 뒤에 일관 배경.
- `Dashboard.tsx`, `LoginScreen.tsx`의 canvas 내부 그라데이션 코드 제거(파티클 애니메이션은 그대로).
- `plexusSettings.globalGradientEnabled` 설정 신규. EffectsSection에서 기존 대시보드/로그인 개별 토글을 단일 전역 토글로 통합.

### 플렉서스 파티클 테마 반응
- `LoginScreen.tsx`, `Dashboard.tsx`: 파티클 타입에서 `color: [number, number, number]` → `colorIdx: number` 로 교체. 애니메이션 루프 상단에서 `getPlexusColors()`/`getColors()` 매 프레임 호출 → `palette[colorIdx % palette.length]` 로 resolve. 테마가 바뀌면 즉시 반영.
- 폴백 팔레트에서 파랑/청록 제거 → accent/accentSub 계열만 유지.

### 씬 뷰 라쏘/스크롤 안정화
- `src/views/ScenesView.tsx` `useLassoSelection`: mousedown 시점 scrollTop/Left 캡처 → mousemove dx/dy 에서 보정 → 스크롤 점프로 인한 가짜 드래그 방지. 임계값 5→8px 완화. `[data-no-lasso]`, `[contenteditable="true"]` 제외 추가. `findScrollParent` 헬퍼(mousedown 1회 캐시).
- `src/components/scenes/UnifiedSceneCard.tsx`: 메모 래퍼 `data-no-lasso`. `scrollIntoView` ref 콜백을 `useRef` + `useEffect`로 전환, `isHighlighted` false→true 전환 시에만 호출.
- `src/components/scenes/UnifiedSceneSheetView.tsx`: `tableRef.focus()` → `focus({ preventScroll: true })` 로 브라우저 자동 스크롤 차단.

### 휴가 pending 상태
- `src/stores/useVacationPendingStore.ts` 신규(Zustand): `pending[]`, `hydrate`, `add`, `remove`, `clearStale`(제거된 이벤트 반환).
- 메인 프로세스 `vacation:pending:load/save` IPC + `pendingSaveChain` 프로미스 체인으로 파일 I/O 직렬화(동시 쓰기 경합 방지).
- `VacationRegisterModal`: 낙관적 flow(add → `submitVacation` → remove + broadcast).
- `VacationWidget`, `CalendarWidget`: pending 이벤트를 amber-400 계열로 병합 렌더. key/id 충돌 방지(`pending-` prefix).
- `App.tsx`: `setInterval(15s)` → `clearStale(30_000)` → 메인 창 전용 타임아웃 토스트. WidgetPopup에는 `hydrate()`만 호출(중복 타이머 방지). 양쪽 모두 `onVacationRegistered/Failed` 구독 → `sonner` 토스트.

### 플로팅 위젯 extra 영속화
- `electron/main.ts` `SavedWidgetState`에 `extra?: Record<string, string>` 필드. `openWidgetPopup`에서 `effectiveExtra = extra ?? savedPos?.extra` 우선순위로 복원. 자동 복원 루프에서도 `state.extra` 명시 전달.

### 자동 로그인 진단 로그
- `src/services/userService.ts` `loadSession`: auth.json 읽기/userId 누락/사용자 매칭 각 분기에 `[auth]` prefix 구조화 로그.
- `src/App.tsx`: rememberMe 분기 + currentUser 설정 결과 로그.
- **근본 수정은 아직 유보** — 빌드 앱 재현 후 실제 원인 파악 뒤 추가 수정 예정.

### 캘린더 로컬 이벤트 처리
- `src/services/calendarService.ts`:
  - `deleteEvent`: 로컬 전용 이벤트(`!sourceCalendarId` 또는 `cal_` prefix)는 GCal API 호출 skip → `invalid_request` 차단.
  - `loadLegacyEvents()` no-op 화: `calendar-events.json` 더 이상 읽지 않음. `syncAll`의 legacy 보존 로직 제거.
  - `broadcastCalendarChange`: window CustomEvent + IPC broadcast 병행 → 다른 BrowserWindow까지 전파.

### Caps Lock 경고
- `src/hooks/useCapsLockWarning.ts` 신규: `KeyboardEvent.getModifierState('CapsLock')` 을 onKeyDown/onKeyUp 공용 핸들러에서 감지.
- `LoginScreen`의 비밀번호 input 하단에, `PasswordChangeModal` 상단에 amber 경고 배너.

### 변경 파일 요약
32개 파일, +3,162 / -163 라인. 주요 영역:
- 서비스/스토어: `calendarService.ts`, `settingsService.ts`, `userService.ts`, `useAppStore.ts`, `useVacationPendingStore.ts`
- Electron: `main.ts`, `preload.ts`
- 타입/목: `types/index.ts`, `mocks/devElectronAPI.ts`
- 뷰: `App.tsx`, `Dashboard.tsx`, `LoginScreen.tsx`, `ScenesView.tsx`, `SettingsView.tsx`, `WidgetPopup.tsx`
- 컴포넌트: `GradientBackdrop.tsx`(신규), `FontColorSection.tsx`(신규), `CalendarWidget.tsx`, `MyTasksWidget.tsx`, `VacationWidget.tsx`, `UnifiedSceneCard.tsx`, `UnifiedSceneSheetView.tsx`, `VacationRegisterModal.tsx`, `EffectsSection.tsx`, `FontSizeSection.tsx`
- 기타: `typography.ts`, `index.css`, `useCapsLockWarning.ts`(신규), `package.json`

설계·구현 플랜 문서(`docs/superpowers/specs/`, `docs/superpowers/plans/`)도 함께 포함됩니다.

---

## 🚧 개발 난항

### 플로팅 BrowserWindow = 별도 렌더러 프로세스
처음에는 Zustand store 구독만으로 플로팅 위젯도 동기화될 것이라 가정했으나, 각 BrowserWindow가 별도 프로세스라 store 인스턴스가 완전히 분리된다는 점을 다시 확인. 결과적으로 **IPC 브로드캐스트가 유일한 동기화 수단**이라는 구조적 제약이 명확해졌고, 이를 전제로 preferences/session/theme/calendar/vacation 5개 채널을 일관된 패턴으로 통일. 또한 "새로 열리는 창이 이미 진행 중인 상태를 어떻게 받을 것인가" 문제를 풀기 위해 메인 프로세스에 `lastKnownSession` 캐시를 도입.

### 카드 선택 시 스크롤 점프의 진짜 원인
처음에는 라쏘 선택 로직만 의심했으나, 사용자 재확인 결과 카드 뷰/시트 뷰 양쪽에서 별개 원인으로 발생하고 있었음.
- 카드 뷰: `ref={isHighlighted ? (el) => el?.scrollIntoView(...) : undefined}` 패턴이 매 렌더마다 새로운 함수 인스턴스를 생성해 React가 mount로 인식 → scrollIntoView 반복 호출.
- 시트 뷰: `tableRef.focus()` 호출이 브라우저 기본 동작으로 자동 스크롤 유발.

두 문제를 각각 `useEffect` 전환과 `preventScroll: true` 옵션으로 해결.

### CSS 카테고리 색상의 Tailwind cascade 문제
글자 카테고리별 CSS 규칙을 그냥 `src/index.css`에 넣으면 Tailwind `@tailwind utilities;`와 같은 specificity에서 source order 경쟁. 코드 리뷰 단계에서 `@layer base { ... }` 래핑으로 Tailwind utilities가 항상 cascade 우위를 갖도록 수정. 명시 색상(`text-text-primary`)이 있는 컴포넌트는 기존 색 그대로 유지되고, 미명시 컴포넌트에만 카테고리 색이 적용되는 의도된 설계가 확립됨.

### Task 분할 과정의 반복 조정
9개 이슈를 단일 PR로 묶기로 결정 → 3개 Chunk × 평균 4개 Task로 쪼갠 플랜을 먼저 쓰고, 각 Task마다 implementer + spec reviewer + code quality reviewer 3단계로 진행. 플랜 리뷰에서 Chunk 3에 과도한 "탐색을 실행자에게 위임" 부분이 지적되어 재작성. 실제 파일 라인 번호와 완전 코드를 명시하는 플랜으로 고친 뒤 실행 정확도가 크게 올라감.

### 휴가 pending 파일 I/O 경합
`fs.writeFileSync` 직접 호출 구조에서 여러 창이 동시에 `vacation:pending:save`를 쏠 경우 쓰기가 교차될 수 있음이 코드 리뷰에서 지적. 메인 프로세스에 `pendingSaveChain = pendingSaveChain.then(...)` 프로미스 체인을 두어 FIFO 직렬화로 해결.

---

## ✅ 테스트 가이드

### 사용자 테스트

> 아래 시나리오를 직접 실행해서 정상 동작을 확인해주세요.

1. **씬 카드/시트 뷰 스크롤 유지**
   - 씬 뷰 → 카드 뷰로 전환 → 스크롤을 맨 위로 올림
   - 2번 컷 메모 영역을 클릭
   - ✅ 기대: 아무 카드도 선택되지 않고 스크롤 그대로 유지
   - 이어서 시트 뷰로 전환 → 스크롤 내린 후 아무 셀이나 클릭
   - ✅ 기대: 스크롤이 움직이지 않고 해당 셀만 선택됨

2. **글자 색상 카테고리별 조절**
   - 설정 → 글꼴 → "글자 색상" 섹션
   - `고대비` 프리셋 클릭
   - ✅ 기대: 제목이 더 밝아지고 캡션은 약간 어두워짐
   - 고급 설정 체크 → 본문 색 변경(예: 빨강)
   - ✅ 기대: 앱 전체 본문 글자가 빨강으로, 제목/캡션은 유지

3. **플로팅 위젯 실시간 동기화**
   - "내 할일"과 대시보드의 어느 위젯이든 플로팅으로 띄움
   - 메인에서 설정 → 글꼴 크기 `xl` 로 변경
   - ✅ 기대: 플로팅 위젯도 즉시 큰 글씨로
   - 이어서 테마를 다른 것으로 변경
   - ✅ 기대: 플로팅 위젯의 액센트 색도 즉시 따라감

4. **캘린더 위젯 실시간 반영**
   - 캘린더 위젯을 대시보드 또는 플로팅으로 띄움
   - 메인에서 ScheduleView(일정 관리) 또는 캘린더 뷰로 이동 → 이벤트 추가/수정/삭제
   - ✅ 기대: 위젯에 변경이 즉시 반영

5. **휴가 등록 대기 + 완료 토스트**
   - 휴가 등록 모달에서 휴가 요청
   - ✅ 기대: 휴가 위젯에 즉시 노란색 "등록 중..." 으로 표시됨
   - 다른 화면으로 나갔다가 휴가 위젯으로 돌아옴
   - ✅ 기대: 노란색 상태가 유지됨
   - 등록이 완료되면
   - ✅ 기대: 어느 화면에서든 "휴가 등록 완료" 토스트 표시 + 노란색이 정식 색상으로 바뀜

6. **비밀번호 Caps Lock 경고**
   - Caps Lock을 켠 상태로 로그인 화면의 비밀번호 입력 칸 클릭/타이핑
   - ✅ 기대: 입력 칸 아래 "⚠️ Caps Lock이 켜져 있습니다" 표시
   - 비밀번호 변경 창에서도 동일하게 확인
   - ✅ 기대: 모달 상단에 amber 배너로 경고 표시

7. **EP 위젯 재시작 복원**
   - EP 1의 "EP 통합 진행률" 플로팅 위젯을 띄움
   - 앱 완전 종료 후 재실행
   - ✅ 기대: 같은 위치/크기로 EP 1 데이터와 함께 복원됨 (이전에는 빈 칸이 나왔음)

8. **전역 그라데이션**
   - 씬 뷰, 에피소드 뷰, 휴가 뷰, 캘린더 등 다양한 화면을 이동
   - ✅ 기대: 모든 뷰 뒤에 은은한 그라데이션 배경이 깔려 있음
   - 설정 → 효과 → "전체 화면 그라데이션 배경" 토글 OFF
   - ✅ 기대: 모든 뷰의 배경이 단색으로

9. **로컬 캘린더 이벤트 삭제**
   - 과거에 로컬로 추가해둔 캘린더 이벤트 또는 pre-insert 상태의 이벤트 삭제
   - ✅ 기대: `invalid_request` 오류 없이 정상 삭제

10. **기존 로컬 캘린더 이벤트 로드 안 됨**
    - 앱 재시작 → 캘린더 뷰/위젯 확인
    - ✅ 기대: `calendar-events.json`에만 있던 legacy 이벤트는 더 이상 표시되지 않음(GCal에 있는 이벤트만 표시)

### 개발자 테스트

자동 테스트 프레임워크는 없습니다. 아래 수동 검증으로 대체:

```bash
# 1. 타입 체크
npx tsc --noEmit

# 2. 렌더러 빌드
npm run build:vite

# 3. 실제 Electron 빌드 (포터블 exe)
npm run build
# → release/BFLOW.exe 실행 후 위 사용자 시나리오 전부 확인
```

추가 확인 사항:
- **이슈 ⑥ 자동 로그인**: 빌드 앱 최초 로그인 → 종료 → 재실행 시 DevTools 콘솔의 `[auth]` 로그 확인 (실패 시 어느 단계에서 멈추는지 파악 가능)
- **하위 호환**: 구버전 `widget-positions.json`/`preferences.json`/`theme.json` 로드 시 crash 없음 확인(`extra`, `fontCategoryColors`, `globalGradientEnabled` 모두 optional)
- **IPC 루프 없음**: 캘린더 이벤트 추가 시 DevTools 콘솔에 `bflow:calendar-changed` 이벤트가 **한 창 당 한 번**만 발행되는지 확인(송신자 제외 로직 검증)

---

## 🧪 코드리뷰 대응 내역 (Codex 자동 리뷰)

> PR 생성 후 [Codex 자동 리뷰 봇](https://chatgpt.com/codex)이 **10차례** 리뷰를 올렸고, **10회의 수정 사이클**로 총 **21건의 지적을 반영**했습니다. 모든 수정 후 `npx tsc --noEmit` + `npm run build:vite` 통과 확인.

### 사이클 1 — 초회 리뷰 대응 (P1 1건 + P2 2건)
| 커밋 | 유형 | 파일 | 요약 |
|---|---|---|---|
| [`776a66a`](https://github.com/baehandoridori/Bflow-BGonly/commit/776a66a) | P1 | `src/services/calendarService.ts` | `deleteEvent`의 `cal_` prefix 가드 제거 — in-flight 이벤트가 실수로 로컬 전용으로 분류돼 GCal 고스트 이벤트가 남는 문제 해결 |
| [`cfd7b21`](https://github.com/baehandoridori/Bflow-BGonly/commit/cfd7b21) | P2 | `src/views/WidgetPopup.tsx` | 휴가 등록 broadcast 수신 시 `useVacationPendingStore.hydrate()` 호출 — 팝업이 stale 상태로 고착되던 문제 해결 |
| [`f05826c`](https://github.com/baehandoridori/Bflow-BGonly/commit/f05826c) | P2 | `src/App.tsx` | 커스텀 테마 경로 early return 전에 broadcast 호출 — 커스텀 accent/sub 변경이 플로팅 위젯에 전파되지 않던 문제 해결 |

### 사이클 2 — 2차 리뷰 대응 (P1 1건 + P2 1건)
| 커밋 | 유형 | 파일 | 요약 |
|---|---|---|---|
| [`bd00dcd`](https://github.com/baehandoridori/Bflow-BGonly/commit/bd00dcd) | P1 | `src/views/WidgetPopup.tsx` · `src/App.tsx` | 팝업 테마 sync를 `loadTheme()` 재로드 → broadcast payload 직접 적용으로 전환. `saveTheme` 쓰기 완료 전 broadcast 레이스 제거 |
| [`03a040d`](https://github.com/baehandoridori/Bflow-BGonly/commit/03a040d) | P2 | `electron/main.ts` · `src/stores/useVacationPendingStore.ts` | pending 추가/제거를 `vacation:broadcast-pending-changed` 채널로 창 간 전파 |

### 사이클 3 — 3차 리뷰 대응 (P2 2건)
| 커밋 | 유형 | 파일 | 요약 |
|---|---|---|---|
| [`6927f7e`](https://github.com/baehandoridori/Bflow-BGonly/commit/6927f7e) | P2 | `src/components/settings/FontColorSection.tsx` | 테마 변경 시 재계산된 폰트 색상을 디스크에 영속화 — 재시작 후 stale 색상 문제 해결 |
| [`365037c`](https://github.com/baehandoridori/Bflow-BGonly/commit/365037c) | P2 | `src/components/vacation/VacationRegisterModal.tsx` | pending `add()` 실패 시에도 토스트로 사용자 피드백 보장 |

### 사이클 4 — 4차 리뷰 대응 (P1 1건 + P2 2건)
| 커밋 | 유형 | 파일 | 요약 |
|---|---|---|---|
| [`737878d`](https://github.com/baehandoridori/Bflow-BGonly/commit/737878d) | P1 | `src/stores/useVacationPendingStore.ts` | `vacationPendingSave` 실패(`{ok: false}`) 시 상태 rollback + throw — 호출자 try/catch 정상 트리거 |
| [`9d13053`](https://github.com/baehandoridori/Bflow-BGonly/commit/9d13053) | P2 | `src/App.tsx` | 세션 broadcast dedupe를 ID 단일값 → JSON.stringify로 확장. name/role/isInitialPassword 등 모든 필드 변경 전파 |
| [`e2237a4`](https://github.com/baehandoridori/Bflow-BGonly/commit/e2237a4) | P2 | `src/components/auth/LoginScreen.tsx` | 로그인 canvas context `alpha: true` + solid fillRect → clearRect. 전역 그라데이션이 로그인 화면에도 노출 |

### 사이클 5 — 5차 리뷰 대응 (P2 2건)
| 커밋 | 유형 | 파일 | 요약 |
|---|---|---|---|
| [`27ced9f`](https://github.com/baehandoridori/Bflow-BGonly/commit/27ced9f) | P2 | `src/components/layout/MainLayout.tsx` · `src/index.css` | MainLayout의 opaque `bg-bg-primary` 제거 + html/body 전역 배경 추가. GradientBackdrop이 인증된 모든 뷰에서 노출 |
| [`b405f38`](https://github.com/baehandoridori/Bflow-BGonly/commit/b405f38) | P2 | `src/services/userService.ts` | `loadSession`이 `loadUsers()` 실패도 try/catch로 포착해 `{session: null, user: null}` 반환 — 복구 가능한 세션 이슈가 초기화 전체 실패로 확산되지 않음 |

### 사이클 6 — 6차 리뷰 대응 (P2 2건)
| 커밋 | 유형 | 파일 | 요약 |
|---|---|---|---|
| [`fffdf15`](https://github.com/baehandoridori/Bflow-BGonly/commit/fffdf15) | P2 | `src/App.tsx` · `src/components/settings/FontColorSection.tsx` | 테마 기반 폰트 색 재계산을 App.tsx 전역 effect로 이동. Font 탭이 열려있지 않아도(Theme 탭에서 테마 변경 시에도) 즉시 재계산·저장·broadcast |
| [`45d0b48`](https://github.com/baehandoridori/Bflow-BGonly/commit/45d0b48) | P2 | `src/components/vacation/VacationRegisterModal.tsx` | `safeRemovePending` 헬퍼로 double-remove 실패가 broadcast/onSubmitEnd를 막지 않도록 가드 |

### 사이클 7 — 7차 리뷰 대응 (P1 1건 + P2 1건)
| 커밋 | 유형 | 파일 | 요약 |
|---|---|---|---|
| [`ccdb06a`](https://github.com/baehandoridori/Bflow-BGonly/commit/ccdb06a) | P1 | `electron/main.ts` · `src/views/WidgetPopup.tsx` | 팝업 `session:request-current` 핸드셰이크 추가. React useEffect 구독 후 메인에 재전송 요청 → `ready-to-show` 타이밍 miss 방어 |
| [`e6be3bd`](https://github.com/baehandoridori/Bflow-BGonly/commit/e6be3bd) | P2 | `electron/main.ts` | `vacation:pending:load`에 `Array.isArray` 가드. 손상된 JSON에서도 runtime crash 방지 |

### 사이클 8 — 8차 리뷰 대응 (P1 1건)
| 커밋 | 유형 | 파일 | 요약 |
|---|---|---|---|
| [`1becfe3`](https://github.com/baehandoridori/Bflow-BGonly/commit/1becfe3) | P1 | `src/components/vacation/VacationRegisterModal.tsx` | pending `add()` 실패 시 early return 제거 → 로컬 캐시 실패가 실제 휴가 등록 API를 막지 않도록 degrade. `pendingAdded` 플래그로 정합성 유지 |

### 사이클 9 — 9차 리뷰 대응 (P2 2건)
| 커밋 | 유형 | 파일 | 요약 |
|---|---|---|---|
| [`6671811`](https://github.com/baehandoridori/Bflow-BGonly/commit/6671811) | P2 | `electron/main.ts` · `src/components/vacation/VacationRegisterModal.tsx` | 휴가 결과 broadcast에 `excludeSenderId` 적용 + 송신 창 로컬 `setToast` 추가. dev/test mode에서도 완료/실패 피드백 보장 |
| [`b01baba`](https://github.com/baehandoridori/Bflow-BGonly/commit/b01baba) | P2 | `src/views/WidgetPopup.tsx` | 플로팅 위젯에도 `<GradientBackdrop />` 마운트 + `plexusSettings.globalGradientEnabled` 구독. 설정 토글이 팝업에도 반영 |

### 사이클 10 — 10차 리뷰 대응 (P2 2건)
| 커밋 | 유형 | 파일 | 요약 |
|---|---|---|---|
| [`60515a4`](https://github.com/baehandoridori/Bflow-BGonly/commit/60515a4) | P2 | `src/components/scenes/UnifiedSceneCard.tsx` | `prevHighlightedRef` 초기값을 `false`로 변경 — 스포트라이트/알림 deep-link로 `highlightSceneId` 사전 설정 시 첫 마운트에 카드가 화면에 정상 진입. 클릭 선택 regression 재발 방지도 유지 |
| [`1179030`](https://github.com/baehandoridori/Bflow-BGonly/commit/1179030) | P2 | `src/components/settings/EffectsSection.tsx` | `persistPlexus` 말미에 `preferencesBroadcastChange({ plexus })` 호출 추가 — "전체 화면 그라데이션 배경" 등 플렉서스 토글 변경이 이미 열린 플로팅 위젯에도 실시간 반영 |

### 리뷰 대응 총계
- Codex 지적 **21건 전부 해소**, 수정 커밋 **20개**
- 검증: 사이클마다 `tsc --noEmit` + `vite build` 통과
- 에스컬레이션 기준: 누적 수정 피로도 관리 위해 사이클 16부터 "확실한 crash/data loss/보안"만 자동 수정, 그 외는 사용자 판단 위임으로 운영

### ⏱️ 루프 운영 통계

| 항목 | 값 |
|---|---|
| PR 생성 ~ 마지막 리뷰 대응 완료 | **약 3시간 30분** (2026-04-19 15:00 UTC ~ 18:30 UTC) |
| Codex 리뷰 수신 간격(평균) | 약 13분 (최단 11분 / 최장 64분) |
| 자동 감지 사이클 실행 | **19회** (4~7분 간격 `ScheduleWakeup` 기반 폴링) |
| 실제 수정 사이클 | **10회** (사이클 2, 4, 6, 8, 10, 11, 13, 15, 17, 그리고 본 사이클) |
| 리뷰 재트리거 코멘트 | 9회 (`@codex review`) |
| 주요 타임스탬프 (UTC) | 1차 15:07 → 5차 16:04 → 9차 17:17 → 10차 18:21 |

**운영 방식**: 매 사이클에 `gh api`로 `reviews`/`comments` 신규 항목을 조회하고 처리된 ID를 `tasks/codex-review-history.txt`에 기록. 새 지적 발견 시 implementer 서브에이전트가 수정 → `tsc`/`build` 검증 → 한글 커밋 → push → `@codex review` 재트리거 → 다음 `ScheduleWakeup` 예약. 종료 조건(연속 미도착 3회 또는 수정 사이클 피로도 누적)에 따라 자동 마감.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


