### PR TITLE
[v1.13.2 hotfix] 씬 800+ 건 대시보드 400 Bad Request 수정

### DIFF
--- a/electron/supabase.ts
+++ b/electron/supabase.ts
@@ -248,13 +248,24 @@ export async function readAllEpisodes(): Promise<SupabaseEpisodeData[]> {
   const sceneCompletionById = new Map<string, { completedBy: string; completedAt: string }>();
   const sceneIds = scenes.map((scene) => scene.id);
   if (sceneIds.length > 0) {
-    const { data: completionRows, error: completionErr } = await supabase
-      .from('metadata')
-      .select('key, value')
-      .eq('type', SCENE_COMPLETION_META_TYPE)
-      .in('key', sceneIds);
-    throwIfError(completionErr);
-    for (const row of completionRows || []) {
+    // PostgREST 는 GET 쿼리의 URL 길이 한계가 약 2~4KB.
+    // UUID 36자 × N개를 `in(...)` 파라미터로 넣으면 200~300개를 넘어서는 순간 400 Bad Request.
+    // 스튜디오 규모 확장(에피소드당 150~300씬 × 수십 에피소드)에 대비해 배치 분할.
+    // 100개 배치 = URL 약 3.7KB, 10,000개 씬도 100회 RTT 로 커버 가능.
+    // 향후 데이터가 수만 건 규모로 커지면 PostgreSQL RPC 함수로 POST 1회 호출로 전환 고려.
+    const BATCH = 100;
+    const completionRows: Array<{ key: string; value: string | null }> = [];
+    for (let i = 0; i < sceneIds.length; i += BATCH) {
+      const chunk = sceneIds.slice(i, i + BATCH);
+      const { data, error } = await supabase
+        .from('metadata')
+        .select('key, value')
+        .eq('type', SCENE_COMPLETION_META_TYPE)
+        .in('key', chunk);
+      throwIfError(error);
+      if (data) completionRows.push(...(data as Array<{ key: string; value: string | null }>));
+    }
+    for (const row of completionRows) {
       const meta = parseSceneCompletionMeta(row.value as string | null | undefined);
       if (!meta) continue;
       sceneCompletionById.set(row.key as string, meta);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/views/ScenesView.tsx
+++ b/src/views/ScenesView.tsx
@@ -2497,6 +2497,7 @@ export function ScenesView() {
 
       try {
         await Promise.all(sheets.map((sheet) => addScene(sheet, sceneId, assignee, memo)));
+        sonnerToast.success(`씬 ${sceneId} 추가 완료 (BG+액팅)`);
         syncInBackground();
       } catch (err) {
         setEpisodes(prevEpisodes);
@@ -2559,7 +2560,10 @@ export function ScenesView() {
 
     try {
       await addScene(targetSheet, sceneId, assignee, memo);
-      if (!skipSync) syncInBackground();
+      if (!skipSync) {
+        sonnerToast.success(`씬 ${sceneId} 추가 완료`);
+        syncInBackground();
+      }
     } catch (err) {
       setEpisodes(prevEpisodes);
       handleSheetError(err, '씬 추가');
@@ -2617,6 +2621,7 @@ export function ScenesView() {
         const { addScenes } = await import('@/services/supabaseService');
         await Promise.all(sheets.map((sheet) => addScenes(sheet, scenesToAdd)));
         await syncInBackground();
+        sonnerToast.success(`${scenesToAdd.length}개 씬 추가 완료 (BG+액팅 양쪽 / 총 ${scenesToAdd.length * sheets.length}개)`);
       } catch (err) {
         sonnerToast.error(`대량 씬 추가 실패: ${err}`);
       } finally {
@@ -2633,6 +2638,7 @@ export function ScenesView() {
       const { addScenes } = await import('@/services/supabaseService');
       await addScenes(targetSheet, scenesToAdd);
       await syncInBackground();
+      sonnerToast.success(`${scenesToAdd.length}개 씬 추가 완료`);
     } catch (err) {
       sonnerToast.error(`대량 씬 추가 실패: ${err}`);
     } finally {


### PR DESCRIPTION
## 📋 업데이트 요약

> v1.13.1 배포 직후 터진 대시보드 공백 문제의 **긴급 수정 + 재발 방지**

- 🐛 **대시보드 / 씬 뷰 / 담당자 뷰가 "아무 데이터도 없다"며 빈 화면으로 뜨던 문제** 수정했습니다. 어진님이 씬을 500개나 추가해버리는 바람에 씬이 일정 개수(약 800건)를 넘어서면서 Supabase 서버가 요청을 거부(`400 Bad Request`)하고 있었어요.
- 🛎️ **씬을 추가할 때 "완료되었습니다" 토스트**가 뜨도록 추가했습니다. 지금까지는 피드백이 없어 "됐나 안 됐나" 싶어 몇 번 더 누르게 되는 이슈가 있었어요. 이번 400 에러를 트리거한 직접 원인이기도 합니다.
- ⚡ **앞으로 에피소드가 계속 쌓여도 (씬 1만 개 규모까지)** 같은 문제가 재발하지 않도록 구조를 바꿨습니다.
- 🔒 DB 구조 변경 없음, 기존 데이터 그대로 유지.

버전: **1.13.1 → 1.13.2** (패치).

---

## 🔧 상세 기술 설명

### 1. 원인 — 씬 800+ 건 누적 → PostgREST URL 길이 초과

`electron/supabase.ts` 의 `readAllEpisodes()` 가 마지막 단계에서 **씬 완료 메타데이터** 를 가져올 때, **모든 활성 씬의 UUID 를 한 번의 `IN (…)` 쿼리** 에 담아 요청했습니다.

```
GET /rest/v1/metadata?key=in.(uuid1,uuid2,…,uuid869)
                           ← UUID 36자 × 869개 ≈ 31 KB URL
```

PostgREST (Supabase REST 계층) 는 GET 요청의 URL 길이를 **약 2~4 KB** 로 제한합니다. 한계를 넘어서자 서버가 `400 Bad Request` 반환 → `throwIfError` 가 에러를 throw → 전체 `readAllEpisodes` 실패 → 렌더러는 빈 배열 받음 → "데이터 없음" 으로 화면에 표시됨.

**누적이 쌓인 경위**: 한솔님이 씬 일괄 추가 기능을 썼는데, **완료 토스트가 없어** 처리됐는지 확인하지 못하고 여러 번 더 실행 → 약 500개가 중복 누적 → 총 씬 수가 기존 ~350 에서 869 까지 급증 → 임계치 돌파. 다만 **근본 원인은 코드 구조** 이며, 자연 증가만으로도 언젠가는 터질 시한폭탄이었습니다. 이번에 더 빨리 들켜서 영구 수정할 수 있었던 셈.

### 2. 수정 1 — metadata 조회를 100개씩 배치 분할

**파일**: `electron/supabase.ts:248-273`

```ts
if (sceneIds.length > 0) {
  // PostgREST 는 GET 쿼리의 URL 길이 한계가 약 2~4KB.
  // UUID 36자 × N개를 `in(...)` 파라미터로 넣으면 200~300개를 넘어서는 순간 400 Bad Request.
  // 스튜디오 규모 확장(에피소드당 150~300씬 × 수십 에피소드)에 대비해 배치 분할.
  // 100개 배치 = URL 약 3.7KB, 10,000개 씬도 100회 RTT 로 커버 가능.
  // 향후 데이터가 수만 건 규모로 커지면 PostgreSQL RPC 함수로 POST 1회 호출로 전환 고려.
  const BATCH = 100;
  const completionRows: Array<{ key: string; value: string | null }> = [];
  for (let i = 0; i < sceneIds.length; i += BATCH) {
    const chunk = sceneIds.slice(i, i + BATCH);
    const { data, error } = await supabase
      .from('metadata')
      .select('key, value')
      .eq('type', SCENE_COMPLETION_META_TYPE)
      .in('key', chunk);
    throwIfError(error);
    if (data) completionRows.push(...(data as Array<{ key: string; value: string | null }>));
  }
  for (const row of completionRows) { /* 기존 조립 로직 그대로 */ }
}
```

**안전 범위 계산**:
| 씬 수 | IN 한 번 URL | 100개 배치 호출 수 | URL/호출 |
|------|------------|----------------|---------|
| 300 | 11 KB ⚠ 위험 | 3회 | 3.7 KB ✅ |
| 869 (현재) | 31 KB ❌ 실패 | 9회 | 3.7 KB ✅ |
| 3,000 (에피 10개 × 300씬) | 107 KB ❌ | 30회 | 3.7 KB ✅ |
| 10,000 | 360 KB ❌ | 100회 | 3.7 KB ✅ |

### 3. 수정 2 — 씬 추가 완료 sonner 토스트 (4 경로)

**파일**: `src/views/ScenesView.tsx`

`handleAddScene` / `handleBulkAddScenes` 의 4개 성공 경로 모두에 토스트 추가:

| 경로 | 기존 | 추가된 토스트 |
|------|------|-------------|
| 단일 씬 `__both__` (BG+액팅 동시) | 토스트 없음 | `씬 {id} 추가 완료 (BG+액팅)` |
| 단일 씬 개별 | 토스트 없음 | `씬 {id} 추가 완료`  |
| 일괄 씬 `__both__` | 토스트 없음 | `{N}개 씬 추가 완료 (BG+액팅 양쪽 / 총 {N*2}개)` |
| 일괄 씬 개별 | 토스트 없음 | `{N}개 씬 추가 완료` |

기존 실패 시 `sonnerToast.error(…)` 는 유지. `skipSync=true` 경로(이미지 업로드 보조 흐름)는 호출자가 완료 토스트 책임이라 중복 토스트 방지를 위해 생략.

### 4. 장기 확장 경로 (주석에 명시)

데이터가 수만 건 규모로 커지면 `read_all_episode_data` PostgreSQL **RPC 함수** 로 전환:
- RPC 는 POST body 로 인자를 전달하므로 URL 길이 한계 없음
- 서버측에서 JOIN 한 번에 조립 가능 → 네트워크 RTT 줄어듦
- 필요 시점에 별도 PR 로 마이그레이션

---

## 🚧 개발 난항

### 왜 이전에는 문제가 없었나
- 1.12.x 까지는 씬 수가 ~350~400 → URL ~13-15 KB 로 PostgREST 의 느슨한 버킷에 통과했을 가능성 (서버/프록시별 한계 편차 큼)
- 1.13 배포 시점에 씬이 800대로 급증 → 어느 프록시에서든 확실히 차단되는 구간 진입
- v1.13.1 빌드 자체 문제는 아니었으나 이번 재빌드 배포를 계기로 표출됨

### 근본 원인 진단 과정
1. `DevTools Console` 의 `"Error invoking remote method 'supabase:read-all': Error: Bad Request"` 문자열만으로는 RLS 위반 / URL 길이 / 쿼리 문법 등 원인 구분 불가
2. `readAllEpisodes` 내 4 개 IN 쿼리 후보 각각의 피연산자 규모 계산:
   - episodes IN (epIds): **2개** → 안전
   - parts IN (partIds): **12개** → 안전
   - scenes IN (partIds): **12개** → 안전
   - metadata IN (sceneIds): **869개** → **범인**
3. Supabase MCP 로 `SELECT COUNT(*) FROM scenes WHERE part_id IN (…)` 실행 → 869 건 확인 → 규모 문제임을 확정

### 근본 원인 (사용자 측) 확인
- 한솔님이 "씬 500개 일괄 추가한 적이 있는데 이게 원인이냐" 질문 → **맞음**
- 일괄 추가 후 토스트가 없어서 완료 여부 판단이 어려웠고, 재시도 클릭이 쌓여 중복 누적 → 씬 수 폭증
- 이 UX 공백이 이번 장애를 **앞당겨 트리거** 한 요인이라 hotfix 와 함께 토스트를 도입해 **재발 방지** 까지 한 번에 처리

---

## ✅ 테스트 가이드

### 사용자 테스트

1. **대시보드 복구 확인 (가장 중요)**
   - 앱 실행 → 로그인 → "전체 현황 대시보드"
   - ✅ 전체 진행률 / 담당자별 현황 / 에피소드 요약 / 부서별 비교 모두 숫자 · 카드 정상 표시
   - ❌ 여전히 빈 카드라면 DevTools Console 에 남은 에러 확인 필요

2. **씬 추가 토스트 (단일)**
   - 씬 뷰에서 "+ 씬 추가" 버튼 → 새 씬 ID 입력 → 저장
   - ✅ 우측 하단에 `씬 {id} 추가 완료` 토스트가 2-3초 뜸

3. **씬 추가 토스트 (일괄, 통합 모드)**
   - "+ 씬 추가" → 여러 개 한 번에 추가 (예: 10개)
   - ✅ `10개 씬 추가 완료` 토스트
   - "통합" 모드에서 BG+액팅 동시 추가 시: `10개 씬 추가 완료 (BG+액팅 양쪽 / 총 20개)`

4. **씬 뷰 전체**
   - 좌측 "씬" 메뉴 클릭
   - ✅ 869 개 씬이 정상 나열, 체크박스 토글 · 단계 변경 모두 즉시 반응

5. **다른 화면 regression 체크**
   - 에피소드 / 담당자 / 팀 / 캘린더 / 휴가 / 설정 → 데이터 표시 정상
   - 메모 위젯(v1.13.1 에서 추가한 WYSIWYG) 도 계속 정상 동작

### 개발자 테스트

```bash
npx tsc --noEmit           # ✅ 통과
npm run build:vite         # ✅ 통과
```

Supabase MCP 로 데이터 규모 확인:
```sql
SELECT
  (SELECT COUNT(*) FROM episodes WHERE status='active')  AS ep,   -- 2
  (SELECT COUNT(*) FROM parts    WHERE status='active')  AS part, -- 12
  (SELECT COUNT(*) FROM scenes
    WHERE part_id IN (SELECT id FROM parts WHERE status='active')) AS scene; -- 869
```
→ 이 규모에서 이전 코드가 터지고, 이번 수정으로 100개씩 **9회 배치 호출** 되어 정상 완료.

---

## 📝 Non-goals (다음 PR에서 처리)

- **`bflow_audit_log` 테이블 + DB 트리거 기반 변경 이력 추적** — 한솔님 요청. 자체 로그인 시스템과 맞물려 트리거에서 actor 식별이 비자명(모든 쿼리 앞에 세션 변수 주입 필요). 긴급 hotfix 스코프를 넘어 별도 PR 로 분리. 설계 브레인스토밍 후 구현 예정.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
