### PR TITLE
[v1.11.2] CLAUDE.md 이미지 저장소 설명을 Supabase Storage로 업데이트

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Supabase(PostgreSQL + Realtime)를 SSOT로 사용 (Google Sheets에서 전환 �
 | 배포 | `G:\공유 드라이브\JBBJ 자료실\한솔이의 두근두근 실험실\Bflow-BGonly\` |
 | 개인 설정 | `%APPDATA%\Bflow-BGonly\` (layout.json, preferences.json) |
 
-**데이터**: 씬/에피소드/체크박스 → Supabase (PostgreSQL), 이미지 → Google Drive (GAS 경유), 위젯 레이아웃/개인 설정 → %APPDATA% 로컬 파일
+**데이터**: 씬/에피소드/체크박스/메모/개인일정 → Supabase (PostgreSQL), 이미지 → Supabase Storage (`scene-images` 버킷, 800px/JPEG 80% 리사이즈), 레거시 Drive 이미지는 `drive-img://` 프로토콜로 표시만 유지, 위젯 레이아웃/개인 설정 → %APPDATA% 로컬 파일
 
 ### 제약 사항
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
## 📋 업데이트 요약

> 개발 문서를 현재 실제 앱 구조에 맞게 업데이트합니다. 앱 동작에는 영향 없습니다.

- 📝 문서: 이미지가 이제 Google Drive가 아닌 Supabase Storage에 저장된다는 점을 CLAUDE.md에 반영

## 🔧 상세 기술 설명

### 배경
- 이전 마이그레이션 PR들(`d3056ae`~`f5229de`)에서 이미지 업로드 경로를 **GAS → Drive** 에서 **Supabase Storage(`scene-images` 버킷)** 로 전환 완료
- 그러나 `CLAUDE.md`의 "데이터 경로" 요약이 업데이트되지 않아 실제 동작과 불일치 → 신규 세션 시 Claude에게 잘못된 컨텍스트가 전달될 가능성

### 변경
- `CLAUDE.md:42` 한 줄 수정
  - 이미지 저장소: Google Drive(GAS) → Supabase Storage (`scene-images` 버킷, 800px/JPEG 80% 리사이즈)
  - 레거시 Drive 이미지는 `drive-img://` 프로토콜로 표시만 유지한다는 점 명시
- `package.json` 1.11.1 → 1.11.2 (docs patch)

## 🚧 개발 난항

특이사항 없음 (문서 정정)

## ✅ 테스트 가이드

### 사용자 테스트
- 별도 테스트 불필요 — 실행 파일 동작에 영향 없음

### 개발자 테스트
- 앞으로 CLAUDE.md를 읽는 Claude/Codex 세션에서 이미지 저장소 컨텍스트가 올바르게 전달되는지 확인
- TypeScript/빌드 영향 없음 (문서 + version 필드만 변경)

🤖 Generated with [Claude Code](https://claude.com/claude-code)