### PR TITLE
[v1.11.0] 짬순 정렬 추가 및 팀원 어록 1건 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/components/widgets/OverallProgressWidget.tsx
+++ b/src/components/widgets/OverallProgressWidget.tsx
@@ -75,6 +75,7 @@ const RANDOM_MESSAGES: MotivMessage[] = [
   { text: '너 지웅이 좋아해?', author: '류이레' },
   { text: '우리 언젠가 분명히 잡혀갈거야.....', author: '정영준' },
   { text: '틀리면 엑쓰', author: '경환엄마' },
+  { text: '응후응후 (여러분 모두 힘든 작업을 하고 계시지만 분명히 힘든 만큼 값진 결과가 되돌아올 것입니다. 포기하지 말고 옆에있는 팀원을 의지하면서 언제나 열심히 즐겁게 오래오래 일하는 스튜디오 장삐쭈가 되었으면 좋겠습니다. 사코팍 화이팅! 스튜디오장삐쭈 화이팅!)', author: '이혜민' },
 ];
 
 function getMessagePool(pct: number): MotivMessage[] {

--- a/src/utils/seniorityOrder.ts
+++ b/src/utils/seniorityOrder.ts
@@ -1,0 +1,29 @@
+/**
+ * 팀원 짬순(입사일 순) 정렬 기준
+ *
+ * 입사일 데이터가 아직 시스템에 없어서 이름 기반 하드코딩 순서로 관리.
+ * 배열 앞쪽일수록 선임(짬 많음). 목록에 없는 이름은 맨 뒤로.
+ */
+export const SENIORITY_ORDER: readonly string[] = [
+  '안류천',
+  '윤성원',
+  '허혜원',
+  '박정인',
+  '지정민',
+  '원동우',
+  '강선영',
+  '이혜민',
+  '이명훈',
+  '배한솔',
+  '이다은',
+  '김어진',
+  '류이레',
+  '류성철',
+  '이승은',
+];
+
+/** 이름의 짬순 인덱스 (0=가장 선임). 목록에 없으면 SENIORITY_ORDER.length 반환. */
+export function getSeniorityIndex(name: string): number {
+  const idx = SENIORITY_ORDER.indexOf(name);
+  return idx === -1 ? SENIORITY_ORDER.length : idx;
+}

--- a/src/views/AssigneeView.tsx
+++ b/src/views/AssigneeView.tsx
@@ -262,7 +262,7 @@ export function AssigneeView() {
   const episodes = useDataStore((s) => s.episodes);
   const episodeTitles = useDataStore((s) => s.episodeTitles);
   const { setView, setSelectedEpisode, setSelectedPart, setSelectedDepartment, setSelectedAssignee, setHighlightSceneId } = useAppStore();
-  const [sortBy, setSortBy] = useState<SortOption>('scenes');
+  const [sortBy, setSortBy] = useState<SortOption>('seniority');
   const [sortAsc, setSortAsc] = useState(false);
 
   const assignees = useMemo(() => {

--- a/src/views/AssigneeView.tsx
+++ b/src/views/AssigneeView.tsx
@@ -4,6 +4,7 @@ import { Users, ChevronDown, ChevronUp } from 'lucide-react';
 import { useDataStore } from '@/stores/useDataStore';
 import { useAppStore } from '@/stores/useAppStore';
 import { sceneProgress, isFullyDone, isNotStarted } from '@/utils/calcStats';
+import { getSeniorityIndex } from '@/utils/seniorityOrder';
 import { DEPARTMENT_CONFIGS, STAGES } from '@/types';
 import type { Scene, Episode, Department, Stage } from '@/types';
 import { cn } from '@/utils/cn';
@@ -252,7 +253,7 @@ function AssigneeCard({ data, onClickScene }: { data: AssigneeData; onClickScene
 /* ────────────────────────────────────────────────
    정렬 옵션
    ──────────────────────────────────────────────── */
-type SortOption = 'name' | 'scenes' | 'progress';
+type SortOption = 'name' | 'scenes' | 'progress' | 'seniority';
 
 /* ────────────────────────────────────────────────
    메인 뷰
@@ -272,6 +273,7 @@ export function AssigneeView() {
         case 'name': cmp = a.name.localeCompare(b.name, 'ko'); break;
         case 'scenes': cmp = a.totalScenes - b.totalScenes; break;
         case 'progress': cmp = a.avgPct - b.avgPct; break;
+        case 'seniority': cmp = getSeniorityIndex(b.name) - getSeniorityIndex(a.name); break;
       }
       return sortAsc ? cmp : -cmp;
     });
@@ -324,6 +326,7 @@ export function AssigneeView() {
             { key: 'name' as SortOption, label: '이름' },
             { key: 'scenes' as SortOption, label: '씬 수' },
             { key: 'progress' as SortOption, label: '진행률' },
+            { key: 'seniority' as SortOption, label: '짬순' },
           ]).map(({ key, label }) => (
             <button
               key={key}

--- a/src/views/TeamView.tsx
+++ b/src/views/TeamView.tsx
@@ -5,6 +5,7 @@ import { useDataStore } from '@/stores/useDataStore';
 import { useAppStore } from '@/stores/useAppStore';
 import { useAuthStore } from '@/stores/useAuthStore';
 import { sceneProgress, isFullyDone, isNotStarted } from '@/utils/calcStats';
+import { getSeniorityIndex } from '@/utils/seniorityOrder';
 import { DEPARTMENT_CONFIGS, STAGES } from '@/types';
 import type { Scene, Department, Stage, AppUser } from '@/types';
 import { cn } from '@/utils/cn';
@@ -317,7 +318,7 @@ function TeamMemberCard({
    정렬 옵션
    ──────────────────────────────────────────────── */
 
-type SortOption = 'name' | 'scenes' | 'progress';
+type SortOption = 'name' | 'scenes' | 'progress' | 'seniority';
 
 /* ────────────────────────────────────────────────
    메인 뷰
@@ -358,6 +359,7 @@ export function TeamView() {
         case 'name': cmp = a.user.name.localeCompare(b.user.name, 'ko'); break;
         case 'scenes': cmp = a.totalScenes - b.totalScenes; break;
         case 'progress': cmp = a.avgPct - b.avgPct; break;
+        case 'seniority': cmp = getSeniorityIndex(b.user.name) - getSeniorityIndex(a.user.name); break;
       }
       return sortAsc ? cmp : -cmp;
     });
@@ -413,6 +415,7 @@ export function TeamView() {
             { key: 'name' as SortOption, label: '이름' },
             { key: 'scenes' as SortOption, label: '씬 수' },
             { key: 'progress' as SortOption, label: '진행률' },
+            { key: 'seniority' as SortOption, label: '짬순' },
           ]).map(({ key, label }) => (
             <button
               key={key}


### PR DESCRIPTION
## 📋 업데이트 요약

> 이번 업데이트에서 달라진 점을 간략하게 정리했습니다.

- ✨ 인원별 현황 / 팀원 현황 화면에서 **"짬순"** 정렬 옵션이 추가됐습니다 — 입사일 기준 선배 순서대로 정렬돼요.
- 🎯 **인원별 현황** 진입 시 기본 정렬이 "짬순"(선임 먼저)으로 변경됐습니다.
- 💬 전체 진행률 위젯 하단의 팀원 어록 풀에 **이혜민님의 장문 응원 메시지**가 추가됐습니다 — 가끔씩 깜짝 등장해요.

## 🔧 상세 기술 설명

### 짬순 정렬 유틸 추가
- `src/utils/seniorityOrder.ts` 신설: 팀원 15명(안류천 → 이승은)을 하드코딩한 배열과 `getSeniorityIndex(name)` 헬퍼 제공.
- 목록에 없는 이름(예: "미배정", 신규 입사자)은 배열 길이 값을 반환해 정렬 시 맨 뒤로 밀리도록 처리.
- 향후 Supabase `users` 테이블에 `joined_at` 컬럼이 추가되면 이 배열만 교체하면 됨 (호출부는 그대로).

### 정렬 옵션 확장 (AssigneeView / TeamView)
- 두 뷰의 `SortOption` 유니온 타입에 `'seniority'` 추가.
- 정렬 로직: `cmp = getSeniorityIndex(b.name) - getSeniorityIndex(a.name)` — `sortAsc=false`(기본) 상태에서 자연스럽게 선임 먼저 나오도록 방향 맞춤.
- 정렬 버튼 목록 배열에 `{ key: 'seniority', label: '짬순' }` 추가.
- `AssigneeView`의 `useState<SortOption>` 초깃값을 `'scenes'` → `'seniority'`로 변경.

### 팀원 어록 풀 확장
- `src/components/widgets/OverallProgressWidget.tsx`의 `RANDOM_MESSAGES` 배열에 이혜민님 장문 메시지 1건 추가.
- 기존 8초 로테이션 로직은 그대로 재사용 (별도 분기 없음).

### 버전
- `package.json`: 1.10.0 → 1.11.0 (feat 포함 → minor 업)

## 🚧 개발 난항

### 짬순 정렬 방향 결정
- **문제**: 기존 정렬 옵션들은 `sortAsc=false`가 "많은 것 먼저 / 높은 것 먼저"로 해석되는데, "짬순"에서 "짬 많은 것(선임) 먼저"를 같은 방향에 맞추려다 보니 인덱스 부호가 헷갈림.
- **해결**: 선임일수록 낮은 인덱스(안류천=0)를 갖도록 정의하고, 정렬 함수에서 `b.idx - a.idx`로 뒤집어 `sortAsc=false`일 때 자연스럽게 선임 먼저 출력되게 함.
- **교훈**: 사용자 멘탈 모델("짬 많은 사람이 위")과 코드 기본값(`sortAsc=false`)을 일치시키려면 cmp 식 자체에서 방향을 맞추는 게 UI 토글 코드를 안 건드려도 돼서 깔끔함.

## ✅ 테스트 가이드

### 사용자 테스트
> 아래 시나리오를 직접 실행해서 정상 동작을 확인해주세요.

1. **인원별 현황 기본 정렬 확인**
   - 사이드바에서 "인원별" 진입
   - ✅ 기대 결과: 상단 정렬 버튼 중 **"짬순 ↓"**이 기본 선택되어 있고, 카드가 **안류천 → 윤성원 → 허혜원 → ...** 순서로 배치됨
   - ❌ 비정상: "씬 수" 등 다른 항목이 기본 선택이거나, 이름 순서가 뒤죽박죽

2. **짬순 정렬 토글**
   - 인원별 현황에서 "짬순" 버튼을 한 번 더 클릭
   - ✅ 기대 결과: 화살표가 ↑로 바뀌고 후임(이승은)이 위로, "미배정"이 최상단으로 이동
   - 다시 클릭하면 원래(선임 먼저)로 복귀

3. **팀원 현황도 동일 확인**
   - "팀원" 뷰 진입 → 정렬 버튼에 "짬순" 노출 확인 (기본값은 기존대로 "씬 수")

4. **팀원 어록 확인**
   - 대시보드 전체 진행률 위젯 하단 문구를 몇 분 지켜보기 (8초마다 바뀜)
   - ✅ 기대 결과: 가끔 이혜민님의 장문 "응후응후 (여러분 모두 힘든 작업을 하고 계시지만...)" 메시지가 등장

### 개발자 테스트
```bash
npm run build:vite
```
> 추가 확인 사항:
> - 팀에 신규 입사자가 생겨 `SENIORITY_ORDER`에 없는 이름이 들어오면 정렬 시 항상 맨 뒤로 가야 함 (렌더 사고는 안 나야 함)
> - 미배정 카드가 "짬순 ↓" 기본 방향에서 최하단에 있는지
