### PR TITLE
[v1.12.1] 상세 모달 드래그·댓글 UX·ACT 라벨 등 6개 UI/UX 이슈 수정

### DIFF
--- a/docs/superpowers/specs/2026-04-22-v1.12.1-bugfixes-design.md
+++ b/docs/superpowers/specs/2026-04-22-v1.12.1-bugfixes-design.md
@@ -119,39 +119,36 @@ className={cn(
 
 ---
 
-## 이슈 A: 댓글 입력란 동적 리사이즈
+## 이슈 A: 댓글 입력란 최대 높이 확장
 
 ### 증상
-현재 `CommentPanel` 입력란은 최대 96px(약 4~5줄)까지 커지고 그 이상은 내부 스크롤. 긴 댓글 작성 시 시야 확보가 부족. 또 height 변경이 즉시 반영되어 애니메이션 없이 튀는 느낌.
+현재 `CommentPanel` 입력란은 최대 96px(약 4~5줄)까지 커지고 그 이상은 내부 스크롤. 긴 댓글 작성 시 시야 확보가 부족.
 
 ### 수정 범위
 - `src/components/scenes/CommentPanel.tsx`
 
 ### 변경
-1. `handleInputChange` 내부 auto-grow 계산:
-   ```ts
-   ta.style.height = `${Math.min(ta.scrollHeight, 96)}px`;
-   // ↓
-   ta.style.height = `${Math.min(ta.scrollHeight, 200)}px`;
-   ```
-2. textarea `className` 의 `max-h-24` 제거 → `max-h-[200px]` 적용. 추가로 `transition-[height] duration-150 ease-out` 로 부드러운 전환.
-3. 메시지 목록 `<div ref={scrollRef}>` 는 이미 `flex-1 overflow-y-auto min-h-0` 이라 입력란이 커지면 자동으로 위쪽으로 밀리며 전송 버튼도 같이 내려옴 (추가 조정 불필요).
+1. `handleInputChange` auto-grow 한계: `Math.min(ta.scrollHeight, 96)` → `Math.min(ta.scrollHeight, 200)`
+2. textarea `className` 의 `max-h-24` → `max-h-[200px]`
 
 ### 효과
 - 최대 10줄 정도까지 자연 확장
-- height 변경 시 부드러운 150ms 전환
-- 입력란 커질수록 메시지 목록 영역 축소 → 전송 버튼은 항상 입력란 우측 정렬 유지
-- **200px 초과 시**: textarea 내부 스크롤(현재 `overflow-y-auto` 유지)로 전환. 컨테이너 밀림 중지. 의도된 동작.
+- 200px 초과 시 textarea 내부 스크롤로 전환
 
-### 리스크
-- `transition` 때문에 빠른 타이핑 시 레이아웃 계산 비용이 약간 증가하나 150ms 짧고 height만 변하므로 미미.
-- 모달 본체 세로 공간 `max-h-[90vh]` 내에서 동작하므로 overflow 문제 없음.
+### 애니메이션 범위 외 (v1.13.0 이슈 A2 로 분리)
+부드러운 리사이즈 애니메이션(Claude Cowork 식 메시지 목록까지 함께 밀려 올라가는 효과)은 여러 구현 시도 결과 다음 제약 확인:
+
+- **CSS transition-[height]** 단독: `style.height = 'auto'` 리셋이 transition 시작점을 깨뜨려 툭 튀는 현상.
+- **double requestAnimationFrame 패턴**: textarea 자체는 부드러워지지만 부모 flex 컨테이너 재분배가 즉시 일어나 메시지 목록이 튀는 현상 잔존.
+- **framer-motion `layout` prop**: vite dev HMR 환경에서 500 에러/모듈 reload 실패를 일으켜 롤백.
+- **`field-sizing: content` CSS**: Chromium 에서 layout 즉시 반영되며 transition 큐를 건너뜀.
+
+v1.12.1 에서는 **기능만 제공**(최대 높이 확장)하고 애니메이션 품질 개선은 별도 세션에서 리팩토링. v1.13.0 이슈 A2 참고.
 
 ### 수동 스모크
 1. 상세 모달 → 댓글 입력란 클릭
 2. 여러 줄 입력하여 높이 확장 관찰 → 96px가 아닌 200px까지 커짐
-3. 높이가 급격히 튀지 않고 부드럽게 애니메이션
-4. 메시지 목록이 위로 밀려 입력란 경계가 자연스럽게 유지
+3. 200px 초과 시 내부 스크롤 전환
 
 ---
 

--- a/docs/superpowers/specs/2026-04-22-v1.12.1-bugfixes-design.md
+++ b/docs/superpowers/specs/2026-04-22-v1.12.1-bugfixes-design.md
@@ -90,17 +90,19 @@ className={cn(
 `flex-1` 로 4등분된 좁은 셀 안에 ACT 라벨(`DEPARTMENT_CONFIGS.acting.stageLabels`) 이 BG보다 길어서 공간이 부족하면 브라우저가 글자 단위 줄바꿈을 시도한다. `whitespace-nowrap` 이 없어 방어가 빠져 있음.
 
 ### 수정 범위
-- `src/components/scenes/UnifiedSceneCard.tsx` (line ~316 `DeptSection` stage 버튼)
+- `src/components/scenes/UnifiedSceneCard.tsx` (line ~320 `DeptSection` stage 버튼)
 
 ### 변경
-`className` 에 `whitespace-nowrap overflow-hidden text-ellipsis` 추가.
+`className` 에 `min-w-0 whitespace-nowrap overflow-hidden text-ellipsis` 추가.
 
 ```tsx
 className={cn(
-  'flex-1 text-center py-2 text-[11px] font-medium rounded-md transition-all cursor-pointer whitespace-nowrap overflow-hidden text-ellipsis',
+  'flex-1 min-w-0 text-center py-2 text-[11px] font-medium rounded-md transition-all cursor-pointer whitespace-nowrap overflow-hidden text-ellipsis',
   ...
 )}
 ```
+
+> **주의**: flex children 의 기본 `min-width: auto` 때문에 `flex-1` 만으로는 글자가 컨테이너를 초과해 `text-ellipsis` 가 트리거되지 않는다. `min-w-0` 을 반드시 같이 넣어야 축소·말줄임이 보장됨.
 
 미등록(부서 없음) 분기의 placeholder div 에도 동일 조치 (시각적 일관성).
 
@@ -139,6 +141,7 @@ className={cn(
 - 최대 10줄 정도까지 자연 확장
 - height 변경 시 부드러운 150ms 전환
 - 입력란 커질수록 메시지 목록 영역 축소 → 전송 버튼은 항상 입력란 우측 정렬 유지
+- **200px 초과 시**: textarea 내부 스크롤(현재 `overflow-y-auto` 유지)로 전환. 컨테이너 밀림 중지. 의도된 동작.
 
 ### 리스크
 - `transition` 때문에 빠른 타이핑 시 레이아웃 계산 비용이 약간 증가하나 150ms 짧고 height만 변하므로 미미.
@@ -199,13 +202,13 @@ style={{
 ### 변경
 인라인 `backgroundColor` 제거, Tailwind 시맨틱 클래스로 전환.
 - 자기 말풍선: `bg-emerald-500/20` (기존 녹색 유지, 브랜드 색)
-- 상대 말풍선: `bg-bg-border/60` (다크/라이트 자동 적응)
+- 상대 말풍선: `bg-bg-border/70` (다크/라이트 자동 적응)
 
 ```tsx
 <div
   className={cn(
     'rounded-xl px-3.5 py-2.5 text-xs leading-relaxed break-words text-text-primary',
-    isOwn ? 'bg-emerald-500/20' : 'bg-bg-border/60',
+    isOwn ? 'bg-emerald-500/20' : 'bg-bg-border/70',
   )}
 >
   {renderText(comment.text)}
@@ -213,6 +216,8 @@ style={{
 ```
 
 `color: 'rgb(var(--color-text-primary))'` 도 `text-text-primary` 클래스로 교체.
+
+> **알파값 선택 근거**: 기존 하드코딩 `#2A2A35` 는 `bg-border` 기본값 `#2D3041` 보다 약간 더 어둡다. `/60` 이면 눈에 띄게 밝아지므로 `/70` 을 기본값으로 하고 다크모드 실사용 후 필요시 `/80` 으로 미세 조정.
 
 ### 효과
 - 다크모드: 거의 동일한 시각 (bg-bg-border 가 기존 `#2D3041` 근처)

--- a/docs/superpowers/specs/2026-04-22-v1.12.1-bugfixes-design.md
+++ b/docs/superpowers/specs/2026-04-22-v1.12.1-bugfixes-design.md
@@ -1,0 +1,274 @@
+# v1.12.1 — UI/UX 버그 6개 일괄 수정 디자인
+
+> **버전**: 1.12.0 → 1.12.1 (패치)
+> **작성일**: 2026-04-22
+> **범위**: 버그 수정 + 소소한 UX 개선 6개. 재구성·환경 재현 필요한 항목은 `2026-04-22-v1.13.0-backlog.md` 로 분리.
+
+---
+
+## 배경
+
+사용자 제보 12개 이슈를 리스크/규모 기준으로 분할.
+
+| 버전 | 이슈 수 | 성격 |
+|------|---------|------|
+| **v1.12.1 (본 문서)** | 6개 | 순수 버그 + 소소한 UX — 낮은 회귀 리스크 |
+| v1.13.0 (별도) | 5개 | 에디터 재설계 · 탭 재구성 · DB 무결성 · 빌드 환경 조사 |
+
+v1.12.1 대상(본 문서에서 다룸):
+- 이슈 1: 상세 모달 댓글 텍스트 선택 불가
+- 이슈 2: 상세 모달 드래그 시 뒤 씬 그리드 라쏘 누수
+- 이슈 5: ACT 단계 라벨 세로 줄바꿈
+- 이슈 A: 댓글 입력란 최대 높이 / 리사이즈 애니메이션 개선
+- 이슈 D: 팀원 뷰 기본 정렬을 짬순(근속순)으로
+- 이슈 E: 댓글 상대방 말풍선 라이트모드 배경 부적절
+
+---
+
+## 공통 원칙
+
+- **최소 변경**: 각 이슈는 파일 1~2개, 평균 10줄 이내의 diff 지향.
+- **시맨틱 토큰 준수**: `tasks/lessons.md` 의 "라이트 모드 하드코딩 금지" 규칙 적용.
+- **기존 훅/유틸 재사용**: 새 추상화 도입 없이 기존 구조 내 조정으로 해결.
+- **개별 커밋**: 이슈별로 커밋 분리해 rollback 용이.
+
+---
+
+## 이슈 1 + 2: 상세 모달이 드래그 이벤트를 훔침
+
+### 증상
+- (이슈 1) 상세 모달의 댓글 영역에서 텍스트를 드래그해도 선택이 안 됨 → 복사 붙여넣기 불가
+- (이슈 2) 모달 내부에서 시작한 드래그가 뒤쪽 씬 그리드에 라쏘 박스를 그려 씬이 선택됨
+
+### 근본 원인
+`src/views/ScenesView.tsx` 의 `useLassoSelection` 훅이 `document` 전역 `mousedown` 을 수신한다. 훅 내부(70줄 근처)에는 이미 "`[data-no-lasso]` 속성을 가진 요소 안에서 시작된 드래그는 라쏘 무시" 규칙이 있다. 상세 모달(`SceneDetailModal`, `UnifiedSceneDetailModal`)은 `<motion.div>` 백드롭 + 본체로 구성되는데, 이 마커가 없어서 훅이 개입하며 라쏘 박스 + 텍스트 선택 차단이 동시에 일어난다.
+
+### 수정 범위
+- `src/components/scenes/SceneDetailModal.tsx`
+- `src/components/scenes/UnifiedSceneDetailModal.tsx`
+
+### 변경
+각 모달의 **최상위 백드롭** (`fixed inset-0 z-50`, `onClick={e => e.target===e.currentTarget && onClose()}` 있는 모션 div) 에 `data-no-lasso` 속성 추가.
+
+```tsx
+<motion.div
+  key="detail-backdrop"
+  data-no-lasso   // ← 추가
+  className="fixed inset-0 z-50 ..."
+  ...
+>
+```
+
+### 효과
+- 모달 내부 어디서 드래그를 시작해도 라쏘 훅의 `closest('[data-no-lasso]')` 매칭이 성립하여 즉시 return → 라쏘 박스 생성 안 됨 (이슈 2 해결).
+- 라쏘가 드래그 초기 `preventDefault`/`setPointerCapture` 류 동작을 하지 않으므로, 텍스트 선택은 브라우저 기본 동작으로 자연 복구 (이슈 1 해결).
+
+### 리스크
+거의 없음. 기존 훅 규칙 재사용. 모달 내부의 다른 드래그 의존 기능(이미지 드롭존 등)은 훅 시작만 차단할 뿐 이벤트 자체는 정상 전파되므로 영향 없음.
+
+### 수동 스모크
+1. 씬 뷰에서 씬 더블클릭 → 상세 모달 열림
+2. 댓글 말풍선 드래그 → 텍스트가 반전되어 선택됨, Ctrl+C 로 복사 가능
+3. 모달 빈 공간에서 뒤쪽 그리드 방향으로 드래그 → 라쏘 박스 안 나타남
+4. 모달 닫기 (X 또는 Esc) 후 씬 뷰 빈 공간 드래그 → 라쏘 정상 동작 (기존 기능 회귀 없음)
+
+---
+
+## 이슈 5: ACT 단계 라벨 세로 줄바꿈
+
+### 증상
+통합 씬 카드에서 단계 라벨(예: LO / 완료 / 검수 / PNG)이 BG 섹션에선 한 줄인데 ACT 섹션에선 글자 단위로 줄바꿈되어 세로로 쌓여 보임.
+
+### 근본 원인
+`src/components/scenes/UnifiedSceneCard.tsx` 의 `DeptSection` stage 버튼:
+```tsx
+className={cn(
+  'flex-1 text-center py-2 text-[11px] font-medium rounded-md ...',
+  ...
+)}
+```
+`flex-1` 로 4등분된 좁은 셀 안에 ACT 라벨(`DEPARTMENT_CONFIGS.acting.stageLabels`) 이 BG보다 길어서 공간이 부족하면 브라우저가 글자 단위 줄바꿈을 시도한다. `whitespace-nowrap` 이 없어 방어가 빠져 있음.
+
+### 수정 범위
+- `src/components/scenes/UnifiedSceneCard.tsx` (line ~316 `DeptSection` stage 버튼)
+
+### 변경
+`className` 에 `whitespace-nowrap overflow-hidden text-ellipsis` 추가.
+
+```tsx
+className={cn(
+  'flex-1 text-center py-2 text-[11px] font-medium rounded-md transition-all cursor-pointer whitespace-nowrap overflow-hidden text-ellipsis',
+  ...
+)}
+```
+
+미등록(부서 없음) 분기의 placeholder div 에도 동일 조치 (시각적 일관성).
+
+### 효과
+라벨은 항상 한 줄. 극단적으로 좁을 때만 오른쪽 말줄임표(`…`) 표시. BG 라벨은 이미 짧아서 말줄임 발생 안 함.
+
+### 리스크
+없음. 기존 레이아웃 상수 불변.
+
+### 수동 스모크
+1. 씬 뷰 전체 모드 → ACT 파트가 있는 씬 카드 확인
+2. 라벨이 한 줄로 표시되는지
+3. 카드 너비를 줄여도(창 좁게) 세로 쌓임 없이 말줄임으로 떨어지는지
+
+---
+
+## 이슈 A: 댓글 입력란 동적 리사이즈
+
+### 증상
+현재 `CommentPanel` 입력란은 최대 96px(약 4~5줄)까지 커지고 그 이상은 내부 스크롤. 긴 댓글 작성 시 시야 확보가 부족. 또 height 변경이 즉시 반영되어 애니메이션 없이 튀는 느낌.
+
+### 수정 범위
+- `src/components/scenes/CommentPanel.tsx`
+
+### 변경
+1. `handleInputChange` 내부 auto-grow 계산:
+   ```ts
+   ta.style.height = `${Math.min(ta.scrollHeight, 96)}px`;
+   // ↓
+   ta.style.height = `${Math.min(ta.scrollHeight, 200)}px`;
+   ```
+2. textarea `className` 의 `max-h-24` 제거 → `max-h-[200px]` 적용. 추가로 `transition-[height] duration-150 ease-out` 로 부드러운 전환.
+3. 메시지 목록 `<div ref={scrollRef}>` 는 이미 `flex-1 overflow-y-auto min-h-0` 이라 입력란이 커지면 자동으로 위쪽으로 밀리며 전송 버튼도 같이 내려옴 (추가 조정 불필요).
+
+### 효과
+- 최대 10줄 정도까지 자연 확장
+- height 변경 시 부드러운 150ms 전환
+- 입력란 커질수록 메시지 목록 영역 축소 → 전송 버튼은 항상 입력란 우측 정렬 유지
+
+### 리스크
+- `transition` 때문에 빠른 타이핑 시 레이아웃 계산 비용이 약간 증가하나 150ms 짧고 height만 변하므로 미미.
+- 모달 본체 세로 공간 `max-h-[90vh]` 내에서 동작하므로 overflow 문제 없음.
+
+### 수동 스모크
+1. 상세 모달 → 댓글 입력란 클릭
+2. 여러 줄 입력하여 높이 확장 관찰 → 96px가 아닌 200px까지 커짐
+3. 높이가 급격히 튀지 않고 부드럽게 애니메이션
+4. 메시지 목록이 위로 밀려 입력란 경계가 자연스럽게 유지
+
+---
+
+## 이슈 D: 팀원 뷰 기본 정렬을 짬순(근속순)으로
+
+### 현황
+`src/utils/seniorityOrder.ts` 에 이미 `SENIORITY_ORDER` 배열과 `getSeniorityIndex` 헬퍼가 존재. `TeamView.tsx` 는 `'seniority'` 를 `SortOption` 으로 지원하고 라벨 "짬순"까지 구현되어 있음. 단지 초기 state 가 `'scenes'` 로 되어 있어 첫 진입 시 씬 개수 순으로 정렬됨.
+
+### 수정 범위
+- `src/views/TeamView.tsx:336`
+
+### 변경
+```tsx
+const [sortBy, setSortBy] = useState<SortOption>('scenes');
+// ↓
+const [sortBy, setSortBy] = useState<SortOption>('seniority');
+```
+
+### 효과
+팀원 뷰 진입 시 짬순(근속순) 기본 정렬. 사용자가 드롭다운에서 다른 기준으로 바꾸면 세션 내에서는 유지(별도 영속화 없음 — 의도적으로 YAGNI).
+
+### 리스크
+없음. 단 한 줄 변경. 선택 상태는 컴포넌트 local state 이므로 다른 뷰와 무관.
+
+### 수동 스모크
+1. 앱 재시작 → 팀원 뷰 진입 → 상단 정렬 드롭다운이 "짬순" 표시, 안류천·윤성원 등 상위 짬원이 위쪽에 노출.
+
+---
+
+## 이슈 E: 댓글 상대방 말풍선 라이트모드 배경
+
+### 증상
+라이트 모드에서 다른 사람 댓글 말풍선이 어두운 회색(#2A2A35)으로 표시되어 흰 배경 위에 이물감.
+
+### 근본 원인
+`src/components/scenes/CommentPanel.tsx:346` 이 인라인 스타일로 하드코딩되어 있음:
+```tsx
+style={{
+  backgroundColor: isOwn ? 'rgba(16, 185, 129, 0.18)' : '#2A2A35',
+  ...
+}}
+```
+다크 전용 표면값 하드코딩 — lessons.md "라이트 모드 하드코딩 금지" 규칙 위반.
+
+### 수정 범위
+- `src/components/scenes/CommentPanel.tsx` 말풍선 렌더 블록 (line ~342–350)
+
+### 변경
+인라인 `backgroundColor` 제거, Tailwind 시맨틱 클래스로 전환.
+- 자기 말풍선: `bg-emerald-500/20` (기존 녹색 유지, 브랜드 색)
+- 상대 말풍선: `bg-bg-border/60` (다크/라이트 자동 적응)
+
+```tsx
+<div
+  className={cn(
+    'rounded-xl px-3.5 py-2.5 text-xs leading-relaxed break-words text-text-primary',
+    isOwn ? 'bg-emerald-500/20' : 'bg-bg-border/60',
+  )}
+>
+  {renderText(comment.text)}
+</div>
+```
+
+`color: 'rgb(var(--color-text-primary))'` 도 `text-text-primary` 클래스로 교체.
+
+### 효과
+- 다크모드: 거의 동일한 시각 (bg-bg-border 가 기존 `#2D3041` 근처)
+- 라이트모드: 연한 회색 말풍선 → 흰 배경 위에서 자연스러움
+- 시맨틱 토큰 기반으로 테마 확장 시에도 자동 적응
+
+### 리스크
+다크 모드에서 미세한 색 차이 가능. 시각 비교 후 필요시 `bg-bg-border/50` 또는 `/70` 로 미세 조정. 기능 영향 없음.
+
+### 수동 스모크
+1. 다크모드 → 타인 댓글 말풍선이 기존과 비슷한 회색
+2. 설정에서 라이트모드로 전환 → 타인 댓글 말풍선이 흰 배경과 조화되는 연한 회색
+3. 자기 댓글은 두 모드 모두 녹색 유지
+
+---
+
+## 버전 & 커밋
+
+### 버전
+`package.json`: `"version": "1.12.0"` → `"1.12.1"`
+
+### 커밋 전략 (이슈별 분리)
+```
+1. fix: 상세 모달 드래그 누수 차단으로 댓글 텍스트 선택 복구 (#이슈1,2)
+2. fix: ACT 단계 라벨 줄바꿈 방지 (#이슈5)
+3. feat: 댓글 입력란 최대 200px + 부드러운 리사이즈 (#이슈A)
+4. feat: 팀원 뷰 기본 정렬을 짬순으로 변경 (#이슈D)
+5. fix: 댓글 말풍선 라이트모드 배경 시맨틱 토큰화 (#이슈E)
+6. chore: v1.12.1 버전 bump
+```
+
+### PR 제목
+`[v1.12.1] 상세 모달 드래그 · 댓글 UX · ACT 라벨 등 6개 UI/UX 이슈 수정`
+
+---
+
+## 검증 전략
+
+### 자동
+- `npx tsc --noEmit` — 타입 오류 0
+- `npm run build:vite` — 빌드 성공
+- `npm run lint` — eslint 경고 증가 없음
+
+### 수동 스모크 (필수)
+- 이슈별 수동 스모크 체크리스트(위 각 섹션 말미) 전부 통과
+- 다크/라이트 모드 각각 댓글 영역 육안 확인
+- 상세 모달 열기/닫기 반복 후 라쏘 기능 정상 (회귀 없음)
+
+---
+
+## 범위 외 (v1.13.0 백로그)
+
+다음 5개 이슈는 `docs/superpowers/specs/2026-04-22-v1.13.0-backlog.md` 로 분리:
+- 이슈 3: 메모 위젯 WYSIWYG 편집 (contentEditable + 에디터 라이브러리)
+- 이슈 4: 빌드된 앱 자동 로그인 실패 (빌드 환경 재현 필요)
+- 이슈 B: 연동 탭 UI 개선 (Supabase 체크 · 휴가관리 collapsible · 버튼 리디자인)
+- 이슈 C: 설정 탭 카테고리 재정리
+- 이슈 F: 삭제된 에피소드/파트/씬 댓글·메모 계승 버그 (DB 무결성 조사)
+- 이슈 7: 위젯 드롭다운 폰트 잘림 재확인 — 스킵(사용자 확인 시 증상 없음)

--- a/docs/superpowers/specs/2026-04-22-v1.13.0-backlog.md
+++ b/docs/superpowers/specs/2026-04-22-v1.13.0-backlog.md
@@ -14,6 +14,7 @@
 |----|------|------|----------|-----------|
 | 3 | 메모 위젯 WYSIWYG 편집 | 에디터 재설계 | 중 | 큼 (2~3일) |
 | 4 | 빌드된 앱 자동 로그인 실패 | 빌드 환경 버그 | 높음 | 중 (수 시간~1일) |
+| A2 | 댓글 입력란 Cowork 식 레이아웃 애니메이션 | UI 완성도 | 낮음 | 중 (수 시간) |
 | B | 연동 탭 UI 개선 | UI 재구성 | 중 | 중 (1일) |
 | C | 설정 탭 카테고리 재정리 | UI 재구성 | 낮음 | 중 (1일) |
 | F | 삭제된 엔티티 댓글·메모 계승 버그 | DB 무결성 | **높음** | 중 (1일) |
@@ -101,6 +102,35 @@
 
 ### 새 세션 시작 프롬프트 초안
 > "B flow 빌드된 Electron 앱에서 자동 로그인이 실패합니다. dev 는 정상이고 build 는 auth.json 을 못 읽는 듯합니다. `electron/main.ts`, `src/services/userService.ts:loadSession`, `src/App.tsx` 를 추적하고, 필요하면 빌드 산출물에 로그 추가해서 원인 찾아주세요. v1.12.1 에서 분리된 이슈 4 입니다."
+
+---
+
+## 이슈 A2: 댓글 입력란 Cowork 식 완전 레이아웃 애니메이션
+
+### 사용자 요청
+"Claude 데스크톱 Cowork UI 처럼 댓글 입력란이 커질 때 메시지 목록도 **같이 부드럽게 밀려 올라가는** 느낌을 원함."
+
+### 현재 상태 (v1.12.1 기준)
+- textarea 자체는 CSS `transition-[height] 150ms` + double RAF 패턴으로 부드럽게 자람
+- 하지만 textarea 를 감싸는 입력 영역 div 는 flex-col 부모 안에서 즉시 재분배되므로 메시지 목록(flex-1) 공간 축소가 즉각적 = "툭 튀는 느낌" 일부 잔존
+- v1.12.1 에서 framer-motion `layout` prop 시도했으나 vite dev HMR 에서 500 에러/reload 실패 → 롤백
+
+### 해결 방향 후보
+1. **framer-motion `layout` prop 안정화**: 왜 HMR 에서 500 이 났는지 재조사 후 적용. 가장 Cowork 에 가까운 결과. 
+   - `<motion.div layout>` 를 input container 에 적용 시 reload 실패 원인 파악 필요 (framer-motion 10.x 와 vite HMR 충돌?)
+2. **CSS `:has()` + grid-template-rows transition**: grid container + animated rows. grid-template-rows 는 transition 불가한 값이 많아 제한적.
+3. **React state 기반 height 관리 + ResizeObserver**: textarea 실제 높이 감지 → input 영역 컨테이너 height 를 state 로 설정 → CSS transition 적용. 복잡하지만 HMR 충돌 없음.
+4. **Cowork 실제 구현 분석**: Anthropic Claude 데스크톱의 실제 DOM 구조/애니메이션 기법 관찰 후 동일 패턴 적용.
+
+### 착수 지점
+- `src/components/scenes/CommentPanel.tsx` 입력 영역 div
+- 관련: v1.12.1 PR 의 CommentPanel 커밋 히스토리 (roll back 된 motion.div 구현 참고)
+
+### 위험
+낮음 — 기능 영향 없는 순수 UX 완성도 개선. 실패해도 v1.12.1 상태로 동작.
+
+### 새 세션 시작 프롬프트 초안
+> "B flow 댓글 입력란을 Claude 데스크톱 Cowork UI 같이 확장 시 메시지 목록이 부드럽게 밀려 올라가게 만들어주세요. v1.12.1 에서 framer-motion layout prop 으로 시도했으나 vite dev HMR 에서 500 에러로 롤백했습니다. 원인 재조사 또는 ResizeObserver 기반 다른 방식 설계 후 구현. `src/components/scenes/CommentPanel.tsx` 입력 영역."
 
 ---
 

--- a/docs/superpowers/specs/2026-04-22-v1.13.0-backlog.md
+++ b/docs/superpowers/specs/2026-04-22-v1.13.0-backlog.md
@@ -1,0 +1,201 @@
+# v1.13.0 백로그 — v1.12.1 에서 분리한 5개 이슈
+
+> **작성일**: 2026-04-22
+> **참조 PR**: `[v1.12.1] 6개 UI/UX 이슈 수정` 과 동시 작성
+> **목적**: 각 이슈가 새 세션에서 cold start 가능하도록 원인·스펙·착수 지점 기록
+>
+> v1.12.1 디자인 문서: `2026-04-22-v1.12.1-bugfixes-design.md`
+
+---
+
+## 백로그 항목 요약
+
+| ID | 제목 | 성격 | 우선순위 | 예상 공수 |
+|----|------|------|----------|-----------|
+| 3 | 메모 위젯 WYSIWYG 편집 | 에디터 재설계 | 중 | 큼 (2~3일) |
+| 4 | 빌드된 앱 자동 로그인 실패 | 빌드 환경 버그 | 높음 | 중 (수 시간~1일) |
+| B | 연동 탭 UI 개선 | UI 재구성 | 중 | 중 (1일) |
+| C | 설정 탭 카테고리 재정리 | UI 재구성 | 낮음 | 중 (1일) |
+| F | 삭제된 엔티티 댓글·메모 계승 버그 | DB 무결성 | **높음** | 중 (1일) |
+
+이슈 7(위젯 드롭다운 폰트 잘림 재확인)은 사용자 확인 결과 현재 증상 없어 **클로즈**.
+
+---
+
+## 이슈 3: 메모 위젯 WYSIWYG 편집
+
+### 사용자 요청
+"메모 위젯에서 **버튼을 누르면 마크다운이 적용된 결과**(볼드/이탤릭/밑줄/취소선)가 편집 중에도 **그대로 보여야 한다**. 지금은 버튼을 눌러도 `**텍스트**` 같은 raw 기호가 그대로 노출된다."
+
+### 현재 상태 (참고용)
+`src/components/widgets/MemoWidget.tsx` 에는 이미:
+- 툴바 `FormatToolbar` (Bold/Italic/Underline/Strikethrough 4개 버튼)
+- `applyMarkdown` — 선택 영역을 `**`, `*`, `__`, `~~` 로 감싸는 헬퍼
+- `inlineFormat` — regex 기반 인라인 마크다운 렌더러
+- `SimpleMarkdown` — 줄 단위 ul/ol/텍스트 처리
+- `previewMode` 토글 (눈/연필 아이콘) 로 편집 ↔ 미리보기 전환
+
+즉 **렌더링은 되어 있으나 편집 중엔 raw 마크다운만 보이는 textarea 구조**. 사용자는 WYSIWYG 를 기대.
+
+### 해결 방향 (설계 필요)
+`<textarea>` → `<div contentEditable="true">` 로 교체하고 서식 버튼은 `document.execCommand` 또는 Selection API 로 구현. 가이드:
+1. **에디터 라이브러리 선택**: TipTap(ProseMirror), Lexical(Meta), Slate 등 후보 비교. 번들 크기·학습 곡선·커스터마이즈 편의 기준.
+2. **저장 형식 결정**: Markdown raw 로 유지(현재 Supabase `memo.tabs[].content` 가 문자열) vs HTML 저장 vs JSON AST. Markdown 유지 시 변환 과정(HTML↔MD) 필요.
+3. **호환성 검증**:
+   - 탭 중복/전환 시 에디터 state 재초기화
+   - Supabase 동기화(debounce 저장)
+   - `memo-sync` storage 이벤트로 외부 변경 반영
+   - 폰트 슬라이더(10~24px) 호환
+   - 기존 `**`, `__` 등 raw 저장 데이터 읽기 호환 (마이그레이션 불필요하도록 Markdown 유지 권장)
+4. **테스트**: 멀티라인 붙여넣기, 줄바꿈, 서식 토글(on/off), undo/redo, 탭 전환 시 상태 유지, 미리보기 모드 유지 여부.
+
+### 착수 지점
+- `src/components/widgets/MemoWidget.tsx` — 전체 재작성 아닌 점진적 전환 권장.
+- 관련 store: `src/services/supabaseService.ts` 의 `upsertMemo`/`readMemo`.
+
+### 위험
+- contentEditable 브라우저별 동작 차이 (Chrome/Electron 환경이라 한 종류만 대응하면 됨)
+- 기존 데이터 호환 — Markdown 저장 유지하면 안전
+- 번들 크기 증가 — Lexical ~80KB, TipTap ~100KB
+
+### 새 세션 시작 프롬프트 초안
+> "B flow MemoWidget 에 WYSIWYG 편집을 도입해주세요. 현재 textarea + 툴바 구조(src/components/widgets/MemoWidget.tsx)로 버튼 누르면 raw 마크다운만 보이는데, 편집 중에도 볼드/이탤릭/밑줄/취소선이 적용된 결과가 보여야 합니다. Supabase 동기화·탭·폰트 슬라이더·미리보기 토글과의 호환성 유지. 디자인부터 승인 후 구현."
+
+---
+
+## 이슈 4: 빌드된 앱 자동 로그인 실패
+
+### 사용자 요청
+"빌드된 Electron 앱에서 **자동 로그인이 제대로 작동하지 않음**. `npm run electron:dev` 에서는 정상."
+
+### 의심 경로
+- `src/services/userService.ts:181-198` `loadSession`
+- `src/App.tsx:420-427` 세션 복원 분기
+- `electron/main.ts:38` `app.name = 'Bflow-BGonly'` (v1.11.1 에서 추가됨)
+- `%APPDATA%\Bflow-BGonly\auth.json` 실제 경로가 dev/prod 일치하는지
+
+### 가능성 있는 원인 (후보)
+1. **asar: false + npm rebuild 비활성화 조합**에서 preload 경로 해석 실패 — `electronAPI` 없어 `readSettings('auth.json')` 호출 자체가 불가.
+2. **app.name 설정 타이밍**: `app.whenReady()` 전후 타이밍에 따라 `app.getPath('userData')` 가 다른 디렉토리로 해석될 가능성.
+3. **portable 빌드 격리**: `portable` 타깃은 매 실행 시 임시 dir 로 전개되는데, userData 는 실제 AppData 를 써야 하는데 바뀌었을 수 있음.
+4. **파일 읽기 시점**: 렌더러 `App.tsx` 가 `loadSession` 호출할 때 main 에서 파일이 아직 준비 안 됐거나 에러 무시하고 null 반환.
+
+### 재현 & 진단 프로토콜
+1. `npm run build` (electron-builder) 실행 → `dist/` 산출물 생성
+2. 산출물 실행하면서 **Windows 이벤트 뷰어** 또는 `process.stdout` 강제 활성화 (portable 에선 콘솔 로그 숨김 가능)
+3. `console.log` 를 일시적으로 `fs.appendFileSync('log.txt', ...)` 로 바꿔 앱 폴더에 로그 출력
+4. 확인 포인트:
+   - `electron/main.ts` 에서 실제 `app.getPath('userData')` 값
+   - `readSettings('auth.json')` 반환값(null/object)
+   - `App.tsx` 에서 `loadSession` 반환값 및 분기 진입 여부
+5. v1.11.1 PR(#30) diff 확인해서 기존 조치 내역 재검토
+
+### 착수 지점
+- `electron/main.ts` — IPC `settings:read` 핸들러
+- `src/services/userService.ts` `loadSession`
+- `src/App.tsx` 초기화 effect
+
+### 위험
+- 빌드 환경 재현에 시간 소요 (electron-builder 빌드 ~5분)
+- 플랫폼/사용자 PC 환경차 가능성 (Windows 11 Pro 기준 테스트)
+
+### 새 세션 시작 프롬프트 초안
+> "B flow 빌드된 Electron 앱에서 자동 로그인이 실패합니다. dev 는 정상이고 build 는 auth.json 을 못 읽는 듯합니다. `electron/main.ts`, `src/services/userService.ts:loadSession`, `src/App.tsx` 를 추적하고, 필요하면 빌드 산출물에 로그 추가해서 원인 찾아주세요. v1.12.1 에서 분리된 이슈 4 입니다."
+
+---
+
+## 이슈 B: 연동 탭 UI 개선
+
+### 사용자 요청
+원문:
+> - 데이터서버 연동 → Supabase 각 항목별 연동 체크표시 (대시보드 스타일)
+> - 휴가관리 API 입력 칸은 기본적으로 접혀있도록 (collapsible)
+> - 연결 테스트, 설정저장 등 버튼은 기존 디자인 톤에 맞게 전문적인 디자인으로 배치
+
+### 의도 해석
+1. Supabase 연동 상태를 **항목별**(URL/Key/Realtime/Storage 등)로 그린라이트/레드라이트 체크
+2. 휴가관리 API 섹션은 평상시에는 접혀있고 필요할 때 펼치기 (접근성 낮은 설정)
+3. 액션 버튼(연결 테스트·저장)은 현재 디자인 톤(유리감·그라데이션·accent 색)에 맞춰 재정렬·재디자인
+
+### 착수 지점
+- `src/components/settings/SheetsSection.tsx` (Supabase 연동 영역)
+- `src/components/settings/SettingsSection.tsx` / `SettingsSidebar.tsx`
+- 관련 서비스: `src/services/supabaseService.ts`, `electron/supabase.ts`
+
+### 선행 설계 필요
+- 항목별 체크 대상(어떤 호출을 ping 으로 볼지) 정의
+- collapsible 기본 상태 유지 메커니즘(열림 상태를 preferences.json에 저장?)
+- 버튼 디자인 시스템(현재 `bg-accent`, `bg-bg-card hover:bg-bg-border` 등 패턴) 정리
+
+### 새 세션 시작 프롬프트 초안
+> "B flow 설정 > 연동 탭 UI 개선 작업입니다. Supabase 항목별 연동 체크 대시보드, 휴가관리 API 섹션 collapsible, 버튼 디자인 정돈. `src/components/settings/SheetsSection.tsx` 근처를 재구성해주세요. 브레인스토밍 필요."
+
+---
+
+## 이슈 C: 설정 탭 카테고리 재정리
+
+### 사용자 요청
+원문:
+> 설정 탭 정리 — 각 카테고리별 그룹핑 및 순서, 배치 조율
+
+### 현재 구조 (참고)
+`src/components/settings/SettingsSidebar.tsx` + 각 `*Section.tsx`:
+- ProfileSection, LoginSection, ThemeSection, FontColorSection, FontSizeSection, EffectsSection, GuideSection, NotificationSection, SheetsSection, ShortcutsSection, StartupSection
+
+### 설계 과제
+- 어떤 그룹을 만들지 (예: 개인화 / 연동 / 편의기능 / 시작 옵션)
+- 각 그룹 내 순서(자주 쓰는 것 상단)
+- 기존 URL 해시/탭 id 호환 유지
+
+### 선행 필요
+- 사용자에게 그룹 정의/순서 확인 (브레인스토밍)
+- 기존 진입 경로(도움말 딥링크 등) 영향 체크
+
+### 새 세션 시작 프롬프트 초안
+> "B flow 설정 탭 카테고리 재정리 작업입니다. 11개 섹션을 그룹핑하고 순서를 조율합니다. `src/components/settings/` 확인 후 브레인스토밍부터."
+
+---
+
+## 이슈 F: 삭제된 에피소드/파트/씬 댓글·메모 계승 버그
+
+### 사용자 제보
+> 에피소드, 파트, 씬을 삭제한 뒤 **같은 이름으로 새로 만들면 이전에 달았던 댓글이나 메모가 그대로 남아 있음**. ID 재사용 또는 삭제 시 연관 데이터 미정리 의심.
+
+### 원인 후보
+1. **댓글·메모의 키가 비자연적 (sheetName:sceneNo 기반 문자열)**: UUID가 아니라 인덱스/이름 기반이면 같은 번호 재생성 시 매핑됨.
+   - 관련: `src/components/scenes/CommentPanel.tsx` 의 `sceneKey = \`${sheetName}:${scene.no}\``
+2. **파트/에피소드 삭제 시 Supabase CASCADE 미설정**: `comments`/`memos`/`revisions` 테이블에 FK CASCADE 없으면 parent 삭제 후 orphan 데이터가 남음.
+3. **Soft-delete vs hard-delete**: 삭제가 soft-delete 라면 같은 이름 생성 시 숨겨진 행과 충돌.
+
+### 진단 프로토콜
+1. Supabase Studio 에서 관련 테이블 스키마(FK, CASCADE) 확인
+2. 테스트 케이스:
+   - 씬 생성 → 댓글 3개 → 씬 삭제 → 같은 sceneId 로 재생성 → 댓글 존재 여부
+   - 파트 삭제 → 재생성 → 댓글·메모 확인
+   - 에피소드 삭제 → 재생성
+3. 서비스 레이어 `deleteScene`, `deletePart`, `deleteEpisode` 에서 연관 데이터 정리 호출 여부 점검
+
+### 해결 방향 (후보)
+- **키 정규화**: 댓글/메모 키를 scene UUID 기반으로 전환 (큰 마이그레이션)
+- **CASCADE FK 설정**: parent 삭제 시 DB 레벨에서 자동 정리 (서버 마이그레이션 필요)
+- **삭제 시 연관 데이터 삭제 호출 추가**: 앱 레이어에서 명시적으로 deleteCommentsByScene 등
+
+### 착수 지점
+- Supabase 스키마 확인 → `DEVLOG/supabase-init.sql`
+- 삭제 서비스: `src/services/supabaseService.ts`, `electron/supabase.ts`
+- 댓글/메모 키 사용처 grep: `getComments`, `upsertMemo`
+
+### 위험 (높음)
+- 프로덕션 데이터 마이그레이션 가능성 → 백업 필수
+- 기존 댓글 키 변경 시 이관 스크립트 필요
+
+### 새 세션 시작 프롬프트 초안
+> "B flow 데이터 무결성 버그. 에피소드/파트/씬 삭제 후 같은 이름으로 재생성하면 이전 댓글·메모가 계승됩니다. Supabase 스키마(FK CASCADE)와 삭제 서비스를 조사해 근본 원인 확인 후 해결 방향 제안부터. 프로덕션 영향 있을 수 있어 백업·드라이런 필수."
+
+---
+
+## 다음 액션
+
+1. v1.12.1 PR 머지 후 이 백로그 문서는 리포에 남겨둠 (검색 가능한 상태로)
+2. 각 이슈는 **우선순위 F > 4 > B > 3 > C** 순서 권장 (사용자 영향도 기준)
+3. 각 이슈는 새 워크트리 + 새 세션에서 착수. 위 "새 세션 시작 프롬프트 초안" 참고.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/components/scenes/CommentPanel.tsx
+++ b/src/components/scenes/CommentPanel.tsx
@@ -111,9 +111,9 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
     setComments(next);
     onCountChange?.(next.length);
     setInput('');
-    // 전송 후 입력란을 min-height(32px) 로 부드럽게 축소
+    // 전송 후 입력란 높이 초기화
     if (inputRef.current) {
-      inputRef.current.style.height = '';
+      inputRef.current.style.height = 'auto';
     }
     setShowMentions(false);
 
@@ -202,23 +202,12 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
   // @멘션 감지
   const handleInputChange = (text: string) => {
     setInput(text);
-    // 입력란 높이: double requestAnimationFrame 으로 transition 강제 발동.
-    // `height='auto'` 직후 바로 px 을 지정하면 브라우저가 같은 프레임에 두 값을 덮어써
-    // transition 이 출발점을 잃는다. 아래 패턴은 한 프레임 동안 "현재 높이" 를 명시적
-    // 으로 유지해 커밋시킨 뒤 다음 프레임에서 새 높이로 변경 → CSS 가 px→px 전환으로
-    // 인식해 transition-[height] 가 정상 발동한다.
+    // 입력란 auto-grow (애니메이션 없이 즉시 리사이즈).
+    // Cowork 식 부드러운 전환은 v1.13.0 백로그 이슈 A2 에서 리팩토링 예정.
     const ta = inputRef.current;
     if (ta) {
-      const currentHeight = ta.offsetHeight;
       ta.style.height = 'auto';
-      const target = Math.min(ta.scrollHeight, 200);
-      ta.style.height = `${currentHeight}px`;
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          const ref = inputRef.current;
-          if (ref) ref.style.height = `${target}px`;
-        });
-      });
+      ta.style.height = `${Math.min(ta.scrollHeight, 200)}px`;
     }
     const lastAt = text.lastIndexOf('@');
     if (lastAt >= 0) {
@@ -414,7 +403,7 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
             value={input}
             onChange={(e) => handleInputChange(e.target.value)}
             placeholder="댓글 입력..."
-            className="flex-1 bg-bg-primary border border-bg-border rounded-xl px-3 py-2 text-xs text-text-primary placeholder:text-text-secondary/40 resize-none focus:outline-none focus:border-accent min-h-[32px] max-h-[200px] overflow-y-auto transition-[height] duration-150 ease-out"
+            className="flex-1 bg-bg-primary border border-bg-border rounded-xl px-3 py-2 text-xs text-text-primary placeholder:text-text-secondary/40 resize-none focus:outline-none focus:border-accent min-h-[32px] max-h-[200px] overflow-y-auto"
             onKeyDown={(e) => {
               // @멘션 드롭다운 키보드 탐색
               if (showMentions && filteredUsers.length > 0) {

--- a/src/components/scenes/CommentPanel.tsx
+++ b/src/components/scenes/CommentPanel.tsx
@@ -341,11 +341,9 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
                       </div>
                     ) : (
                       <div
-                        className="rounded-xl px-3.5 py-2.5 text-xs leading-relaxed break-words"
-                        style={{
-                          backgroundColor: isOwn ? 'rgba(16, 185, 129, 0.18)' : '#2A2A35',
-                          color: 'rgb(var(--color-text-primary))',
-                        }}
+                        className={`rounded-xl px-3.5 py-2.5 text-xs leading-relaxed break-words text-text-primary ${
+                          isOwn ? 'bg-emerald-500/20' : 'bg-bg-border/70'
+                        }`}
                       >
                         {renderText(comment.text)}
                       </div>

--- a/src/components/scenes/CommentPanel.tsx
+++ b/src/components/scenes/CommentPanel.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { motion } from 'framer-motion';
 import { Pencil, Trash2 } from 'lucide-react';
 import { useAuthStore } from '@/stores/useAuthStore';
 import { useAppStore } from '@/stores/useAppStore';
@@ -203,15 +202,23 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
   // @멘션 감지
   const handleInputChange = (text: string) => {
     setInput(text);
-    // 입력란 높이: textarea scrollHeight 기준 즉시 px 설정.
-    // 부드러운 애니메이션은 부모 motion.div 의 `layout` prop 이 담당한다 — textarea
-    // 크기 변화 → 부모 input 영역 컨테이너의 height 변화를 framer-motion 이 프레임
-    // 간 보간해 스무스한 transition 을 만들어줌. textarea 자체에 transition 을 걸면
-    // layout 애니메이션과 충돌해 "이중 보간" 이 되므로 textarea 는 즉시 반영만.
+    // 입력란 높이: double requestAnimationFrame 으로 transition 강제 발동.
+    // `height='auto'` 직후 바로 px 을 지정하면 브라우저가 같은 프레임에 두 값을 덮어써
+    // transition 이 출발점을 잃는다. 아래 패턴은 한 프레임 동안 "현재 높이" 를 명시적
+    // 으로 유지해 커밋시킨 뒤 다음 프레임에서 새 높이로 변경 → CSS 가 px→px 전환으로
+    // 인식해 transition-[height] 가 정상 발동한다.
     const ta = inputRef.current;
     if (ta) {
+      const currentHeight = ta.offsetHeight;
       ta.style.height = 'auto';
-      ta.style.height = `${Math.min(ta.scrollHeight, 200)}px`;
+      const target = Math.min(ta.scrollHeight, 200);
+      ta.style.height = `${currentHeight}px`;
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          const ref = inputRef.current;
+          if (ref) ref.style.height = `${target}px`;
+        });
+      });
     }
     const lastAt = text.lastIndexOf('@');
     if (lastAt >= 0) {
@@ -382,14 +389,8 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
         )}
       </div>
 
-      {/* 입력 영역 — motion.div layout 으로 높이 변화를 자동 애니메이션.
-          textarea 자체는 즉시 리사이즈되고 parent 의 layout 변화가 부드럽게 보간되어
-          메시지 목록까지 같이 밀려 내려가는 Cowork 식 동작이 나온다. */}
-      <motion.div
-        layout
-        transition={{ type: 'tween', duration: 0.15, ease: 'easeOut' }}
-        className="px-4 py-3 border-t border-bg-border relative"
-      >
+      {/* 입력 영역 */}
+      <div className="px-4 py-3 border-t border-bg-border relative">
         {/* @멘션 자동완성 */}
         {showMentions && filteredUsers.length > 0 && (
           <div ref={mentionDropdownRef} className="absolute bottom-full left-4 right-4 mb-1 bg-bg-card border border-bg-border rounded-lg shadow-lg max-h-32 overflow-y-auto z-10">
@@ -413,7 +414,7 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
             value={input}
             onChange={(e) => handleInputChange(e.target.value)}
             placeholder="댓글 입력..."
-            className="flex-1 bg-bg-primary border border-bg-border rounded-xl px-3 py-2 text-xs text-text-primary placeholder:text-text-secondary/40 resize-none focus:outline-none focus:border-accent min-h-[32px] max-h-[200px] overflow-y-auto"
+            className="flex-1 bg-bg-primary border border-bg-border rounded-xl px-3 py-2 text-xs text-text-primary placeholder:text-text-secondary/40 resize-none focus:outline-none focus:border-accent min-h-[32px] max-h-[200px] overflow-y-auto transition-[height] duration-150 ease-out"
             onKeyDown={(e) => {
               // @멘션 드롭다운 키보드 탐색
               if (showMentions && filteredUsers.length > 0) {
@@ -456,7 +457,7 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
             )}
           </button>
         </div>
-      </motion.div>
+      </div>
     </div>
   );
 }

--- a/src/components/scenes/CommentPanel.tsx
+++ b/src/components/scenes/CommentPanel.tsx
@@ -111,7 +111,10 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
     setComments(next);
     onCountChange?.(next.length);
     setInput('');
-    // field-sizing: content 가 자동으로 다시 min-h 로 축소 — 수동 리셋 불필요
+    // 전송 후 입력란을 min-height(32px) 로 부드럽게 축소
+    if (inputRef.current) {
+      inputRef.current.style.height = '';
+    }
     setShowMentions(false);
 
     try {
@@ -199,8 +202,27 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
   // @멘션 감지
   const handleInputChange = (text: string) => {
     setInput(text);
-    // 높이 조절은 CSS `field-sizing: content` 가 담당 — JS auto-grow 불필요
-    // (이전 `style.height = 'auto'` 리셋 방식은 transition 을 깨뜨려 툭툭 튀는 현상이 있었음)
+    // ── 입력란 높이 부드러운 자동 조절 ──
+    //
+    // 순진하게 `height='auto'` → `height=newPx` 만 하면 transition 의 "시작 지점"이
+    // auto 라서 애니메이션이 깨진다 (툭툭 튀는 현상).
+    //
+    // 해결: (1) transition 을 잠깐 끄고, (2) auto 로 scrollHeight 측정 후 (3) 이전
+    // 높이를 복원한 상태로 force reflow 해 브라우저에 "현재 상태 = 이전 높이" 로
+    // 고정. (4) transition 복원 + 목표 높이 지정 → 브라우저가 px→px 전환으로 인식해
+    // 지정된 150ms ease-out 을 제대로 발동한다.
+    const ta = inputRef.current;
+    if (ta) {
+      const prev = ta.style.height;
+      ta.style.transition = 'none';
+      ta.style.height = 'auto';
+      const target = Math.min(ta.scrollHeight, 200);
+      ta.style.height = prev || `${target}px`;
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      ta.offsetHeight; // force reflow
+      ta.style.transition = '';
+      ta.style.height = `${target}px`;
+    }
     const lastAt = text.lastIndexOf('@');
     if (lastAt >= 0) {
       const afterAt = text.slice(lastAt + 1);
@@ -395,7 +417,7 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
             value={input}
             onChange={(e) => handleInputChange(e.target.value)}
             placeholder="댓글 입력..."
-            className="flex-1 bg-bg-primary border border-bg-border rounded-xl px-3 py-2 text-xs text-text-primary placeholder:text-text-secondary/40 resize-none focus:outline-none focus:border-accent min-h-[32px] max-h-[200px] overflow-y-auto field-sizing-content transition-[height] duration-150 ease-out"
+            className="flex-1 bg-bg-primary border border-bg-border rounded-xl px-3 py-2 text-xs text-text-primary placeholder:text-text-secondary/40 resize-none focus:outline-none focus:border-accent min-h-[32px] max-h-[200px] overflow-y-auto transition-[height] duration-150 ease-out"
             onKeyDown={(e) => {
               // @멘션 드롭다운 키보드 탐색
               if (showMentions && filteredUsers.length > 0) {

--- a/src/components/scenes/CommentPanel.tsx
+++ b/src/components/scenes/CommentPanel.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { motion } from 'framer-motion';
 import { Pencil, Trash2 } from 'lucide-react';
 import { useAuthStore } from '@/stores/useAuthStore';
 import { useAppStore } from '@/stores/useAppStore';
@@ -202,26 +203,15 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
   // @멘션 감지
   const handleInputChange = (text: string) => {
     setInput(text);
-    // ── 입력란 높이 부드러운 자동 조절 ──
-    //
-    // 순진하게 `height='auto'` → `height=newPx` 만 하면 transition 의 "시작 지점"이
-    // auto 라서 애니메이션이 깨진다 (툭툭 튀는 현상).
-    //
-    // 해결: (1) transition 을 잠깐 끄고, (2) auto 로 scrollHeight 측정 후 (3) 이전
-    // 높이를 복원한 상태로 force reflow 해 브라우저에 "현재 상태 = 이전 높이" 로
-    // 고정. (4) transition 복원 + 목표 높이 지정 → 브라우저가 px→px 전환으로 인식해
-    // 지정된 150ms ease-out 을 제대로 발동한다.
+    // 입력란 높이: textarea scrollHeight 기준 즉시 px 설정.
+    // 부드러운 애니메이션은 부모 motion.div 의 `layout` prop 이 담당한다 — textarea
+    // 크기 변화 → 부모 input 영역 컨테이너의 height 변화를 framer-motion 이 프레임
+    // 간 보간해 스무스한 transition 을 만들어줌. textarea 자체에 transition 을 걸면
+    // layout 애니메이션과 충돌해 "이중 보간" 이 되므로 textarea 는 즉시 반영만.
     const ta = inputRef.current;
     if (ta) {
-      const prev = ta.style.height;
-      ta.style.transition = 'none';
       ta.style.height = 'auto';
-      const target = Math.min(ta.scrollHeight, 200);
-      ta.style.height = prev || `${target}px`;
-      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-      ta.offsetHeight; // force reflow
-      ta.style.transition = '';
-      ta.style.height = `${target}px`;
+      ta.style.height = `${Math.min(ta.scrollHeight, 200)}px`;
     }
     const lastAt = text.lastIndexOf('@');
     if (lastAt >= 0) {
@@ -392,8 +382,14 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
         )}
       </div>
 
-      {/* 입력 영역 */}
-      <div className="px-4 py-3 border-t border-bg-border relative">
+      {/* 입력 영역 — motion.div layout 으로 높이 변화를 자동 애니메이션.
+          textarea 자체는 즉시 리사이즈되고 parent 의 layout 변화가 부드럽게 보간되어
+          메시지 목록까지 같이 밀려 내려가는 Cowork 식 동작이 나온다. */}
+      <motion.div
+        layout
+        transition={{ type: 'tween', duration: 0.15, ease: 'easeOut' }}
+        className="px-4 py-3 border-t border-bg-border relative"
+      >
         {/* @멘션 자동완성 */}
         {showMentions && filteredUsers.length > 0 && (
           <div ref={mentionDropdownRef} className="absolute bottom-full left-4 right-4 mb-1 bg-bg-card border border-bg-border rounded-lg shadow-lg max-h-32 overflow-y-auto z-10">
@@ -417,7 +413,7 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
             value={input}
             onChange={(e) => handleInputChange(e.target.value)}
             placeholder="댓글 입력..."
-            className="flex-1 bg-bg-primary border border-bg-border rounded-xl px-3 py-2 text-xs text-text-primary placeholder:text-text-secondary/40 resize-none focus:outline-none focus:border-accent min-h-[32px] max-h-[200px] overflow-y-auto transition-[height] duration-150 ease-out"
+            className="flex-1 bg-bg-primary border border-bg-border rounded-xl px-3 py-2 text-xs text-text-primary placeholder:text-text-secondary/40 resize-none focus:outline-none focus:border-accent min-h-[32px] max-h-[200px] overflow-y-auto"
             onKeyDown={(e) => {
               // @멘션 드롭다운 키보드 탐색
               if (showMentions && filteredUsers.length > 0) {
@@ -460,7 +456,7 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
             )}
           </button>
         </div>
-      </div>
+      </motion.div>
     </div>
   );
 }

--- a/src/components/scenes/CommentPanel.tsx
+++ b/src/components/scenes/CommentPanel.tsx
@@ -205,7 +205,7 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
     const ta = inputRef.current;
     if (ta) {
       ta.style.height = 'auto';
-      ta.style.height = `${Math.min(ta.scrollHeight, 96)}px`;
+      ta.style.height = `${Math.min(ta.scrollHeight, 200)}px`;
     }
     const lastAt = text.lastIndexOf('@');
     if (lastAt >= 0) {
@@ -401,7 +401,7 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
             value={input}
             onChange={(e) => handleInputChange(e.target.value)}
             placeholder="댓글 입력..."
-            className="flex-1 bg-bg-primary border border-bg-border rounded-xl px-3 py-2 text-xs text-text-primary placeholder:text-text-secondary/40 resize-none focus:outline-none focus:border-accent min-h-[32px] max-h-24 overflow-y-auto"
+            className="flex-1 bg-bg-primary border border-bg-border rounded-xl px-3 py-2 text-xs text-text-primary placeholder:text-text-secondary/40 resize-none focus:outline-none focus:border-accent min-h-[32px] max-h-[200px] overflow-y-auto transition-[height] duration-150 ease-out"
             onKeyDown={(e) => {
               // @멘션 드롭다운 키보드 탐색
               if (showMentions && filteredUsers.length > 0) {

--- a/src/components/scenes/CommentPanel.tsx
+++ b/src/components/scenes/CommentPanel.tsx
@@ -111,9 +111,7 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
     setComments(next);
     onCountChange?.(next.length);
     setInput('');
-    if (inputRef.current) {
-      inputRef.current.style.height = 'auto';
-    }
+    // field-sizing: content 가 자동으로 다시 min-h 로 축소 — 수동 리셋 불필요
     setShowMentions(false);
 
     try {
@@ -201,12 +199,8 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
   // @멘션 감지
   const handleInputChange = (text: string) => {
     setInput(text);
-    // Auto-grow textarea (모든 키 입력 시 실행 — 멘션 드롭다운 중에도)
-    const ta = inputRef.current;
-    if (ta) {
-      ta.style.height = 'auto';
-      ta.style.height = `${Math.min(ta.scrollHeight, 200)}px`;
-    }
+    // 높이 조절은 CSS `field-sizing: content` 가 담당 — JS auto-grow 불필요
+    // (이전 `style.height = 'auto'` 리셋 방식은 transition 을 깨뜨려 툭툭 튀는 현상이 있었음)
     const lastAt = text.lastIndexOf('@');
     if (lastAt >= 0) {
       const afterAt = text.slice(lastAt + 1);
@@ -266,8 +260,8 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
 
   return (
     <div className="flex flex-col h-full">
-      {/* 댓글 목록 — 채팅 스타일 */}
-      <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-3 space-y-4 min-h-0">
+      {/* 댓글 목록 — 채팅 스타일. select-text: 말풍선·이름·시간 모두 드래그 선택 가능 (복사용) */}
+      <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-3 space-y-4 min-h-0 select-text">
         {comments.length === 0 ? (
           <div className="text-center py-10">
             <p className="text-text-secondary text-xs">아직 의견이 없습니다</p>
@@ -401,7 +395,7 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
             value={input}
             onChange={(e) => handleInputChange(e.target.value)}
             placeholder="댓글 입력..."
-            className="flex-1 bg-bg-primary border border-bg-border rounded-xl px-3 py-2 text-xs text-text-primary placeholder:text-text-secondary/40 resize-none focus:outline-none focus:border-accent min-h-[32px] max-h-[200px] overflow-y-auto transition-[height] duration-150 ease-out"
+            className="flex-1 bg-bg-primary border border-bg-border rounded-xl px-3 py-2 text-xs text-text-primary placeholder:text-text-secondary/40 resize-none focus:outline-none focus:border-accent min-h-[32px] max-h-[200px] overflow-y-auto field-sizing-content transition-[height] duration-150 ease-out"
             onKeyDown={(e) => {
               // @멘션 드롭다운 키보드 탐색
               if (showMentions && filteredUsers.length > 0) {

--- a/src/components/scenes/SceneDetailModal.tsx
+++ b/src/components/scenes/SceneDetailModal.tsx
@@ -665,9 +665,10 @@ export function SceneDetailModal({
 
   return (
     <AnimatePresence>
-      {/* 백드롭 */}
+      {/* 백드롭 — data-no-lasso: 모달 내부 드래그가 뒤쪽 씬 그리드 라쏘를 트리거하지 않도록 */}
       <motion.div
         key="detail-backdrop"
+        data-no-lasso
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}

--- a/src/components/scenes/UnifiedSceneCard.tsx
+++ b/src/components/scenes/UnifiedSceneCard.tsx
@@ -278,7 +278,7 @@ function DeptSection({
         </div>
         <div className="flex rounded-lg bg-bg-primary/70 border border-bg-border/40 p-1 gap-0.5">
           {STAGES.map((stage) => (
-            <div key={stage} className="flex-1 text-center py-1.5 text-[11px] font-medium text-text-secondary/30 rounded-md">
+            <div key={stage} className="flex-1 min-w-0 text-center py-1.5 text-[11px] font-medium text-text-secondary/30 rounded-md whitespace-nowrap overflow-hidden text-ellipsis">
               {cfg.stageLabels[stage]}
             </div>
           ))}
@@ -317,7 +317,7 @@ function DeptSection({
               key={stage}
               onClick={(e) => { e.stopPropagation(); onToggle(sheetName, sceneId, stage); }}
               className={cn(
-                'flex-1 text-center py-2 text-[11px] font-medium rounded-md transition-all cursor-pointer',
+                'flex-1 min-w-0 text-center py-2 text-[11px] font-medium rounded-md transition-all cursor-pointer whitespace-nowrap overflow-hidden text-ellipsis',
                 !isDone && 'text-text-secondary/60 hover:text-text-primary hover:bg-bg-border/25',
                 stageCellPendingClass(stage),
               )}

--- a/src/components/scenes/UnifiedSceneDetailModal.tsx
+++ b/src/components/scenes/UnifiedSceneDetailModal.tsx
@@ -225,7 +225,9 @@ export function UnifiedSceneDetailModal({
 
   return (
     <AnimatePresence>
+      {/* data-no-lasso: 모달 내부 드래그가 뒤쪽 씬 그리드 라쏘를 트리거하지 않도록 */}
       <motion.div
+        data-no-lasso
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}

--- a/src/index.css
+++ b/src/index.css
@@ -109,6 +109,19 @@ input, textarea, select, [contenteditable="true"] {
   -webkit-user-select: text;
   user-select: text;
 }
+/* .select-text 유틸을 붙인 요소와 그 자식들은 텍스트 드래그 선택 허용
+   (전역 `* { user-select: none }` 이 자식들까지 덮기 때문에 children 까지 명시적으로 풀어줘야 한다.
+   댓글 말풍선·상세 모달 읽기 영역 등에서 복사 붙여넣기가 가능해야 하는 경우 사용) */
+.select-text,
+.select-text * {
+  -webkit-user-select: text;
+  user-select: text;
+}
+
+/* textarea content 기반 자동 리사이즈 — JS auto-grow 없이 부드러운 CSS transition 유지 */
+.field-sizing-content {
+  field-sizing: content;
+}
 
 /* ─── 라이트↔다크 전환 트랜지션 ─── */
 body.theme-ready *,

--- a/src/index.css
+++ b/src/index.css
@@ -118,11 +118,6 @@ input, textarea, select, [contenteditable="true"] {
   user-select: text;
 }
 
-/* textarea content 기반 자동 리사이즈 — JS auto-grow 없이 부드러운 CSS transition 유지 */
-.field-sizing-content {
-  field-sizing: content;
-}
-
 /* ─── 라이트↔다크 전환 트랜지션 ─── */
 body.theme-ready *,
 body.theme-ready *::before,

--- a/src/views/TeamView.tsx
+++ b/src/views/TeamView.tsx
@@ -333,7 +333,7 @@ export function TeamView() {
     highlightUserName, setHighlightUserName,
   } = useAppStore();
 
-  const [sortBy, setSortBy] = useState<SortOption>('scenes');
+  const [sortBy, setSortBy] = useState<SortOption>('seniority');
   const [sortAsc, setSortAsc] = useState(false);
 
   // 하이라이트 대상 ref


### PR DESCRIPTION
## 📋 업데이트 요약

> 이번 패치에서 달라진 점을 간략하게 정리했습니다.

- 🐛 **상세 모달 안에서 댓글 드래그 복구** — 씬 상세 팝업에서 댓글 글자·이름·시간을 드래그해서 복사할 수 있게 됐습니다
- 🐛 **모달 열린 상태에서 뒤 씬 그리드가 흔들리던 문제 해결** — 상세 모달 안을 드래그해도 뒤쪽 씬이 라쏘로 선택되지 않습니다
- 🐛 **액팅(ACT) 단계 라벨이 세로로 쪼개 보이던 문제 수정** — LO/완료/검수/PNG 라벨이 항상 한 줄로 표시됩니다
- ✨ **댓글 입력란 최대 높이 확장** — 약 4줄(96px) → 10줄(200px)까지 자랄 수 있고, 초과 시 내부 스크롤
- ✨ **팀원 뷰 기본 정렬을 짬순으로 변경** — 첫 진입 시 근속 순서대로 표시됩니다 (이전에는 씬 개수 순)
- 🐛 **라이트 모드 댓글 말풍선 배경 수정** — 남이 단 댓글 배경이 라이트 모드에서도 자연스러운 회색으로 보입니다

## 🔧 상세 기술 설명

### 이슈 1, 2 · 상세 모달 드래그 누수 차단
2단계로 수정. 처음엔 `useLassoSelection` (ScenesView.tsx) 훅만 원인으로 봤으나 스모크 테스트 결과 텍스트 선택은 여전히 막힘. 실제로는 두 레이어가 함께 막고 있었음:

1. **1차 수정 — data-no-lasso 마커**: `SceneDetailModal`, `UnifiedSceneDetailModal` 최상위 백드롭 `<motion.div>`에 `data-no-lasso` 속성 추가. 라쏘 훅 70줄 필터가 이 마커가 붙은 요소 안에서 시작된 드래그는 무시 → 모달 안 드래그가 뒤 그리드 라쏘를 트리거하지 않음 (이슈 2 해결).

2. **2차 수정 — index.css user-select 덮어쓰기**: 그런데 댓글 말풍선 텍스트 선택은 여전히 막힘. 확인해보니 `index.css`의 전역 규칙 `* { user-select: none }` 이 모든 요소에 적용되고 input/textarea 만 `text` 허용. 댓글 말풍선(일반 div)은 기본 차단 상태. `.select-text, .select-text *` 규칙을 추가해 이 유틸 붙은 subtree 전체에 `user-select: text` 허용 → `CommentPanel` 스크롤 영역에 `select-text` 클래스 적용 → 텍스트 드래그 + Ctrl+C 복사 가능 (이슈 1 해결).

- 관련 파일: `src/components/scenes/SceneDetailModal.tsx`, `src/components/scenes/UnifiedSceneDetailModal.tsx`, `src/components/scenes/CommentPanel.tsx`, `src/index.css`

### 이슈 5 · ACT 단계 라벨 줄바꿈 방지
`DeptSection` stage 버튼이 `flex-1`로 4등분된 상태에서 ACT 긴 라벨이 공간 부족으로 글자 단위 줄바꿈 발생. `whitespace-nowrap overflow-hidden text-ellipsis` + **`min-w-0`** 추가. flex child 기본 `min-width: auto` 때문에 `min-w-0` 없으면 ellipsis가 트리거되지 않음.
- 관련 파일: `src/components/scenes/UnifiedSceneCard.tsx`

### 이슈 A · 댓글 입력란 최대 높이 확장 (애니메이션은 v1.13.0 분리)
- auto-grow 한계 `Math.min(scrollHeight, 96)` → `Math.min(scrollHeight, 200)`
- CSS `max-h-24` → `max-h-[200px]`
- 200px 초과 시 textarea 내부 스크롤로 자동 전환

> **범위 축소**: 원래 부드러운 리사이즈 애니메이션도 포함이었으나 여러 구현 시도가 모두 기대 수준에 못 미침 (아래 "개발 난항" 참고). 최대 높이 확장만 이번 PR에 반영, 애니메이션 품질은 **v1.13.0 이슈 A2** 로 분리.

- 관련 파일: `src/components/scenes/CommentPanel.tsx`

### 이슈 D · 팀원 뷰 기본 정렬
`TeamView.tsx:336` 초기 state `'scenes'` → `'seniority'` 한 줄 교체. `seniorityOrder.ts`의 헬퍼와 SortOption 드롭다운은 모두 기존 구현 재사용.
- 관련 파일: `src/views/TeamView.tsx`

### 이슈 E · 댓글 말풍선 라이트모드 시맨틱화
인라인 `backgroundColor: '#2A2A35'` 하드코딩 제거. Tailwind 시맨틱 클래스로 전환: 자기 말풍선 `bg-emerald-500/20`, 상대 말풍선 `bg-bg-border/70`. `tasks/lessons.md`의 "라이트 모드 표면 하드코딩 금지" 규칙 준수.
- 관련 파일: `src/components/scenes/CommentPanel.tsx`

### 문서
- 디자인 스펙: `docs/superpowers/specs/2026-04-22-v1.12.1-bugfixes-design.md`
- v1.13.0 백로그: `docs/superpowers/specs/2026-04-22-v1.13.0-backlog.md` — 6개 이슈(A2·3·4·B·C·F)에 각각 cold-start 프롬프트 포함

## 🚧 개발 난항

### 스코프 확장 관리
- **문제**: 초기 6개 이슈로 시작했으나 중간에 사용자가 추가 6개 요청 (댓글 리사이즈, 연동 탭 UI, 설정 탭 정리, 팀원 정렬, 라이트모드, 삭제 계승 버그)
- **해결**: 브레인스토밍 단계에서 성격별 분할 — v1.12.1 (순수 버그·소소한 UX 6개), v1.13.0 (재구성·환경·DB 5개)
- **교훈**: 패치 릴리스는 "같은 리스크 프로파일"로만 묶어야 리뷰·롤백 가능

### 이슈 1 원인 오진 (1차 → 2차 수정)
- **문제**: `data-no-lasso`만으로 해결될 줄 알았는데 스모크 테스트 결과 텍스트 선택은 여전히 차단. 라쏘 훅 한 겹이 아니라 **CSS 전역 규칙 + 라쏘 훅 두 겹**이 막고 있었음
- **해결**: `index.css`의 `* { user-select: none }` 확인 후 `.select-text` 유틸 추가로 해제
- **교훈**: 드래그 차단은 브라우저 레벨(CSS user-select)과 JS 레벨(이벤트 훅) 양쪽 가능성 → 스모크 실패 시 즉시 두 쪽 모두 의심

### 이슈 A 애니메이션 4번의 시도 끝에 포기
Claude 데스크톱 Cowork UI 같은 부드러운 리사이즈를 목표로 4가지 접근을 순차 시도:

1. **CSS transition-[height] 단독**: `height='auto'` 리셋이 transition 시작점을 깨뜨려 툭 튀는 현상
2. **`field-sizing: content` CSS**: Chromium 에서 layout 즉시 반영되어 transition 큐 건너뜀
3. **double requestAnimationFrame 패턴**: textarea 자체는 부드러워지지만 부모 flex 컨테이너 재분배가 instant → 메시지 목록 여전히 튀어 올라감
4. **framer-motion `layout` prop**: vite dev HMR 에서 500 에러 + 모듈 reload 실패 발생

사용자 결정: "애니메이션 관련은 없애달라, 나중에 리팩토링" → 모든 애니메이션 로직 제거, 최대 높이 확장만 유지. 제대로 된 구현은 v1.13.0 이슈 A2 에서 ResizeObserver/CSS grid/framer-motion 재조사 후 브레인스토밍.

**교훈**: "버그 수정" 요청이 실제로는 "미니 피쳐"인 경우가 있음. 패치 릴리스 안에 플랫폼 경계를 건드리는 UX 작업을 욱여넣지 말 것.

### 이슈 7 스킵
원본 요청에 "데이원 위젯 드롭다운 폰트 잘림 재확인"이 있었으나 사용자가 "데이원이란 단어는 무시해도 돼", "이슈 7이 뭐지?" 라고 답함. 현재 증상 없음으로 판단, 클로즈.

## ✅ 테스트 가이드

### 사용자 테스트
> 아래 6가지 시나리오를 직접 확인해주세요.

1. **상세 모달 댓글 드래그**
   - 씬을 더블클릭해 상세 모달 열기
   - 우측 댓글 말풍선의 글자/이름/시간을 마우스로 드래그
   - ✅ 기대: 글자가 반전되어 선택됨, Ctrl+C → 메모장 등에 붙여넣기 가능

2. **모달 뒤 라쏘 누수**
   - 상세 모달 연 상태에서 모달 중앙 빈 공간을 모달 바깥 방향으로 드래그
   - ✅ 기대: 뒤쪽 씬 그리드에 라쏘 박스 생성 안 됨

3. **ACT 단계 라벨**
   - 씬 뷰 전체 모드에서 ACT 파트가 있는 씬 카드 보기
   - ✅ 기대: LO/완료/검수/PNG 라벨이 한 줄로 표시. 창 좁혀도 세로로 쌓이지 않음 (말줄임)

4. **댓글 입력란 확장**
   - 상세 모달 댓글 입력란에 여러 줄 입력
   - ✅ 기대: 약 10줄(200px)까지 커진 뒤 내부 스크롤로 전환
   - ⚠️ 커지는 순간 애니메이션 없이 즉시 반영 (v1.13.0 에서 리팩토링 예정)

5. **팀원 뷰 기본 정렬**
   - 앱 종료 후 재실행 → 팀원 뷰 진입
   - ✅ 기대: 상단 정렬 드롭다운이 "짬순", 안류천·윤성원·허혜원 등 선임이 위쪽

6. **라이트 모드 댓글 말풍선**
   - 설정 → 라이트 모드 전환 → 상세 모달 댓글 확인
   - ✅ 기대: 흰 배경 위에 자연스러운 연한 회색 말풍선 (자기 댓글은 녹색 유지)

### 회귀 확인
- 상세 모달 닫은 뒤 씬 뷰 빈 공간 드래그 → 라쏘 정상 동작
- 댓글 작성/수정/삭제/@멘션 모두 정상
- 씬 카드 단일 클릭·더블클릭·Ctrl+클릭 선택 모두 정상
- 팀원 뷰 다른 정렬 옵션(이름순/진행률/씬 개수)도 정상

### 개발자 테스트
\`\`\`bash
npx tsc --noEmit
npm run build:vite
npm run electron:dev
\`\`\`

## 📦 변경 파일 요약

| 파일 | 주요 변경 |
|------|-----------|
| `src/components/scenes/SceneDetailModal.tsx` | data-no-lasso 추가 |
| `src/components/scenes/UnifiedSceneDetailModal.tsx` | data-no-lasso 추가 |
| `src/components/scenes/UnifiedSceneCard.tsx` | stage 버튼 ellipsis + min-w-0 |
| `src/components/scenes/CommentPanel.tsx` | select-text 영역, max-h-200px, 말풍선 시맨틱화 |
| `src/views/TeamView.tsx` | 기본 정렬 'seniority' |
| `src/index.css` | `.select-text` 유틸 추가 |
| `package.json` | 1.12.0 → 1.12.1 |
| `docs/superpowers/specs/*.md` | 디자인 스펙 + v1.13.0 백로그 신규 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)