### PR TITLE
[v1.12.2] 씬·파트 삭제 댓글 계승 버그 해결 + BG·ACT 댓글 통합

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # ROADMAP.md — Bflow 프로덕션 현황 관리 도구 개발 로드맵
 
-> **최종 갱신**: 2026-03-14 (Phase 9 Supabase 마이그레이션 진행 반영)
+> **최종 갱신**: 2026-04-23 (v1.12.2 — 이슈 F 씬·파트 삭제 댓글 계승 버그 해결 + BG·ACT 댓글 통합)
 > **프로젝트**: Bflow (Studio JBBJ 프로덕션 진행 현황 대시보드)
 > **담당**: Claude × 한솔 (Studio JBBJ)
 > **현재 상태**: Phase 0 (0-4 제외) 완료, Phase 1~2 완료, Phase 4-1~4-3 완료, Phase 6 Step 1~4 완료, Phase 7 완료, Phase 8-0~8-1, 8-3~8-5 완료, Phase 9 M-0, M-2 완료 + M-3 부분 완료

--- a/electron/supabase.ts
+++ b/electron/supabase.ts
@@ -736,9 +736,13 @@ export async function addComment(
   mentions: string[],
   createdAt: string,
 ): Promise<void> {
-  // 이슈 F(2026-04-23): scene_uuid 저장 — 씬 삭제 시 CASCADE로 자동 정리되게 함.
+  // 이슈 F(2026-04-23) + Codex P1(2차): 댓글 경로의 sceneId는 scene.no (=sort_order).
+  // sort_order 정확 매칭으로 scene_number 표기 규칙과 무관하게 정확히 식별.
   // 씬을 못 찾으면 댓글 저장 자체를 거부(앞으로 고아 댓글 신규 생성 차단).
-  const sceneUuid = await resolveSceneUuidWithRetry(partUuid, sceneId);
+  const sortOrder = Number(String(sceneId).trim());
+  const sceneUuid = Number.isFinite(sortOrder)
+    ? await resolveSceneUuidBySortOrderWithRetry(partUuid, sortOrder)
+    : null;
   if (!sceneUuid) {
     throw new Error(`댓글 저장 실패: 씬을 찾을 수 없음 (partUuid=${partUuid}, sceneId=${sceneId})`);
   }
@@ -956,7 +960,9 @@ export async function addRevision(
       sceneIdForResolve = lowerSegment.slice(4);
     }
   }
-  const sceneUuid = await resolveSceneUuidWithRetry(resolvedPartUuid, sceneIdForResolve);
+  // Codex P1 2차(2026-04-23): 리비전 sceneKey 숫자는 normalizeSceneIdKey 결과(예: "a035"→"35")로
+  // scene_number 파생 값이다. sort_order 와 일치가 보장되지 않으므로 반드시 scene_number 매칭 경로로.
+  const sceneUuid = await resolveSceneUuidByNumberWithRetry(resolvedPartUuid, sceneIdForResolve);
   if (!sceneUuid) {
     throw new Error(`리비전 저장 실패: 씬을 찾을 수 없음 (partUuid=${resolvedPartUuid}, sceneId=${sceneId})`);
   }
@@ -1077,44 +1083,47 @@ export async function writeMetadata(type: string, key: string, value: string): P
 // ═══════════════════════════════════════════════
 
 /**
- * partUuid + sceneId(문자열) → scenes 테이블의 scene UUID를 반환.
- * 이슈 F 해결(2026-04-23) + Codex P1(2026-04-23):
+ * scene UUID 조회 경로가 두 갈래로 나뉜다 (Codex P1 2차, 2026-04-23):
  *
- * 댓글 흐름의 sceneId는 `scene.no` (=scenes.sort_order)에서 오므로 scene_number 접두사/패딩 규칙과
- * 무관하게 sort_order 매칭이 가장 정확하다. 리비전은 사용자가 입력한 원본 scene_number 문자열
- * (예: "sc001", "v2a001")이 전달될 수 있어 scene_number 직접 매칭 fallback이 필요하다.
+ *   A) 댓글 경로: `sceneKey = sheetName:scene.no` 이고 `scene.no === scenes.sort_order`.
+ *      → `resolveSceneUuidBySortOrder` 사용. sort_order 정확 매칭이 항상 올바름.
  *
- * 매칭 순서:
- *   1) sceneId가 숫자면 sort_order = parseInt(sceneId) 매칭 (댓글 경로 정답)
- *   2) part_letter + LPAD(3) 정규화된 scene_number 매칭 (기존 규칙)
- *   3) 원본 lowercase sceneId를 scene_number 로 직접 매칭 (커스텀 prefix 대응)
+ *   B) 리비전 경로: `sceneKey = EP:partLetter:normalizedNumberOrRaw`.
+ *      숫자 segment("35")는 `normalizeSceneIdKey("a035", "A")` 결과의 숫자부이므로
+ *      sort_order 와 일치 보장 없음 (삭제·재배치로 어긋날 수 있음).
+ *      `raw-...` alias segment는 decode 후 custom scene_number 가 됨.
+ *      → `resolveSceneUuidByNumber` 사용. scene_number 정규화 매칭이 정답.
+ *
+ * 두 함수는 호출자가 의도를 명확히 표현하도록 분리되었다. 공유 매칭을 피해
+ * "어쩌다 sort_order 와 숫자부가 같아서 올바른 씬이 잡히는" 우연을 제거한다.
  */
-export async function resolveSceneUuid(
-  partUuid: string,
-  sceneId: string,
-): Promise<string | null> {
-  if (!partUuid || !sceneId) return null;
 
-  const trimmed = String(sceneId).trim();
+/** 댓글 경로 전용 — scene.no(=sort_order) 정확 매칭. */
+export async function resolveSceneUuidBySortOrder(
+  partUuid: string,
+  sortOrder: number,
+): Promise<string | null> {
+  if (!partUuid || !Number.isFinite(sortOrder)) return null;
+  const { data } = await supabase
+    .from('scenes')
+    .select('id')
+    .eq('part_id', partUuid)
+    .eq('sort_order', sortOrder)
+    .limit(1)
+    .maybeSingle();
+  return data?.id || null;
+}
+
+/** 리비전 경로 전용 — scene_number 기반 매칭.
+ *  숫자는 part_letter + LPAD(3) 로 정규화, 그 외 custom prefix("sc001")는 lowercase 원본으로. */
+export async function resolveSceneUuidByNumber(
+  partUuid: string,
+  sceneNumberLike: string,
+): Promise<string | null> {
+  if (!partUuid || !sceneNumberLike) return null;
+  const trimmed = String(sceneNumberLike).trim();
   const lower = trimmed.toLowerCase();
 
-  // 1차: sort_order 매칭 — 앱의 scene.no ↔ DB의 sort_order 가 동일하므로
-  // scene_number 표기 규칙(접두사/패딩/커스텀)과 무관하게 정확히 식별된다.
-  if (/^\d+$/.test(trimmed)) {
-    const sortOrder = Number(trimmed);
-    if (Number.isFinite(sortOrder)) {
-      const { data: byOrder } = await supabase
-        .from('scenes')
-        .select('id')
-        .eq('part_id', partUuid)
-        .eq('sort_order', sortOrder)
-        .limit(1)
-        .maybeSingle();
-      if (byOrder?.id) return byOrder.id;
-    }
-  }
-
-  // 2차: scene_number 정규화 매칭 (part_letter + 3자리 zero-pad).
   const { data: part } = await supabase
     .from('parts')
     .select('part_id')
@@ -1136,7 +1145,7 @@ export async function resolveSceneUuid(
     .maybeSingle();
   if (byNumber?.id) return byNumber.id;
 
-  // 3차: 커스텀 prefix (예: "sc001", "v2a001") — 원본을 scene_number 로 그대로 매칭.
+  // custom prefix (예: "sc001") — 정규화된 값과 다르면 원본으로 한번 더 시도
   if (normalized !== lower) {
     const { data: byRaw } = await supabase
       .from('scenes')
@@ -1152,21 +1161,34 @@ export async function resolveSceneUuid(
 }
 
 /**
- * resolveSceneUuid 재시도판.
- * 낙관적 UI가 씬을 먼저 보여주고 DB 저장이 늦을 때 댓글/리비전 저장이 레이스로 실패하는
- * 문제를 완화한다. 500ms → 1000ms 백오프로 최대 3회 시도.
+ * 후방 호환용 — 과거에 이 이름을 참조하던 외부 경로가 남아 있을 경우를 위한 얇은 래퍼.
+ * 새 코드는 반드시 resolveSceneUuidBySortOrder 또는 resolveSceneUuidByNumber 중 의도에
+ * 맞는 함수를 직접 사용할 것.
  */
-async function resolveSceneUuidWithRetry(
+export async function resolveSceneUuid(
   partUuid: string,
   sceneId: string,
 ): Promise<string | null> {
+  return resolveSceneUuidByNumber(partUuid, sceneId);
+}
+
+/** 낙관적 UI ↔ DB 저장 레이스 완화용 재시도 래퍼. 0→500→1000ms 백오프. */
+async function withRetry<T>(fn: () => Promise<T | null>): Promise<T | null> {
   const delays = [0, 500, 1000];
   for (const delay of delays) {
     if (delay > 0) await new Promise((r) => setTimeout(r, delay));
-    const uuid = await resolveSceneUuid(partUuid, sceneId);
-    if (uuid) return uuid;
+    const result = await fn();
+    if (result) return result;
   }
   return null;
+}
+
+async function resolveSceneUuidBySortOrderWithRetry(partUuid: string, sortOrder: number): Promise<string | null> {
+  return withRetry(() => resolveSceneUuidBySortOrder(partUuid, sortOrder));
+}
+
+async function resolveSceneUuidByNumberWithRetry(partUuid: string, sceneNumberLike: string): Promise<string | null> {
+  return withRetry(() => resolveSceneUuidByNumber(partUuid, sceneNumberLike));
 }
 
 /**

--- a/electron/supabase.ts
+++ b/electron/supabase.ts
@@ -943,8 +943,19 @@ export async function addRevision(
   }
 
   // 이슈 F(2026-04-23): scene_uuid 저장 — 씬 삭제 시 CASCADE 자동 정리.
-  // sceneId가 리비전 sceneKey(예: "EP02:A:35") 형식일 수 있어 마지막 segment만 추출.
-  const sceneIdForResolve = sceneId.includes(':') ? sceneId.split(':').pop() || sceneId : sceneId;
+  // sceneId가 리비전 sceneKey(예: "EP02:A:35" 또는 "EP02:A:raw-sc001") 형식일 수 있어 마지막 segment 추출.
+  // Codex P2(2026-04-23): alias-collision 케이스에서 segment가 `raw-${encodeURIComponent(rawSceneId)}`
+  // 형태로 들어올 수 있으므로 반드시 decode해야 실제 scene_number와 매칭된다.
+  const rawSegment = sceneId.includes(':') ? sceneId.split(':').pop() || sceneId : sceneId;
+  const lowerSegment = rawSegment.trim().toLowerCase();
+  let sceneIdForResolve = rawSegment;
+  if (lowerSegment.startsWith('raw-')) {
+    try {
+      sceneIdForResolve = decodeURIComponent(lowerSegment.slice(4));
+    } catch {
+      sceneIdForResolve = lowerSegment.slice(4);
+    }
+  }
   const sceneUuid = await resolveSceneUuidWithRetry(resolvedPartUuid, sceneIdForResolve);
   if (!sceneUuid) {
     throw new Error(`리비전 저장 실패: 씬을 찾을 수 없음 (partUuid=${resolvedPartUuid}, sceneId=${sceneId})`);
@@ -1067,9 +1078,16 @@ export async function writeMetadata(type: string, key: string, value: string): P
 
 /**
  * partUuid + sceneId(문자열) → scenes 테이블의 scene UUID를 반환.
- * 이슈 F 해결(2026-04-23): 댓글·리비전을 씬과 FK CASCADE로 연결하기 위해
- * part_letter 소문자 + sceneId 3자리 zero-pad 규칙으로 scene_number 재구성 후 조회.
- * 숫자가 아닌 sceneId는 lower/trim 적용해 그대로 사용.
+ * 이슈 F 해결(2026-04-23) + Codex P1(2026-04-23):
+ *
+ * 댓글 흐름의 sceneId는 `scene.no` (=scenes.sort_order)에서 오므로 scene_number 접두사/패딩 규칙과
+ * 무관하게 sort_order 매칭이 가장 정확하다. 리비전은 사용자가 입력한 원본 scene_number 문자열
+ * (예: "sc001", "v2a001")이 전달될 수 있어 scene_number 직접 매칭 fallback이 필요하다.
+ *
+ * 매칭 순서:
+ *   1) sceneId가 숫자면 sort_order = parseInt(sceneId) 매칭 (댓글 경로 정답)
+ *   2) part_letter + LPAD(3) 정규화된 scene_number 매칭 (기존 규칙)
+ *   3) 원본 lowercase sceneId를 scene_number 로 직접 매칭 (커스텀 prefix 대응)
  */
 export async function resolveSceneUuid(
   partUuid: string,
@@ -1077,6 +1095,26 @@ export async function resolveSceneUuid(
 ): Promise<string | null> {
   if (!partUuid || !sceneId) return null;
 
+  const trimmed = String(sceneId).trim();
+  const lower = trimmed.toLowerCase();
+
+  // 1차: sort_order 매칭 — 앱의 scene.no ↔ DB의 sort_order 가 동일하므로
+  // scene_number 표기 규칙(접두사/패딩/커스텀)과 무관하게 정확히 식별된다.
+  if (/^\d+$/.test(trimmed)) {
+    const sortOrder = Number(trimmed);
+    if (Number.isFinite(sortOrder)) {
+      const { data: byOrder } = await supabase
+        .from('scenes')
+        .select('id')
+        .eq('part_id', partUuid)
+        .eq('sort_order', sortOrder)
+        .limit(1)
+        .maybeSingle();
+      if (byOrder?.id) return byOrder.id;
+    }
+  }
+
+  // 2차: scene_number 정규화 매칭 (part_letter + 3자리 zero-pad).
   const { data: part } = await supabase
     .from('parts')
     .select('part_id')
@@ -1085,20 +1123,32 @@ export async function resolveSceneUuid(
   if (!part) return null;
 
   const partLetter = String(part.part_id || '').trim().slice(0, 1).toLowerCase();
-  const trimmed = String(sceneId).trim().toLowerCase();
-  const normalized = /^\d+$/.test(trimmed) && partLetter
-    ? `${partLetter}${trimmed.padStart(3, '0')}`
-    : trimmed;
+  const normalized = /^\d+$/.test(lower) && partLetter
+    ? `${partLetter}${lower.padStart(3, '0')}`
+    : lower;
 
-  const { data: scene } = await supabase
+  const { data: byNumber } = await supabase
     .from('scenes')
     .select('id')
     .eq('part_id', partUuid)
     .eq('scene_number', normalized)
     .limit(1)
     .maybeSingle();
+  if (byNumber?.id) return byNumber.id;
 
-  return scene?.id || null;
+  // 3차: 커스텀 prefix (예: "sc001", "v2a001") — 원본을 scene_number 로 그대로 매칭.
+  if (normalized !== lower) {
+    const { data: byRaw } = await supabase
+      .from('scenes')
+      .select('id')
+      .eq('part_id', partUuid)
+      .eq('scene_number', lower)
+      .limit(1)
+      .maybeSingle();
+    if (byRaw?.id) return byRaw.id;
+  }
+
+  return null;
 }
 
 /**

--- a/electron/supabase.ts
+++ b/electron/supabase.ts
@@ -963,7 +963,15 @@ export async function addRevision(
   // Codex P1 2차(2026-04-23): 리비전 sceneKey 숫자는 normalizeSceneIdKey 결과(예: "a035"→"35")로
   // scene_number 파생 값이다. sort_order 와 일치가 보장되지 않으므로 반드시 scene_number 매칭 경로로.
   const sceneUuid = await resolveSceneUuidByNumberWithRetry(resolvedPartUuid, sceneIdForResolve);
-  if (!sceneUuid) {
+
+  // Codex P2 5차(2026-04-23): unified 뷰의 dup/disambiguated 씬은 실제 scenes.scene_number 가 아닌
+  // synthetic ID (예: "merged-${encodeURIComponent(mergedKey)}", "dup:..." in mergedSceneHelpers.ts)
+  // 로 sceneKey 를 생성한다. 이 경우 scene_uuid 매칭이 본질적으로 불가능하므로 저장 자체를 막으면
+  // 해당 데이터 형태의 사용자는 리비전을 아예 기록할 수 없다. scene_uuid 컬럼은 nullable 이므로
+  // synthetic 으로 확인된 경우에만 null 저장을 허용한다 (CASCADE 는 포기하되 저장 가능성 보장).
+  const lowerResolve = sceneIdForResolve.toLowerCase();
+  const isSyntheticMergedId = lowerResolve.startsWith('merged-') || lowerResolve.startsWith('dup:');
+  if (!sceneUuid && !isSyntheticMergedId) {
     throw new Error(`리비전 저장 실패: 씬을 찾을 수 없음 (partUuid=${resolvedPartUuid}, sceneId=${sceneId})`);
   }
 
@@ -971,7 +979,7 @@ export async function addRevision(
     id,
     part_id: resolvedPartUuid,
     scene_id: sceneId,
-    scene_uuid: sceneUuid,
+    scene_uuid: sceneUuid, // null 가능 — synthetic merged ID 의 경우
     revision_no: revisionNo,
     status,
     priority,

--- a/electron/supabase.ts
+++ b/electron/supabase.ts
@@ -422,6 +422,22 @@ export async function addPart(
   throwIfError(epErr);
 
   const depts = department ? [department] : ['bg', 'acting'];
+
+  // 이슈 F(2026-04-23): 같은 이름의 soft-deleted 파트가 있으면 진짜 DELETE로 정리.
+  // UNIQUE(episode_id, part_id, department) 제약이 deleted 행을 잡고 있어 재생성이 실패하던 문제 해결.
+  // CASCADE 덕분에 해당 파트의 자식 scenes·comments·comp_revisions까지 자동 정리되어
+  // '같은 이름 재생성 시 데이터 계승' 버그도 동시에 차단.
+  for (const d of depts) {
+    const { error: delErr } = await supabase
+      .from('parts')
+      .delete()
+      .eq('episode_id', ep!.id)
+      .eq('part_id', partId)
+      .eq('department', d)
+      .eq('status', 'deleted');
+    if (delErr) throwIfError(delErr);
+  }
+
   const rows = depts.map((d) => ({
     episode_id: ep!.id,
     part_id: partId,
@@ -720,10 +736,18 @@ export async function addComment(
   mentions: string[],
   createdAt: string,
 ): Promise<void> {
+  // 이슈 F(2026-04-23): scene_uuid 저장 — 씬 삭제 시 CASCADE로 자동 정리되게 함.
+  // 씬을 못 찾으면 댓글 저장 자체를 거부(앞으로 고아 댓글 신규 생성 차단).
+  const sceneUuid = await resolveSceneUuidWithRetry(partUuid, sceneId);
+  if (!sceneUuid) {
+    throw new Error(`댓글 저장 실패: 씬을 찾을 수 없음 (partUuid=${partUuid}, sceneId=${sceneId})`);
+  }
+
   const { error } = await supabase.from('comments').insert({
     id: commentId,
     part_id: partUuid,
     scene_id: sceneId,
+    scene_uuid: sceneUuid,
     user_id: userId,
     user_name: userName,
     text,
@@ -918,10 +942,19 @@ export async function addRevision(
     resolvedPartUuid = await resolvePartUuid(sceneId, lookupDepartment || department);
   }
 
+  // 이슈 F(2026-04-23): scene_uuid 저장 — 씬 삭제 시 CASCADE 자동 정리.
+  // sceneId가 리비전 sceneKey(예: "EP02:A:35") 형식일 수 있어 마지막 segment만 추출.
+  const sceneIdForResolve = sceneId.includes(':') ? sceneId.split(':').pop() || sceneId : sceneId;
+  const sceneUuid = await resolveSceneUuidWithRetry(resolvedPartUuid, sceneIdForResolve);
+  if (!sceneUuid) {
+    throw new Error(`리비전 저장 실패: 씬을 찾을 수 없음 (partUuid=${resolvedPartUuid}, sceneId=${sceneId})`);
+  }
+
   const { error } = await supabase.from('comp_revisions').insert({
     id,
     part_id: resolvedPartUuid,
     scene_id: sceneId,
+    scene_uuid: sceneUuid,
     revision_no: revisionNo,
     status,
     priority,
@@ -1031,6 +1064,60 @@ export async function writeMetadata(type: string, key: string, value: string): P
 // ═══════════════════════════════════════════════
 // 내부 헬퍼: sheetName → part UUID 변환
 // ═══════════════════════════════════════════════
+
+/**
+ * partUuid + sceneId(문자열) → scenes 테이블의 scene UUID를 반환.
+ * 이슈 F 해결(2026-04-23): 댓글·리비전을 씬과 FK CASCADE로 연결하기 위해
+ * part_letter 소문자 + sceneId 3자리 zero-pad 규칙으로 scene_number 재구성 후 조회.
+ * 숫자가 아닌 sceneId는 lower/trim 적용해 그대로 사용.
+ */
+export async function resolveSceneUuid(
+  partUuid: string,
+  sceneId: string,
+): Promise<string | null> {
+  if (!partUuid || !sceneId) return null;
+
+  const { data: part } = await supabase
+    .from('parts')
+    .select('part_id')
+    .eq('id', partUuid)
+    .single();
+  if (!part) return null;
+
+  const partLetter = String(part.part_id || '').trim().slice(0, 1).toLowerCase();
+  const trimmed = String(sceneId).trim().toLowerCase();
+  const normalized = /^\d+$/.test(trimmed) && partLetter
+    ? `${partLetter}${trimmed.padStart(3, '0')}`
+    : trimmed;
+
+  const { data: scene } = await supabase
+    .from('scenes')
+    .select('id')
+    .eq('part_id', partUuid)
+    .eq('scene_number', normalized)
+    .limit(1)
+    .maybeSingle();
+
+  return scene?.id || null;
+}
+
+/**
+ * resolveSceneUuid 재시도판.
+ * 낙관적 UI가 씬을 먼저 보여주고 DB 저장이 늦을 때 댓글/리비전 저장이 레이스로 실패하는
+ * 문제를 완화한다. 500ms → 1000ms 백오프로 최대 3회 시도.
+ */
+async function resolveSceneUuidWithRetry(
+  partUuid: string,
+  sceneId: string,
+): Promise<string | null> {
+  const delays = [0, 500, 1000];
+  for (const delay of delays) {
+    if (delay > 0) await new Promise((r) => setTimeout(r, delay));
+    const uuid = await resolveSceneUuid(partUuid, sceneId);
+    if (uuid) return uuid;
+  }
+  return null;
+}
 
 /**
  * sheetName (예: "EP01_A_BG") → parts 테이블의 UUID를 반환.

--- a/electron/supabase.ts
+++ b/electron/supabase.ts
@@ -1114,8 +1114,25 @@ export async function resolveSceneUuidBySortOrder(
   return data?.id || null;
 }
 
+/**
+ * `src/utils/sceneIdKey.ts#normalizeSceneIdKey` 와 동일한 규칙을 electron 쪽에서도 사용하기 위한
+ * 로컬 복제. 두 코드는 서로 다른 번들에 속하므로 런타임 import 대신 로직을 복제한다.
+ * 동일 규칙 유지를 위해 sceneIdKey.ts 를 수정할 때는 이 함수도 함께 갱신해야 한다.
+ */
+function normalizeSceneIdKeyLocal(sceneNumber: string, partLetter: string): string {
+  const raw = String(sceneNumber || '').trim().toLowerCase();
+  if (!raw) return '';
+  if (/^\d+$/.test(raw)) return String(Number(raw));
+  if (partLetter && new RegExp(`^${partLetter}[a-z]*\\d+$`).test(raw)) {
+    const trailing = raw.match(/\d+$/)?.[0];
+    return trailing ? String(Number(trailing)) : raw;
+  }
+  return raw;
+}
+
 /** 리비전 경로 전용 — scene_number 기반 매칭.
- *  숫자는 part_letter + LPAD(3) 로 정규화, 그 외 custom prefix("sc001")는 lowercase 원본으로. */
+ *  숫자는 part_letter + LPAD(3) 로 정규화, 그 외 custom prefix("sc001")는 lowercase 원본으로.
+ *  alias-prefixed 씬(예: "ac001") 대응을 위해 정규화 키 기반 fallback 추가. */
 export async function resolveSceneUuidByNumber(
   partUuid: string,
   sceneNumberLike: string,
@@ -1136,6 +1153,7 @@ export async function resolveSceneUuidByNumber(
     ? `${partLetter}${lower.padStart(3, '0')}`
     : lower;
 
+  // 1차: part_letter + LPAD(3) canonical 매칭 (대부분 케이스)
   const { data: byNumber } = await supabase
     .from('scenes')
     .select('id')
@@ -1145,7 +1163,7 @@ export async function resolveSceneUuidByNumber(
     .maybeSingle();
   if (byNumber?.id) return byNumber.id;
 
-  // custom prefix (예: "sc001") — 정규화된 값과 다르면 원본으로 한번 더 시도
+  // 2차: custom prefix (예: "sc001", "v2a001") — 원본 lowercase 그대로 한 번 더
   if (normalized !== lower) {
     const { data: byRaw } = await supabase
       .from('scenes')
@@ -1155,6 +1173,24 @@ export async function resolveSceneUuidByNumber(
       .limit(1)
       .maybeSingle();
     if (byRaw?.id) return byRaw.id;
+  }
+
+  // 3차(Codex P1 4차, 2026-04-23): alias-prefixed 씬 대응.
+  // 예를 들어 part A 에 "ac001" 만 있고 "a001" 이 없는 프로젝트에서 sceneKey 숫자 "1" 이 전달되면
+  // 1·2차 모두 실패한다. 이때 파트의 모든 씬을 가져와 normalizeSceneIdKey 규칙으로 같은 정규화 키를
+  // 가진 씬을 찾는다. 유일하면 매칭, collision 이면 안전하게 null.
+  const targetKey = normalizeSceneIdKeyLocal(lower, partLetter);
+  if (targetKey) {
+    const { data: allScenes } = await supabase
+      .from('scenes')
+      .select('id, scene_number')
+      .eq('part_id', partUuid);
+    if (allScenes && allScenes.length > 0) {
+      const matches = allScenes.filter(
+        (s) => normalizeSceneIdKeyLocal(String(s.scene_number || ''), partLetter) === targetKey,
+      );
+      if (matches.length === 1) return matches[0].id as string;
+    }
   }
 
   return null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bflow",
-  "version": "1.11.1",
+  "version": "1.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bflow",
-      "version": "1.11.1",
+      "version": "1.12.2",
       "license": "UNLICENSED",
       "dependencies": {
         "@liveblocks/client": "^3.14.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/components/scenes/CommentPanel.tsx
+++ b/src/components/scenes/CommentPanel.tsx
@@ -40,25 +40,25 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const mentionDropdownRef = useRef<HTMLDivElement>(null);
 
-  // 댓글 로드 — primary + optional secondary 를 양쪽 조회 후 시간순 병합
+  // 댓글 로드 — loadPartComments가 이미 BG·ACT 양쪽 파트를 통합 조회하므로
+  // 이슈 F-2(2026-04-23) 이후로는 primary 한 번 조회만으로 양쪽 댓글이 모두 포함된다.
+  // secondarySceneKey 를 추가로 조회하면 같은 댓글이 두 번 merge되어 React key 중복 경고 발생.
   const loadComments = useCallback(() => {
-    const primaryPromise = getComments(sceneKey).then((list) =>
-      list.map<SceneCommentWithSource>((c) => ({ ...c, _sourceKey: sceneKey })),
-    );
-    const secondaryPromise = secondarySceneKey
-      ? getComments(secondarySceneKey).then((list) =>
-          list.map<SceneCommentWithSource>((c) => ({ ...c, _sourceKey: secondarySceneKey })),
-        )
-      : Promise.resolve([]);
-
-    Promise.all([primaryPromise, secondaryPromise]).then(([a, b]) => {
-      const merged = [...a, ...b].sort(
-        (x, y) => new Date(x.createdAt).getTime() - new Date(y.createdAt).getTime(),
-      );
-      setComments(merged);
-      onCountChange?.(merged.length);
+    getComments(sceneKey).then((list) => {
+      const sorted = list
+        .map<SceneCommentWithSource>((c) => ({ ...c, _sourceKey: sceneKey }))
+        .sort((x, y) => new Date(x.createdAt).getTime() - new Date(y.createdAt).getTime());
+      // 안전장치: 혹시 모를 상류 중복 제거.
+      const seen = new Set<string>();
+      const deduped = sorted.filter((c) => {
+        if (seen.has(c.id)) return false;
+        seen.add(c.id);
+        return true;
+      });
+      setComments(deduped);
+      onCountChange?.(deduped.length);
     });
-  }, [sceneKey, secondarySceneKey]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [sceneKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => { loadComments(); }, [loadComments]);
 

--- a/src/components/scenes/CommentPanel.tsx
+++ b/src/components/scenes/CommentPanel.tsx
@@ -40,17 +40,30 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const mentionDropdownRef = useRef<HTMLDivElement>(null);
 
-  // 댓글 로드 — loadPartComments가 이미 BG·ACT 양쪽 파트를 통합 조회하므로
-  // 이슈 F-2(2026-04-23) 이후로는 primary 한 번 조회만으로 양쪽 댓글이 모두 포함된다.
-  // secondarySceneKey 를 추가로 조회하면 같은 댓글이 두 번 merge되어 React key 중복 경고 발생.
+  // 댓글 로드 — primary + optional secondary 조회 후 시간순 병합.
+  //
+  // 모드별 동작:
+  // - sheets 모드: loadPartComments 가 BG·ACT 양쪽 파트를 통합 조회하므로 primary 결과에 이미
+  //   양쪽 댓글이 모두 포함된다. secondary 결과는 primary 와 겹치지만 commentId dedupe 로 안전.
+  // - 로컬(파일) 모드 (Codex P2 2차, 2026-04-23): getComments 가 단일 sceneKey 만 읽으므로
+  //   통합 뷰 상세 모달에서 counterpart 부서 댓글을 보려면 secondary 도 반드시 조회해야 한다.
   const loadComments = useCallback(() => {
-    getComments(sceneKey).then((list) => {
-      const sorted = list
-        .map<SceneCommentWithSource>((c) => ({ ...c, _sourceKey: sceneKey }))
-        .sort((x, y) => new Date(x.createdAt).getTime() - new Date(y.createdAt).getTime());
-      // 안전장치: 혹시 모를 상류 중복 제거.
+    const primaryPromise = getComments(sceneKey).then((list) =>
+      list.map<SceneCommentWithSource>((c) => ({ ...c, _sourceKey: sceneKey })),
+    );
+    const secondaryPromise = secondarySceneKey
+      ? getComments(secondarySceneKey).then((list) =>
+          list.map<SceneCommentWithSource>((c) => ({ ...c, _sourceKey: secondarySceneKey })),
+        )
+      : Promise.resolve([] as SceneCommentWithSource[]);
+
+    Promise.all([primaryPromise, secondaryPromise]).then(([a, b]) => {
+      const merged = [...a, ...b].sort(
+        (x, y) => new Date(x.createdAt).getTime() - new Date(y.createdAt).getTime(),
+      );
+      // commentId 기준 중복 제거 — sheets 모드 통합 조회로 primary·secondary가 겹쳐도 안전.
       const seen = new Set<string>();
-      const deduped = sorted.filter((c) => {
+      const deduped = merged.filter((c) => {
         if (seen.has(c.id)) return false;
         seen.add(c.id);
         return true;
@@ -58,7 +71,7 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
       setComments(deduped);
       onCountChange?.(deduped.length);
     });
-  }, [sceneKey]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [sceneKey, secondarySceneKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => { loadComments(); }, [loadComments]);
 

--- a/src/components/scenes/UnifiedSceneCard.tsx
+++ b/src/components/scenes/UnifiedSceneCard.tsx
@@ -31,6 +31,8 @@ interface UnifiedSceneCardProps {
   searchQuery?: string;
   bgCommentCount: number;
   actCommentCount: number;
+  /** Codex P2 6차(2026-04-23): 양쪽 sheet 댓글 id 유니온 크기. 제공되면 Math.max fallback 대신 사용. */
+  totalCommentCount?: number;
   onToggle: (sheetName: string, sceneId: string, stage: Stage) => void;
   onDelete: (sheetName: string, sceneIndex: number) => void;
   onOpenDetail: (sheetName: string, sceneIndex: number) => void;
@@ -51,6 +53,7 @@ export function UnifiedSceneCard({
   searchQuery,
   bgCommentCount,
   actCommentCount,
+  totalCommentCount,
   onToggle,
   onDelete,
   onOpenDetail,
@@ -168,14 +171,18 @@ export function UnifiedSceneCard({
             )}
           </div>
           <div className="flex items-center gap-1.5">
-            {/* 이슈 F-2(2026-04-23): bgCommentCount·actCommentCount 둘 다 이미 BG·ACT 통합 결과라
-                더하면 2배 집계됨. 최댓값 하나만 사용 (대부분 둘이 같음, 한쪽 sheet 캐시가 낙관적으로 먼저 반영될 땐 다를 수 있어 max). */}
-            {Math.max(bgCommentCount, actCommentCount) > 0 && (
-              <span className="flex items-center gap-0.5 bg-accent/15 text-accent px-1.5 py-0.5 rounded-full" title={`의견 ${Math.max(bgCommentCount, actCommentCount)}개`}>
-                <MessageCircle size={10} fill="currentColor" />
-                <span className="text-[10px] font-bold">{Math.max(bgCommentCount, actCommentCount)}</span>
-              </span>
-            )}
+            {/* Codex P2 6차(2026-04-23): 정확한 total 은 ScenesView 가 commentIdsByKey 로 계산해
+                `totalCommentCount` 로 전달. 없으면 Math.max 로 fallback (대부분 BG·ACT 동일값). */}
+            {(() => {
+              const displayCount = totalCommentCount ?? Math.max(bgCommentCount, actCommentCount);
+              if (displayCount <= 0) return null;
+              return (
+                <span className="flex items-center gap-0.5 bg-accent/15 text-accent px-1.5 py-0.5 rounded-full" title={`의견 ${displayCount}개`}>
+                  <MessageCircle size={10} fill="currentColor" />
+                  <span className="text-[10px] font-bold">{displayCount}</span>
+                </span>
+              );
+            })()}
             <span className="bg-bg-primary/80 border border-bg-border/45 text-text-primary px-2.5 py-1 rounded-full text-[12px] font-semibold tabular-nums">
               {combinedPct}%
             </span>

--- a/src/components/scenes/UnifiedSceneCard.tsx
+++ b/src/components/scenes/UnifiedSceneCard.tsx
@@ -168,10 +168,12 @@ export function UnifiedSceneCard({
             )}
           </div>
           <div className="flex items-center gap-1.5">
-            {(bgCommentCount + actCommentCount) > 0 && (
-              <span className="flex items-center gap-0.5 bg-accent/15 text-accent px-1.5 py-0.5 rounded-full" title={`의견 ${bgCommentCount + actCommentCount}개`}>
+            {/* 이슈 F-2(2026-04-23): bgCommentCount·actCommentCount 둘 다 이미 BG·ACT 통합 결과라
+                더하면 2배 집계됨. 최댓값 하나만 사용 (대부분 둘이 같음, 한쪽 sheet 캐시가 낙관적으로 먼저 반영될 땐 다를 수 있어 max). */}
+            {Math.max(bgCommentCount, actCommentCount) > 0 && (
+              <span className="flex items-center gap-0.5 bg-accent/15 text-accent px-1.5 py-0.5 rounded-full" title={`의견 ${Math.max(bgCommentCount, actCommentCount)}개`}>
                 <MessageCircle size={10} fill="currentColor" />
-                <span className="text-[10px] font-bold">{bgCommentCount + actCommentCount}</span>
+                <span className="text-[10px] font-bold">{Math.max(bgCommentCount, actCommentCount)}</span>
               </span>
             )}
             <span className="bg-bg-primary/80 border border-bg-border/45 text-text-primary px-2.5 py-1 rounded-full text-[12px] font-semibold tabular-nums">

--- a/src/components/scenes/UnifiedSceneSheetView.tsx
+++ b/src/components/scenes/UnifiedSceneSheetView.tsx
@@ -18,6 +18,8 @@ interface UnifiedSceneSheetViewProps {
   bgSheetName: string | null;
   actSheetName: string | null;
   commentCounts: Record<string, number>;
+  /** Codex P2 6차(2026-04-23): ambiguous skip 케이스에서 정확한 union 크기 계산을 위한 id 맵. */
+  commentIdsByKey?: Record<string, string[]>;
   searchQuery?: string;
   selectedSceneIds: Set<string>;
   sceneGroupMode: SceneGroupMode;
@@ -271,6 +273,7 @@ export function UnifiedSceneSheetView({
   bgSheetName,
   actSheetName,
   commentCounts,
+  commentIdsByKey,
   searchQuery,
   selectedSceneIds,
   sceneGroupMode,
@@ -653,6 +656,7 @@ export function UnifiedSceneSheetView({
                 bgSheetName,
                 actSheetName,
                 commentCounts,
+                commentIdsByKey,
               );
 
               return (

--- a/src/services/commentService.ts
+++ b/src/services/commentService.ts
@@ -63,29 +63,47 @@ function parseSceneKey(sceneKey: string): { sheetName: string; sceneId: string }
   return { sheetName: sceneKey.substring(0, idx), sceneId: sceneKey.substring(idx + 1) };
 }
 
+/** BG↔ACT 상대 sheetName. 같은 장면의 댓글을 양쪽 탭에서 공유하기 위해 사용. */
+function getCounterpartSheetName(sheetName: string): string | null {
+  if (sheetName.endsWith('_BG')) return sheetName.slice(0, -3) + '_ACT';
+  if (sheetName.endsWith('_ACT')) return sheetName.slice(0, -4) + '_BG';
+  return null;
+}
+
+function getRelatedSheetNames(sheetName: string): string[] {
+  const cp = getCounterpartSheetName(sheetName);
+  return cp ? [sheetName, cp] : [sheetName];
+}
+
 /**
  * 특정 파트의 댓글을 시트에서 로드 (캐시).
+ * 이슈 F-2(2026-04-23): 같은 장면의 BG·ACT 댓글을 함께 조회해 한쪽에서 작성한 댓글이
+ * 반대 부서 탭·카드 뷰 뱃지에서도 보이게 함. 저장은 그대로 원본 파트에만 한다.
  */
 export async function loadPartComments(sheetName: string): Promise<CommentsStore> {
   if (sheetPartCache.has(sheetName)) return sheetPartCache.get(sheetName)!;
 
-  // Supabase: sheetName → part UUID 해석 (스토어에서 조회)
-  let partUuid: string | undefined;
+  const related = getRelatedSheetNames(sheetName);
+  const partUuids: string[] = [];
   try {
     const { useDataStore } = await import('../stores/useDataStore');
-    const part = useDataStore.getState().episodes
-      .flatMap((ep) => ep.parts)
-      .find((p) => p.sheetName === sheetName);
-    partUuid = part?.id;
+    const allParts = useDataStore.getState().episodes.flatMap((ep) => ep.parts);
+    for (const sn of related) {
+      const p = allParts.find((pp) => pp.sheetName === sn);
+      if (p?.id) partUuids.push(p.id);
+    }
   } catch { /* 무시 */ }
 
   let rawComments: { id: string; partId: string; sceneId: string; userId: string; userName: string; text: string; mentions: string[]; createdAt: string; editedAt: string | null }[] = [];
 
   let supabaseFailed = false;
-  if (partUuid) {
-    // Supabase 경로
+  if (partUuids.length > 0) {
+    // Supabase 경로 — 관련 파트(BG·ACT) UUID 모두에서 조회
     try {
-      rawComments = (await window.electronAPI.supabaseReadComments(partUuid)) as typeof rawComments;
+      const results = await Promise.all(
+        partUuids.map((uuid) => window.electronAPI.supabaseReadComments(uuid) as Promise<typeof rawComments>),
+      );
+      rawComments = results.flat();
     } catch (err) {
       console.warn('[댓글] Supabase 로드 실패, Sheets fallback:', err);
       supabaseFailed = true;
@@ -93,7 +111,7 @@ export async function loadPartComments(sheetName: string): Promise<CommentsStore
   }
 
   // Supabase 실패 또는 partUuid 없을 때 Sheets fallback
-  if (rawComments.length === 0 && (!partUuid || supabaseFailed)) {
+  if (rawComments.length === 0 && (partUuids.length === 0 || supabaseFailed)) {
     try {
       const result = await window.electronAPI.sheetsReadComments(sheetName);
       if (result.ok) {
@@ -107,7 +125,12 @@ export async function loadPartComments(sheetName: string): Promise<CommentsStore
   }
 
   const store: CommentsStore = {};
+  const seenIds = new Set<string>();
   for (const c of rawComments) {
+    // 통합 조회 중복 제거 (안전장치)
+    if (seenIds.has(c.id)) continue;
+    seenIds.add(c.id);
+    // 키는 요청된 sheetName 기준 — 호출자(카드 뷰 뱃지)가 같은 키로 조회할 수 있게.
     const key = `${sheetName}:${c.sceneId}`;
     if (!store[key]) store[key] = [];
     store[key].push({
@@ -125,11 +148,18 @@ export async function loadPartComments(sheetName: string): Promise<CommentsStore
   return store;
 }
 
-/** 파트 캐시 무효화 + 컴포넌트에 리로드 신호 전달 */
+/**
+ * 파트 캐시 무효화 + 컴포넌트에 리로드 신호 전달.
+ * BG↔ACT 양쪽 캐시를 함께 비워 한쪽 갱신이 다른 쪽 뷰에도 반영되게 함.
+ */
 export function invalidatePartCache(sheetName?: string): void {
-  if (sheetName) sheetPartCache.delete(sheetName);
-  else sheetPartCache.clear();
-  // CommentPanel 등 구독 컴포넌트에 다시 불러오라는 신호
+  if (sheetName) {
+    sheetPartCache.delete(sheetName);
+    const cp = getCounterpartSheetName(sheetName);
+    if (cp) sheetPartCache.delete(cp);
+  } else {
+    sheetPartCache.clear();
+  }
   window.dispatchEvent(new CustomEvent('bflow:comments-invalidated', { detail: { sheetName } }));
 }
 
@@ -163,12 +193,18 @@ export async function addComment(sceneKey: string, comment: SceneComment): Promi
       comment.userId, comment.userName, comment.text,
       comment.mentions, comment.createdAt,
     );
-    // 캐시 업데이트
-    const store = sheetPartCache.get(sheetName);
-    if (store) {
-      if (!store[sceneKey]) store[sceneKey] = [];
-      store[sceneKey].push(comment);
+    // 캐시 업데이트 — 원본 sheet 캐시에만 낙관적 반영.
+    // 반대 부서 sheet 캐시는 invalidate해서 다음 조회 시 통합 재조회로 반영 (중복 삽입 방지).
+    const ownStore = sheetPartCache.get(sheetName);
+    if (ownStore) {
+      if (!ownStore[sceneKey]) ownStore[sceneKey] = [];
+      ownStore[sceneKey].push(comment);
     }
+    const counterpart = getCounterpartSheetName(sheetName);
+    if (counterpart) sheetPartCache.delete(counterpart);
+    // 자기 창 카드 뷰 뱃지 즉시 갱신 (ScenesView 리스너 트리거).
+    // 주의: 이벤트만 발화. 캐시 비우기는 이미 위에서 처리했음 (invalidatePartCache 호출 금지 — 무한 루프 방지).
+    window.dispatchEvent(new CustomEvent('bflow:comments-invalidated', { detail: { sheetName } }));
     // 다른 창에 댓글 변경 알림
     window.electronAPI?.dataNotifyChange?.({
       type: 'comment', sheetName, sceneId, commentAction: 'add',
@@ -189,14 +225,15 @@ export async function updateComment(
   if (sheetsMode) {
     const { sheetName, sceneId } = parseSceneKey(sceneKey);
     await window.electronAPI.supabaseEditComment(commentId, text, mentions);
-    // 캐시 업데이트
+    // 캐시 업데이트 — commentId 기준으로 모든 캐시/리스트를 순회 (BG·ACT 양쪽 매핑 반영)
     sheetPartCache.forEach((store) => {
-      const list = store[sceneKey];
-      if (list) {
+      for (const list of Object.values(store)) {
         const idx = list.findIndex(c => c.id === commentId);
         if (idx >= 0) list[idx] = { ...list[idx], text, mentions, editedAt };
       }
     });
+    // 자기 창 뱃지/패널 즉시 갱신
+    window.dispatchEvent(new CustomEvent('bflow:comments-invalidated', { detail: { sheetName } }));
     // 다른 창에 댓글 변경 알림
     window.electronAPI?.dataNotifyChange?.({
       type: 'comment', sheetName, sceneId, commentAction: 'edit',
@@ -216,14 +253,19 @@ export async function deleteComment(sceneKey: string, commentId: string): Promis
   if (sheetsMode) {
     const { sheetName, sceneId } = parseSceneKey(sceneKey);
     await window.electronAPI.supabaseDeleteComment(commentId);
-    // 캐시에서 제거
+    // 캐시에서 제거 — commentId 기준으로 모든 캐시/리스트 순회 (BG·ACT 양쪽 반영)
     sheetPartCache.forEach((store) => {
-      const list = store[sceneKey];
-      if (list) {
-        store[sceneKey] = list.filter(c => c.id !== commentId);
-        if (store[sceneKey].length === 0) delete store[sceneKey];
+      for (const key of Object.keys(store)) {
+        const list = store[key];
+        const filtered = list.filter(c => c.id !== commentId);
+        if (filtered.length !== list.length) {
+          if (filtered.length === 0) delete store[key];
+          else store[key] = filtered;
+        }
       }
     });
+    // 자기 창 뱃지/패널 즉시 갱신
+    window.dispatchEvent(new CustomEvent('bflow:comments-invalidated', { detail: { sheetName } }));
     // 다른 창에 댓글 변경 알림
     window.electronAPI?.dataNotifyChange?.({
       type: 'comment', sheetName, sceneId, commentAction: 'delete',

--- a/src/services/commentService.ts
+++ b/src/services/commentService.ts
@@ -138,7 +138,14 @@ export async function loadPartComments(sheetName: string): Promise<CommentsStore
     } catch { /* fallback도 실패 */ }
   }
 
-  /** 댓글 row를 요청된 sheet 기준 scene.no 문자열로 변환. 매칭 씬이 없으면 null 반환(skip). */
+  /**
+   * 댓글 row를 요청된 sheet 기준 scene.no 문자열로 변환. 매칭 씬이 없으면 null 반환(skip).
+   *
+   * Codex P1 3차(2026-04-23): 정규화만으로 매칭하면 alias-collision (예: `a001`·`ac001` 이
+   * 같은 키로 정규화) 상황에서 상대 부서 댓글이 다른 물리 씬에 붙을 수 있다. 순서:
+   *   1) 원본 scene_number(lowercase) 정확 매칭 — collision 영향 없음, 일반 케이스 대부분 해결
+   *   2) 정규화 매칭 — 단 requested part 에 같은 정규화 씬이 "유일"할 때만. 2개 이상이면 skip.
+   */
   const mapToRequestedSceneNo = (row: typeof rawComments[number]): string | null => {
     // 요청 파트 메타를 못 얻었거나 fallback 경로 등은 원본 scene_id 를 그대로 사용(이전 동작과 호환).
     if (!requestedPart) return row.sceneId;
@@ -147,15 +154,26 @@ export async function loadPartComments(sheetName: string): Promise<CommentsStore
     // 자기 파트 댓글이면 그대로
     if (!sourcePart || sourcePart.id === requestedPart.id) return row.sceneId;
 
-    // 상대 부서 댓글: 원본 파트에서 해당 scene.no 의 씬을 찾아 scene_number 정규화 → 요청 파트에서 같은 정규화 씬
     const sourceScene = sourcePart.scenes.find((s) => String(s.no) === String(row.sceneId));
     if (!sourceScene) return null;
+
+    // 1차: 원본 scene_number 정확 매칭 (lowercase + trim). collision 안전.
+    const sourceSceneNumber = (sourceScene.sceneId || '').trim().toLowerCase();
+    if (sourceSceneNumber) {
+      const exactMatch = requestedPart.scenes.find(
+        (s) => (s.sceneId || '').trim().toLowerCase() === sourceSceneNumber,
+      );
+      if (exactMatch) return String(exactMatch.no);
+    }
+
+    // 2차: 정규화 매칭 — 유일한 매칭일 때만 허용. 2개 이상이면 alias-collision 이므로 skip.
     const normalizedSource = normalizeSceneIdKey(sourceScene.sceneId, sourcePart.partId);
     if (!normalizedSource) return null;
-    const matchedScene = requestedPart.scenes.find((s) =>
-      normalizeSceneIdKey(s.sceneId, requestedPart!.partId) === normalizedSource,
+    const normalizedMatches = requestedPart.scenes.filter(
+      (s) => normalizeSceneIdKey(s.sceneId, requestedPart!.partId) === normalizedSource,
     );
-    return matchedScene ? String(matchedScene.no) : null;
+    if (normalizedMatches.length === 1) return String(normalizedMatches[0].no);
+    return null;
   };
 
   const store: CommentsStore = {};

--- a/src/services/commentService.ts
+++ b/src/services/commentService.ts
@@ -8,6 +8,9 @@
  * sceneKey 형식: "sheetName:sceneNo" (예: "EP01_A_BG:3")
  */
 
+import type { Part } from '../types';
+import { normalizeSceneIdKey } from '../utils/sceneIdKey';
+
 const COMMENTS_FILE = 'comments.json';
 
 export interface SceneComment {
@@ -79,18 +82,29 @@ function getRelatedSheetNames(sheetName: string): string[] {
  * 특정 파트의 댓글을 시트에서 로드 (캐시).
  * 이슈 F-2(2026-04-23): 같은 장면의 BG·ACT 댓글을 함께 조회해 한쪽에서 작성한 댓글이
  * 반대 부서 탭·카드 뷰 뱃지에서도 보이게 함. 저장은 그대로 원본 파트에만 한다.
+ *
+ * Codex P1(2026-04-23): 상대 부서 댓글을 요청된 sheet 키로 재매핑할 때 단순히
+ * `${sheetName}:${c.sceneId}`로 작성하면 BG·ACT scene.no 가 비대칭(삭제/추가로 어긋난 경우)
+ * 일 때 엉뚱한 카드에 매핑된다. 댓글이 달린 "장면"의 scene_number 를 정규화하여 요청 파트에서
+ * 같은 정규화 값을 가진 씬의 scene.no 로 키를 재구성한다. 매칭 씬이 없으면 안전하게 skip.
  */
 export async function loadPartComments(sheetName: string): Promise<CommentsStore> {
   if (sheetPartCache.has(sheetName)) return sheetPartCache.get(sheetName)!;
 
   const related = getRelatedSheetNames(sheetName);
+  let requestedPart: Part | undefined;
+  const partByUuid = new Map<string, Part>();
   const partUuids: string[] = [];
   try {
     const { useDataStore } = await import('../stores/useDataStore');
-    const allParts = useDataStore.getState().episodes.flatMap((ep) => ep.parts);
+    const allParts: Part[] = useDataStore.getState().episodes.flatMap((ep) => ep.parts);
+    requestedPart = allParts.find((p) => p.sheetName === sheetName);
     for (const sn of related) {
       const p = allParts.find((pp) => pp.sheetName === sn);
-      if (p?.id) partUuids.push(p.id);
+      if (p?.id) {
+        partUuids.push(p.id);
+        partByUuid.set(p.id, p);
+      }
     }
   } catch { /* 무시 */ }
 
@@ -124,14 +138,37 @@ export async function loadPartComments(sheetName: string): Promise<CommentsStore
     } catch { /* fallback도 실패 */ }
   }
 
+  /** 댓글 row를 요청된 sheet 기준 scene.no 문자열로 변환. 매칭 씬이 없으면 null 반환(skip). */
+  const mapToRequestedSceneNo = (row: typeof rawComments[number]): string | null => {
+    // 요청 파트 메타를 못 얻었거나 fallback 경로 등은 원본 scene_id 를 그대로 사용(이전 동작과 호환).
+    if (!requestedPart) return row.sceneId;
+    const sourcePart = row.partId ? partByUuid.get(row.partId) : undefined;
+
+    // 자기 파트 댓글이면 그대로
+    if (!sourcePart || sourcePart.id === requestedPart.id) return row.sceneId;
+
+    // 상대 부서 댓글: 원본 파트에서 해당 scene.no 의 씬을 찾아 scene_number 정규화 → 요청 파트에서 같은 정규화 씬
+    const sourceScene = sourcePart.scenes.find((s) => String(s.no) === String(row.sceneId));
+    if (!sourceScene) return null;
+    const normalizedSource = normalizeSceneIdKey(sourceScene.sceneId, sourcePart.partId);
+    if (!normalizedSource) return null;
+    const matchedScene = requestedPart.scenes.find((s) =>
+      normalizeSceneIdKey(s.sceneId, requestedPart!.partId) === normalizedSource,
+    );
+    return matchedScene ? String(matchedScene.no) : null;
+  };
+
   const store: CommentsStore = {};
   const seenIds = new Set<string>();
   for (const c of rawComments) {
     // 통합 조회 중복 제거 (안전장치)
     if (seenIds.has(c.id)) continue;
     seenIds.add(c.id);
-    // 키는 요청된 sheetName 기준 — 호출자(카드 뷰 뱃지)가 같은 키로 조회할 수 있게.
-    const key = `${sheetName}:${c.sceneId}`;
+
+    const targetSceneNo = mapToRequestedSceneNo(c);
+    if (targetSceneNo == null) continue; // 비대칭으로 대응 씬이 없으면 안전하게 skip
+
+    const key = `${sheetName}:${targetSceneNo}`;
     if (!store[key]) store[key] = [];
     store[key].push({
       id: c.id,

--- a/src/utils/mergedSceneHelpers.ts
+++ b/src/utils/mergedSceneHelpers.ts
@@ -451,9 +451,12 @@ export function getMergedCommentBadgeCounts(
     ? (commentCounts[`${actSheetName}:${merged.actScene.no}`] ?? 0)
     : 0;
 
+  // 이슈 F-2(2026-04-23): commentCounts의 각 sheet 값은 이미 loadPartComments가
+  // BG·ACT를 통합해 돌려준 결과다. 두 값을 더하면 같은 댓글이 2배로 집계되므로
+  // 최댓값을 취해 정확한 총합을 유지한다.
   return {
     bg,
     act,
-    total: bg + act,
+    total: Math.max(bg, act),
   };
 }

--- a/src/utils/mergedSceneHelpers.ts
+++ b/src/utils/mergedSceneHelpers.ts
@@ -443,20 +443,29 @@ export function getMergedCommentBadgeCounts(
   bgSheetName: string | null,
   actSheetName: string | null,
   commentCounts: Record<string, number>,
+  commentIdsByKey?: Record<string, readonly string[]>,
 ) {
-  const bg = merged.bgScene && bgSheetName
-    ? (commentCounts[`${bgSheetName}:${merged.bgScene.no}`] ?? 0)
-    : 0;
-  const act = merged.actScene && actSheetName
-    ? (commentCounts[`${actSheetName}:${merged.actScene.no}`] ?? 0)
-    : 0;
+  const bgKey = merged.bgScene && bgSheetName ? `${bgSheetName}:${merged.bgScene.no}` : null;
+  const actKey = merged.actScene && actSheetName ? `${actSheetName}:${merged.actScene.no}` : null;
 
-  // 이슈 F-2(2026-04-23): commentCounts의 각 sheet 값은 이미 loadPartComments가
-  // BG·ACT를 통합해 돌려준 결과다. 두 값을 더하면 같은 댓글이 2배로 집계되므로
-  // 최댓값을 취해 정확한 총합을 유지한다.
-  return {
-    bg,
-    act,
-    total: Math.max(bg, act),
-  };
+  const bg = bgKey ? (commentCounts[bgKey] ?? 0) : 0;
+  const act = actKey ? (commentCounts[actKey] ?? 0) : 0;
+
+  // 이슈 F-2(2026-04-23) + Codex P2 6차(2026-04-23):
+  // loadPartComments 의 `mapToRequestedSceneNo` 가 alias-collision 등 ambiguous 케이스에서 skip하면
+  // BG sheet 결과와 ACT sheet 결과가 서로 다른 댓글 집합이 될 수 있다. 이 때 Math.max 는 한쪽에만
+  // 있는 댓글을 누락해 과소 집계하고, CommentPanel(primary+secondary 병합)과 뱃지 숫자가 어긋난다.
+  // commentIdsByKey 가 제공되면 양쪽 sheet 의 commentId 유니온 크기를 total 로 사용해 정확도 확보.
+  let total: number;
+  if (commentIdsByKey) {
+    const ids = new Set<string>();
+    if (bgKey) for (const id of commentIdsByKey[bgKey] ?? []) ids.add(id);
+    if (actKey) for (const id of commentIdsByKey[actKey] ?? []) ids.add(id);
+    total = ids.size;
+  } else {
+    // 후방 호환 경로 — id map 없으면 Math.max fallback (대부분 케이스에선 동일 값)
+    total = Math.max(bg, act);
+  }
+
+  return { bg, act, total };
 }

--- a/src/views/ScenesView.tsx
+++ b/src/views/ScenesView.tsx
@@ -2650,8 +2650,13 @@ export function ScenesView() {
     }
     const sceneUuid = targetScene.id;
     const sceneNo = targetScene.no;
+    const badgeKey = `${sheetName}:${sceneNo}`;
 
     const prevEpisodes = currentEpisodes;
+    // Codex P2 8차(2026-04-23): 실패 롤백 시 뱃지 state 도 복원할 수 있도록 이전 값 보관.
+    const prevCommentCount = commentCounts[badgeKey];
+    const prevCommentIds = commentIdsByKey[badgeKey];
+
     deleteSceneOptimistic(sheetName, sceneIndex);
 
     // 이슈 F(2026-04-23): 낙관적으로 로컬 state 에서 뱃지 숫자를 즉시 비움.
@@ -2660,12 +2665,12 @@ export function ScenesView() {
     // 캐시 무효화는 DB 삭제 성공 후에만 수행한다.
     setCommentCounts((prev) => {
       const next = { ...prev };
-      delete next[`${sheetName}:${sceneNo}`];
+      delete next[badgeKey];
       return next;
     });
     setCommentIdsByKey((prev) => {
       const next = { ...prev };
-      delete next[`${sheetName}:${sceneNo}`];
+      delete next[badgeKey];
       return next;
     });
 
@@ -2676,6 +2681,13 @@ export function ScenesView() {
       syncInBackground();
     } catch (err) {
       setEpisodes(prevEpisodes);
+      // Codex P2 8차(2026-04-23): 씬이 롤백되었는데 뱃지가 0 으로 남으면 사용자 혼란 → 함께 복원.
+      if (prevCommentCount !== undefined) {
+        setCommentCounts((prev) => ({ ...prev, [badgeKey]: prevCommentCount }));
+      }
+      if (prevCommentIds !== undefined) {
+        setCommentIdsByKey((prev) => ({ ...prev, [badgeKey]: prevCommentIds }));
+      }
       handleSheetError(err, '씬 삭제');
       syncInBackground();
     }
@@ -2733,14 +2745,19 @@ export function ScenesView() {
     const prevEpisodes = useDataStore.getState().episodes;
     const prevSelectedPart = selectedPart;
 
+    // Codex P2 8차(2026-04-23): 씬 삭제와 동일 race — DB 호출 전 invalidatePartCache 를 부르면
+    // 이벤트 리스너가 즉시 reload → 파트가 아직 살아있어 스테일 댓글이 뱃지에 다시 채워짐.
+    // 낙관적 단계에서는 UI state 만 업데이트(deletePartOptimistic 은 에피소드 상태만 건드림),
+    // 캐시 무효화는 DB 성공 후 수행.
     for (const sn of sheetNames) {
       deletePartOptimistic(sn);
-      invalidatePartCache(sn);
     }
     setSelectedPart(null);
 
     try {
       await Promise.all(sheetNames.map((sn) => softDeletePart(sn)));
+      // DB 삭제 성공 후에만 캐시 무효화 + 이벤트 전파 → reload 가 최신 상태 반환.
+      for (const sn of sheetNames) invalidatePartCache(sn);
       syncInBackground();
     } catch (err) {
       setEpisodes(prevEpisodes);

--- a/src/views/ScenesView.tsx
+++ b/src/views/ScenesView.tsx
@@ -1566,6 +1566,9 @@ export function ScenesView() {
 
   // 전체 댓글 카운트 로드
   const [commentCounts, setCommentCounts] = useState<Record<string, number>>({});
+  // Codex P2 6차(2026-04-23): ambiguous skip 으로 BG/ACT 댓글 집합이 달라질 수 있어
+  // `getMergedCommentBadgeCounts` 가 union 크기를 산출할 수 있도록 id list 도 함께 유지.
+  const [commentIdsByKey, setCommentIdsByKey] = useState<Record<string, string[]>>({});
   // 댓글 카운트 로딩은 currentPart 정의 후 아래에서 수행 (useEffect)
 
   // Shift+Click 범위 선택을 위한 마지막 클릭 인덱스
@@ -1804,6 +1807,17 @@ export function ScenesView() {
           });
           for (const [key, list] of Object.entries(store)) {
             next[key] = list.length;
+          }
+          return next;
+        });
+        setCommentIdsByKey((prev) => {
+          const next = { ...prev };
+          const prefix = `${sheetName}:`;
+          Object.keys(next).forEach((key) => {
+            if (key.startsWith(prefix)) delete next[key];
+          });
+          for (const [key, list] of Object.entries(store)) {
+            next[key] = list.map((c) => c.id);
           }
           return next;
         });
@@ -2647,6 +2661,11 @@ export function ScenesView() {
       delete next[`${sheetName}:${sceneNo}`];
       return next;
     });
+    setCommentIdsByKey((prev) => {
+      const next = { ...prev };
+      delete next[`${sheetName}:${sceneNo}`];
+      return next;
+    });
 
     try {
       await deleteSceneFromSupabase(sceneUuid);
@@ -3471,6 +3490,7 @@ export function ScenesView() {
                 bgSheetName={bgPart?.sheetName ?? null}
                 actSheetName={actPart?.sheetName ?? null}
                 commentCounts={commentCounts}
+                commentIdsByKey={commentIdsByKey}
                 searchQuery={searchQuery}
                 selectedSceneIds={selectedSceneIds}
                 sceneGroupMode={sceneGroupMode}
@@ -3504,6 +3524,7 @@ export function ScenesView() {
                           bgPart?.sheetName ?? null,
                           actPart?.sheetName ?? null,
                           commentCounts,
+                          commentIdsByKey,
                         );
                         if (!primary) return null;
                         return (
@@ -3518,6 +3539,7 @@ export function ScenesView() {
                             searchQuery={searchQuery}
                             bgCommentCount={commentBadgeCounts.bg}
                             actCommentCount={commentBadgeCounts.act}
+                            totalCommentCount={commentBadgeCounts.total}
                             onToggle={(sheet, id, stage) => handleToggleForSheet(sheet, id, stage)}
                             onDelete={(sheet, idx) => handleDeleteSceneForSheet(sheet, idx)}
                             onOpenDetail={(sheet, idx) => { setDetailContext({ sheetName: sheet, sceneIndex: idx }); setDetailSceneIndex(idx); }}
@@ -3549,6 +3571,7 @@ export function ScenesView() {
                     bgPart?.sheetName ?? null,
                     actPart?.sheetName ?? null,
                     commentCounts,
+                    commentIdsByKey,
                   );
                   if (!primary) return null;
                   return (
@@ -3563,6 +3586,7 @@ export function ScenesView() {
                       searchQuery={searchQuery}
                       bgCommentCount={commentBadgeCounts.bg}
                       actCommentCount={commentBadgeCounts.act}
+                      totalCommentCount={commentBadgeCounts.total}
                       onToggle={(sheet, id, stage) => handleToggleForSheet(sheet, id, stage)}
                       onDelete={(sheet, idx) => handleDeleteSceneForSheet(sheet, idx)}
                       onOpenDetail={(sheet, idx) => { setDetailContext({ sheetName: sheet, sceneIndex: idx }); setDetailSceneIndex(idx); }}

--- a/src/views/ScenesView.tsx
+++ b/src/views/ScenesView.tsx
@@ -1785,8 +1785,11 @@ export function ScenesView() {
     setPendingDeepLink(null);
   }, [pendingDeepLink, episodes]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // 댓글 카운트 로드 (currentPart 또는 bgPart/actPart 정의 후)
-  useEffect(() => {
+  // 댓글 카운트 로드 (currentPart 또는 bgPart/actPart 정의 후).
+  // 주의: 이 함수 내부에서 invalidatePartCache 를 호출하면 'bflow:comments-invalidated' 이벤트가
+  // 발화되어 아래 리스너가 다시 이 함수를 호출하는 무한 루프가 발생한다. 캐시 무효화는
+  // 소스(댓글 add/edit/delete, 씬 삭제 핸들러, App.tsx Realtime 처리) 쪽에서만 책임진다.
+  const reloadCommentCounts = useCallback(() => {
     const sheetsToLoad = selectedDepartment === 'all'
       ? [bgPart?.sheetName, actPart?.sheetName].filter(Boolean) as string[]
       : currentPart ? [currentPart.sheetName] : [];
@@ -1795,6 +1798,10 @@ export function ScenesView() {
       loadPartComments(sheetName).then((store) => {
         setCommentCounts((prev) => {
           const next = { ...prev };
+          const prefix = `${sheetName}:`;
+          Object.keys(next).forEach((key) => {
+            if (key.startsWith(prefix)) delete next[key];
+          });
           for (const [key, list] of Object.entries(store)) {
             next[key] = list.length;
           }
@@ -1802,7 +1809,20 @@ export function ScenesView() {
         });
       }).catch(() => {});
     });
-  }, [detailSceneIndex, detailContext, currentPart?.sheetName, bgPart?.sheetName, actPart?.sheetName, selectedDepartment]);
+  }, [selectedDepartment, bgPart?.sheetName, actPart?.sheetName, currentPart?.sheetName]);
+
+  useEffect(() => {
+    reloadCommentCounts();
+    // 이슈 F(2026-04-23): 씬 수 변화(삭제/추가/재생성)도 트리거. 재생성 시 잔존 뱃지 방지.
+  }, [reloadCommentCounts, detailSceneIndex, detailContext, bgPart?.scenes.length, actPart?.scenes.length, currentPart?.scenes.length]);
+
+  // 이슈 F-2(2026-04-23): 댓글 추가/수정/삭제로 캐시가 무효화되면 카드 뷰 뱃지도 즉시 갱신.
+  // 이 시점에는 소스 쪽에서 이미 캐시를 비운 뒤이므로 재조회만 하면 된다 (invalidate 재호출 금지).
+  useEffect(() => {
+    const handler = () => reloadCommentCounts();
+    window.addEventListener('bflow:comments-invalidated', handler);
+    return () => window.removeEventListener('bflow:comments-invalidated', handler);
+  }, [reloadCommentCounts]);
 
   // 에피소드 제목/메모 → App.tsx에서 병렬 로드됨 (글로벌 스토어)
 
@@ -2615,9 +2635,18 @@ export function ScenesView() {
       return;
     }
     const sceneUuid = targetScene.id;
+    const sceneNo = targetScene.no;
 
     const prevEpisodes = currentEpisodes;
     deleteSceneOptimistic(sheetName, sceneIndex);
+
+    // 이슈 F(2026-04-23): CASCADE로 DB 댓글/리비전이 사라지니 로컬 캐시·카운트도 즉시 정리.
+    invalidatePartCache(sheetName);
+    setCommentCounts((prev) => {
+      const next = { ...prev };
+      delete next[`${sheetName}:${sceneNo}`];
+      return next;
+    });
 
     try {
       await deleteSceneFromSupabase(sceneUuid);
@@ -2666,20 +2695,29 @@ export function ScenesView() {
   };
 
   // ─── 파트 삭제 ─────────────────────
-  const handleDeletePart = async (sheetName: string) => {
-    const part = parts.find((p) => p.sheetName === sheetName);
-    if (!part) return;
-    if (!confirm(`${part.partId}파트를 삭제하시겠습니까?\n(시트에서 숨김 처리됩니다)`)) return;
+  // BG·ACT 동시 선택(전체 뷰)에서도 한 번의 확인으로 양쪽 파트를 함께 삭제 처리.
+  const handleDeletePartsForSheets = async (sheetNames: string[]) => {
+    if (sheetNames.length === 0) return;
+    const allParts = useDataStore.getState().episodes.flatMap((ep) => ep.parts);
+    const targetParts = sheetNames
+      .map((sn) => allParts.find((p) => p.sheetName === sn))
+      .filter((p): p is NonNullable<typeof p> => !!p);
+    if (targetParts.length === 0) return;
 
-    // 롤백용 스냅샷
+    const partLabel = [...new Set(targetParts.map((p) => p.partId))].join('·');
+    if (!confirm(`${partLabel}파트를 삭제하시겠습니까?\n파트에 속한 모든 씬·댓글·리비전도 함께 정리됩니다.`)) return;
+
     const prevEpisodes = useDataStore.getState().episodes;
     const prevSelectedPart = selectedPart;
 
-    deletePartOptimistic(sheetName);
+    for (const sn of sheetNames) {
+      deletePartOptimistic(sn);
+      invalidatePartCache(sn);
+    }
     setSelectedPart(null);
 
     try {
-      await softDeletePart(sheetName);
+      await Promise.all(sheetNames.map((sn) => softDeletePart(sn)));
       syncInBackground();
     } catch (err) {
       setEpisodes(prevEpisodes);
@@ -2689,11 +2727,13 @@ export function ScenesView() {
     }
   };
 
+  const handleDeletePart = (sheetName: string) => handleDeletePartsForSheets([sheetName]);
+
   // ─── 에피소드 삭제 ────────────────────
   const handleDeleteEpisode = async () => {
     if (!currentEp) return;
     const epDisplayName = episodeTitles[currentEp.episodeNumber] || currentEp.title;
-    if (!confirm(`"${epDisplayName}"를 삭제하시겠습니까?\n(시트에서 숨김 처리됩니다)`)) return;
+    if (!confirm(`"${epDisplayName}"를 삭제하시겠습니까?\n에피소드의 모든 파트·씬·댓글도 함께 정리됩니다. 아카이빙을 원하면 우클릭 메뉴에서 '아카이빙하기'를 이용해주세요.`)) return;
 
     // 롤백용 스냅샷
     const prevEpisodes = useDataStore.getState().episodes;
@@ -4115,11 +4155,10 @@ export function ScenesView() {
               label: '파트 삭제',
               icon: <Trash2 size={12} />,
               danger: true,
-              disabled: partMenuTarget.sheetNames.length !== 1,
+              disabled: partMenuTarget.sheetNames.length === 0,
               onClick: () => {
-                const targetSheetName = partMenuTarget.sheetNames[0];
-                if (targetSheetName) {
-                  handleDeletePart(targetSheetName);
+                if (partMenuTarget.sheetNames.length > 0) {
+                  handleDeletePartsForSheets(partMenuTarget.sheetNames);
                 }
               },
             },

--- a/src/views/ScenesView.tsx
+++ b/src/views/ScenesView.tsx
@@ -2654,8 +2654,10 @@ export function ScenesView() {
     const prevEpisodes = currentEpisodes;
     deleteSceneOptimistic(sheetName, sceneIndex);
 
-    // 이슈 F(2026-04-23): CASCADE로 DB 댓글/리비전이 사라지니 로컬 캐시·카운트도 즉시 정리.
-    invalidatePartCache(sheetName);
+    // 이슈 F(2026-04-23): 낙관적으로 로컬 state 에서 뱃지 숫자를 즉시 비움.
+    // Codex P2 7차(2026-04-23): 여기서 invalidatePartCache 를 부르면 `bflow:comments-invalidated`
+    // 이벤트가 즉시 발화되어 리스너가 DB 재조회 → 씬이 아직 남아 있어 뱃지가 다시 채워지는 race.
+    // 캐시 무효화는 DB 삭제 성공 후에만 수행한다.
     setCommentCounts((prev) => {
       const next = { ...prev };
       delete next[`${sheetName}:${sceneNo}`];
@@ -2669,6 +2671,8 @@ export function ScenesView() {
 
     try {
       await deleteSceneFromSupabase(sceneUuid);
+      // CASCADE 로 DB 쪽 댓글/리비전은 이 시점에 확실히 사라졌으므로 캐시 무효화 + 이벤트 전파.
+      invalidatePartCache(sheetName);
       syncInBackground();
     } catch (err) {
       setEpisodes(prevEpisodes);


### PR DESCRIPTION
## 📋 업데이트 요약

> 이번 업데이트에서 달라진 점을 간략하게 정리했습니다.

- 🐛 **씬이나 파트를 삭제하고 같은 이름으로 다시 만들면 예전 댓글이 따라오던 버그**를 고쳤습니다.
- 🔄 **BG 탭에서 쓴 댓글이 ACT 탭에서도 보입니다** (이전 v1.11~v1.12.1 에서 시도했다가 롤백된 기능을 이번에 완성).
- 🐛 **"duplicate key" 오류**로 파트를 같은 이름으로 재생성하지 못하던 문제를 해결했습니다.
- 🐛 **카드 뷰 뱃지 숫자가 실제 댓글 수의 2배로 보이던 문제**를 고쳤습니다.
- ⚡ **댓글 저장 직후 카드 뷰 뱃지가 즉시 갱신**됩니다 (탭 이동 없이).
- ⚡ **씬 삭제·재생성 시 뱃지도 즉시 사라집니다**.
- 🔧 **전체 뷰에서도 파트 삭제가 가능**해졌고, 삭제 확인창의 "시트에서 숨김 처리됩니다" 레거시 문구를 실제 동작에 맞게 교체했습니다.

---

## 🔧 상세 기술 설명

### DB 스키마 변경 (이슈 F 근본 해결)
Supabase 프로덕션에 마이그레이션 `issue_f_add_scene_uuid_fk_cascade` 적용 완료.
- `comments`·`comp_revisions` 에 `scene_uuid UUID REFERENCES scenes(id) ON DELETE CASCADE` 컬럼 추가
- 기존 살아있는 댓글 10건에 `scene_uuid` 자동 백필 (part_letter + LPAD 3자리 정규화 규칙)
- 고아 댓글 2건(테스트성)은 `comments_archive` 테이블로 이동 후 원본에서 삭제
- 인덱스: `idx_comments_scene_uuid`, `idx_comp_revisions_scene_uuid`

### 댓글/리비전 저장 로직 — `electron/supabase.ts`
- `resolveSceneUuid`: `partUuid + sceneId` → scene UUID 조회 (앱의 canonical 정규화와 동일 규칙)
- `resolveSceneUuidWithRetry`: 0 → 500ms → 1000ms 백오프 3회 재시도 (낙관적 씬 ↔ DB 저장 레이스 완화)
- `addComment`·`addRevision` 에 `scene_uuid` 저장 + 씬 없으면 저장 거부 (고아 신규 생성 원천 차단)
- `addPart`: 동일 이름 soft-deleted 파트를 **진짜 DELETE 후 재생성** (CASCADE로 자식 자동 정리)

### 댓글 BG↔ACT 통합 조회 — `src/services/commentService.ts`
- `loadPartComments` 가 BG·ACT 양쪽 파트 UUID 에서 comments 조회 후 요청된 sheetName 기준 키로 통합
- `invalidatePartCache` 는 BG↔ACT 양쪽 캐시 모두 비움
- `addComment`/`editComment`/`deleteComment` 끝에 `bflow:comments-invalidated` 이벤트 dispatch (자기 창도 즉시 갱신)

### UI — 이중 집계·중복 표시 제거
- `src/components/scenes/CommentPanel.tsx`: primary+secondary 이중 조회 제거 (이미 통합 조회됨)
- `src/components/scenes/UnifiedSceneCard.tsx`: `bgCommentCount + actCommentCount` → `Math.max(bg, act)`
- `src/utils/mergedSceneHelpers.ts`: `total: bg + act` → `total: Math.max(bg, act)`
- `src/views/ScenesView.tsx`:
  - `reloadCommentCounts` 훅 분리 + `scenes.length` 변화 의존성 추가
  - `bflow:comments-invalidated` 이벤트 구독 (무한 루프 방지 위해 리스너 내부에선 invalidate 재호출 금지)
  - 씬 삭제 핸들러에 캐시 무효화 + stale `commentCounts` 키 즉시 제거
  - `handleDeletePartsForSheets` 신설: 전체 뷰에서 BG·ACT 동시 삭제 한 번의 확인창으로 처리
  - 파트·에피소드 삭제 확인 문구 현행화

---

## 🚧 개발 난항

### 1. 씬 식별자 표기 불일치로 인한 고아 판정 오류
- **문제**: 1차 조사에서 `scenes.scene_number`("a001")와 `comments.scene_id`("1") 단순 문자열 비교로 판정 → **12개 댓글 전부 고아**로 오판. 실제 팀원 업무 댓글까지 삭제할 뻔함.
- **해결**: 앱의 canonical 정규화(`normalizePartId + LPAD(3)`) 규칙을 SQL로 재구현 → 살아있는 10건 정확히 백필, 테스트성 고아 2건만 archive 이동.
- **교훈**: 마이그레이션 스크립트는 **반드시 앱의 정규화 규칙과 동일한 매칭**을 써야 함.

### 2. 낙관적 UI vs DB 저장 레이스
- **문제**: 새 씬을 UI에 표시 후 즉시 댓글 작성 시도하면 DB에 씬이 아직 없어 scene_uuid 조회 실패 → "씬을 찾을 수 없음" 에러.
- **해결**: 서버에서 `resolveSceneUuidWithRetry`로 짧은 재시도(최대 1.5초).
- **교훈**: 낙관적 UI 환경에선 읽기 실패 시 안전장치로 재시도가 필요.

### 3. 무한 루프 사고
- **문제**: `reloadCommentCounts` 안에서 `invalidatePartCache` 호출 → `bflow:comments-invalidated` 이벤트 dispatch → 동일 리스너 재호출 → 무한 반복. 앱이 로딩에서 멈춤.
- **해결**: 캐시 무효화 책임을 "소스(댓글 저장, 씬 삭제, Realtime 이벤트)"로만 국한, 리스너는 재조회만.
- **교훈**: 이벤트 기반 재로드에서 리스너가 동일 이벤트를 다시 발화시키면 필연적 루프. 책임 분리 필수.

### 4. 이중·삼중 집계
- **문제**: `loadPartComments`가 이미 BG·ACT 통합 결과를 주는데, `CommentPanel`에서 primary+secondary 합치고, `getMergedCommentBadgeCounts`에서 bg+act 합치고, `UnifiedSceneCard`에서도 bg+act 합쳐 → 댓글 1개가 최대 6개로 표시.
- **해결**: 통합 결과를 그대로 쓰고 모든 합산 지점에서 단일 조회 또는 `Math.max`로 교체.
- **교훈**: "한 번에 통합"은 명확히 문서화해서 호출자가 또 합치지 않게.

---

## ✅ 테스트 가이드

### 사용자 테스트
> 아래 시나리오를 직접 실행해서 정상 동작을 확인해주세요.

1. **씬 삭제 → 재생성 시 댓글 사라짐**
   - 댓글 있는 씬을 삭제하고 같은 번호로 새 씬 추가
   - ✅ 기대: 새 씬엔 댓글이 없고, 카드 뷰 뱃지도 즉시 사라짐
   - ❌ 비정상: 예전 댓글이 보이거나 뱃지 숫자 잔존

2. **파트 재생성 성공**
   - EP1의 B/C/D 파트 중 하나를 같은 이름으로 추가 시도
   - ✅ 기대: "duplicate key" 오류 없이 깨끗한 파트 생성
   - ❌ 비정상: 에러 토스트 발생

3. **BG·ACT 댓글 통합**
   - BG 탭에서 댓글 작성 → ACT 탭 같은 씬 열기 → 전체 뷰 카드 뷰 뱃지 확인
   - ✅ 기대: 세 경로 모두 댓글 표시
   - ❌ 비정상: 한 경로에서만 보임

4. **카드 뱃지 숫자 정확**
   - 댓글 1개 작성 → 뱃지가 "1"로 표시
   - ✅ 기대: 실제 댓글 수와 일치

5. **댓글 저장 후 즉시 갱신**
   - 상세 모달에서 댓글 작성 → 닫기
   - ✅ 기대: 카드 뷰 뱃지 즉시 반영 (탭 이동 불필요)

6. **전체 뷰 파트 삭제**
   - 전체 뷰에서 파트 우클릭 → "파트 삭제"
   - ✅ 기대: "파트 내 씬·댓글도 함께 정리됩니다" 확인창 후 BG·ACT 동시 삭제

### 개발자 테스트
```bash
npx tsc --noEmit        # 타입 체크 통과 확인
npx vite build          # 프로덕션 빌드 확인
```

**Supabase 확인**:
- `comments`·`comp_revisions` 테이블에 `scene_uuid` 컬럼 + FK + `ON DELETE CASCADE` 존재
- `comments_archive` 테이블 존재 (고아 댓글 2건 보관 중)

🤖 Generated with [Claude Code](https://claude.com/claude-code)