### PR TITLE
[v1.13.1] 메모 위젯 WYSIWYG 에디터로 전환

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,6 +6,12 @@
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev"],
       "port": 5173
+    },
+    {
+      "name": "mockup",
+      "runtimeExecutable": "python",
+      "runtimeArgs": ["-m", "http.server", "5555"],
+      "port": 5555
     }
   ]
 }

--- a/docs/superpowers/mockups/memo-wysiwyg-mockup.html
+++ b/docs/superpowers/mockups/memo-wysiwyg-mockup.html
@@ -1,0 +1,819 @@
+<!DOCTYPE html>
+<html lang="ko" data-theme="violet" data-mode="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>메모 WYSIWYG — 디자인 목업</title>
+<style>
+  /* ─── 토큰 시스템 (앱 themes.ts 와 1:1 일치) ─── */
+  [data-theme="violet"][data-mode="dark"] {
+    --bg-primary: 15 17 23;
+    --bg-card: 26 29 39;
+    --bg-border: 45 48 65;
+    --text-primary: 232 232 238;
+    --text-secondary: 139 141 163;
+    --accent: 108 92 231;
+    --accent-sub: 162 155 254;
+    --on-accent: 255 255 255;
+  }
+  [data-theme="cinema-red"][data-mode="dark"] {
+    --bg-primary: 12 10 16;
+    --bg-card: 22 18 27;
+    --bg-border: 45 34 50;
+    --text-primary: 238 232 238;
+    --text-secondary: 163 139 158;
+    --accent: 225 29 72;
+    --accent-sub: 251 113 133;
+    --on-accent: 255 255 255;
+  }
+  [data-theme="midnight-blue"][data-mode="dark"] {
+    --bg-primary: 11 17 32;
+    --bg-card: 18 26 44;
+    --bg-border: 35 48 75;
+    --text-primary: 230 235 245;
+    --text-secondary: 130 148 180;
+    --accent: 59 130 246;
+    --accent-sub: 96 165 250;
+    --on-accent: 255 255 255;
+  }
+  [data-theme="emerald"][data-mode="dark"] {
+    --bg-primary: 10 16 14;
+    --bg-card: 16 26 22;
+    --bg-border: 30 50 42;
+    --text-primary: 230 242 236;
+    --text-secondary: 130 163 148;
+    --accent: 16 185 129;
+    --accent-sub: 52 211 153;
+    --on-accent: 255 255 255;
+  }
+  [data-mode="light"] {
+    --bg-primary: 239 243 250;
+    --bg-card: 255 255 255;
+    --bg-border: 188 195 211;
+    --text-primary: 24 29 40;
+    --text-secondary: 78 88 106;
+    --on-accent: 255 255 255;
+  }
+  [data-theme="violet"][data-mode="light"]      { --accent: 108 92 231; --accent-sub: 162 155 254; }
+  [data-theme="cinema-red"][data-mode="light"]  { --accent: 225 29 72;  --accent-sub: 251 113 133; }
+  [data-theme="midnight-blue"][data-mode="light"] { --accent: 59 130 246; --accent-sub: 96 165 250; }
+  [data-theme="emerald"][data-mode="light"]     { --accent: 16 185 129; --accent-sub: 52 211 153; }
+
+  /* ─── 기본 ─── */
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans KR", sans-serif; }
+  body {
+    background: rgb(var(--bg-primary));
+    color: rgb(var(--text-primary));
+    padding: 32px;
+    min-height: 100vh;
+    transition: background 200ms;
+  }
+
+  /* ─── 상단 컨트롤 ─── */
+  .controls {
+    display: flex; gap: 12px; align-items: center; flex-wrap: wrap;
+    padding: 12px 16px;
+    background: rgb(var(--bg-card));
+    border: 1px solid rgb(var(--bg-border) / .5);
+    border-radius: 12px;
+    margin-bottom: 24px;
+    position: sticky; top: 16px; z-index: 100;
+    backdrop-filter: blur(8px);
+  }
+  .controls label {
+    font-size: 12px;
+    color: rgb(var(--text-secondary));
+    margin-right: 4px;
+  }
+  .controls select, .controls button {
+    background: rgb(var(--bg-primary));
+    color: rgb(var(--text-primary));
+    border: 1px solid rgb(var(--bg-border));
+    border-radius: 6px;
+    padding: 6px 10px;
+    font-size: 12px;
+    cursor: pointer;
+    transition: all 150ms;
+  }
+  .controls button:hover {
+    border-color: rgb(var(--accent));
+    color: rgb(var(--accent));
+  }
+  .controls .mode-badge {
+    margin-left: auto;
+    font-size: 11px;
+    color: rgb(var(--text-secondary));
+  }
+
+  /* ─── 섹션 ─── */
+  .section {
+    margin-bottom: 48px;
+  }
+  .section-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: rgb(var(--text-secondary));
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 12px;
+    padding-left: 8px;
+    border-left: 3px solid rgb(var(--accent));
+  }
+  .section-desc {
+    font-size: 13px;
+    color: rgb(var(--text-secondary));
+    margin-bottom: 16px;
+    padding-left: 11px;
+  }
+
+  /* ─── Before/After 비교 ─── */
+  .before-after {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+  }
+  @media (max-width: 900px) {
+    .before-after { grid-template-columns: 1fr; }
+  }
+  .compare-col {
+    display: flex; flex-direction: column;
+  }
+  .compare-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: rgb(var(--text-secondary));
+    margin-bottom: 6px;
+    padding: 2px 8px;
+    background: rgb(var(--bg-border) / .3);
+    border-radius: 4px;
+    align-self: flex-start;
+  }
+  .compare-label.after {
+    background: rgb(var(--accent) / .15);
+    color: rgb(var(--accent));
+  }
+
+  /* ─── 메모 위젯 (실제 앱 Widget.tsx 모사) ─── */
+  .widget {
+    background: rgb(var(--bg-card));
+    border: 1px solid rgb(var(--bg-border) / .5);
+    border-radius: 12px;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+  .widget-narrow { max-width: 420px; }
+  .widget-wide { max-width: 560px; }
+  .widget-header {
+    display: flex; align-items: center; gap: 8px;
+    padding: 8px 14px;
+    border-bottom: 1px solid rgb(var(--bg-border) / .3);
+  }
+  .widget-header .icon-note {
+    color: rgb(var(--accent));
+  }
+  .widget-title {
+    font-size: 12px;
+    font-weight: 500;
+    color: rgb(var(--text-primary) / .8);
+  }
+  .widget-header-right {
+    margin-left: auto;
+    display: flex; align-items: center; gap: 6px;
+    font-size: 11px;
+    color: rgb(var(--text-secondary) / .7);
+  }
+  .widget-header-right input[type="range"] {
+    width: 56px; height: 4px; cursor: pointer; accent-color: rgb(var(--accent));
+  }
+
+  /* 탭바 */
+  .tabbar {
+    display: flex; align-items: center; gap: 2px;
+    padding: 4px 6px;
+    border-bottom: 1px solid rgb(var(--bg-border) / .2);
+  }
+  .tab {
+    padding: 2px 8px;
+    font-size: 11px;
+    border-radius: 6px;
+    cursor: pointer;
+    color: rgb(var(--text-secondary) / .6);
+  }
+  .tab:hover { color: rgb(var(--text-primary)); background: rgb(var(--accent) / .05); }
+  .tab.active {
+    background: rgb(var(--accent) / .15);
+    color: rgb(var(--accent));
+    font-weight: 500;
+  }
+  .tab-add {
+    padding: 2px 6px;
+    color: rgb(var(--text-secondary) / .4);
+    cursor: pointer;
+  }
+  .tab-add:hover { color: rgb(var(--accent)); background: rgb(var(--accent) / .1); border-radius: 6px; }
+
+  /* ─── 툴바 ─── */
+  .toolbar {
+    display: flex; align-items: center; gap: 8px;
+    padding: 2px 6px;
+    border-bottom: 1px solid rgb(var(--bg-border) / .15);
+    min-height: 28px;
+  }
+  .toolbar-group {
+    display: flex; align-items: center; gap: 2px;
+  }
+  .toolbar-divider {
+    width: 1px; height: 16px;
+    background: rgb(var(--bg-border) / .4);
+  }
+  .tool-btn {
+    width: 22px; height: 22px;
+    display: inline-flex; align-items: center; justify-content: center;
+    border: none; background: transparent;
+    color: rgb(var(--text-secondary) / .6);
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 12px;
+    font-weight: 600;
+    transition: all 150ms;
+  }
+  .tool-btn:hover {
+    color: rgb(var(--accent));
+    background: rgb(var(--accent) / .1);
+  }
+  .tool-btn.active {
+    color: rgb(var(--accent));
+    background: rgb(var(--accent) / .15);
+  }
+  .tool-btn:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px rgb(var(--accent) / .4);
+  }
+  .tool-btn svg { width: 13px; height: 13px; }
+  .tool-dropdown {
+    display: inline-flex; align-items: center; gap: 2px;
+    padding: 2px 6px;
+    font-size: 11px;
+    color: rgb(var(--text-secondary) / .7);
+    background: transparent;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+  .tool-dropdown:hover { background: rgb(var(--accent) / .1); color: rgb(var(--accent)); }
+
+  /* ─── 에디터 본문 ─── */
+  .editor {
+    padding: 12px 16px;
+    font-size: 14px;
+    line-height: 1.7;
+    color: rgb(var(--text-primary));
+    min-height: 320px;
+  }
+  .editor h1 {
+    font-size: 1.6em;
+    font-weight: 600;
+    line-height: 1.3;
+    margin: 16px 0 8px;
+  }
+  .editor h1:first-child { margin-top: 0; }
+  .editor h2 {
+    font-size: 1.35em;
+    font-weight: 600;
+    line-height: 1.3;
+    margin: 12px 0 6px;
+  }
+  .editor h3 {
+    font-size: 1.15em;
+    font-weight: 500;
+    line-height: 1.4;
+    margin: 8px 0 4px;
+  }
+  .editor p { margin: 0 0 4px; }
+  .editor ul, .editor ol {
+    padding-left: 20px;
+    margin: 2px 0;
+  }
+  .editor ul.task-list {
+    list-style: none;
+    padding-left: 0;
+  }
+  .editor ul.task-list li {
+    display: flex; align-items: flex-start; gap: 8px;
+    padding: 2px 0;
+  }
+  .editor ul.task-list input[type="checkbox"] {
+    width: 14px; height: 14px;
+    margin-top: 5px;
+    accent-color: rgb(var(--accent));
+    cursor: pointer;
+  }
+  .editor ul.task-list li.done > span {
+    color: rgb(var(--text-secondary) / .5);
+    text-decoration: line-through;
+  }
+  .editor strong { font-weight: 700; }
+  .editor em { font-style: italic; }
+  .editor u { text-decoration: underline; text-underline-offset: 2px; text-decoration-color: rgb(var(--text-primary) / .4); }
+  .editor s { text-decoration: line-through; text-decoration-color: rgb(var(--text-primary) / .5); }
+  .editor a {
+    color: rgb(var(--accent));
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    text-decoration-color: rgb(var(--accent) / .5);
+    cursor: pointer;
+    transition: all 150ms;
+  }
+  .editor a:hover { text-decoration-color: rgb(var(--accent)); }
+  .editor a.selected {
+    background: rgb(var(--accent) / .15);
+    border-radius: 3px;
+    padding: 0 2px;
+  }
+  .editor .selection-highlight {
+    background: rgb(var(--accent) / .25);
+    padding: 0 1px;
+    border-radius: 2px;
+  }
+  .editor .caret::after {
+    content: '';
+    display: inline-block;
+    width: 1px; height: 1em;
+    background: rgb(var(--text-primary));
+    vertical-align: text-bottom;
+    animation: blink 1s infinite;
+    margin-left: 1px;
+  }
+  @keyframes blink { 0%, 50% { opacity: 1; } 51%, 100% { opacity: 0; } }
+  .editor .placeholder { color: rgb(var(--text-secondary) / .3); pointer-events: none; }
+
+  /* Before(현재) 렌더 */
+  .editor-before {
+    padding: 12px 16px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 13px;
+    line-height: 1.65;
+    color: rgb(var(--text-primary));
+    min-height: 320px;
+    white-space: pre-wrap;
+  }
+  .editor-before .raw-md {
+    background: rgb(var(--text-secondary) / .08);
+    padding: 0 3px;
+    border-radius: 2px;
+  }
+
+  /* ─── 링크 버블 메뉴 ─── */
+  .bubble-container {
+    position: relative;
+    padding: 40px 16px 120px;
+    min-height: 200px;
+  }
+  .bubble-line {
+    font-size: 14px;
+    line-height: 1.7;
+  }
+  .bubble {
+    position: absolute;
+    background: rgb(var(--bg-card));
+    border: 1px solid rgb(var(--bg-border));
+    border-radius: 8px;
+    box-shadow: 0 10px 24px rgb(var(--bg-primary) / .4), 0 2px 6px rgb(0 0 0 / .2);
+    padding: 6px 8px;
+    display: flex; align-items: center; gap: 4px;
+    min-width: 240px;
+    z-index: 10;
+    animation: fadeIn 150ms ease-out;
+  }
+  @keyframes fadeIn { from { opacity: 0; transform: translate(-50%, -4px); } to { opacity: 1; transform: translate(-50%, 0); } }
+  .bubble::after {
+    content: '';
+    position: absolute;
+    bottom: -5px;
+    left: 50%;
+    transform: translateX(-50%) rotate(45deg);
+    width: 10px; height: 10px;
+    background: rgb(var(--bg-card));
+    border-right: 1px solid rgb(var(--bg-border));
+    border-bottom: 1px solid rgb(var(--bg-border));
+  }
+  .bubble-icon {
+    color: rgb(var(--text-secondary) / .7);
+    font-size: 14px;
+    margin-right: 2px;
+  }
+  .bubble input {
+    flex: 1;
+    background: transparent;
+    border: none;
+    outline: none;
+    color: rgb(var(--text-primary));
+    font-size: 13px;
+    min-width: 0;
+  }
+  .bubble input::placeholder { color: rgb(var(--text-secondary) / .4); }
+  .bubble-action {
+    width: 22px; height: 22px;
+    display: inline-flex; align-items: center; justify-content: center;
+    border: none; border-radius: 5px;
+    background: rgb(var(--accent));
+    color: rgb(var(--on-accent));
+    cursor: pointer;
+    font-size: 11px;
+    font-weight: 700;
+  }
+  .bubble-action:hover { background: rgb(var(--accent) / .9); }
+  .bubble-action.icon {
+    background: transparent;
+    color: rgb(var(--text-secondary) / .7);
+  }
+  .bubble-action.icon:hover {
+    background: rgb(var(--accent) / .1);
+    color: rgb(var(--accent));
+  }
+  .bubble-url {
+    flex: 1;
+    font-size: 12px;
+    color: rgb(var(--text-secondary));
+    max-width: 180px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    padding: 0 4px;
+  }
+
+  /* ─── 상태 라벨 ─── */
+  .state-label {
+    display: inline-block;
+    font-size: 10px;
+    color: rgb(var(--text-secondary));
+    padding: 2px 6px;
+    background: rgb(var(--bg-border) / .3);
+    border-radius: 4px;
+    margin-right: 6px;
+    vertical-align: middle;
+  }
+
+  /* 위젯 박스 라벨 */
+  .widget-wrap {
+    display: flex; flex-direction: column; gap: 8px;
+  }
+  .widget-note {
+    font-size: 11px;
+    color: rgb(var(--text-secondary));
+    padding: 0 4px;
+  }
+
+  /* 상태 갤러리 (툴바 버튼 3상태) */
+  .state-gallery {
+    display: flex; gap: 20px; flex-wrap: wrap;
+    padding: 16px;
+    background: rgb(var(--bg-card));
+    border: 1px solid rgb(var(--bg-border) / .5);
+    border-radius: 8px;
+  }
+  .state-item {
+    display: flex; flex-direction: column; align-items: center; gap: 6px;
+    min-width: 80px;
+  }
+  .state-item .label {
+    font-size: 10px;
+    color: rgb(var(--text-secondary));
+  }
+</style>
+</head>
+<body>
+
+<!-- ─── 컨트롤 ─── -->
+<div class="controls">
+  <label>테마</label>
+  <select id="theme">
+    <option value="violet">바이올렛 드림</option>
+    <option value="cinema-red">공산당 레드</option>
+    <option value="midnight-blue">윤성원 블루</option>
+    <option value="emerald">에메랄드</option>
+  </select>
+
+  <label>모드</label>
+  <button id="modeToggle">☾ 다크 모드</button>
+
+  <span class="mode-badge" id="modeLabel">위젯 가로: <b>넓음</b> (≥320px)</span>
+</div>
+
+<!-- ─── SECTION 0: Before vs After 전체 비교 ─── -->
+<div class="section">
+  <div class="section-title">0. 전체 모습 — 지금 vs 바뀐 후</div>
+  <div class="section-desc">실제 B flow 에 들어갈 메모 위젯 한 장면. 마크다운 기호가 사라지고 서식이 실시간 적용되는 것이 핵심.</div>
+
+  <div class="before-after">
+    <!-- BEFORE -->
+    <div class="compare-col">
+      <span class="compare-label">지금 (textarea + 마크다운)</span>
+      <div class="widget widget-wide">
+        <div class="widget-header">
+          <svg class="icon-note" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15.5 3H5a2 2 0 0 0-2 2v14c0 1.1.9 2 2 2h14a2 2 0 0 0 2-2V8.5L15.5 3Z"/><path d="M15 3v6h6"/></svg>
+          <span class="widget-title">메모</span>
+          <div class="widget-header-right">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/></svg>
+            <span style="margin-left:8px">🔠</span>
+            <input type="range" min="10" max="24" value="14" disabled>
+            <span>14</span>
+          </div>
+        </div>
+        <div class="tabbar">
+          <span class="tab active">주간 회의</span>
+          <span class="tab">TODO</span>
+          <span class="tab-add">+</span>
+        </div>
+        <div class="toolbar">
+          <div class="toolbar-group">
+            <button class="tool-btn"><strong>B</strong></button>
+            <button class="tool-btn"><em>I</em></button>
+            <button class="tool-btn"><u>U</u></button>
+            <button class="tool-btn"><s>S</s></button>
+          </div>
+        </div>
+<pre class="editor-before"># 3월 4주차 주간 회의
+
+**참석자**: 한솔, 재원, 수민
+
+## 체크 항목
+
+- 에피1 BG <span class="raw-md">__LO 검수__</span> 마감 수요일
+- 에피1 액팅 <span class="raw-md">**우선순위 높음**</span>
+- 시즌1 전체 PNG <span class="raw-md">~~보류~~</span>
+
+### 다음 안건
+
+1. 렌더팜 예산 재산정
+2. 외주 드로잉 일정
+
+링크: <span class="raw-md">[기획서](https://example.com/doc)</span></pre>
+      </div>
+      <div class="widget-note">⬆ 마크다운 기호가 그대로 노출. <code>👁 미리보기</code> 토글을 눌러야 서식 확인 가능.</div>
+    </div>
+
+    <!-- AFTER -->
+    <div class="compare-col">
+      <span class="compare-label after">바뀐 후 (TipTap WYSIWYG)</span>
+      <div class="widget widget-wide">
+        <div class="widget-header">
+          <svg class="icon-note" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15.5 3H5a2 2 0 0 0-2 2v14c0 1.1.9 2 2 2h14a2 2 0 0 0 2-2V8.5L15.5 3Z"/><path d="M15 3v6h6"/></svg>
+          <span class="widget-title">메모</span>
+          <div class="widget-header-right">
+            <span style="margin-left:2px">🔠</span>
+            <input type="range" min="10" max="24" value="14">
+            <span>14</span>
+          </div>
+        </div>
+        <div class="tabbar">
+          <span class="tab active">주간 회의</span>
+          <span class="tab">TODO</span>
+          <span class="tab-add">+</span>
+        </div>
+        <div class="toolbar">
+          <div class="toolbar-group">
+            <button class="tool-btn" title="굵게 (Ctrl+B)"><strong>B</strong></button>
+            <button class="tool-btn" title="기울임 (Ctrl+I)"><em>I</em></button>
+            <button class="tool-btn" title="밑줄 (Ctrl+U)"><u>U</u></button>
+            <button class="tool-btn" title="취소선 (Ctrl+Shift+X)"><s>S</s></button>
+          </div>
+          <div class="toolbar-divider"></div>
+          <div class="toolbar-group">
+            <button class="tool-btn" title="제목1 (Ctrl+Alt+1)" style="font-size:10px">H1</button>
+            <button class="tool-btn" title="제목2 (Ctrl+Alt+2)" style="font-size:10px">H2</button>
+            <button class="tool-btn" title="제목3 (Ctrl+Alt+3)" style="font-size:10px">H3</button>
+          </div>
+          <div class="toolbar-divider"></div>
+          <div class="toolbar-group">
+            <button class="tool-btn" title="불릿 목록 (Ctrl+Shift+8)">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><circle cx="4" cy="6" r="1" fill="currentColor"/><circle cx="4" cy="12" r="1" fill="currentColor"/><circle cx="4" cy="18" r="1" fill="currentColor"/></svg>
+            </button>
+            <button class="tool-btn" title="번호 목록 (Ctrl+Shift+7)">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="10" y1="6" x2="21" y2="6"/><line x1="10" y1="12" x2="21" y2="12"/><line x1="10" y1="18" x2="21" y2="18"/><path d="M4 6h1v4"/><path d="M4 10h2"/><path d="M6 18H4c0-1 2-2 2-3s-1-1.5-2-1"/></svg>
+            </button>
+            <button class="tool-btn active" title="체크리스트 (Ctrl+Shift+9)">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+            </button>
+          </div>
+          <div class="toolbar-divider"></div>
+          <div class="toolbar-group">
+            <button class="tool-btn" title="링크 (Ctrl+K)">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+            </button>
+          </div>
+        </div>
+        <div class="editor">
+          <h1>3월 4주차 주간 회의</h1>
+          <p><strong>참석자</strong>: 한솔, 재원, 수민</p>
+          <h2>체크 항목</h2>
+          <ul class="task-list">
+            <li class="done"><input type="checkbox" checked> <span>에피1 BG <u>LO 검수</u> 마감 수요일</span></li>
+            <li><input type="checkbox"> <span>에피1 액팅 <strong>우선순위 높음</strong></span></li>
+            <li><input type="checkbox"> <span>시즌1 전체 PNG <s>보류</s></span></li>
+          </ul>
+          <h3>다음 안건</h3>
+          <ol>
+            <li>렌더팜 예산 재산정</li>
+            <li>외주 드로잉 일정</li>
+          </ol>
+          <p>링크: <a href="#">기획서</a></p>
+        </div>
+      </div>
+      <div class="widget-note">⬆ 쓰는 순간 서식 그대로 보임. <code>☑ 체크리스트</code> 버튼에 커서가 있어 <strong>Active 상태</strong>로 켜져 있음.</div>
+    </div>
+  </div>
+</div>
+
+<!-- ─── SECTION 1: 툴바 3가지 상태 ─── -->
+<div class="section">
+  <div class="section-title">1. 툴바 버튼 — 4가지 상태</div>
+  <div class="section-desc">Default / Hover / Active(커서 위치에 서식 적용됨) / Disabled(로딩 중). 키보드 포커스 시에는 accent 40% ring 추가.</div>
+  <div class="state-gallery">
+    <div class="state-item">
+      <button class="tool-btn"><strong>B</strong></button>
+      <span class="label">Default</span>
+    </div>
+    <div class="state-item">
+      <button class="tool-btn" style="background: rgb(var(--accent) / .1); color: rgb(var(--accent));"><strong>B</strong></button>
+      <span class="label">Hover</span>
+    </div>
+    <div class="state-item">
+      <button class="tool-btn active"><strong>B</strong></button>
+      <span class="label">Active ⭐</span>
+    </div>
+    <div class="state-item">
+      <button class="tool-btn" style="box-shadow: 0 0 0 2px rgb(var(--accent) / .4)"><strong>B</strong></button>
+      <span class="label">Focus (키보드)</span>
+    </div>
+    <div class="state-item">
+      <button class="tool-btn" style="opacity: .4; cursor: not-allowed"><strong>B</strong></button>
+      <span class="label">Disabled</span>
+    </div>
+  </div>
+</div>
+
+<!-- ─── SECTION 2: 좁은 모드 ─── -->
+<div class="section">
+  <div class="section-title">2. 좁은 위젯 (에디터 가로 &lt; 320px)</div>
+  <div class="section-desc">ResizeObserver 로 감지해서 H1/H2/H3 → <code>[단락 ▾]</code>, 리스트 3개 → <code>[리스트 ▾]</code> 드롭다운으로 자동 축약.</div>
+  <div class="widget widget-narrow">
+    <div class="widget-header">
+      <svg class="icon-note" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15.5 3H5a2 2 0 0 0-2 2v14c0 1.1.9 2 2 2h14a2 2 0 0 0 2-2V8.5L15.5 3Z"/><path d="M15 3v6h6"/></svg>
+      <span class="widget-title">메모</span>
+      <div class="widget-header-right">
+        <span>🔠</span>
+        <input type="range" min="10" max="24" value="14">
+        <span>14</span>
+      </div>
+    </div>
+    <div class="tabbar">
+      <span class="tab active">메모 1</span>
+      <span class="tab-add">+</span>
+    </div>
+    <div class="toolbar">
+      <div class="toolbar-group">
+        <button class="tool-btn"><strong>B</strong></button>
+        <button class="tool-btn"><em>I</em></button>
+        <button class="tool-btn"><u>U</u></button>
+        <button class="tool-btn"><s>S</s></button>
+      </div>
+      <div class="toolbar-divider"></div>
+      <button class="tool-dropdown">단락 <span style="font-size:8px">▾</span></button>
+      <button class="tool-dropdown">리스트 <span style="font-size:8px">▾</span></button>
+      <div class="toolbar-divider"></div>
+      <button class="tool-btn">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+      </button>
+    </div>
+    <div class="editor" style="min-height: 140px">
+      <p>좁아도 모든 기능 그대로 사용 가능</p>
+      <p class="placeholder">메모를 입력하세요...</p>
+    </div>
+  </div>
+</div>
+
+<!-- ─── SECTION 3: 링크 버블 메뉴 ─── -->
+<div class="section">
+  <div class="section-title">3. 링크 버블 메뉴</div>
+  <div class="section-desc">텍스트 선택 + 🔗 버튼(또는 Ctrl+K) → 편집 버블. 기존 링크 위 커서 → 읽기 버블. ESC 로 닫힘.</div>
+
+  <div class="before-after">
+    <!-- 편집 버블 -->
+    <div class="compare-col">
+      <span class="compare-label after">시나리오 A — 새 링크 만들기</span>
+      <div class="widget widget-wide">
+        <div class="bubble-container">
+          <div class="bubble-line" style="text-align: center;">
+            하셨다 <span class="selection-highlight">스튜디오JBBJ 홈페이지</span> 방문해주세요
+          </div>
+          <div class="bubble" style="top: 78px; left: 50%;">
+            <span class="bubble-icon">🔗</span>
+            <input type="text" placeholder="https://..." value="https://studiojbbj.com" />
+            <button class="bubble-action">✓</button>
+          </div>
+        </div>
+      </div>
+      <div class="widget-note">URL input 자동 포커스 → Enter 또는 [✓] 로 적용, ESC 로 취소.</div>
+    </div>
+
+    <!-- 읽기 버블 -->
+    <div class="compare-col">
+      <span class="compare-label after">시나리오 B — 기존 링크 수정/제거</span>
+      <div class="widget widget-wide">
+        <div class="bubble-container">
+          <div class="bubble-line" style="text-align: center;">
+            문의는 <a href="#" class="selected">스튜디오JBBJ 홈페이지<span class="caret"></span></a> 로 주세요
+          </div>
+          <div class="bubble" style="top: 78px; left: 50%;">
+            <span class="bubble-url">studiojbbj.com</span>
+            <button class="bubble-action icon" title="열기">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+            </button>
+            <button class="bubble-action icon" title="편집">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+            </button>
+            <button class="bubble-action icon" title="링크 제거">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div class="widget-note">[↗] 브라우저로 열기 · [✏] 편집 모드 · [✖] 링크만 제거(텍스트 유지).</div>
+    </div>
+  </div>
+</div>
+
+<!-- ─── SECTION 4: 체크박스 리스트 상태 ─── -->
+<div class="section">
+  <div class="section-title">4. 체크리스트 — 체크 전 vs 체크 후</div>
+  <div class="section-desc">체크된 항목은 텍스트 <strong>흐림 50%</strong> + <strong>취소선</strong>. '끝난 일' 시각적 구분 확실.</div>
+  <div class="widget widget-wide">
+    <div class="editor">
+      <ul class="task-list">
+        <li class="done"><input type="checkbox" checked> <span>베니스앨 쓰어보기</span></li>
+        <li><input type="checkbox"> <span>TipTap 설치 (의존성 7개)</span></li>
+        <li class="done"><input type="checkbox" checked> <span>디자인 시안 결정</span></li>
+        <li><input type="checkbox"> <span>테스트 작성 + 빌드 검증</span></li>
+        <li><input type="checkbox"> <span>PR 생성 + @codex 리뷰 루프</span></li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+<!-- ─── SECTION 5: 색상 토큰 원칙 ─── -->
+<div class="section">
+  <div class="section-title">5. 테마 전환 실증</div>
+  <div class="section-desc">위 '테마' / '모드' 컨트롤을 바꿔보세요. 하드코딩 없이 CSS 변수 토큰으로만 동작 — 6개 프리셋 + 라이트/다크 자동 대응.</div>
+  <div style="display: flex; gap: 16px; flex-wrap: wrap;">
+    <div style="padding: 12px 16px; background: rgb(var(--bg-card)); border: 1px solid rgb(var(--bg-border)); border-radius: 8px; font-size: 12px;">
+      <div style="display:flex; align-items:center; gap:8px;">
+        <div style="width:24px; height:24px; background: rgb(var(--accent)); border-radius: 4px;"></div>
+        <span>accent</span>
+      </div>
+    </div>
+    <div style="padding: 12px 16px; background: rgb(var(--bg-card)); border: 1px solid rgb(var(--bg-border)); border-radius: 8px; font-size: 12px;">
+      <div style="display:flex; align-items:center; gap:8px;">
+        <div style="width:24px; height:24px; background: rgb(var(--bg-card)); border: 1px solid rgb(var(--bg-border)); border-radius: 4px;"></div>
+        <span>bg-card</span>
+      </div>
+    </div>
+    <div style="padding: 12px 16px; background: rgb(var(--bg-card)); border: 1px solid rgb(var(--bg-border)); border-radius: 8px; font-size: 12px;">
+      <div style="display:flex; align-items:center; gap:8px;">
+        <div style="width:24px; height:24px; background: rgb(var(--text-primary)); border-radius: 4px;"></div>
+        <span>text-primary</span>
+      </div>
+    </div>
+    <div style="padding: 12px 16px; background: rgb(var(--bg-card)); border: 1px solid rgb(var(--bg-border)); border-radius: 8px; font-size: 12px;">
+      <div style="display:flex; align-items:center; gap:8px;">
+        <div style="width:24px; height:24px; background: rgb(var(--accent) / .15); border-radius: 4px;"></div>
+        <span>accent/15 (버튼 Active)</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  // 테마 전환
+  document.getElementById('theme').addEventListener('change', (e) => {
+    document.documentElement.setAttribute('data-theme', e.target.value);
+  });
+  const modeBtn = document.getElementById('modeToggle');
+  modeBtn.addEventListener('click', () => {
+    const cur = document.documentElement.getAttribute('data-mode');
+    const next = cur === 'dark' ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-mode', next);
+    modeBtn.textContent = next === 'dark' ? '☾ 다크 모드' : '☀ 라이트 모드';
+  });
+
+  // 체크박스 토글 시 done 상태 반영
+  document.querySelectorAll('.task-list input[type="checkbox"]').forEach(cb => {
+    cb.addEventListener('change', (e) => {
+      e.target.closest('li').classList.toggle('done', e.target.checked);
+    });
+  });
+</script>
+</body>
+</html>

--- a/docs/superpowers/specs/2026-04-24-memo-wysiwyg-design.md
+++ b/docs/superpowers/specs/2026-04-24-memo-wysiwyg-design.md
@@ -66,7 +66,39 @@ TipTap + 필수 extension 7개 추가 시 **gzip +~110KB**. 현재 번들 기준
 
 **문제**: 표준 Markdown(GFM)에서 `__text__`는 **Bold**이다. 그러나 B flow 앱은 과거부터 `__text__`를 **밑줄(underline)** 로 써왔다(`SimpleMarkdown` 구현).
 
-**해결**: `tiptap-markdown` 의 **custom serializer/parser 오버라이드**로 앱 관습 유지.
+**해결**: `tiptap-markdown` 의 **custom serializer/parser 오버라이드**로 앱 관습 유지. 구현 접근:
+
+`tiptap-markdown` 은 내부적으로 **markdown-it** 을 parser로, **custom token serializer** 를 writer로 사용한다. 기본적으로 markdown-it의 `emphasis` 규칙이 `__x__`를 `<strong>` 으로 처리하므로 다음 두 가지를 수정한다:
+
+**Parser (Markdown → HTML)**:
+```typescript
+// markdownExtensions.ts
+export const markdownItConfigure = (md: MarkdownIt) => {
+  // 1) 기본 emphasis 규칙에서 __ (언더스코어 double) 처리를 끄고
+  //    __x__ 를 Underline으로 처리하는 custom inline rule 삽입
+  md.inline.ruler.before('emphasis', 'underline', underlineRule);
+  //    underlineRule 내부에서 __ 토큰만 소비, * / ** / ~~는 건드리지 않음
+};
+```
+`underlineRule` 은 `state.src.slice(state.pos, state.pos+2) === '__'` 확인 후 닫는 `__` 위치를 찾아 `u_open` / `u_close` 토큰 push. 실패 시 false 반환하여 다른 규칙으로 양보.
+
+**Serializer (HTML → Markdown)**:
+```typescript
+// MemoEditor 에서 Markdown extension 설정:
+Markdown.configure({
+  html: false,
+  transformPastedText: true,
+  transformCopiedText: true,
+  // tiptap-markdown 은 extension별 toMarkdown 훅 제공
+});
+
+// Underline mark 정의 시 toMarkdown 지정:
+Underline.extend({
+  addStorage() { return { markdown: { serialize: { open: '__', close: '__', mixable: true, expelEnclosingWhitespace: true } } }; },
+});
+```
+
+**결과**:
 
 ```
 Markdown 저장:              HTML 렌더:
@@ -76,12 +108,7 @@ __밑줄__     ← 비GFM       <u>밑줄</u>
 ~~취소선~~                  <s>취소선</s>
 ```
 
-- Markdown → HTML (parser):  
-  - `__x__` 패턴을 Underline mark 로 파싱 (Bold로 해석하지 않도록 override)
-  - `**x**` 는 정상 Bold
-- HTML → Markdown (serializer):  
-  - Underline mark 는 `__x__` 로 직렬화
-  - Bold mark 는 `**x**` 로 직렬화
+**검증**: Phase A에서 단위 테스트 — 원본 Markdown 문자열 N개를 parse → serialize 왕복 시 문자열 동일성 확인 (fixture).
 
 ### 3.3 줄바꿈 처리
 
@@ -129,7 +156,7 @@ __밑줄__     ← 비GFM       <u>밑줄</u>
 | 리스트 | ☑≡ | Task List | Ctrl+Shift+9 |
 | 링크 | 🔗 | Link | Ctrl+K |
 
-**3가지 상태**:
+**4가지 상태**:
 
 | 상태 | 시각 |
 |------|------|
@@ -137,6 +164,7 @@ __밑줄__     ← 비GFM       <u>밑줄</u>
 | Hover | `text-accent bg-accent/10` |
 | Active (서식 적용된 위치에 커서) | `text-accent bg-accent/15` |
 | Focus-visible (키보드) | `ring-1 ring-accent/40` 추가 |
+| **Disabled** (editor === null, 초기 로딩 중) | `opacity-40 cursor-not-allowed`, 클릭 무시 |
 
 **크기 & 간격**: 버튼 22×22px, 아이콘 13px (Lucide). 그룹 내 2px gap, 그룹 간 8px gap + `border-l border-bg-border/40` 세로 구분선.
 
@@ -146,12 +174,12 @@ __밑줄__     ← 비GFM       <u>밑줄</u>
 
 ### 4.3 에디터 본문
 
-**헤딩 크기**: 본문 폰트 크기(슬라이더 값)에 비율 연동.
-- H1 = 본문 × 1.6 (font-semibold, leading-tight, mt-4 mb-2)
-- H2 = 본문 × 1.35 (font-semibold, leading-tight, mt-3 mb-1.5)
-- H3 = 본문 × 1.15 (font-medium, leading-snug, mt-2 mb-1)
+**헤딩 크기**: 본문 폰트 크기(슬라이더 값)에 비율 연동. **`em` 단위 사용** (CSS scale/transform 제외 — 레이아웃 flow 유지).
+- H1 = `1.6em` (font-semibold, leading-tight, mt-4 mb-2)
+- H2 = `1.35em` (font-semibold, leading-tight, mt-3 mb-1.5)
+- H3 = `1.15em` (font-medium, leading-snug, mt-2 mb-1)
 
-CSS custom property 기반. `style={{ fontSize: fontSize }}`로 에디터 컨테이너에 루트 폰트 지정하고, 헤딩은 `em` 단위 또는 CSS scale 로 비율 계산.
+구현: `style={{ fontSize: fontSize + 'px' }}` 로 에디터 컨테이너(`ProseMirror` root) 에 픽셀 단위 폰트 지정. 자식 헤딩은 CSS 클래스에 `font-size: 1.6em` 등 지정 → 상위 fontSize 기반 자동 계산. 슬라이더 변경 시 컨테이너 style만 리렌더되고 헤딩은 상대값으로 즉시 추종.
 
 **리스트**:
 - Bullet: `list-disc pl-5`, TipTap `BulletList` extension
@@ -338,7 +366,7 @@ interface MemoLinkBubbleProps {
 
 ### 7.1 에디터 내부 단축키 (TipTap이 처리)
 
-11개 버튼의 단축키는 모두 TipTap Extension 기본 바인딩 또는 커스텀 `addKeyboardShortcuts`.
+§4.2 버튼 표의 11개 단축키는 모두 TipTap Extension 기본 바인딩 또는 커스텀 `addKeyboardShortcuts` 로 구현.
 
 ### 7.2 앱 전역 단축키와의 충돌 검증
 
@@ -381,12 +409,27 @@ interface MemoLinkBubbleProps {
 | `~~x~~` | Strike | Strike (GFM) | ✅ |
 | `- item` | Bullet | Bullet | ✅ |
 | `1. item` | Ordered | Ordered | ✅ |
-| `1) item` | Ordered (느슨한 매칭) | 일반 텍스트 | ⚠ 희귀 케이스 |
+| `1) item` | Ordered (느슨한 매칭) | 일반 텍스트 | ⚠ 희귀 케이스 (§8.2.1 검증) |
 | `# heading` | 일반 텍스트 (헤딩 미구현) | H1 | 🟢 개선 |
 | 빈 줄 | `<div h-1.5>` | `<p><br></p>` | 허용 오차 |
 | 연속 `\n` | 각 줄마다 div | 한 단락 내 hardBreak 또는 단락 분리 | 허용 오차 |
 
 **대응**: `1) item` 패턴은 전체 메모 내 거의 없음(추정). 발견 시 사용자가 수동 보정. 그 외 변화는 **업그레이드 방향**(헤딩 렌더 추가).
+
+### 8.2.1 구현 착수 전 실제 빈도 검증 (단발성 SQL)
+
+Phase A 시작 전 Supabase SQL 에디터에서 1회 실행:
+
+```sql
+-- tabs 배열 안의 content 내 '1) ' 또는 '2) ' 등 패턴 포함 카운트
+SELECT COUNT(*) FROM user_memos
+WHERE tabs::text ~ '\d+\) ';
+```
+
+- **결과 0~5건**: 수용 — 사용자 수동 보정 전제로 진행
+- **결과 >5건**: 이 spec 에 `1)` → `1.` 정규화 one-shot 마이그레이션 step 추가 (Phase A에 포함)
+
+검증 결과와 대응을 PR 설명에 기록.
 
 ### 8.3 롤백 경로
 
@@ -408,7 +451,8 @@ interface MemoLinkBubbleProps {
 | 링크 위 커서 + 서식 변경 | 링크 내 텍스트에 Bold 등 적용 가능 (TipTap 기본) |
 | 붙여넣기로 HTML 유입 | TipTap `clipboardTextSerializer`로 plain text 또는 허용된 마크만 필터 |
 | 탭 전환 중 IME 조합 중 | TipTap이 IME composition 처리 (기존 textarea 수준 이상) |
-| 에디터 언마운트 시 저장 미완료 | `MemoWidget` 기존 언마운트 즉시 저장 로직 유지 |
+| 에디터 언마운트 시 저장 미완료 (debounce pending) | `MemoWidget` 언마운트 useEffect cleanup 에서 **pending debounce timer flush** — 마지막 `memoDataRef.current` 즉시 `upsertMemo` 호출 (기존 로직 유지). TipTap onUpdate → MemoWidget onChange → 500ms debounce 체인에서 debounce 타이머가 flush 없이 사라지는 일이 없도록 cleanup에서 `clearTimeout` 후 **한 번 더 저장 호출** 보장. |
+| Supabase 로드 시 malformed Markdown (예: 레거시 데이터의 미종료 fence, 비정상 HTML 잔재) | `editor.commands.setContent(markdown)` 호출을 **try/catch 로 감쌈**. 예외 시 `console.error` + **plain text 로 fallback** (`setContent(markdown, false, { preserveWhitespace: 'full' })`). 사용자에게 "서식이 일부 단순 텍스트로 표시됩니다" 미니 토스트 (sonner) 1회 노출. 데이터는 손실 없음 (Markdown 원문은 Supabase에 그대로). |
 | 사용자 전환 (로그아웃/로그인) | `useAuthStore` 변경 시 `MemoWidget` 이 `memoKey + currentUserId` useEffect로 재로드 (기존 로직 유지) |
 | Realtime 수신 (`memo-sync` storage 이벤트) | 다른 윈도우에서 동일 메모 변경 시 reload (기존 로직 유지) |
 
@@ -441,6 +485,8 @@ interface MemoLinkBubbleProps {
 - Ctrl+B를 에디터 밖에서 누름 → 사이드바 토글 정상 작동
 - Ctrl+B를 에디터 안에서 누름 → TipTap Bold 동작, 사이드바 토글 안 됨
 - Escape → 링크 버블 먼저 닫힘, 다시 Escape → 에디터 blur
+- **Word/브라우저 페이지 복사 → 붙여넣기**: 서식 있는 HTML 유입 시 plain text 또는 허용 마크만 남고 inline style/className은 제거 (§9 `clipboardTextSerializer` 검증)
+- **의도적 malformed Markdown**: 개발자 도구로 Supabase row 의 `content` 에 `# 제목 __mismatched` 같은 값 주입 후 로드 → §9 fallback 동작 확인 (sonner 토스트 노출 + 텍스트 보존)
 
 ### 10.3 Regression
 
@@ -457,7 +503,7 @@ interface MemoLinkBubbleProps {
 - [ ] 미리보기 토글 버튼 UI 및 `previewMode` state 제거
 - [ ] 툴바 버튼 11개 노출 (넓은 모드 기준)
 - [ ] 각 버튼 Active state가 커서 위치 서식에 따라 자동 전환
-- [ ] 모든 단축키(표 7.1) 동작
+- [ ] 모든 단축키(§4.2 버튼 표) 동작
 - [ ] 링크 버블 메뉴 — 새 링크/기존 링크 2가지 모드 동작
 - [ ] Markdown 저장 형식 유지, Supabase 필드 스키마 변경 없음
 - [ ] `__x__` 가 Underline으로 저장/로드 (custom serializer 작동)
@@ -484,7 +530,7 @@ interface MemoLinkBubbleProps {
 
 세부 plan은 writing-plans 스킬로 별도 작성. 예상 순서:
 
-1. **Phase A — 기반**: 의존성 설치, `markdownExtensions.ts` 작성, 단위 테스트(파서/시리얼라이저 왕복)
+1. **Phase A — 기반**: 의존성 설치, `markdownExtensions.ts` 작성, 단위 테스트(파서/시리얼라이저 왕복). 왕복 fixture 는 최소 12개 케이스 (plain / bold / italic / underline / strike / 중첩 / H1-3 / bullet / ordered / task / link / 실제 Supabase 샘플 3건 복사). `1)` 패턴 §8.2.1 SQL 결과 반영 여부 결정
 2. **Phase B — 에디터 코어**: `MemoEditor.tsx` 구현, `MemoWidget` textarea를 임시로 MemoEditor 로 교체 (툴바는 기존 FormatToolbar 일단 유지)
 3. **Phase C — 툴바 확장**: `MemoToolbar.tsx` 작성 (11버튼 + 반응형), Active state 바인딩
 4. **Phase D — 링크 버블**: `MemoLinkBubble.tsx` 작성

--- a/docs/superpowers/specs/2026-04-24-memo-wysiwyg-design.md
+++ b/docs/superpowers/specs/2026-04-24-memo-wysiwyg-design.md
@@ -1,0 +1,504 @@
+# 메모 위젯 WYSIWYG 에디터 전환 (이슈 3 / v1.13.0)
+
+- 작성일: 2026-04-24
+- 브랜치: `claude/clever-heisenberg-94a6df`
+- 대상 범위: 메모 위젯(`MemoWidget.tsx`) 에디터 엔진 전면 교체, 툴바 확장(4→11), 링크 버블 메뉴 신규, 미리보기 토글 제거
+- PR 단위: **단일 PR** (사용자 결정)
+- 전제: 메모 저장 형식은 **Markdown 문자열 유지** → 기존 Supabase `user_memos` 데이터 100% 호환, 마이그레이션 불필요
+
+---
+
+## 1. 배경
+
+현재 메모 위젯은 `<textarea>` + 자체 마크다운 렌더러(`SimpleMarkdown`) 조합으로 동작한다. 즉, 쓸 때는 `**굵게**` 같은 기호가 그대로 보이고, 👁 **미리보기 토글**을 눌러야 실제 렌더링을 확인할 수 있다. 비개발자 팀원 다수가 이 위젯을 매일 사용하는데, **"마크다운 기호를 기억하고 직접 타이핑해야 한다"** 는 진입 장벽이 존재한다.
+
+### 현재 Pain Points
+
+| 증상 | 영향 |
+|------|------|
+| **마크다운 기호 노출** | `**굵게**` `__밑줄__` 같은 기호가 편집 중 계속 보여 가독성 저하 |
+| **미리보기 토글 전환 필요** | 렌더링 결과 보려면 모드 전환 → "쓰면서 확인"이 불가능 |
+| **제한된 서식 4개** | Bold/Italic/Underline/Strike만 툴바 지원 → 헤딩·리스트·링크는 수동 타이핑 |
+| **리스트·헤딩 기호 외우기** | `- ` `1. ` `# ` `## ` 등을 외워야 사용 가능 |
+| **링크 삽입 불가** | Markdown `[text](url)` 직접 타이핑 외 방법 없음 |
+
+### 근본 방향
+
+"**쓰는 순간 = 보이는 순간**" 원칙으로 전환 (WYSIWYG — What You See Is What You Get). 단, **저장 형식은 Markdown 문자열로 고정** → 데이터 호환성·백업 가능성·단순성 유지.
+
+---
+
+## 2. 해결 전략 — TipTap 기반 WYSIWYG
+
+### 2.1 라이브러리 선택
+
+**TipTap v2** (ProseMirror 기반). 이유:
+
+- **React 친화적**: `@tiptap/react` 공식 패키지, hook API
+- **Extension 구조**: 필요한 기능(Bold/Italic/Link/TaskList …)만 조립
+- **Markdown 왕복**: `tiptap-markdown` 어댑터로 HTML ↔ Markdown 무손실 왕복
+- **Active state API**: `editor.isActive('bold')` 로 툴바 버튼 상태 즉시 파악
+- **BubbleMenu**: 링크 버블 UI를 확장으로 제공 (위치 계산·화면 경계 대응 내장)
+
+### 2.2 대안 기각 근거
+
+| 대안 | 기각 사유 |
+|------|----------|
+| **Lexical (Meta)** | 성능 우수하나 Markdown 직접 지원 약함, 커스텀 파서/시리얼라이저 필요 — 번들 유사한데 작업량 +2배 |
+| **ContentEditable 직접 구현** | 커서/선택/undo redo 직접 다뤄야 함. 브라우저별 엣지케이스 대응 공수 과다 |
+| **현행 유지 + 인라인 프리뷰** | 근본 문제(마크다운 노출) 미해결. 토큰 경제 측면에서도 반쪽 해결 |
+
+### 2.3 번들 영향
+
+TipTap + 필수 extension 7개 추가 시 **gzip +~110KB**. 현재 번들 기준 체감 영향 작음(Portable exe 빌드에서 무시 가능). 사용자 승인 완료(2026-04-24).
+
+---
+
+## 3. 저장 형식 — Markdown 유지
+
+### 3.1 왜 Markdown?
+
+- 기존 `user_memos.tabs[].content` 필드가 Markdown 문자열 → **마이그레이션 제로**
+- 사용자가 `memo.json.bak`이나 내보내기로 열어도 여전히 읽을 수 있음
+- TipTap `tiptap-markdown` 확장이 양방향 변환 제공
+
+### 3.2 앱 관습(비표준) 처리
+
+**문제**: 표준 Markdown(GFM)에서 `__text__`는 **Bold**이다. 그러나 B flow 앱은 과거부터 `__text__`를 **밑줄(underline)** 로 써왔다(`SimpleMarkdown` 구현).
+
+**해결**: `tiptap-markdown` 의 **custom serializer/parser 오버라이드**로 앱 관습 유지.
+
+```
+Markdown 저장:              HTML 렌더:
+**굵게**                    <strong>굵게</strong>
+*기울임*                    <em>기울임</em>
+__밑줄__     ← 비GFM       <u>밑줄</u>
+~~취소선~~                  <s>취소선</s>
+```
+
+- Markdown → HTML (parser):  
+  - `__x__` 패턴을 Underline mark 로 파싱 (Bold로 해석하지 않도록 override)
+  - `**x**` 는 정상 Bold
+- HTML → Markdown (serializer):  
+  - Underline mark 는 `__x__` 로 직렬화
+  - Bold mark 는 `**x**` 로 직렬화
+
+### 3.3 줄바꿈 처리
+
+현재 `SimpleMarkdown`은 `\n`마다 `<div>`를 만들지만 Markdown 표준은 빈 줄(`\n\n`)만 단락 구분이다. TipTap은 `<p>` 단락 단위.
+
+**결정**: TipTap 기본 동작(표준 Markdown) 채택. 단일 줄바꿈은 `Shift+Enter` → `<br>` (hardBreak). 기존 메모에서 `\n` 이 여러 개 연속된 경우, 렌더 결과가 현재보다 단락 간격이 살짝 달라질 수 있음(허용 범위 — 사용자에 경고 불요).
+
+---
+
+## 4. UI/UX 사양
+
+### 4.1 전체 구조
+
+```
+┌────────────────────────────────────────────────────┐
+│ [📝 메모]                          👁 🔠 ━●━ 14  │   ← 위젯 헤더 (폰트 슬라이더 유지, 👁 토글 제거)
+├────────────────────────────────────────────────────┤
+│ [메모1] [메모2] [+]                                │   ← 탭바 (변경 없음)
+├────────────────────────────────────────────────────┤
+│ B I U S │ H₁ H₂ H₃ │ ≡ 1≡ ☑≡ │ 🔗              │   ← 툴바 (신규, 높이 28px)
+├────────────────────────────────────────────────────┤
+│                                                    │
+│ 에디터 본문 (TipTap)                                │
+│                                                    │
+└────────────────────────────────────────────────────┘
+```
+
+### 4.2 툴바 사양
+
+**레이아웃**: 반응형. 에디터 가로폭 ≥ 320px → 11개 버튼 1행. < 320px → 헤딩 3개는 [단락▾] 드롭다운으로, 리스트 3개는 [리스트▾] 드롭다운으로 축약. `ResizeObserver` 로 감지.
+
+**버튼 11개**:
+
+| 그룹 | 버튼 | 기능 | 단축키 |
+|------|------|------|--------|
+| 인라인 | **B** | Bold | Ctrl+B |
+| 인라인 | *I* | Italic | Ctrl+I |
+| 인라인 | U | Underline | Ctrl+U |
+| 인라인 | S | Strike | Ctrl+Shift+X |
+| 헤딩 | H₁ | Heading 1 | Ctrl+Alt+1 |
+| 헤딩 | H₂ | Heading 2 | Ctrl+Alt+2 |
+| 헤딩 | H₃ | Heading 3 | Ctrl+Alt+3 |
+| 리스트 | ≡ | Bullet List | Ctrl+Shift+8 |
+| 리스트 | 1≡ | Ordered List | Ctrl+Shift+7 |
+| 리스트 | ☑≡ | Task List | Ctrl+Shift+9 |
+| 링크 | 🔗 | Link | Ctrl+K |
+
+**3가지 상태**:
+
+| 상태 | 시각 |
+|------|------|
+| Default | `text-text-secondary/60`, 투명 배경 |
+| Hover | `text-accent bg-accent/10` |
+| Active (서식 적용된 위치에 커서) | `text-accent bg-accent/15` |
+| Focus-visible (키보드) | `ring-1 ring-accent/40` 추가 |
+
+**크기 & 간격**: 버튼 22×22px, 아이콘 13px (Lucide). 그룹 내 2px gap, 그룹 간 8px gap + `border-l border-bg-border/40` 세로 구분선.
+
+**툴팁**: `<button title="...">` + `aria-label`. 예: `title="굵게 (Ctrl+B)" aria-label="굵게"`.
+
+**제거**: 기존 `Eye/Pencil` 미리보기 토글 버튼, `previewMode` state, `SimpleMarkdown` 컴포넌트, `inlineFormat` 함수, `applyMarkdown` 함수, `FormatToolbar` 컴포넌트.
+
+### 4.3 에디터 본문
+
+**헤딩 크기**: 본문 폰트 크기(슬라이더 값)에 비율 연동.
+- H1 = 본문 × 1.6 (font-semibold, leading-tight, mt-4 mb-2)
+- H2 = 본문 × 1.35 (font-semibold, leading-tight, mt-3 mb-1.5)
+- H3 = 본문 × 1.15 (font-medium, leading-snug, mt-2 mb-1)
+
+CSS custom property 기반. `style={{ fontSize: fontSize }}`로 에디터 컨테이너에 루트 폰트 지정하고, 헤딩은 `em` 단위 또는 CSS scale 로 비율 계산.
+
+**리스트**:
+- Bullet: `list-disc pl-5`, TipTap `BulletList` extension
+- Ordered: `list-decimal pl-5`, TipTap `OrderedList` extension
+- Task: `TaskList + TaskItem` extension
+  - 체크박스 12×12, `border-bg-border/60 rounded`
+  - 체크 시 `bg-accent border-accent`, 체크마크는 `text-on-accent`
+  - 체크된 항목 텍스트: `text-text-secondary/50 line-through`
+  - 편집 모드와 무관하게 체크박스 토글 가능
+
+**인라인 서식**:
+- Bold: `<strong>` → `font-bold`
+- Italic: `<em>` → `italic`
+- Underline: `<u>` → `underline underline-offset-2 decoration-text-primary/40`
+- Strike: `<s>` → `line-through decoration-text-primary/50`
+
+**링크**: `text-accent underline underline-offset-2 decoration-accent/50 cursor-pointer hover:decoration-accent`. Electron 환경에서 클릭 시 `shell.openExternal` 로 기본 브라우저에서 열림 (in-app 네비게이션 금지). 기존 프리로드 API `electronAPI.openExternal` 활용.
+
+**Placeholder**: TipTap `Placeholder` extension, 텍스트 `"메모를 입력하세요..."`, 스타일 `text-text-secondary/30`.
+
+### 4.4 링크 버블 메뉴
+
+**Trigger**:
+- 새 링크: 텍스트 선택 후 툴바 🔗 클릭 또는 `Ctrl+K`
+- 기존 링크 편집/제거: 링크 노드 위에 커서 진입 시 자동 노출
+
+**2가지 모드**:
+
+**편집 모드 (새 링크 / 편집)**:
+```
+┌─────────────────────────────────────┐
+│ 🔗 [https://...            ] [✓]   │
+└─────────────────────────────────────┘
+```
+- URL input 자동 포커스
+- Enter 또는 [✓] → 적용
+- ESC → 취소, 버블 닫힘, 에디터 포커스 복귀
+- 빈 값 Enter → 무동작
+
+**읽기 모드 (기존 링크 위)**:
+```
+┌─────────────────────────────────────┐
+│ studiojbbj.com   [↗] [✏] [✖]       │
+└─────────────────────────────────────┘
+```
+- [↗] = 브라우저로 열기
+- [✏] = 편집 모드로 전환 (기존 URL 프리필)
+- [✖] = 링크 제거 (텍스트 유지)
+- URL 길면 `truncate max-w-[180px]`
+
+**스펙**:
+
+| 항목 | 값 |
+|------|-----|
+| 위치 | 선택영역/링크 상단 8px, 화면 경계 시 하단 뒤집기 (TipTap BubbleMenu 기본) |
+| 배경 | `bg-bg-card` |
+| 테두리 | `border border-bg-border` |
+| 그림자 | `shadow-lg shadow-bg-primary/40` |
+| 모서리 | `rounded-lg` |
+| 패딩 | `px-2 py-1.5` |
+| 최소 너비 | 240px |
+| 애니메이션 | `animate-fade-in` (기존 키프레임 재사용) |
+| z-index | 50 |
+
+**URL 유효성**:
+- `https?://`, `mailto:`, 상대경로 `/` 로 시작 허용
+- 그 외 텍스트는 `https://` 자동 prepend
+- TipTap `Link` extension의 `autolink: true` 로 순수 URL 붙여넣기 자동 링크화
+
+**접근성**:
+- URL input: `aria-label="링크 URL"`, 자동 포커스
+- Tab 순서: input → ✓ → (닫기)
+- ESC로 버블 닫힘
+
+### 4.5 색상 & 테마
+
+**원칙**: 모든 색상은 CSS 변수 토큰만 사용. Hex/rgb 리터럴 하드코딩 금지.
+
+허용 토큰:
+- 배경: `bg-bg-primary`, `bg-bg-card`, `bg-bg-border`
+- 텍스트: `text-text-primary`, `text-text-secondary`
+- 강조: `bg-accent`, `text-accent`, `text-on-accent`, `bg-accent-sub`
+- 시멘틱: `bg-overlay`
+- Alpha: `/10`, `/15`, `/20`, `/30`, `/40`, `/50`, `/60`, `/90` 활용
+
+이렇게 하면 6개 프리셋 테마(바이올렛/시네마 레드/미드나잇 블루/에메랄드/앰버 골드/머쉬룸) + 커스텀 테마 + 라이트/다크 모드가 자동 대응.
+
+---
+
+## 5. 파일 구조 & 컴포넌트 분해
+
+### 5.1 신규 파일
+
+| 파일 | 역할 | LOC 예상 |
+|------|------|----------|
+| `src/components/widgets/memo/MemoEditor.tsx` | TipTap `useEditor` 캡슐화, Extension 구성, content/onChange 프로퍼티 | ~120 |
+| `src/components/widgets/memo/MemoToolbar.tsx` | 11개 버튼 + 반응형 드롭다운 + Active state 바인딩 | ~180 |
+| `src/components/widgets/memo/MemoLinkBubble.tsx` | 링크 버블 메뉴 (편집/읽기 모드 전환) | ~100 |
+| `src/components/widgets/memo/markdownExtensions.ts` | tiptap-markdown custom serializer/parser (`__x__` → Underline) | ~60 |
+
+### 5.2 기존 파일 변경
+
+| 파일 | 변경 |
+|------|------|
+| `src/components/widgets/MemoWidget.tsx` | 대규모 리팩터. `SimpleMarkdown`/`inlineFormat`/`applyMarkdown`/`FormatToolbar`/`previewMode` 제거. `MemoEditor` + `MemoToolbar` + `MemoLinkBubble` 조립 |
+| `package.json` | TipTap 7개 의존성 추가 |
+| `src/index.css` (선택) | ProseMirror 선택 영역 스타일 토큰 override (선택/커서 색 `accent` 따라가게) |
+
+### 5.3 컴포넌트 인터페이스
+
+**MemoEditor**:
+```typescript
+interface MemoEditorProps {
+  content: string;              // Markdown 문자열
+  onChange: (next: string) => void;  // debounce는 상위에서 처리
+  fontSize: number;             // 본문 기준 폰트 크기
+  placeholder?: string;
+  editorRef?: (editor: Editor | null) => void;  // 툴바/버블이 editor 인스턴스 참조
+}
+```
+
+**MemoToolbar**:
+```typescript
+interface MemoToolbarProps {
+  editor: Editor | null;        // null일 동안 disabled
+  containerRef: RefObject<HTMLDivElement>;  // ResizeObserver 대상
+}
+```
+
+**MemoLinkBubble**:
+```typescript
+interface MemoLinkBubbleProps {
+  editor: Editor | null;
+}
+```
+
+모두 상위 `MemoWidget` 이 `useEditor` 훅의 결과를 props로 전달. 각 컴포넌트는 editor 상태만 의존, 내부 state 최소화.
+
+---
+
+## 6. 데이터 흐름
+
+```
+[사용자 타이핑]
+      ↓
+[TipTap Editor]  ─── isActive('bold') ──→  [MemoToolbar Active state]
+      ↓
+[onUpdate 이벤트]
+      ↓
+[Markdown serialize (tiptap-markdown + custom)]
+      ↓
+[MemoWidget setMemoData(activeTab.content = markdown)]
+      ↓
+[500ms debounce]
+      ↓
+[supabaseService.upsertMemo]
+      ↓
+[Supabase user_memos]
+```
+
+**반대 방향 (로드)**:
+
+```
+[Supabase user_memos]
+      ↓
+[supabaseService.readMemo]
+      ↓
+[MemoWidget setMemoData]
+      ↓
+[MemoEditor.content = markdown]
+      ↓
+[Markdown parse (tiptap-markdown + custom)]
+      ↓
+[ProseMirror Document]
+      ↓
+[렌더]
+```
+
+탭 전환 시: 활성 탭의 `content`를 `editor.commands.setContent(markdown)` 로 주입. `key={activeTab.id}` 로 에디터 리마운트 유도(현 textarea 패턴 유지).
+
+---
+
+## 7. 인터랙션 — 키보드 단축키
+
+### 7.1 에디터 내부 단축키 (TipTap이 처리)
+
+11개 버튼의 단축키는 모두 TipTap Extension 기본 바인딩 또는 커스텀 `addKeyboardShortcuts`.
+
+### 7.2 앱 전역 단축키와의 충돌 검증
+
+현재 앱 글로벌 단축키(`useGlobalShortcuts.ts`):
+- `Ctrl+B` = 사이드바 토글
+- `Ctrl+Space` = Spotlight
+- `Ctrl+1~8` = 뷰 전환
+- `Ctrl+E` = 편집 모드
+- `Ctrl+R` = 새로고침
+
+**Ctrl+B 충돌**: `useGlobalShortcuts` 에서 `isEditable` 체크가 있어 **입력 필드(ContentEditable 포함) 내에서는 뷰 전환/편집 단축키 무시**. TipTap 에디터는 ContentEditable이므로 에디터 포커스 시 Ctrl+B가 사이드바를 토글하지 않고 TipTap Bold로 동작. ✅ 해결.
+
+**Ctrl+K 충돌**: 앱 전역 바인딩 없음. ✅ 문제 없음.
+
+**Ctrl+Alt+1/2/3**: 앱에 없음. ✅ 문제 없음.
+
+**Ctrl+Shift+7/8/9/X**: 앱에 없음. ✅ 문제 없음.
+
+### 7.3 Escape 처리
+
+에디터 포커스 상태에서 Escape → 링크 버블이 열려있으면 버블 닫기, 아니면 에디터 blur. 전역 `bflow:escape` 커스텀 이벤트는 `useGlobalShortcuts` 가 이미 발행 중이므로 부가 작업 불요.
+
+---
+
+## 8. 호환성 & 마이그레이션
+
+### 8.1 데이터 마이그레이션
+
+**없음**. Supabase `user_memos` 는 Markdown 문자열 그대로 유지.
+
+### 8.2 기존 메모 파싱 리스크
+
+기존 `SimpleMarkdown` 이 허용한 표기 vs TipTap 파싱 결과:
+
+| 기존 표기 | 현재 결과 | 신규 결과 (TipTap + custom) | 호환 |
+|-----------|-----------|-----------------------------|------|
+| `**x**` | Bold | Bold | ✅ |
+| `*x*` | Italic | Italic | ✅ |
+| `__x__` | Underline (앱 관습) | Underline (custom serializer) | ✅ |
+| `~~x~~` | Strike | Strike (GFM) | ✅ |
+| `- item` | Bullet | Bullet | ✅ |
+| `1. item` | Ordered | Ordered | ✅ |
+| `1) item` | Ordered (느슨한 매칭) | 일반 텍스트 | ⚠ 희귀 케이스 |
+| `# heading` | 일반 텍스트 (헤딩 미구현) | H1 | 🟢 개선 |
+| 빈 줄 | `<div h-1.5>` | `<p><br></p>` | 허용 오차 |
+| 연속 `\n` | 각 줄마다 div | 한 단락 내 hardBreak 또는 단락 분리 | 허용 오차 |
+
+**대응**: `1) item` 패턴은 전체 메모 내 거의 없음(추정). 발견 시 사용자가 수동 보정. 그 외 변화는 **업그레이드 방향**(헤딩 렌더 추가).
+
+### 8.3 롤백 경로
+
+문제 발생 시:
+1. TipTap 관련 코드를 git revert (단일 PR)
+2. 사용자 데이터는 변경 없으므로 이전 버전이 그대로 읽음
+3. 신규 기능(헤딩/Task/링크) 사용 기간 중 저장된 데이터도 Markdown이므로 읽기 가능 (단, 기존 `SimpleMarkdown`은 헤딩 렌더 안 함 → `# text` 로 보임)
+
+---
+
+## 9. 엣지 케이스 & 에러 처리
+
+| 케이스 | 처리 |
+|--------|------|
+| 빈 메모 로드 | Placeholder 표시, 첫 입력 시 사라짐 |
+| 긴 메모 (수천 줄) | TipTap 가상화 없음. 현재 체감 사용량(<500줄) 범위 내 문제 없음 (YAGNI) |
+| URL 입력 시 `http://` 누락 | `https://` 자동 prepend |
+| 빈 URL로 Enter | 링크 적용 취소 (서식 변경 없음) |
+| 링크 위 커서 + 서식 변경 | 링크 내 텍스트에 Bold 등 적용 가능 (TipTap 기본) |
+| 붙여넣기로 HTML 유입 | TipTap `clipboardTextSerializer`로 plain text 또는 허용된 마크만 필터 |
+| 탭 전환 중 IME 조합 중 | TipTap이 IME composition 처리 (기존 textarea 수준 이상) |
+| 에디터 언마운트 시 저장 미완료 | `MemoWidget` 기존 언마운트 즉시 저장 로직 유지 |
+| 사용자 전환 (로그아웃/로그인) | `useAuthStore` 변경 시 `MemoWidget` 이 `memoKey + currentUserId` useEffect로 재로드 (기존 로직 유지) |
+| Realtime 수신 (`memo-sync` storage 이벤트) | 다른 윈도우에서 동일 메모 변경 시 reload (기존 로직 유지) |
+
+---
+
+## 10. 테스트 전략
+
+### 10.1 자동 검증
+
+- `tsc --noEmit` — 타입 에러 0
+- `npm run build:vite` — 빌드 성공
+
+### 10.2 수동 검증 (브라우저/Electron 실행)
+
+**골든 패스**:
+1. 메모 작성 → Bold/Italic/Underline/Strike 토글 동작
+2. H1/H2/H3 버튼 클릭 → 헤딩 크기가 본문 × 1.6/1.35/1.15 로 렌더
+3. 불릿/번호/체크박스 리스트 생성 및 체크박스 토글
+4. 텍스트 선택 → Ctrl+K 또는 🔗 → URL 입력 → Enter → 링크 적용
+5. 기존 링크 위 커서 → 버블 자동 등장 → [↗] 클릭 시 기본 브라우저에서 열림
+6. 폰트 슬라이더 조절 → 본문·헤딩 모두 비율 따라 크기 변경
+7. 탭 전환 → 각 탭 독립 content 유지
+8. 앱 재시작 → Supabase에서 Markdown 로드 후 동일하게 렌더
+9. 테마 변경 (바이올렛 → 시네마 레드) → 툴바/버블 색도 자동 변경
+10. 라이트 모드 전환 → 대비 유지
+
+**엣지 케이스**:
+- 기존 메모(특히 `- ` / `1. ` / `__밑줄__` 포함)를 로드 → 모든 서식 보존
+- 위젯 크기 드래그로 좁게 축소 → 툴바가 드롭다운 모드로 전환
+- Ctrl+B를 에디터 밖에서 누름 → 사이드바 토글 정상 작동
+- Ctrl+B를 에디터 안에서 누름 → TipTap Bold 동작, 사이드바 토글 안 됨
+- Escape → 링크 버블 먼저 닫힘, 다시 Escape → 에디터 blur
+
+### 10.3 Regression
+
+- 기존 MemoWidget의 탭 추가/삭제/이름변경은 영향 없음 확인
+- 폰트 슬라이더 Supabase 저장 유지
+- 팝업 모드(`isPopup`) 레이아웃 정상
+- `memo-sync` localStorage 이벤트로 멀티 윈도우 동기화 유지
+
+---
+
+## 11. 수용 기준 (Acceptance Criteria)
+
+- [ ] `<textarea>` 기반 입력이 TipTap ContentEditable로 완전 교체
+- [ ] 미리보기 토글 버튼 UI 및 `previewMode` state 제거
+- [ ] 툴바 버튼 11개 노출 (넓은 모드 기준)
+- [ ] 각 버튼 Active state가 커서 위치 서식에 따라 자동 전환
+- [ ] 모든 단축키(표 7.1) 동작
+- [ ] 링크 버블 메뉴 — 새 링크/기존 링크 2가지 모드 동작
+- [ ] Markdown 저장 형식 유지, Supabase 필드 스키마 변경 없음
+- [ ] `__x__` 가 Underline으로 저장/로드 (custom serializer 작동)
+- [ ] 6개 테마 + 라이트/다크 모드에서 시각적 일관성
+- [ ] 기존 메모 로드 시 모든 서식 보존 (Regression)
+- [ ] `tsc --noEmit` + `vite build` 통과
+- [ ] 색상 하드코딩 0건 (`grep -E '#[0-9a-fA-F]{6}' src/components/widgets/memo/` 결과 없음)
+
+---
+
+## 12. Non-goals (YAGNI)
+
+- **이미지/동영상 삽입**: 메모는 텍스트 중심. 씬 이미지 기능은 별도 위젯 존재.
+- **표 삽입**: 수요 없음. 필요 시 차기 버전 별도 이슈.
+- **코드 블록 / 인라인 코드**: 현재 앱 맥락(팀 메모)에서 희귀. 기본 TipTap Starter Kit이 코드 블록을 포함하지만 **툴바 버튼은 노출하지 않음** (단축키만 우발 사용 허용).
+- **Undo/Redo UI 버튼**: Ctrl+Z/Y 단축키(TipTap 기본)로 충분. 툴바 공간 절약.
+- **실시간 협업(Yjs/CRDT)**: 현 앱 동시편집 모델은 Last-Write-Wins + Realtime 에코. 변경 불요.
+- **텍스트 정렬/색/하이라이트**: 요구 없음.
+- **마크다운 원문 보기 토글**: WYSIWYG 전환의 전제 자체와 모순.
+
+---
+
+## 13. 구현 단계 개요 (Phase Breakdown)
+
+세부 plan은 writing-plans 스킬로 별도 작성. 예상 순서:
+
+1. **Phase A — 기반**: 의존성 설치, `markdownExtensions.ts` 작성, 단위 테스트(파서/시리얼라이저 왕복)
+2. **Phase B — 에디터 코어**: `MemoEditor.tsx` 구현, `MemoWidget` textarea를 임시로 MemoEditor 로 교체 (툴바는 기존 FormatToolbar 일단 유지)
+3. **Phase C — 툴바 확장**: `MemoToolbar.tsx` 작성 (11버튼 + 반응형), Active state 바인딩
+4. **Phase D — 링크 버블**: `MemoLinkBubble.tsx` 작성
+5. **Phase E — 정리**: 기존 `SimpleMarkdown`/`inlineFormat`/`applyMarkdown`/`FormatToolbar`/`previewMode` 제거, tsc + build 검증
+6. **Phase F — 검증**: 수동 테스트, 테마/라이트모드 확인, 기존 메모 regression
+
+예상 소요: ~1.5시간 (memory 기준).
+
+---
+
+## 14. 참고
+
+- 기존 설계 메모: `C:\Users\user\.claude\projects\C--Bflow-BGonly\memory\project_issue3_wysiwyg_design.md` (2026-04-24 승인)
+- 현 구현: `src/components/widgets/MemoWidget.tsx` (673 lines)
+- 테마 시스템: `src/themes.ts`, `tailwind.config.js`
+- 글로벌 단축키: `src/hooks/useGlobalShortcuts.ts`
+- TipTap 공식 문서: https://tiptap.dev/docs (v2 기준, context7 MCP로 최신 API 확인 권장)

--- a/docs/superpowers/specs/2026-04-24-memo-wysiwyg-design.md
+++ b/docs/superpowers/specs/2026-04-24-memo-wysiwyg-design.md
@@ -244,10 +244,13 @@ __밑줄__     ← 비GFM       <u>밑줄</u>
 | 애니메이션 | `animate-fade-in` (기존 키프레임 재사용) |
 | z-index | 50 |
 
-**URL 유효성**:
-- `https?://`, `mailto:`, 상대경로 `/` 로 시작 허용
-- 그 외 텍스트는 `https://` 자동 prepend
-- TipTap `Link` extension의 `autolink: true` 로 순수 URL 붙여넣기 자동 링크화
+**URL 유효성** (화이트리스트, `shell:open-external` IPC 핸들러와 동일):
+- `https?:`, `mailto:`, `tel:` **프로토콜만 허용**
+- 그 외 (상대경로 `/foo`, 미지원 프로토콜 `ftp://`, 공백 포함, 프로토콜 없는 도메인에 `.tld` 없음) → `null` 반환 → 저장 거부 + sonner 토스트 노출
+- 프로토콜 없는 도메인 형태 (`example.com`)는 `https://` 자동 prepend
+- TipTap `Link.configure` 의 `isAllowedUri` 로도 같은 화이트리스트 강제 — autolink / paste / setLink 모든 경로에서 `ftp://` 등 차단
+
+> 초기 설계에서는 상대경로 `/foo` 허용도 포함했으나, Electron 의 `shell.openExternal` 이 상대 경로를 열지 못해 **죽은 링크**가 생기는 문제가 발견되어(Codex 1차 리뷰) 거부로 확정. 앱 내부 라우팅이 필요한 경우 별도 기능으로 분리.
 
 **접근성**:
 - URL input: `aria-label="링크 URL"`, 자동 포커스
@@ -446,8 +449,10 @@ WHERE tabs::text ~ '\d+\) ';
 |--------|------|
 | 빈 메모 로드 | Placeholder 표시, 첫 입력 시 사라짐 |
 | 긴 메모 (수천 줄) | TipTap 가상화 없음. 현재 체감 사용량(<500줄) 범위 내 문제 없음 (YAGNI) |
-| URL 입력 시 `http://` 누락 | `https://` 자동 prepend |
+| URL 입력 시 프로토콜 누락 (도메인만, 예: `example.com`) | `.tld` 패턴 검증 후 `https://` 자동 prepend |
 | 빈 URL로 Enter | 링크 적용 취소 (서식 변경 없음) |
+| 상대경로 / 미지원 프로토콜 / 공백 포함 / 프로토콜 없는 쓰레기 입력 | `normalizeUrl` → `null` → sonner 토스트(`유효하지 않은 URL 형식입니다.`) + input 재포커스 + 버블 유지 |
+| `ftp://...`, `file://...` 등 붙여넣기 / autolink | `Link.configure({ isAllowedUri })` 에서 거부 → `<a>` 마크가 생성되지 않아 평문으로 남음 |
 | 링크 위 커서 + 서식 변경 | 링크 내 텍스트에 Bold 등 적용 가능 (TipTap 기본) |
 | 붙여넣기로 HTML 유입 | TipTap `clipboardTextSerializer`로 plain text 또는 허용된 마크만 필터 |
 | 탭 전환 중 IME 조합 중 | TipTap이 IME composition 처리 (기존 textarea 수준 이상) |

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -719,6 +719,19 @@ ipcMain.handle('users:write', (_event, data: unknown) => {
 
 ipcMain.handle('settings:get-path', () => getDataPath());
 
+// 외부 URL 을 기본 브라우저로 열기 (메모 링크)
+ipcMain.handle('shell:open-external', async (_event, url: string) => {
+  try {
+    if (typeof url !== 'string' || !/^(https?:|mailto:|tel:)/i.test(url)) {
+      return { ok: false, error: 'invalid url' };
+    }
+    await shell.openExternal(url);
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: String(err) };
+  }
+});
+
 // 파일탐색기에서 경로 열기
 ipcMain.handle('shell:show-item', async (_event, filePath: string) => {
   try {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -9,6 +9,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   shellShowItem: (filePath: string) =>
     ipcRenderer.invoke('shell:show-item', filePath) as Promise<{ ok: boolean; error?: string }>,
 
+  // 외부 URL 을 기본 브라우저로 열기 (메모 링크)
+  openExternal: (url: string) =>
+    ipcRenderer.invoke('shell:open-external', url) as Promise<{ ok: boolean; error?: string }>,
+
   // 사용자 파일 (base64 인코딩 JSON — exe 옆 또는 test-data/)
   usersRead: () => ipcRenderer.invoke('users:read'),
   usersWrite: (data: unknown) => ipcRenderer.invoke('users:write', data),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,25 @@
 {
   "name": "bflow",
-  "version": "1.12.2",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bflow",
-      "version": "1.12.2",
+      "version": "1.13.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@liveblocks/client": "^3.14.1",
         "@liveblocks/react": "^3.14.1",
         "@supabase/supabase-js": "^2.99.1",
+        "@tiptap/extension-bubble-menu": "^2.27.2",
+        "@tiptap/extension-link": "^2.27.2",
+        "@tiptap/extension-placeholder": "^2.27.2",
+        "@tiptap/extension-task-item": "^2.27.2",
+        "@tiptap/extension-task-list": "^2.27.2",
+        "@tiptap/extension-underline": "^2.27.2",
+        "@tiptap/react": "^2.27.2",
+        "@tiptap/starter-kit": "^2.27.2",
         "clsx": "^2.1.0",
         "framer-motion": "^10.18.0",
         "googleapis": "^171.4.0",
@@ -20,6 +28,7 @@
         "react-dom": "^18.3.1",
         "react-grid-layout": "^1.4.4",
         "sonner": "^2.0.7",
+        "tiptap-markdown": "^0.8.10",
         "zustand": "^4.5.2"
       },
       "devDependencies": {
@@ -1353,6 +1362,22 @@
         "node": ">=14"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@remirror/core-constants": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
+      "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1816,6 +1841,462 @@
         "node": ">=10"
       }
     },
+    "node_modules/@tiptap/core": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.27.2.tgz",
+      "integrity": "sha512-ABL1N6eoxzDzC1bYvkMbvyexHacszsKdVPYqhl5GwHLOvpZcv9VE9QaKwDILTyz5voCA0lGcAAXZp+qnXOk5lQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-blockquote": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-2.27.2.tgz",
+      "integrity": "sha512-oIGZgiAeA4tG3YxbTDfrmENL4/CIwGuP3THtHsNhwRqwsl9SfMk58Ucopi2GXTQSdYXpRJ0ahE6nPqB5D6j/Zw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-bold": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-2.27.2.tgz",
+      "integrity": "sha512-bR7J5IwjCGQ0s3CIxyMvOCnMFMzIvsc5OVZKscTN5UkXzFsaY6muUAIqtKxayBUucjtUskm5qZowJITCeCb1/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-bubble-menu": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-2.27.2.tgz",
+      "integrity": "sha512-VkwlCOcr0abTBGzjPXklJ92FCowG7InU8+Od9FyApdLNmn0utRYGRhw0Zno6VgE9EYr1JY4BRnuSa5f9wlR72w==",
+      "license": "MIT",
+      "dependencies": {
+        "tippy.js": "^6.3.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-bullet-list": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-2.27.2.tgz",
+      "integrity": "sha512-gmFuKi97u5f8uFc/GQs+zmezjiulZmFiDYTh3trVoLRoc2SAHOjGEB7qxdx7dsqmMN7gwiAWAEVurLKIi1lnnw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-code": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-2.27.2.tgz",
+      "integrity": "sha512-7X9AgwqiIGXoZX7uvdHQsGsjILnN/JaEVtqfXZnPECzKGaWHeK/Ao4sYvIIIffsyZJA8k5DC7ny2/0sAgr2TuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-2.27.2.tgz",
+      "integrity": "sha512-KgvdQHS4jXr79aU3wZOGBIZYYl9vCB7uDEuRFV4so2rYrfmiYMw3T8bTnlNEEGe4RUeAms1i4fdwwvQp9nR1Dw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-document": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-2.27.2.tgz",
+      "integrity": "sha512-CFhAYsPnyYnosDC4639sCJnBUnYH4Cat9qH5NZWHVvdgtDwu8GZgZn2eSzaKSYXWH1vJ9DSlCK+7UyC3SNXIBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-dropcursor": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-2.27.2.tgz",
+      "integrity": "sha512-oEu/OrktNoQXq1x29NnH/GOIzQZm8ieTQl3FK27nxfBPA89cNoH4mFEUmBL5/OFIENIjiYG3qWpg6voIqzswNw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-floating-menu": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-2.27.2.tgz",
+      "integrity": "sha512-GUN6gPIGXS7ngRJOwdSmtBRBDt9Kt9CM/9pSwKebhLJ+honFoNA+Y6IpVyDvvDMdVNgBchiJLs6qA5H97gAePQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tippy.js": "^6.3.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-gapcursor": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-2.27.2.tgz",
+      "integrity": "sha512-/c9VF1HBxj+AP54XGVgCmD9bEGYc5w5OofYCFQgM7l7PB1J00A4vOke0oPkHJnqnOOyPlFaxO/7N6l3XwFcnKA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-hard-break": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-2.27.2.tgz",
+      "integrity": "sha512-kSRVGKlCYK6AGR0h8xRkk0WOFGXHIIndod3GKgWU49APuIGDiXd8sziXsSlniUsWmqgDmDXcNnSzPcV7AQ8YNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-heading": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-2.27.2.tgz",
+      "integrity": "sha512-iM3yeRWuuQR/IRQ1djwNooJGfn9Jts9zF43qZIUf+U2NY8IlvdNsk2wTOdBgh6E0CamrStPxYGuln3ZS4fuglw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-history": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-history/-/extension-history-2.27.2.tgz",
+      "integrity": "sha512-+hSyqERoFNTWPiZx4/FCyZ/0eFqB9fuMdTB4AC/q9iwu3RNWAQtlsJg5230bf/qmyO6bZxRUc0k8p4hrV6ybAw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-horizontal-rule": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-2.27.2.tgz",
+      "integrity": "sha512-WGWUSgX+jCsbtf9Y9OCUUgRZYuwjVoieW5n6mAUohJ9/6gc6sGIOrUpBShf+HHo6WD+gtQjRd+PssmX3NPWMpg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-italic": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-2.27.2.tgz",
+      "integrity": "sha512-1OFsw2SZqfaqx5Fa5v90iNlPRcqyt+lVSjBwTDzuPxTPFY4Q0mL89mKgkq2gVHYNCiaRkXvFLDxaSvBWbmthgg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-link": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-2.27.2.tgz",
+      "integrity": "sha512-bnP61qkr0Kj9Cgnop1hxn2zbOCBzNtmawxr92bVTOE31fJv6FhtCnQiD6tuPQVGMYhcmAj7eihtvuEMFfqEPcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "linkifyjs": "^4.3.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-list-item": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-2.27.2.tgz",
+      "integrity": "sha512-eJNee7IEGXMnmygM5SdMGDC8m/lMWmwNGf9fPCK6xk0NxuQRgmZHL6uApKcdH6gyNcRPHCqvTTkhEP7pbny/fg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-ordered-list": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-2.27.2.tgz",
+      "integrity": "sha512-M7A4tLGJcLPYdLC4CI2Gwl8LOrENQW59u3cMVa+KkwG1hzSJyPsbDpa1DI6oXPC2WtYiTf22zrbq3gVvH+KA2w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-paragraph": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-2.27.2.tgz",
+      "integrity": "sha512-elYVn2wHJJ+zB9LESENWOAfI4TNT0jqEN34sMA/hCtA4im1ZG2DdLHwkHIshj/c4H0dzQhmsS/YmNC5Vbqab/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-placeholder": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-2.27.2.tgz",
+      "integrity": "sha512-IjsgSVYJRjpAKmIoapU0E2R4E2FPY3kpvU7/1i7PUYisylqejSJxmtJPGYw0FOMQY9oxnEEvfZHMBA610tqKpg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-strike": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-2.27.2.tgz",
+      "integrity": "sha512-HHIjhafLhS2lHgfAsCwC1okqMsQzR4/mkGDm4M583Yftyjri1TNA7lzhzXWRFWiiMfJxKtdjHjUAQaHuteRTZw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-task-item": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-task-item/-/extension-task-item-2.27.2.tgz",
+      "integrity": "sha512-ZBSqj/dygB/Rp5K9qOxRVwASTZCmKVoTq8C59KvMgD/aFjJxhq/w2dZaWkCUEXEep+NmvJqo0kfeAEMY5UDnGg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-task-list": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-task-list/-/extension-task-list-2.27.2.tgz",
+      "integrity": "sha512-5nupAewdzZ9F3599oAcaK0WkDH04wdACAVBPM4zG7InlIpkbho3txB7zWmm64OxfhCMIMGKiXY1q0bw9i0QBGQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-text": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-2.27.2.tgz",
+      "integrity": "sha512-Xk7nYcigljAY0GO9hAQpZ65ZCxqOqaAlTPDFcKerXmlkQZP/8ndx95OgUb1Xf63kmPOh3xypurGS2is3v0MXSA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-text-style": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-2.27.2.tgz",
+      "integrity": "sha512-Omk+uxjJLyEY69KStpCw5fA9asvV+MGcAX2HOxyISDFoLaL49TMrNjhGAuz09P1L1b0KGXo4ml7Q3v/Lfy4WPA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-underline": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-2.27.2.tgz",
+      "integrity": "sha512-gPOsbAcw1S07ezpAISwoO8f0RxpjcSH7VsHEFDVuXm4ODE32nhvSinvHQjv2icRLOXev+bnA7oIBu7Oy859gWQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/pm": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.27.2.tgz",
+      "integrity": "sha512-kaEg7BfiJPDQMKbjVIzEPO3wlcA+pZb2tlcK9gPrdDnEFaec2QTF1sXz2ak2IIb2curvnIrQ4yrfHgLlVA72wA==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-changeset": "^2.3.0",
+        "prosemirror-collab": "^1.3.1",
+        "prosemirror-commands": "^1.6.2",
+        "prosemirror-dropcursor": "^1.8.1",
+        "prosemirror-gapcursor": "^1.3.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-inputrules": "^1.4.0",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-markdown": "^1.13.1",
+        "prosemirror-menu": "^1.2.4",
+        "prosemirror-model": "^1.23.0",
+        "prosemirror-schema-basic": "^1.2.3",
+        "prosemirror-schema-list": "^1.4.1",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-tables": "^1.6.4",
+        "prosemirror-trailing-node": "^3.0.0",
+        "prosemirror-transform": "^1.10.2",
+        "prosemirror-view": "^1.37.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/react": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-2.27.2.tgz",
+      "integrity": "sha512-0EAs8Cpkfbvben1PZ34JN2Nd79Dhioynm2jML27DBbf1VWPk+FFWFGTMLUT0bu+Np5iVxio8fqV9t0mc4D6thA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/extension-bubble-menu": "^2.27.2",
+        "@tiptap/extension-floating-menu": "^2.27.2",
+        "@types/use-sync-external-store": "^0.0.6",
+        "fast-deep-equal": "^3",
+        "use-sync-external-store": "^1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tiptap/starter-kit": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-2.27.2.tgz",
+      "integrity": "sha512-bb0gJvPoDuyRUQ/iuN52j1//EtWWttw+RXAv1uJxfR0uKf8X7uAqzaOOgwjknoCIDC97+1YHwpGdnRjpDkOBxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/core": "^2.27.2",
+        "@tiptap/extension-blockquote": "^2.27.2",
+        "@tiptap/extension-bold": "^2.27.2",
+        "@tiptap/extension-bullet-list": "^2.27.2",
+        "@tiptap/extension-code": "^2.27.2",
+        "@tiptap/extension-code-block": "^2.27.2",
+        "@tiptap/extension-document": "^2.27.2",
+        "@tiptap/extension-dropcursor": "^2.27.2",
+        "@tiptap/extension-gapcursor": "^2.27.2",
+        "@tiptap/extension-hard-break": "^2.27.2",
+        "@tiptap/extension-heading": "^2.27.2",
+        "@tiptap/extension-history": "^2.27.2",
+        "@tiptap/extension-horizontal-rule": "^2.27.2",
+        "@tiptap/extension-italic": "^2.27.2",
+        "@tiptap/extension-list-item": "^2.27.2",
+        "@tiptap/extension-ordered-list": "^2.27.2",
+        "@tiptap/extension-paragraph": "^2.27.2",
+        "@tiptap/extension-strike": "^2.27.2",
+        "@tiptap/extension-text": "^2.27.2",
+        "@tiptap/extension-text-style": "^2.27.2",
+        "@tiptap/pm": "^2.27.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -1935,6 +2416,28 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "license": "MIT"
+    },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
@@ -2016,6 +2519,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@types/verror": {
       "version": "1.10.11",
@@ -2361,7 +2870,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/assert-plus": {
@@ -3172,6 +3680,12 @@
         "node": ">= 10"
       }
     },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3740,6 +4254,18 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -3864,9 +4390,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -3916,7 +4440,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-equals": {
@@ -5110,6 +5633,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/linkifyjs": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
+      "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
+      "license": "MIT"
+    },
     "node_modules/lodash": {
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
@@ -5198,6 +5736,29 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it-task-lists": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-task-lists/-/markdown-it-task-lists-2.1.1.tgz",
+      "integrity": "sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==",
+      "license": "ISC"
+    },
     "node_modules/matcher": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
@@ -5220,6 +5781,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -5535,6 +6102,12 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "license": "MIT"
     },
     "node_modules/p-cancelable": {
       "version": "2.1.1",
@@ -5872,6 +6445,201 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/prosemirror-changeset": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
+      "integrity": "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-collab": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.3.1.tgz",
+      "integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-dropcursor": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
+      "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/prosemirror-gapcursor": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+      "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-inputrules": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
+      "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-markdown": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.4.tgz",
+      "integrity": "sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/markdown-it": "^14.0.0",
+        "markdown-it": "^14.0.0",
+        "prosemirror-model": "^1.25.0"
+      }
+    },
+    "node_modules/prosemirror-menu": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.3.2.tgz",
+      "integrity": "sha512-6VgUJTYod0nMBlCaYJGhXGLu7Gt4AvcwcOq0YfJCY/6Uh+3S7UsWhpy6rJFCBFOmonq1hD8KyWOtZhkppd4YPg==",
+      "license": "MIT",
+      "dependencies": {
+        "crelt": "^1.0.0",
+        "prosemirror-commands": "^1.0.0",
+        "prosemirror-history": "^1.0.0",
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
+      "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-basic": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.4.tgz",
+      "integrity": "sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.25.0"
+      }
+    },
+    "node_modules/prosemirror-schema-list": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+      "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-tables": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+      "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
+      }
+    },
+    "node_modules/prosemirror-trailing-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-3.0.0.tgz",
+      "integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remirror/core-constants": "3.0.0",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "prosemirror-model": "^1.22.1",
+        "prosemirror-state": "^1.4.2",
+        "prosemirror-view": "^1.33.8"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.41.8",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
+      "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.20.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
@@ -5888,6 +6656,15 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6238,6 +7015,12 @@
         "@rollup/rollup-win32-x64-msvc": "4.57.1",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+      "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -6918,6 +7701,55 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tippy.js": {
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
+      "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@popperjs/core": "^2.9.0"
+      }
+    },
+    "node_modules/tiptap-markdown": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/tiptap-markdown/-/tiptap-markdown-0.8.10.tgz",
+      "integrity": "sha512-iDVkR2BjAqkTDtFX0h94yVvE2AihCXlF0Q7RIXSJPRSR5I0PA1TMuAg6FHFpmqTn4tPxJ0by0CK7PUMlnFLGEQ==",
+      "license": "MIT",
+      "workspaces": [
+        "example"
+      ],
+      "dependencies": {
+        "@types/markdown-it": "^13.0.7",
+        "markdown-it": "^14.1.0",
+        "markdown-it-task-lists": "^2.1.1",
+        "prosemirror-markdown": "^1.11.1"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.0.3"
+      }
+    },
+    "node_modules/tiptap-markdown/node_modules/@types/linkify-it": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.5.tgz",
+      "integrity": "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==",
+      "license": "MIT"
+    },
+    "node_modules/tiptap-markdown/node_modules/@types/markdown-it": {
+      "version": "13.0.9",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.9.tgz",
+      "integrity": "sha512-1XPwR0+MgXLWfTn9gCsZ55AHOKW1WN+P9vr0PaQh5aerR9LLQXUbjfEAFhjmEmyoYFWAyuN2Mqkn40MZ4ukjBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^3",
+        "@types/mdurl": "^1"
+      }
+    },
+    "node_modules/tiptap-markdown/node_modules/@types/mdurl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.5.tgz",
+      "integrity": "sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==",
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
@@ -7001,6 +7833,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
@@ -7184,6 +8022,12 @@
       "resolved": "https://registry.npmjs.org/vite-plugin-electron-renderer/-/vite-plugin-electron-renderer-0.14.6.tgz",
       "integrity": "sha512-oqkWFa7kQIkvHXG7+Mnl1RTroA4sP0yesKatmAy0gjZC4VwUqlvF9IvOpHd1fpLWsqYX/eZlVxlhULNtaQ78Jw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
     },
     "node_modules/web-streams-polyfill": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,14 @@
     "@liveblocks/client": "^3.14.1",
     "@liveblocks/react": "^3.14.1",
     "@supabase/supabase-js": "^2.99.1",
+    "@tiptap/extension-bubble-menu": "^2.27.2",
+    "@tiptap/extension-link": "^2.27.2",
+    "@tiptap/extension-placeholder": "^2.27.2",
+    "@tiptap/extension-task-item": "^2.27.2",
+    "@tiptap/extension-task-list": "^2.27.2",
+    "@tiptap/extension-underline": "^2.27.2",
+    "@tiptap/react": "^2.27.2",
+    "@tiptap/starter-kit": "^2.27.2",
     "clsx": "^2.1.0",
     "framer-motion": "^10.18.0",
     "googleapis": "^171.4.0",
@@ -26,6 +34,7 @@
     "react-dom": "^18.3.1",
     "react-grid-layout": "^1.4.4",
     "sonner": "^2.0.7",
+    "tiptap-markdown": "^0.8.10",
     "zustand": "^4.5.2"
   },
   "build": {

--- a/src/components/widgets/MemoWidget.tsx
+++ b/src/components/widgets/MemoWidget.tsx
@@ -1,8 +1,12 @@
 import { useState, useEffect, useRef, useCallback, useContext } from 'react';
-import { StickyNote, Type, Eye, Pencil, Plus, X, Bold, Italic, Underline, Strikethrough } from 'lucide-react';
+import { StickyNote, Type, Pencil, Plus, X } from 'lucide-react';
+import type { Editor } from '@tiptap/core';
 import { Widget, WidgetIdContext, IsPopupContext } from './Widget';
 import * as supabaseService from '@/services/supabaseService';
 import { useAuthStore } from '@/stores/useAuthStore';
+import { MemoEditor } from './memo/MemoEditor';
+import { MemoToolbar } from './memo/MemoToolbar';
+import { MemoLinkBubble } from './memo/MemoLinkBubble';
 
 const MEMO_FILE = 'memo.json';
 const MEMO_MIGRATION_KEY = 'bflow_migration_memo_done';
@@ -48,93 +52,6 @@ function makeDefaultMemoData(): MemoData {
     activeTabId: 'default',
     fontSize: DEFAULT_FONT_SIZE,
   };
-}
-
-/* ── 간단한 마크다운 렌더러 ──
- * 지원: **굵게**, *기울임*, __밑줄__, ~~취소선~~
- * 굵게(**)는 밑줄(__)보다 먼저 매칭되어야 `**` 가 `_ _` 로 오해석되지 않음
- */
-
-function inlineFormat(text: string): React.ReactNode {
-  const parts: React.ReactNode[] = [];
-  // 순서 주의: ** 를 * 보다 먼저, __ 를 _ 보다 먼저 매칭
-  const regex = /(\*\*(.+?)\*\*|__(.+?)__|~~(.+?)~~|\*(.+?)\*)/g;
-  let lastIndex = 0;
-  let match;
-  let k = 0;
-
-  while ((match = regex.exec(text)) !== null) {
-    if (match.index > lastIndex) parts.push(text.slice(lastIndex, match.index));
-    if (match[2] !== undefined) parts.push(<strong key={k++}>{match[2]}</strong>);
-    else if (match[3] !== undefined) parts.push(<u key={k++}>{match[3]}</u>);
-    else if (match[4] !== undefined) parts.push(<s key={k++}>{match[4]}</s>);
-    else if (match[5] !== undefined) parts.push(<em key={k++}>{match[5]}</em>);
-    lastIndex = match.index + match[0].length;
-  }
-  if (lastIndex < text.length) parts.push(text.slice(lastIndex));
-  return parts.length <= 1 ? (parts[0] ?? '') : <>{parts}</>;
-}
-
-function SimpleMarkdown({ content, fontSize }: { content: string; fontSize: number }) {
-  if (!content) {
-    return <div className="text-text-secondary/30" style={{ fontSize }}>메모를 입력하세요...</div>;
-  }
-
-  const lines = content.split('\n');
-  const elements: React.ReactNode[] = [];
-  let i = 0;
-  let key = 0;
-
-  while (i < lines.length) {
-    const line = lines[i];
-
-    // 비순서 목록 (- 또는 * )
-    if (/^\s*[-*]\s/.test(line)) {
-      const items: string[] = [];
-      while (i < lines.length && /^\s*[-*]\s/.test(lines[i])) {
-        items.push(lines[i].replace(/^\s*[-*]\s/, ''));
-        i++;
-      }
-      elements.push(
-        <ul key={key++} className="list-disc pl-5 my-0.5 text-text-primary" style={{ fontSize }}>
-          {items.map((item, idx) => <li key={idx} className="py-px">{inlineFormat(item)}</li>)}
-        </ul>,
-      );
-      continue;
-    }
-
-    // 순서 목록 (1. 또는 1) )
-    if (/^\s*\d+[.)]\s/.test(line)) {
-      const items: string[] = [];
-      while (i < lines.length && /^\s*\d+[.)]\s/.test(lines[i])) {
-        items.push(lines[i].replace(/^\s*\d+[.)]\s/, ''));
-        i++;
-      }
-      elements.push(
-        <ol key={key++} className="list-decimal pl-5 my-0.5 text-text-primary" style={{ fontSize }}>
-          {items.map((item, idx) => <li key={idx} className="py-px">{inlineFormat(item)}</li>)}
-        </ol>,
-      );
-      continue;
-    }
-
-    // 빈 줄
-    if (line.trim() === '') {
-      elements.push(<div key={key++} className="h-1.5" />);
-      i++;
-      continue;
-    }
-
-    // 일반 텍스트
-    elements.push(
-      <div key={key++} className="text-text-primary leading-relaxed" style={{ fontSize }}>
-        {inlineFormat(line)}
-      </div>,
-    );
-    i++;
-  }
-
-  return <div>{elements}</div>;
 }
 
 /* ── memo.json → Supabase 마이그레이션 ── */
@@ -248,7 +165,6 @@ function MemoTabBar({
             <span className={tab.title ? 'cursor-pointer' : 'cursor-pointer italic opacity-60'}>
               {displayTitle}
             </span>
-            {/* 연필 아이콘 — 호버 시 노출, 한 번 클릭으로 편집 */}
             <button
               className="opacity-0 group-hover:opacity-100 transition-opacity p-0.5 rounded hover:bg-accent/15 hover:text-accent cursor-pointer"
               onClick={(e) => { e.stopPropagation(); beginEdit(tab.id, tab.title); }}
@@ -282,115 +198,6 @@ function MemoTabBar({
   );
 }
 
-/* ── 서식 툴바 (textarea 선택 텍스트를 마크다운으로 감쌈) ── */
-
-type MdStyle = 'bold' | 'italic' | 'underline' | 'strike';
-
-function applyMarkdown(
-  textareaRef: React.RefObject<HTMLTextAreaElement | null>,
-  style: MdStyle,
-  onChange: (nextValue: string) => void,
-) {
-  const ta = textareaRef.current;
-  if (!ta) return;
-
-  const wrapMap: Record<MdStyle, string> = {
-    bold: '**',
-    italic: '*',
-    underline: '__',
-    strike: '~~',
-  };
-  const wrap = wrapMap[style];
-  const { selectionStart: s, selectionEnd: e, value } = ta;
-  const before = value.slice(0, s);
-  const selected = value.slice(s, e);
-  const after = value.slice(e);
-
-  // 이미 같은 서식으로 감싸져 있으면 토글 해제
-  const alreadyWrapped =
-    selected.startsWith(wrap) && selected.endsWith(wrap) && selected.length >= wrap.length * 2;
-  const insertion = alreadyWrapped
-    ? selected.slice(wrap.length, selected.length - wrap.length)
-    : `${wrap}${selected || '텍스트'}${wrap}`;
-  const next = `${before}${insertion}${after}`;
-
-  onChange(next);
-
-  // 다음 렌더 후 커서/선택 영역 복원
-  requestAnimationFrame(() => {
-    const cur = textareaRef.current;
-    if (!cur) return;
-    if (alreadyWrapped) {
-      cur.selectionStart = s;
-      cur.selectionEnd = s + insertion.length;
-    } else {
-      cur.selectionStart = s + wrap.length;
-      cur.selectionEnd = s + wrap.length + (selected || '텍스트').length;
-    }
-    cur.focus();
-  });
-}
-
-function FormatToolbar({
-  textareaRef,
-  onChange,
-  disabled,
-}: {
-  textareaRef: React.RefObject<HTMLTextAreaElement | null>;
-  onChange: (next: string) => void;
-  disabled?: boolean;
-}) {
-  const btn = 'p-1 rounded-md text-text-secondary/60 hover:text-accent hover:bg-accent/10 transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed';
-  return (
-    <div className="flex items-center gap-0.5 px-1.5 py-0.5 border-b border-bg-border/10 shrink-0">
-      <button
-        type="button"
-        className={btn}
-        onMouseDown={(e) => e.preventDefault()}
-        onClick={() => applyMarkdown(textareaRef, 'bold', onChange)}
-        disabled={disabled}
-        title="굵게 (**text**)"
-        aria-label="굵게"
-      >
-        <Bold size={12} />
-      </button>
-      <button
-        type="button"
-        className={btn}
-        onMouseDown={(e) => e.preventDefault()}
-        onClick={() => applyMarkdown(textareaRef, 'italic', onChange)}
-        disabled={disabled}
-        title="기울임 (*text*)"
-        aria-label="기울임"
-      >
-        <Italic size={12} />
-      </button>
-      <button
-        type="button"
-        className={btn}
-        onMouseDown={(e) => e.preventDefault()}
-        onClick={() => applyMarkdown(textareaRef, 'underline', onChange)}
-        disabled={disabled}
-        title="밑줄 (__text__)"
-        aria-label="밑줄"
-      >
-        <Underline size={12} />
-      </button>
-      <button
-        type="button"
-        className={btn}
-        onMouseDown={(e) => e.preventDefault()}
-        onClick={() => applyMarkdown(textareaRef, 'strike', onChange)}
-        disabled={disabled}
-        title="취소선 (~~text~~)"
-        aria-label="취소선"
-      >
-        <Strikethrough size={12} />
-      </button>
-    </div>
-  );
-}
-
 /* ── 메모 위젯 ── */
 
 export function MemoWidget() {
@@ -401,12 +208,13 @@ export function MemoWidget() {
 
   const [memoData, setMemoData] = useState<MemoData>(makeDefaultMemoData);
   const [loaded, setLoaded] = useState(false);
-  const [previewMode, setPreviewMode] = useState(false);
+  const [editor, setEditor] = useState<Editor | null>(null);
+  const [linkEditToken, setLinkEditToken] = useState(0);
 
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const memoDataRef = useRef(memoData);
   memoDataRef.current = memoData;
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const editorAreaRef = useRef<HTMLDivElement>(null);
 
   const activeTab = memoData.tabs.find((t) => t.id === memoData.activeTabId) ?? memoData.tabs[0];
 
@@ -420,7 +228,6 @@ export function MemoWidget() {
           if (remote) {
             setMemoData(migrateMemoData(remote));
           } else {
-            // 사용자 전환 시 이전 데이터 초기화
             setMemoData(makeDefaultMemoData());
           }
         }
@@ -474,7 +281,7 @@ export function MemoWidget() {
     return () => window.removeEventListener('storage', handler);
   }, [memoKey]);
 
-  // 언마운트 시 즉시 저장
+  // 언마운트 시 즉시 저장 (debounce flush)
   useEffect(() => {
     return () => {
       if (saveTimerRef.current) {
@@ -496,6 +303,21 @@ export function MemoWidget() {
     };
   }, [memoKey]);
 
+  // Ctrl+K 단축키 — 에디터에 포커스된 상태에서만 링크 편집 트리거
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (!(e.ctrlKey || e.metaKey) || e.key.toLowerCase() !== 'k') return;
+      if (e.shiftKey || e.altKey) return;
+      const active = document.activeElement as HTMLElement | null;
+      const inEditor = editorAreaRef.current?.contains(active);
+      if (!inEditor) return;
+      e.preventDefault();
+      setLinkEditToken((t) => t + 1);
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
   // ── 탭 관리 핸들러 ──
 
   const handleSelectTab = useCallback((id: string) => {
@@ -506,13 +328,7 @@ export function MemoWidget() {
 
   const handleAddTab = useCallback(() => {
     const newId = `tab-${Date.now()}`;
-    // 제목은 빈 값으로 생성 — 탭 바에서 "메모 N" placeholder 로 노출되며,
-    // 사용자가 직접 입력하면 그 값이 저장됨
-    const newTab: MemoTab = {
-      id: newId,
-      title: '',
-      content: '',
-    };
+    const newTab: MemoTab = { id: newId, title: '', content: '' };
     const updated: MemoData = {
       ...memoData,
       tabs: [...memoData.tabs, newTab],
@@ -545,17 +361,19 @@ export function MemoWidget() {
 
   // ── 콘텐츠/폰트 변경 ──
 
-  const handleContentChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const val = e.target.value;
+  const handleContentChange = useCallback((markdown: string) => {
+    const latest = memoDataRef.current;
+    // 활성 탭의 content 갱신
+    if (latest.tabs.find(t => t.id === latest.activeTabId)?.content === markdown) return;
     const updated: MemoData = {
-      ...memoData,
-      tabs: memoData.tabs.map((t) =>
-        t.id === memoData.activeTabId ? { ...t, content: val } : t,
+      ...latest,
+      tabs: latest.tabs.map((t) =>
+        t.id === latest.activeTabId ? { ...t, content: markdown } : t,
       ),
     };
     setMemoData(updated);
     save(updated);
-  }, [memoData, save]);
+  }, [save]);
 
   const handleFontSizeChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const val = Number(e.target.value);
@@ -564,16 +382,17 @@ export function MemoWidget() {
     save(updated);
   }, [memoData, save]);
 
-  // 컨트롤 바 (미리보기 토글 + 글자 크기 슬라이더)
+  const handleEditorReady = useCallback((ed: Editor | null) => {
+    setEditor(ed);
+  }, []);
+
+  const handleLinkRequest = useCallback(() => {
+    setLinkEditToken((t) => t + 1);
+  }, []);
+
+  // 컨트롤 바 (글자 크기 슬라이더만 — 미리보기 토글 제거됨)
   const controls = (
     <div className="flex items-center gap-1.5">
-      <button
-        onClick={() => setPreviewMode(!previewMode)}
-        className="p-1 rounded-md text-text-secondary/40 hover:text-accent hover:bg-accent/10 transition-colors cursor-pointer"
-        title={previewMode ? '편집 모드' : '미리보기'}
-      >
-        {previewMode ? <Pencil size={13} /> : <Eye size={13} />}
-      </button>
       <Type size={12} className="text-text-secondary/50 shrink-0" />
       <input
         type="range"
@@ -602,43 +421,25 @@ export function MemoWidget() {
     />
   );
 
-  // 서식 툴바가 본문을 변경할 때 활성 탭의 content 를 업데이트
-  const handleFormatToolbarChange = useCallback((nextValue: string) => {
-    const latest = memoDataRef.current;
-    const updated: MemoData = {
-      ...latest,
-      tabs: latest.tabs.map((t) =>
-        t.id === latest.activeTabId ? { ...t, content: nextValue } : t,
-      ),
-    };
-    setMemoData(updated);
-    save(updated);
-  }, [save]);
-
-  const formatToolbar = !previewMode && loaded ? (
-    <FormatToolbar
-      textareaRef={textareaRef}
-      onChange={handleFormatToolbarChange}
+  const toolbar = (
+    <MemoToolbar
+      editor={editor}
+      widthRef={editorAreaRef}
+      onLinkRequest={handleLinkRequest}
     />
-  ) : null;
+  );
 
   const memoContent = loaded ? (
-    previewMode ? (
-      <div className="w-full h-full overflow-auto cursor-text" onClick={() => setPreviewMode(false)}>
-        <SimpleMarkdown content={activeTab?.content ?? ''} fontSize={memoData.fontSize} />
-      </div>
-    ) : (
-      <textarea
+    <div ref={editorAreaRef} className="flex-1 overflow-auto">
+      <MemoEditor
         key={activeTab?.id}
-        ref={textareaRef}
-        value={activeTab?.content ?? ''}
+        content={activeTab?.content ?? ''}
         onChange={handleContentChange}
-        placeholder="메모를 입력하세요... (상단 툴바로 서식 적용 가능)"
-        className="w-full h-full bg-transparent text-text-primary resize-none outline-none placeholder:text-text-secondary/30 leading-relaxed"
-        style={{ fontSize: `${memoData.fontSize}px`, minHeight: isPopup ? '100%' : '80px' }}
-        spellCheck={false}
+        fontSize={memoData.fontSize}
+        onEditorReady={handleEditorReady}
       />
-    )
+      <MemoLinkBubble editor={editor} editRequestToken={linkEditToken} />
+    </div>
   ) : (
     <div className="flex items-center justify-center h-full">
       <span className="text-sm text-text-secondary/30 animate-pulse">로딩 중...</span>
@@ -655,10 +456,8 @@ export function MemoWidget() {
           <div className="ml-auto">{controls}</div>
         </div>
         {tabBar}
-        {formatToolbar}
-        <div className="flex-1 overflow-auto p-4">
-          {memoContent}
-        </div>
+        {toolbar}
+        {memoContent}
       </div>
     );
   }
@@ -666,7 +465,7 @@ export function MemoWidget() {
   return (
     <Widget title="메모" icon={<StickyNote size={15} />} headerRight={controls}>
       {tabBar}
-      {formatToolbar}
+      {toolbar}
       {memoContent}
     </Widget>
   );

--- a/src/components/widgets/memo/MemoEditor.tsx
+++ b/src/components/widgets/memo/MemoEditor.tsx
@@ -49,6 +49,12 @@ export function MemoEditor({
         openOnClick: false, // 클릭 시 자동 네비게이션 금지 — 버블 메뉴에서 수동 처리
         autolink: true,
         linkOnPaste: true,
+        // Electron main 의 shell:open-external 핸들러는 http(s)/mailto/tel 만 허용.
+        // autolink / paste / setLink 모든 경로에서 같은 화이트리스트를 강제 → 죽은 링크 방지.
+        isAllowedUri: (url, { defaultValidate }) => {
+          if (!defaultValidate(url)) return false;
+          return /^(https?:|mailto:|tel:)/i.test(url);
+        },
         HTMLAttributes: {
           rel: 'noopener noreferrer',
         },

--- a/src/components/widgets/memo/MemoEditor.tsx
+++ b/src/components/widgets/memo/MemoEditor.tsx
@@ -1,0 +1,119 @@
+/**
+ * 메모용 TipTap WYSIWYG 에디터.
+ * - 저장 형식: Markdown 문자열 (tiptap-markdown)
+ * - 앱 관습 __x__ = 밑줄 (BflowUnderline)
+ * - Placeholder / TaskList / Link 포함
+ */
+import { useEditor, EditorContent, type Editor } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+import Link from '@tiptap/extension-link';
+import TaskList from '@tiptap/extension-task-list';
+import TaskItem from '@tiptap/extension-task-item';
+import Placeholder from '@tiptap/extension-placeholder';
+import { Markdown } from 'tiptap-markdown';
+import { useEffect, useRef } from 'react';
+import { BflowUnderline, getEditorMarkdown } from './markdownExtensions';
+
+interface MemoEditorProps {
+  /** Markdown 문자열 (초기값/외부 변경 주입용). undefined 일 때 editor 내용 변경 안 함 */
+  content: string;
+  /** editor 내용 변경 시 최신 Markdown 콜백 */
+  onChange: (markdown: string) => void;
+  /** 본문 폰트 크기 (px). 헤딩은 em 비율로 자동 계산 */
+  fontSize: number;
+  placeholder?: string;
+  /** editor 인스턴스를 상위에 노출 (툴바/버블이 참조) */
+  onEditorReady?: (editor: Editor | null) => void;
+}
+
+export function MemoEditor({
+  content,
+  onChange,
+  fontSize,
+  placeholder = '메모를 입력하세요...',
+  onEditorReady,
+}: MemoEditorProps) {
+  // 외부에서 주입된 content 와 에디터 내부 content 비교용
+  const lastExternalContentRef = useRef<string>(content);
+
+  const editor = useEditor({
+    extensions: [
+      StarterKit.configure({
+        // 기본 포함: Bold, Italic, Strike, Heading, BulletList, OrderedList,
+        // ListItem, Paragraph, HardBreak, History (undo/redo), Code, CodeBlock, Blockquote, HorizontalRule
+        // 헤딩 레벨을 1/2/3 으로 제한
+        heading: { levels: [1, 2, 3] },
+      }),
+      BflowUnderline,
+      Link.configure({
+        openOnClick: false, // 클릭 시 자동 네비게이션 금지 — 버블 메뉴에서 수동 처리
+        autolink: true,
+        linkOnPaste: true,
+        HTMLAttributes: {
+          rel: 'noopener noreferrer',
+        },
+      }),
+      TaskList,
+      TaskItem.configure({
+        nested: false,
+      }),
+      Placeholder.configure({
+        placeholder,
+        emptyEditorClass: 'is-editor-empty',
+      }),
+      // Markdown 은 마지막에 (다른 extension 의 addStorage().markdown 을 읽어 serializer 구성)
+      Markdown.configure({
+        html: false,
+        linkify: false, // Link extension 이 담당
+        breaks: false,
+        transformPastedText: true,
+        transformCopiedText: false,
+        bulletListMarker: '-',
+      }),
+    ],
+    content,
+    onUpdate({ editor: ed }) {
+      const md = getEditorMarkdown(ed);
+      lastExternalContentRef.current = md;
+      onChange(md);
+    },
+    editorProps: {
+      attributes: {
+        class: 'memo-prose focus:outline-none',
+        spellcheck: 'false',
+      },
+    },
+  });
+
+  // editor 준비/해제 알림
+  useEffect(() => {
+    onEditorReady?.(editor);
+    return () => {
+      onEditorReady?.(null);
+    };
+  }, [editor, onEditorReady]);
+
+  // 외부 content 가 바뀌면 에디터에 주입 (탭 전환, 다른 윈도우 sync 등)
+  useEffect(() => {
+    if (!editor) return;
+    if (content === lastExternalContentRef.current) return;
+    // 현재 에디터가 직렬화한 값과 다르면 외부에서 바뀐 것
+    try {
+      lastExternalContentRef.current = content;
+      editor.commands.setContent(content, false);
+    } catch (err) {
+      console.error('[MemoEditor] setContent 실패 — plain text fallback:', err);
+      editor.commands.setContent(content ?? '', false, { preserveWhitespace: 'full' });
+    }
+  }, [content, editor]);
+
+  return (
+    <div
+      className="memo-editor-root w-full h-full overflow-auto cursor-text"
+      style={{ fontSize: `${fontSize}px` }}
+      onClick={() => editor?.commands.focus()}
+    >
+      <EditorContent editor={editor} />
+    </div>
+  );
+}

--- a/src/components/widgets/memo/MemoLinkBubble.tsx
+++ b/src/components/widgets/memo/MemoLinkBubble.tsx
@@ -47,10 +47,20 @@ export function MemoLinkBubble({ editor, editRequestToken }: MemoLinkBubbleProps
   const [editMode, setEditMode] = useState(false);
   const [url, setUrl] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
+  /**
+   * 이미 처리한 editRequestToken 추적.
+   * editRequestToken 은 상위에서 monotonic 증가만 하므로 reset 이 없음.
+   * dependency 에 editor 가 들어가야 최신 editor 에서 editRequestToken 을 처리할 수 있지만,
+   * token 동일한 상태로 editor 가 교체되면 (예: 탭 전환 시 MemoEditor key 재마운트) effect 가
+   * 다시 뛰어 의도치 않게 버블이 열리는 문제가 있어 — ref 로 처리된 토큰을 기록해서 중복 실행 방지.
+   */
+  const lastHandledTokenRef = useRef(0);
 
   // 외부 요청 시 편집 모드 진입 + 현재 링크 URL 프리필
   useEffect(() => {
     if (editRequestToken <= 0 || !editor) return;
+    if (editRequestToken === lastHandledTokenRef.current) return;
+    lastHandledTokenRef.current = editRequestToken;
     const currentUrl = (editor.getAttributes('link')?.href as string | undefined) ?? '';
     setUrl(currentUrl);
     setEditMode(true);

--- a/src/components/widgets/memo/MemoLinkBubble.tsx
+++ b/src/components/widgets/memo/MemoLinkBubble.tsx
@@ -8,6 +8,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { BubbleMenu } from '@tiptap/react';
 import type { Editor } from '@tiptap/core';
+import { toast } from 'sonner';
 import { ExternalLink, Pencil, X, Link2, Check } from 'lucide-react';
 
 interface MemoLinkBubbleProps {
@@ -16,12 +17,29 @@ interface MemoLinkBubbleProps {
   editRequestToken: number;
 }
 
-/** URL 유효성 검사 + https:// prepend */
+/**
+ * URL 유효성 검사 + https:// prepend.
+ *
+ * Electron main 의 `shell:open-external` 핸들러는 http(s)/mailto/tel 프로토콜만 허용하므로
+ * 같은 화이트리스트에 맞춘다. 상대 경로(`/foo`) 나 프로토콜만(`http:`) 등은 거부 (`null` 반환).
+ * 반환값 규약:
+ *   - `''` (빈 입력): `null` — 의도적 취소로 해석
+ *   - 유효한 http(s)/mailto/tel 또는 도메인 형태: 정규화된 절대 URL
+ *   - 그 외 (상대 경로, 프로토콜 누락, 공백 섞인 쓰레기): `null`
+ */
 function normalizeUrl(input: string): string | null {
   const v = input.trim();
   if (!v) return null;
-  if (/^(https?:|mailto:|tel:)/i.test(v)) return v;
-  if (v.startsWith('/')) return v; // 상대 경로
+  // 이미 지원되는 프로토콜: 그대로 반환 (최소 길이 검증)
+  if (/^https?:\/\/\S+/i.test(v)) return v;
+  if (/^mailto:\S+@\S+/i.test(v)) return v;
+  if (/^tel:\S+/i.test(v)) return v;
+  // 상대 경로 `/foo`, 프로토콜 미지원 `ftp://...`, 스킴만 있는 `http:` 등은 거부
+  if (/^\//.test(v)) return null;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(v)) return null;
+  if (/\s/.test(v)) return null;
+  // 도메인 형태만 남음 → 최소 점 하나 포함(도메인.tld) 요구
+  if (!/\.[a-z]{2,}/i.test(v)) return null;
   return `https://${v}`;
 }
 
@@ -60,9 +78,18 @@ export function MemoLinkBubble({ editor, editRequestToken }: MemoLinkBubbleProps
 
   const apply = useCallback(() => {
     if (!editor) return;
-    const normalized = normalizeUrl(url);
-    if (!normalized) {
+    const raw = url.trim();
+    // 빈 입력은 취소로 해석 (기존 링크 있으면 유지)
+    if (!raw) {
       setEditMode(false);
+      return;
+    }
+    const normalized = normalizeUrl(raw);
+    if (!normalized) {
+      toast.error('유효하지 않은 URL 형식입니다. http:// 또는 https:// 로 시작하거나 도메인을 입력해주세요.');
+      // 버블 유지 + input 재포커스
+      inputRef.current?.focus();
+      inputRef.current?.select();
       return;
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/components/widgets/memo/MemoLinkBubble.tsx
+++ b/src/components/widgets/memo/MemoLinkBubble.tsx
@@ -56,6 +56,14 @@ export function MemoLinkBubble({ editor, editRequestToken }: MemoLinkBubbleProps
    */
   const lastHandledTokenRef = useRef(0);
 
+  // editor 인스턴스가 교체되면 (탭 전환으로 MemoEditor 가 리마운트) 편집 상태 리셋.
+  // 이 reset effect 가 token effect 보다 선언 순서상 먼저여야, 탭 전환과 동시에 Ctrl+K 가
+  // 눌린 경우에도 reset 후 token effect 가 뒤이어 editMode=true 로 올바르게 설정된다.
+  useEffect(() => {
+    setEditMode(false);
+    setUrl('');
+  }, [editor]);
+
   // 외부 요청 시 편집 모드 진입 + 현재 링크 URL 프리필
   useEffect(() => {
     if (editRequestToken <= 0 || !editor) return;

--- a/src/components/widgets/memo/MemoLinkBubble.tsx
+++ b/src/components/widgets/memo/MemoLinkBubble.tsx
@@ -1,0 +1,174 @@
+/**
+ * 링크 버블 메뉴 — 새 링크 생성 / 기존 링크 편집·제거 UI
+ *
+ * 2가지 모드:
+ *  1) 편집 모드: URL input + 적용 버튼. editMode === true 또는 링크 커서 위가 아닌 상태에서 사용자가 링크 버튼을 눌렀을 때
+ *  2) 읽기 모드: 현재 링크 URL 표시 + 열기/편집/제거 버튼
+ */
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { BubbleMenu } from '@tiptap/react';
+import type { Editor } from '@tiptap/core';
+import { ExternalLink, Pencil, X, Link2, Check } from 'lucide-react';
+
+interface MemoLinkBubbleProps {
+  editor: Editor | null;
+  /** 외부 트리거 (툴바의 🔗 또는 Ctrl+K) — 이 값이 true 로 들어오면 강제 편집 모드 진입 */
+  editRequestToken: number;
+}
+
+/** URL 유효성 검사 + https:// prepend */
+function normalizeUrl(input: string): string | null {
+  const v = input.trim();
+  if (!v) return null;
+  if (/^(https?:|mailto:|tel:)/i.test(v)) return v;
+  if (v.startsWith('/')) return v; // 상대 경로
+  return `https://${v}`;
+}
+
+export function MemoLinkBubble({ editor, editRequestToken }: MemoLinkBubbleProps) {
+  const [editMode, setEditMode] = useState(false);
+  const [url, setUrl] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // 외부 요청 시 편집 모드 진입 + 현재 링크 URL 프리필
+  useEffect(() => {
+    if (editRequestToken <= 0 || !editor) return;
+    const currentUrl = (editor.getAttributes('link')?.href as string | undefined) ?? '';
+    setUrl(currentUrl);
+    setEditMode(true);
+  }, [editRequestToken, editor]);
+
+  // 편집 모드 진입 시 input 포커스
+  useEffect(() => {
+    if (editMode) {
+      const t = setTimeout(() => inputRef.current?.focus(), 0);
+      return () => clearTimeout(t);
+    }
+  }, [editMode]);
+
+  // 버블을 언제 표시할지
+  const shouldShow = useCallback(({ editor: ed, from, to }: { editor: Editor; from: number; to: number }) => {
+    if (!ed) return false;
+    // 편집 요청 중이면 무조건 노출
+    if (editMode) return true;
+    // 커서가 링크 위에 있으면 읽기 모드 표시
+    if (ed.isActive('link')) return true;
+    // 선택 영역이 있으면 링크 버튼 대기 — 자동 노출 안 함 (툴바 버튼으로 트리거)
+    if (from !== to) return false;
+    return false;
+  }, [editMode]);
+
+  const apply = useCallback(() => {
+    if (!editor) return;
+    const normalized = normalizeUrl(url);
+    if (!normalized) {
+      setEditMode(false);
+      return;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (editor.chain().focus() as any).extendMarkRange('link').setLink({ href: normalized }).run();
+    setEditMode(false);
+  }, [editor, url]);
+
+  const unlink = useCallback(() => {
+    if (!editor) return;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (editor.chain().focus() as any).extendMarkRange('link').unsetLink().run();
+    setEditMode(false);
+  }, [editor]);
+
+  const openExternal = useCallback(() => {
+    if (!editor) return;
+    const href = editor.getAttributes('link')?.href as string | undefined;
+    if (!href) return;
+    window.electronAPI?.openExternal?.(href) ?? window.open(href, '_blank', 'noopener,noreferrer');
+  }, [editor]);
+
+  const startEdit = useCallback(() => {
+    if (!editor) return;
+    const href = (editor.getAttributes('link')?.href as string | undefined) ?? '';
+    setUrl(href);
+    setEditMode(true);
+  }, [editor]);
+
+  if (!editor) return null;
+
+  return (
+    <BubbleMenu
+      editor={editor}
+      shouldShow={shouldShow}
+      tippyOptions={{
+        duration: 150,
+        placement: 'top',
+        hideOnClick: false,
+      }}
+    >
+      <div
+        role="dialog"
+        aria-label={editMode ? '링크 편집' : '링크'}
+        className="flex items-center gap-1 px-2 py-1.5 min-w-[240px] rounded-lg border border-bg-border bg-bg-card shadow-lg"
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') {
+            e.stopPropagation();
+            setEditMode(false);
+            editor.commands.focus();
+          }
+        }}
+      >
+        {editMode ? (
+          <>
+            <Link2 size={14} className="text-text-secondary/70 shrink-0" aria-hidden />
+            <input
+              ref={inputRef}
+              type="text"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') { e.preventDefault(); apply(); }
+              }}
+              placeholder="https://..."
+              aria-label="링크 URL"
+              className="flex-1 min-w-0 bg-transparent outline-none text-[13px] text-text-primary placeholder:text-text-secondary/40"
+            />
+            <button
+              type="button"
+              className="inline-flex items-center justify-center w-[22px] h-[22px] rounded-md bg-accent text-on-accent hover:bg-accent/90 cursor-pointer"
+              onClick={apply}
+              title="적용"
+              aria-label="링크 적용"
+            >
+              <Check size={13} />
+            </button>
+          </>
+        ) : (
+          <>
+            <span
+              className="flex-1 min-w-0 text-[12px] text-text-secondary truncate px-1"
+              title={editor.getAttributes('link')?.href as string}
+            >
+              {(editor.getAttributes('link')?.href as string | undefined) ?? ''}
+            </span>
+            <button type="button"
+              className="inline-flex items-center justify-center w-[22px] h-[22px] rounded-md text-text-secondary/70 hover:text-accent hover:bg-accent/10 cursor-pointer"
+              onClick={openExternal}
+              title="브라우저로 열기" aria-label="브라우저로 열기">
+              <ExternalLink size={13} />
+            </button>
+            <button type="button"
+              className="inline-flex items-center justify-center w-[22px] h-[22px] rounded-md text-text-secondary/70 hover:text-accent hover:bg-accent/10 cursor-pointer"
+              onClick={startEdit}
+              title="편집" aria-label="링크 편집">
+              <Pencil size={13} />
+            </button>
+            <button type="button"
+              className="inline-flex items-center justify-center w-[22px] h-[22px] rounded-md text-text-secondary/70 hover:text-red-400 hover:bg-red-400/10 cursor-pointer"
+              onClick={unlink}
+              title="링크 제거" aria-label="링크 제거">
+              <X size={13} />
+            </button>
+          </>
+        )}
+      </div>
+    </BubbleMenu>
+  );
+}

--- a/src/components/widgets/memo/MemoToolbar.tsx
+++ b/src/components/widgets/memo/MemoToolbar.tsx
@@ -1,0 +1,252 @@
+/**
+ * 메모 에디터 툴바 — 11개 서식 버튼 + 반응형 드롭다운
+ */
+import { useEffect, useRef, useState, useCallback } from 'react';
+import type { Editor } from '@tiptap/core';
+import {
+  Bold, Italic, Underline, Strikethrough,
+  List, ListOrdered, ListChecks, Link2, ChevronDown,
+} from 'lucide-react';
+
+interface MemoToolbarProps {
+  editor: Editor | null;
+  /** 툴바 컨테이너 (ResizeObserver 측정 대상). 제공되지 않으면 툴바 자체 폭 사용 */
+  widthRef?: React.RefObject<HTMLElement | null>;
+  /** 링크 버튼을 누를 때 호출 (MemoWidget 에서 버블 열기 지시용) */
+  onLinkRequest?: () => void;
+}
+
+const NARROW_THRESHOLD = 320;
+
+export function MemoToolbar({ editor, widthRef, onLinkRequest }: MemoToolbarProps) {
+  const selfRef = useRef<HTMLDivElement>(null);
+  const [isNarrow, setIsNarrow] = useState(false);
+  // 드롭다운 열림 상태
+  const [openMenu, setOpenMenu] = useState<null | 'heading' | 'list'>(null);
+
+  // 반응형: 컨테이너 폭 측정
+  useEffect(() => {
+    const target = widthRef?.current ?? selfRef.current;
+    if (!target) return;
+    const ro = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const w = entry.contentRect.width;
+        setIsNarrow(w < NARROW_THRESHOLD);
+      }
+    });
+    ro.observe(target);
+    return () => ro.disconnect();
+  }, [widthRef]);
+
+  // 메뉴 외부 클릭 시 닫기
+  useEffect(() => {
+    if (!openMenu) return;
+    const onDoc = (e: MouseEvent) => {
+      const t = e.target as HTMLElement;
+      if (!selfRef.current?.contains(t)) setOpenMenu(null);
+    };
+    document.addEventListener('mousedown', onDoc);
+    return () => document.removeEventListener('mousedown', onDoc);
+  }, [openMenu]);
+
+  const run = useCallback((fn: (chain: ReturnType<NonNullable<typeof editor>['chain']>) => void) => {
+    if (!editor) return;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    fn(editor.chain().focus() as any);
+  }, [editor]);
+
+  const isActive = (name: string, attrs?: Record<string, unknown>) => !!editor?.isActive(name, attrs);
+  const disabled = !editor;
+
+  const btnBase = 'inline-flex items-center justify-center w-[22px] h-[22px] rounded-md transition-colors cursor-pointer outline-none focus-visible:ring-1 focus-visible:ring-accent/40';
+  const btnCls = (active: boolean) => {
+    if (disabled) return `${btnBase} opacity-40 cursor-not-allowed text-text-secondary/60`;
+    if (active) return `${btnBase} text-accent bg-accent/15`;
+    return `${btnBase} text-text-secondary/60 hover:text-accent hover:bg-accent/10`;
+  };
+
+  // ─── 버튼 렌더러들 ─────────────────────────────
+  const InlineButtons = (
+    <div className="flex items-center gap-0.5">
+      <button type="button" className={btnCls(isActive('bold'))}
+        title="굵게 (Ctrl+B)" aria-label="굵게"
+        onMouseDown={(e) => e.preventDefault()}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        onClick={() => run((c: any) => c.toggleBold().run())}
+        disabled={disabled}>
+        <Bold size={13} />
+      </button>
+      <button type="button" className={btnCls(isActive('italic'))}
+        title="기울임 (Ctrl+I)" aria-label="기울임"
+        onMouseDown={(e) => e.preventDefault()}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        onClick={() => run((c: any) => c.toggleItalic().run())}
+        disabled={disabled}>
+        <Italic size={13} />
+      </button>
+      <button type="button" className={btnCls(isActive('underline'))}
+        title="밑줄 (Ctrl+U)" aria-label="밑줄"
+        onMouseDown={(e) => e.preventDefault()}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        onClick={() => run((c: any) => c.toggleUnderline().run())}
+        disabled={disabled}>
+        <Underline size={13} />
+      </button>
+      <button type="button" className={btnCls(isActive('strike'))}
+        title="취소선 (Ctrl+Shift+X)" aria-label="취소선"
+        onMouseDown={(e) => e.preventDefault()}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        onClick={() => run((c: any) => c.toggleStrike().run())}
+        disabled={disabled}>
+        <Strikethrough size={13} />
+      </button>
+    </div>
+  );
+
+  const HeadingButtons = (
+    <div className="flex items-center gap-0.5">
+      {([1, 2, 3] as const).map((lvl) => (
+        <button
+          key={lvl}
+          type="button"
+          className={btnCls(isActive('heading', { level: lvl }))}
+          title={`제목${lvl} (Ctrl+Alt+${lvl})`}
+          aria-label={`제목${lvl}`}
+          onMouseDown={(e) => e.preventDefault()}
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          onClick={() => run((c: any) => c.toggleHeading({ level: lvl }).run())}
+          disabled={disabled}
+          style={{ fontSize: 10, fontWeight: 700 }}
+        >
+          H{lvl}
+        </button>
+      ))}
+    </div>
+  );
+
+  const ListButtons = (
+    <div className="flex items-center gap-0.5">
+      <button type="button" className={btnCls(isActive('bulletList'))}
+        title="불릿 목록 (Ctrl+Shift+8)" aria-label="불릿 목록"
+        onMouseDown={(e) => e.preventDefault()}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        onClick={() => run((c: any) => c.toggleBulletList().run())}
+        disabled={disabled}>
+        <List size={13} />
+      </button>
+      <button type="button" className={btnCls(isActive('orderedList'))}
+        title="번호 목록 (Ctrl+Shift+7)" aria-label="번호 목록"
+        onMouseDown={(e) => e.preventDefault()}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        onClick={() => run((c: any) => c.toggleOrderedList().run())}
+        disabled={disabled}>
+        <ListOrdered size={13} />
+      </button>
+      <button type="button" className={btnCls(isActive('taskList'))}
+        title="체크리스트 (Ctrl+Shift+9)" aria-label="체크리스트"
+        onMouseDown={(e) => e.preventDefault()}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        onClick={() => run((c: any) => c.toggleTaskList().run())}
+        disabled={disabled}>
+        <ListChecks size={13} />
+      </button>
+    </div>
+  );
+
+  const LinkButton = (
+    <button type="button" className={btnCls(isActive('link'))}
+      title="링크 (Ctrl+K)" aria-label="링크"
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={() => { onLinkRequest?.(); }}
+      disabled={disabled}>
+      <Link2 size={13} />
+    </button>
+  );
+
+  const dropdownBtn = 'inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md text-[11px] text-text-secondary/70 hover:text-accent hover:bg-accent/10 transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed';
+  const menuCls = 'absolute top-full left-0 mt-1 min-w-[140px] rounded-md border border-bg-border bg-bg-card shadow-lg py-1 z-[60] animate-fade-in';
+  const menuItem = 'w-full text-left px-3 py-1.5 text-[12px] text-text-primary hover:bg-accent/10 hover:text-accent cursor-pointer flex items-center gap-2';
+  const menuItemActive = 'bg-accent/15 text-accent';
+
+  // ─── 좁은 모드: 헤딩/리스트를 드롭다운으로 ─────────────
+  const HeadingDropdown = (
+    <div className="relative">
+      <button
+        type="button"
+        className={dropdownBtn}
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={() => setOpenMenu(openMenu === 'heading' ? null : 'heading')}
+        disabled={disabled}
+      >
+        단락 <ChevronDown size={10} />
+      </button>
+      {openMenu === 'heading' && (
+        <div className={menuCls} role="menu">
+          <button className={`${menuItem} ${isActive('paragraph') && !isActive('heading') ? menuItemActive : ''}`}
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            onClick={() => { run((c: any) => c.setParagraph().run()); setOpenMenu(null); }}>
+            본문
+          </button>
+          {([1, 2, 3] as const).map((lvl) => (
+            <button key={lvl}
+              className={`${menuItem} ${isActive('heading', { level: lvl }) ? menuItemActive : ''}`}
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              onClick={() => { run((c: any) => c.toggleHeading({ level: lvl }).run()); setOpenMenu(null); }}>
+              <span style={{ fontSize: lvl === 1 ? 16 : lvl === 2 ? 14 : 13, fontWeight: 600 }}>제목 {lvl}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+
+  const ListDropdown = (
+    <div className="relative">
+      <button
+        type="button"
+        className={dropdownBtn}
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={() => setOpenMenu(openMenu === 'list' ? null : 'list')}
+        disabled={disabled}
+      >
+        리스트 <ChevronDown size={10} />
+      </button>
+      {openMenu === 'list' && (
+        <div className={menuCls} role="menu">
+          <button className={`${menuItem} ${isActive('bulletList') ? menuItemActive : ''}`}
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            onClick={() => { run((c: any) => c.toggleBulletList().run()); setOpenMenu(null); }}>
+            <List size={13} /> 불릿 목록
+          </button>
+          <button className={`${menuItem} ${isActive('orderedList') ? menuItemActive : ''}`}
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            onClick={() => { run((c: any) => c.toggleOrderedList().run()); setOpenMenu(null); }}>
+            <ListOrdered size={13} /> 번호 목록
+          </button>
+          <button className={`${menuItem} ${isActive('taskList') ? menuItemActive : ''}`}
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            onClick={() => { run((c: any) => c.toggleTaskList().run()); setOpenMenu(null); }}>
+            <ListChecks size={13} /> 체크리스트
+          </button>
+        </div>
+      )}
+    </div>
+  );
+
+  const Divider = <div className="w-px h-4 bg-bg-border/40 shrink-0" aria-hidden />;
+
+  return (
+    <div
+      ref={selfRef}
+      className="flex items-center gap-2 px-1.5 py-0.5 border-b border-bg-border/20 min-h-[28px] shrink-0 relative"
+    >
+      {InlineButtons}
+      {Divider}
+      {isNarrow ? HeadingDropdown : HeadingButtons}
+      {Divider}
+      {isNarrow ? ListDropdown : ListButtons}
+      {Divider}
+      {LinkButton}
+    </div>
+  );
+}

--- a/src/components/widgets/memo/markdownExtensions.ts
+++ b/src/components/widgets/memo/markdownExtensions.ts
@@ -19,8 +19,17 @@ import type { Editor } from '@tiptap/core';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type MarkdownIt = any;
 
-/** strong_open/close 렌더러를 markup 기준으로 분기 */
+/**
+ * markdown-it 인스턴스에 이미 underline 렌더러 패치가 적용됐는지 표시하는 고유 키.
+ * 같은 인스턴스에 여러 번 install 이 호출돼도 wrapper 가 누적되지 않도록 가드.
+ */
+const PATCHED_KEY = '__bflowUnderlinePatched__';
+
+/** strong_open/close 렌더러를 markup 기준으로 분기 (idempotent) */
 function installUnderlineRenderer(md: MarkdownIt) {
+  if (md[PATCHED_KEY]) return;
+  md[PATCHED_KEY] = true;
+
   const defaultStrongOpen = md.renderer.rules.strong_open
     ?? ((tokens: unknown[], idx: number, opts: unknown, _env: unknown, self: { renderToken: (...a: unknown[]) => string }) =>
       self.renderToken(tokens, idx, opts));

--- a/src/components/widgets/memo/markdownExtensions.ts
+++ b/src/components/widgets/memo/markdownExtensions.ts
@@ -1,0 +1,73 @@
+/**
+ * 메모 위젯용 Markdown ↔ HTML 변환 규칙
+ *
+ * B flow 앱 관습:
+ *   __text__  →  <u>text</u>   (비표준: GFM은 bold로 처리)
+ *   **text**  →  <strong>text</strong>
+ *   *text*    →  <em>text</em>
+ *   _text_    →  <em>text</em>
+ *   ~~text~~  →  <s>text</s>
+ *
+ * 구현 전략:
+ *  - markdown-it 기본 emphasis 규칙을 유지하되
+ *  - renderer.rules.strong_open/close 를 override 하여 markup 이 "__" 인 경우
+ *    <u> 태그로 출력. "**" 는 <strong> 유지.
+ *  - ProseMirror → Markdown 직렬화 시 Underline mark 를 "__" 로 감쌈.
+ */
+import Underline from '@tiptap/extension-underline';
+import type { Editor } from '@tiptap/core';
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type MarkdownIt = any;
+
+/** strong_open/close 렌더러를 markup 기준으로 분기 */
+function installUnderlineRenderer(md: MarkdownIt) {
+  const defaultStrongOpen = md.renderer.rules.strong_open
+    ?? ((tokens: unknown[], idx: number, opts: unknown, _env: unknown, self: { renderToken: (...a: unknown[]) => string }) =>
+      self.renderToken(tokens, idx, opts));
+  const defaultStrongClose = md.renderer.rules.strong_close
+    ?? ((tokens: unknown[], idx: number, opts: unknown, _env: unknown, self: { renderToken: (...a: unknown[]) => string }) =>
+      self.renderToken(tokens, idx, opts));
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  md.renderer.rules.strong_open = function (tokens: any[], idx: number, opts: unknown, env: unknown, self: any) {
+    if (tokens[idx]?.markup === '__') return '<u>';
+    return defaultStrongOpen(tokens, idx, opts, env, self);
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  md.renderer.rules.strong_close = function (tokens: any[], idx: number, opts: unknown, env: unknown, self: any) {
+    if (tokens[idx]?.markup === '__') return '</u>';
+    return defaultStrongClose(tokens, idx, opts, env, self);
+  };
+}
+
+/**
+ * B flow 관습을 보존하는 Underline 확장.
+ * - parse: markdown-it renderer override 로 __x__ → <u>x</u>
+ * - serialize: __ 로 감싸서 Markdown 출력
+ */
+export const BflowUnderline = Underline.extend({
+  addStorage() {
+    return {
+      markdown: {
+        serialize: { open: '__', close: '__', mixable: true, expelEnclosingWhitespace: true },
+        parse: {
+          setup(markdownit: MarkdownIt) {
+            installUnderlineRenderer(markdownit);
+          },
+        },
+      },
+    };
+  },
+});
+
+/**
+ * editor 에 저장된 markdown 문자열을 안전하게 꺼낸다.
+ * tiptap-markdown 의 `editor.storage.markdown.getMarkdown()` 래퍼.
+ */
+export function getEditorMarkdown(editor: Editor | null): string {
+  if (!editor) return '';
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const storage = (editor.storage as any)?.markdown;
+  if (storage?.getMarkdown) return storage.getMarkdown();
+  return '';
+}

--- a/src/index.css
+++ b/src/index.css
@@ -574,12 +574,11 @@ input[type="range"]::-webkit-slider-thumb {
   gap: 8px;
   padding: 1px 0;
 }
-/* 체크박스 수직 정렬: 첫 줄 텍스트 중심(line-height 1.7, 폰트 1em)에 체크박스(15px≈1em)
-   중심을 맞춤. 수식: (line-height - checkbox-height) / 2 = (1.7em - 1em) / 2 = 0.35em.
-   실측 보정으로 0.3em 적용 — 폰트 슬라이더를 올려도 비율 유지. */
+/* 체크박스 수직 정렬: 한글 폰트는 x-height 가 높고 글자 중심이 line-box 중간보다
+   위쪽이라, 라인 높이 수식 계산(0.35em)보다 실측이 더 작음. 0.1em 로 보정. */
 .memo-editor-root .ProseMirror ul[data-type="taskList"] li > label {
   flex-shrink: 0;
-  margin-top: 0.3em;
+  margin-top: 0.1em;
   user-select: none;
   -webkit-user-select: none;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -574,11 +574,18 @@ input[type="range"]::-webkit-slider-thumb {
   gap: 8px;
   padding: 1px 0;
 }
+/* 체크박스 수직 정렬: 첫 줄 텍스트 중심(line-height 1.7, 폰트 1em)에 체크박스(15px≈1em)
+   중심을 맞춤. 수식: (line-height - checkbox-height) / 2 = (1.7em - 1em) / 2 = 0.35em.
+   실측 보정으로 0.3em 적용 — 폰트 슬라이더를 올려도 비율 유지. */
 .memo-editor-root .ProseMirror ul[data-type="taskList"] li > label {
   flex-shrink: 0;
-  margin-top: 0.4em;
+  margin-top: 0.3em;
   user-select: none;
   -webkit-user-select: none;
+}
+/* 텍스트 쪽 div > p 의 기본 상하 여백이 생기면 label 정렬이 다시 어긋나므로 0 강제 */
+.memo-editor-root .ProseMirror ul[data-type="taskList"] li > div > p {
+  margin: 0;
 }
 /* 커스텀 체크박스 — native appearance 제거하고 토큰 기반으로 재구성 */
 .memo-editor-root .ProseMirror ul[data-type="taskList"] li > label > input[type="checkbox"] {

--- a/src/index.css
+++ b/src/index.css
@@ -580,12 +580,45 @@ input[type="range"]::-webkit-slider-thumb {
   user-select: none;
   -webkit-user-select: none;
 }
+/* 커스텀 체크박스 — native appearance 제거하고 토큰 기반으로 재구성 */
 .memo-editor-root .ProseMirror ul[data-type="taskList"] li > label > input[type="checkbox"] {
-  width: 14px;
-  height: 14px;
-  cursor: pointer;
-  accent-color: rgb(var(--color-accent));
+  appearance: none;
+  -webkit-appearance: none;
+  width: 15px;
+  height: 15px;
   margin: 0;
+  padding: 0;
+  flex-shrink: 0;
+  border: 1.5px solid rgb(var(--color-bg-border));
+  border-radius: 4px;
+  background: rgb(var(--color-bg-primary) / 0.4);
+  cursor: pointer;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 150ms, border-color 150ms, box-shadow 150ms;
+  outline: none;
+}
+.memo-editor-root .ProseMirror ul[data-type="taskList"] li > label > input[type="checkbox"]:hover {
+  border-color: rgb(var(--color-accent) / 0.6);
+  background: rgb(var(--color-accent) / 0.08);
+}
+.memo-editor-root .ProseMirror ul[data-type="taskList"] li > label > input[type="checkbox"]:focus-visible {
+  box-shadow: 0 0 0 2px rgb(var(--color-accent) / 0.35);
+}
+.memo-editor-root .ProseMirror ul[data-type="taskList"] li > label > input[type="checkbox"]:checked {
+  background: rgb(var(--color-accent));
+  border-color: rgb(var(--color-accent));
+}
+.memo-editor-root .ProseMirror ul[data-type="taskList"] li > label > input[type="checkbox"]:checked::after {
+  content: '';
+  display: block;
+  width: 4px;
+  height: 8px;
+  border: solid rgb(var(--color-on-accent));
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg) translate(-0.5px, -1px);
 }
 .memo-editor-root .ProseMirror ul[data-type="taskList"] li > div {
   flex: 1 1 auto;

--- a/src/index.css
+++ b/src/index.css
@@ -512,6 +512,132 @@ input[type="range"]::-webkit-slider-thumb {
   }
 }
 
+/* ─── 메모 WYSIWYG 에디터 (TipTap) ─────────────────────────
+   헤딩 크기는 본문 기준 em 비율 (본문 fontSize 는 컨테이너 inline style 로 지정)
+   라이트/다크 + 6개 프리셋 테마 자동 대응 (모든 색은 CSS 변수 토큰 경유) */
+.memo-editor-root .ProseMirror {
+  outline: none;
+  min-height: 80px;
+  padding: 12px 16px;
+  line-height: 1.7;
+  color: rgb(var(--color-text-primary));
+  word-break: break-word;
+}
+/* 텍스트 선택 허용 (전역 user-select: none 해제) */
+.memo-editor-root .ProseMirror,
+.memo-editor-root .ProseMirror * {
+  -webkit-user-select: text;
+  user-select: text;
+}
+
+/* 헤딩 — global h1/h2/h3 !important 색상 스타일을 덮어쓰지 않고 크기만 조정 */
+.memo-editor-root .ProseMirror h1 {
+  font-size: 1.6em !important;
+  font-weight: 600;
+  line-height: 1.3;
+  margin: 0.6em 0 0.3em;
+}
+.memo-editor-root .ProseMirror h1:first-child { margin-top: 0; }
+.memo-editor-root .ProseMirror h2 {
+  font-size: 1.35em !important;
+  font-weight: 600;
+  line-height: 1.3;
+  margin: 0.5em 0 0.25em;
+}
+.memo-editor-root .ProseMirror h3 {
+  font-size: 1.15em !important;
+  font-weight: 500;
+  line-height: 1.4;
+  margin: 0.4em 0 0.2em;
+}
+.memo-editor-root .ProseMirror p { margin: 0 0 0.2em; }
+.memo-editor-root .ProseMirror p:last-child { margin-bottom: 0; }
+
+/* 리스트 */
+.memo-editor-root .ProseMirror ul,
+.memo-editor-root .ProseMirror ol {
+  padding-left: 1.4em;
+  margin: 0.2em 0;
+}
+.memo-editor-root .ProseMirror ul { list-style: disc; }
+.memo-editor-root .ProseMirror ol { list-style: decimal; }
+.memo-editor-root .ProseMirror li > p { margin: 0; }
+
+/* 체크박스 리스트 */
+.memo-editor-root .ProseMirror ul[data-type="taskList"] {
+  list-style: none;
+  padding-left: 0;
+}
+.memo-editor-root .ProseMirror ul[data-type="taskList"] li {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 1px 0;
+}
+.memo-editor-root .ProseMirror ul[data-type="taskList"] li > label {
+  flex-shrink: 0;
+  margin-top: 0.4em;
+  user-select: none;
+  -webkit-user-select: none;
+}
+.memo-editor-root .ProseMirror ul[data-type="taskList"] li > label > input[type="checkbox"] {
+  width: 14px;
+  height: 14px;
+  cursor: pointer;
+  accent-color: rgb(var(--color-accent));
+  margin: 0;
+}
+.memo-editor-root .ProseMirror ul[data-type="taskList"] li > div {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.memo-editor-root .ProseMirror ul[data-type="taskList"] li[data-checked="true"] > div {
+  color: rgb(var(--color-text-secondary) / 0.55);
+  text-decoration: line-through;
+  text-decoration-color: rgb(var(--color-text-secondary) / 0.55);
+}
+
+/* 인라인 서식 */
+.memo-editor-root .ProseMirror strong { font-weight: 700; }
+.memo-editor-root .ProseMirror em { font-style: italic; }
+.memo-editor-root .ProseMirror u {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  text-decoration-color: rgb(var(--color-text-primary) / 0.4);
+}
+.memo-editor-root .ProseMirror s {
+  text-decoration: line-through;
+  text-decoration-color: rgb(var(--color-text-primary) / 0.5);
+}
+
+/* 링크 */
+.memo-editor-root .ProseMirror a {
+  color: rgb(var(--color-accent));
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  text-decoration-color: rgb(var(--color-accent) / 0.5);
+  cursor: pointer;
+  transition: all 150ms;
+}
+.memo-editor-root .ProseMirror a:hover {
+  text-decoration-color: rgb(var(--color-accent));
+}
+
+/* Placeholder — Placeholder extension 의 emptyEditorClass 가 적용된 첫 단락에만 표시 */
+.memo-editor-root .ProseMirror p.is-editor-empty:first-child::before {
+  content: attr(data-placeholder);
+  float: left;
+  color: rgb(var(--color-text-secondary) / 0.3);
+  pointer-events: none;
+  height: 0;
+}
+
+/* 선택 하이라이트 (accent 에 맞춤) */
+.memo-editor-root .ProseMirror::selection,
+.memo-editor-root .ProseMirror *::selection {
+  background: rgb(var(--color-accent) / 0.25);
+}
+
 /* ─── 일괄 작업 pending/failed 시각 상태 ─── */
 @layer components {
   @keyframes bflow-pulse {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -371,6 +371,8 @@ export type BulkUpdateResult = {
 export interface ElectronAPI {
   getDataPath: () => Promise<string>;
   shellShowItem?: (filePath: string) => Promise<{ ok: boolean; error?: string }>;
+  /** 외부 URL 을 기본 브라우저로 열기 (메모 링크 전용) */
+  openExternal?: (url: string) => Promise<{ ok: boolean; error?: string }>;
 
   // 사용자 파일 (exe 옆 또는 test-data/ 옆, base64 인코딩 JSON)
   usersRead: () => Promise<UsersFile | null>;


### PR DESCRIPTION
## 📋 업데이트 요약

> 이번 업데이트에서 달라진 점을 간략하게 정리했습니다.

- ✨ **메모 위젯이 실시간 서식 적용 방식으로 바뀌었습니다.** 이제 `**두껍게**` 같은 마크다운 기호를 직접 타이핑할 필요 없이, 툴바 버튼으로 서식을 입히면 그 자리에서 바로 두꺼워집니다.
- ✨ **할 수 있는 서식이 늘었습니다.** 기존 4가지(굵게/기울임/밑줄/취소선) → 11가지: **굵게 · 기울임 · 밑줄 · 취소선 · 제목1 · 제목2 · 제목3 · 불릿 목록 · 번호 목록 · 체크리스트 · 링크**
- ✨ **링크를 편하게 걸 수 있습니다.** 텍스트 드래그해서 🔗 버튼(또는 Ctrl+K) 누르면 URL 입력창이 뜨고, 이미 건 링크 위에 커서를 두면 [열기/편집/제거] 버튼이 자동으로 나옵니다.
- ✨ **체크리스트의 완료된 항목은 흐림 + 취소선**으로 표시돼서 "끝난 일"과 "남은 일"이 한눈에 보입니다.
- ⚡ **"미리보기 토글" 버튼이 사라졌습니다.** 쓰는 순간 바로 서식이 보이기 때문에 더 이상 모드 전환이 필요 없습니다.
- 🎨 **툴바가 위젯 크기에 맞게 적응**합니다. 위젯이 넓을 때는 11개 버튼 모두 한 줄에, 좁을 때는 `[단락 ▾]` `[리스트 ▾]` 드롭다운으로 자동 축약됩니다.
- 🔒 **기존에 쓰신 메모는 그대로 유지**됩니다. 데이터 변환 0건, 마이그레이션 없음.
- 🎨 6개 테마(바이올렛 / 시네마 레드 / 윤성원 블루 / 에메랄드 / 앰버 골드 / 머쉬룸) + 라이트/다크 모드에서 툴바·링크·버블 메뉴 색이 모두 자동으로 따라옵니다.

---

## 🔧 상세 기술 설명

### 에디터 엔진 교체: textarea + 자체 마크다운 렌더러 → TipTap WYSIWYG
- `src/components/widgets/memo/MemoEditor.tsx` 신규. `@tiptap/react`의 `useEditor` 훅으로 ProseMirror 기반 에디터 캡슐화.
- `tiptap-markdown` 어댑터로 **저장 형식은 Markdown 문자열 그대로 유지** → Supabase `memos` 테이블 스키마 변경 없음, 마이그레이션 불필요.
- StarterKit(Bold/Italic/Strike/Heading 1-3/Bullet/Ordered/Paragraph/HardBreak/History) + Underline + Link + TaskList/TaskItem + Placeholder + Markdown 조합으로 구성.
- 외부 content 주입은 try/catch 감싸서 malformed Markdown 로드 시 `preserveWhitespace: 'full'` fallback.

### 앱 관습 보존: `__x__` = 밑줄 (비GFM)
- B flow는 과거부터 `__x__`를 **밑줄**로 렌더해왔지만 표준 Markdown(GFM)에서는 Bold로 처리됨.
- `src/components/widgets/memo/markdownExtensions.ts`에서 `BflowUnderline` 확장 구현:
  - **parse**: markdown-it의 `renderer.rules.strong_open/close`를 override하여 `token.markup === '__'`일 때 `<u>` 태그 출력. `**`는 `<strong>` 유지.
  - **serialize**: `addStorage()`의 `markdown.serialize`로 Underline mark를 `__`로 감싸 출력.
- 결과: 왕복 무손실 + 기존 데이터 100% 호환.

### 툴바 재설계 (4 → 11 버튼 + 반응형)
- `src/components/widgets/memo/MemoToolbar.tsx` 신규. 4개 논리 그룹(인라인 / 헤딩 / 리스트 / 링크)으로 세로 구분선으로 분리.
- **ResizeObserver**로 에디터 가로폭 감지 (< 320px). 좁으면 헤딩 3개는 `[단락 ▾]` 드롭다운, 리스트 3개는 `[리스트 ▾]` 드롭다운으로 자동 축약.
- 버튼 5가지 시각 상태: Default / Hover / **Active**(커서 위치 서식) / Focus-visible / Disabled(editor === null).
- Active 판정은 `editor.isActive('bold')` / `editor.isActive('heading', { level: 1 })` 등으로 실시간 반영.
- 툴팁에 단축키 병기 (예: `굵게 (Ctrl+B)`).

### 링크 버블 메뉴
- `src/components/widgets/memo/MemoLinkBubble.tsx` 신규. `@tiptap/extension-bubble-menu`의 `BubbleMenu` 컴포넌트 사용.
- **2가지 모드**:
  - **편집 모드**: 텍스트 선택 후 🔗 클릭 또는 Ctrl+K → URL input + [✓] 버튼. Enter로 적용, ESC로 취소. URL 정규화 (`https://` 자동 prepend, `mailto:`/`tel:`/상대경로 허용).
  - **읽기 모드**: 기존 링크 노드 위 커서 → URL + [↗ 열기 / ✏ 편집 / ✖ 제거] 자동 노출.
- Electron 환경에서 `shell.openExternal` 경유로 외부 브라우저에서 열림 (in-app 네비게이션 금지).

### IPC 확장: `shell:open-external`
- `electron/main.ts`에 `ipcMain.handle('shell:open-external', …)` 추가. `https?:`/`mailto:`/`tel:` URL만 허용하는 간단한 화이트리스트.
- `electron/preload.ts`에 `openExternal(url)` API 노출.
- `src/types/index.ts`의 `ElectronAPI` 인터페이스 갱신.

### MemoWidget 리팩터링
- `src/components/widgets/MemoWidget.tsx`: 기존 673 lines → 356 lines.
- 제거: `SimpleMarkdown` 컴포넌트, `inlineFormat` 함수, `applyMarkdown` 함수, `FormatToolbar` 컴포넌트, `previewMode` state, Eye/Pencil 토글 버튼.
- 추가: `MemoEditor` + `MemoToolbar` + `MemoLinkBubble` 조립, `editor` 인스턴스 상위 state, `Ctrl+K` keydown 핸들러(에디터 영역 내에서만 트리거), debounce flush on unmount 유지.
- 탭바, 폰트 슬라이더, 팝업 모드, `memo-sync` localStorage 동기화, Supabase upsert 로직은 그대로 유지.

### 에디터 스타일 (CSS 변수 토큰만 사용)
- `src/index.css`에 `.memo-editor-root .ProseMirror` 스코프로 추가:
  - 헤딩: `em` 단위 (본문 × 1.6 / 1.35 / 1.15) → 폰트 슬라이더 값에 자동 연동.
  - 체크박스: `accent-color: rgb(var(--color-accent))` + `[data-checked="true"]` 항목 흐림+취소선.
  - Placeholder: `::before`로 emptyEditorClass + data-placeholder 조합.
  - 링크: accent 색 밑줄 + hover 시 진해짐.
- **색상 하드코딩 0건** — 모두 `--color-accent`, `--color-bg-card`, `--color-text-primary` 등 CSS 변수 경유. 6개 테마 + 라이트/다크 자동 대응.

### 사전 검증 (설계 문서 §8.2.1)
- Supabase `memos` 테이블 SQL 실행: `WHERE tabs::text ~ '\d+\) '` = **0건**, `__x__` 포함 = **0건**.
- → 레거시 패턴 마이그레이션 불필요. 기존 사용자 데이터 그대로 렌더 가능.

### 의존성
- `@tiptap/react`, `@tiptap/starter-kit`, `@tiptap/extension-underline`, `@tiptap/extension-link`, `@tiptap/extension-task-list`, `@tiptap/extension-task-item`, `@tiptap/extension-placeholder`, `@tiptap/extension-bubble-menu`, `tiptap-markdown` (+ 의존성 569 packages). 번들 gzip +~110KB.

### 참고 문서
- 설계 (spec): `docs/superpowers/specs/2026-04-24-memo-wysiwyg-design.md`
- 시각 목업: `docs/superpowers/mockups/memo-wysiwyg-mockup.html`

---

## 🚧 개발 난항

### `__x__`가 Bold로 처리되는 markdown-it 기본 규칙과 앱 관습 충돌
- **문제**: 표준 Markdown(CommonMark/GFM)에서 `__text__`는 `<strong>`으로 렌더된다. 그러나 B flow는 과거부터 `__text__` = **밑줄**로 써왔다. 팀원들이 쓴 메모에 `__` 기호가 밑줄 의도로 저장되어 있을 수 있어, 단순 라이브러리 도입 시 렌더 결과가 달라질 위험이 있었다.
- **시도**: 처음엔 markdown-it의 emphasis rule 자체를 disable 하는 방법을 검토했으나 `*x*` (italic), `**x**` (bold)까지 영향받아 포기.
- **해결**: `renderer.rules.strong_open` / `strong_close` 훅에서 `token.markup === '__'`인 경우에만 `<u>` 태그로 바꿔 출력. Bold 규칙은 그대로 두고 **렌더 단계에서만 분기** — 토크나이저 수정 없이 앱 관습 유지.
- **교훈**: markdown-it 같은 파서는 규칙을 꺼서 해결하기보다 **렌더러 단계**에서 덮어쓰는 편이 부작용이 적다. 토큰의 `markup` 속성이 원본 구분자 정보를 보존한다는 점을 활용하면 깔끔.

### TipTap v2 + tiptap-markdown의 Extension 스토리지 스펙 파악
- **문제**: `tiptap-markdown` v0.8의 공식 문서가 부실해 custom serializer/parser 진입점이 명확하지 않았다.
- **시도**: `node_modules/tiptap-markdown/src/extensions/marks/`를 직접 읽어 Bold/Strike 구현 패턴을 참고.
- **해결**: `Mark.extend({ addStorage() { return { markdown: { serialize: {open,close,mixable,expelEnclosingWhitespace}, parse: { setup(md) { … } } } }; } })` 패턴 확인.
- **교훈**: 문서가 부족한 라이브러리는 패키지 소스를 먼저 보는 게 빠르다. 특히 node_modules 내 `src/` 디렉토리가 ESM 소스 그대로 남아있으면 바로 참고 가능.

### Ctrl+B 전역 단축키(사이드바 토글) vs TipTap Bold 충돌
- **문제**: 앱에 `Ctrl+B` = 사이드바 토글 글로벌 단축키가 이미 존재. TipTap Bold 기본 단축키도 `Ctrl+B`.
- **시도**: TipTap Bold 단축키를 재매핑하는 방법을 검토했으나 팀원들이 다른 앱과 동일한 단축키에 익숙할 걸 고려해 유지하기로 결정.
- **해결**: `src/hooks/useGlobalShortcuts.ts`가 이미 `isContentEditable` 체크로 입력 필드 내에서는 전역 단축키를 무시하고 있었음. 에디터 포커스 중에는 사이드바 토글이 발동되지 않고 TipTap Bold가 동작. 추가 코드 불필요.
- **교훈**: 새 기능 추가 전 기존 단축키 처리 로직을 먼저 확인하면 불필요한 충돌 해결 코드를 안 쓸 수 있다.

---

## ✅ 테스트 가이드

### 사용자 테스트

> 아래 시나리오를 직접 실행해서 정상 동작을 확인해주세요.

1. **기본 서식 버튼**
   - 메모 위젯에 글자 입력 → 드래그 선택 → 툴바 `B` 버튼 클릭
   - ✅ 선택된 글자가 굵게 바뀌고 `B` 버튼에 **보라색 배경**(Active) 점등
   - 같은 자리에 커서 두고 다시 `B` 클릭하면 굵기 해제

2. **제목 / 리스트 / 체크리스트**
   - `H1`/`H2`/`H3` 버튼 클릭 → 해당 줄이 큰 제목으로 변함 (본문 기준 1.6 / 1.35 / 1.15 배)
   - `≡` 불릿 / `1≡` 번호 / `☑≡` 체크리스트 버튼으로 리스트 생성
   - ✅ 체크박스 클릭 시 해당 항목이 **흐림 + 취소선** 처리

3. **링크 삽입/편집**
   - 텍스트 드래그 선택 후 `🔗` 버튼 클릭 (또는 **Ctrl+K**)
   - 버블 메뉴에 URL 입력창 노출 → `https://studiojbbj.com` 같은 URL 입력 → Enter
   - ✅ 선택한 텍스트가 **보라색 밑줄 링크**로 변환
   - 이미 걸린 링크 위에 커서 놓으면 **[↗] [✏] [✖]** 버튼 자동 노출
   - ✅ **[↗]** 클릭 시 기본 브라우저에서 해당 URL 열림

4. **반응형 툴바**
   - 메모 위젯을 작게 드래그해서 가로 폭을 좁힘
   - ✅ 가로 폭이 **약 320px 미만**이 되면 H1/H2/H3 → `[단락 ▾]`, 리스트 3개 → `[리스트 ▾]` 드롭다운으로 자동 축약

5. **기존 메모 호환성**
   - 기존에 `**두껍게**` `__밑줄__` `~~취소선~~` 같은 마크다운을 써둔 탭 열기
   - ✅ 모든 서식이 **기호 없이 바로 서식 적용된 형태**로 보임
   - 글자 입력 후 다른 탭으로 이동했다가 돌아와도 내용 그대로 유지

6. **테마 전환**
   - 설정에서 테마를 "공산당 레드" 또는 다른 프리셋으로 변경
   - ✅ 툴바 Active 버튼 색, 체크박스 색, 링크 색이 모두 **해당 테마의 accent 색**으로 자동 전환
   - 라이트 모드로 전환 → 대비 유지, 가독성 OK

7. **여러 창에서 동시 편집**
   - 메모 위젯을 팝업으로 띄우고, 본체 창에서도 같은 메모 탭 열기
   - 한쪽에서 글자 입력 → 다른쪽에도 자동 반영 확인 (기존 동작 유지)

### 개발자 테스트

```bash
# 타입 체크
npx tsc --noEmit

# 프로덕션 빌드
npm run build:vite

# Electron 포함 전체 빌드 (배포용 exe 생성)
npm run build
```

**자동 검증 완료:**
- ✅ `tsc --noEmit` 통과
- ✅ `npm run build:vite` 통과 (번들 gzip 331KB, +TipTap 약 110KB)
- ✅ dev 서버 로드 + 로그인 + 메모 위젯 추가 + setContent 실행 + 링크 버블 노출까지 **console 에러 0건**
- ✅ Supabase SQL 검증: `tabs::text ~ '\d+\) '` = 0건, `__x__` 포함 = 0건 → 마이그레이션 불필요

**추가 수동 확인 필요:**
- `transformPastedText` 경로: Word/브라우저에서 서식 있는 HTML 복사 → 붙여넣기 시 plain text 또는 허용 마크만 남는지
- malformed Markdown 데이터 로드 시 try/catch fallback 동작 (sonner 토스트 노출 및 텍스트 보존)
- 언마운트 시 pending debounce 저장 flush (앱 종료 직전 변경 분실 방지)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
