### PR TITLE
[v1.13.4] G:\ 경로 자동 링크화 + 씬 모달 드래그 닫힘 수정

### DIFF
--- a/docs/superpowers/plans/2026-04-27-gpath-link.md
+++ b/docs/superpowers/plans/2026-04-27-gpath-link.md
@@ -1,0 +1,728 @@
+# G:\ 경로 자동 링크화 Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 메모/댓글/메모위젯에 입력된 `G:\` 경로를 클릭 가능한 PathBadge로 자동 변환하고, 기존 리비전(CompositingView)도 같은 공용 컴포넌트로 일괄 통합한다.
+
+**Architecture:** 정규식 1개를 단일 상수로 export 하고 4곳(textarea 표시·댓글 renderText·TipTap Mark·CompositingView)이 공유한다. 표시 단계 변환은 `PathLinkifiedText` 컴포넌트, 편집 중에도 자동 변환은 TipTap 커스텀 Mark로 분리한다. 클릭 핸들러는 기존 IPC `shell:show-item`을 그대로 재사용한다.
+
+**Tech Stack:** React 18 + TypeScript, TipTap 2 + tiptap-markdown, Lucide 아이콘, Vitest + @testing-library/react.
+
+**Source spec:** [`docs/superpowers/specs/2026-04-27-gpath-link-design.md`](../specs/2026-04-27-gpath-link-design.md)
+
+---
+
+## File Structure
+
+```
+신규
+  src/utils/pathLink.ts                                       [공용 유틸]
+  src/utils/__tests__/pathLink.test.ts                        [단위 테스트]
+  src/components/common/PathBadge.tsx                         [공용 컴포넌트]
+  src/components/common/PathLinkifiedText.tsx                 [텍스트 합성]
+  src/components/common/__tests__/PathLinkifiedText.test.tsx  [통합 테스트]
+  src/components/widgets/memo/extensions/PathLinkMark.ts      [TipTap Mark]
+  src/components/widgets/memo/extensions/__tests__/PathLinkMark.test.ts
+  src/styles/path-link.css                                    [CSS]
+
+수정
+  src/views/CompositingView.tsx                               [PathBadge 갈아끼기]
+  src/components/scenes/UnifiedSceneDetailModal.tsx           [InlineTextareaRow 표시]
+  src/components/scenes/CommentPanel.tsx                      [renderText 합성]
+  src/components/widgets/memo/MemoEditor.tsx                  [PathLinkMark 등록 + handleClickOn]
+  src/main.tsx                                                [path-link.css import]
+```
+
+---
+
+## Chunk 1: 공용 유틸 + 컴포넌트 (TDD)
+
+### Task 1.1: pathLink.ts 유틸 (TDD)
+
+**Files:**
+- Create: `src/utils/pathLink.ts`
+- Test: `src/utils/__tests__/pathLink.test.ts`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+```typescript
+// src/utils/__tests__/pathLink.test.ts
+import { describe, it, expect } from 'vitest';
+import { tokenizeGPaths, shortenPath } from '../pathLink';
+
+describe('tokenizeGPaths', () => {
+  it('빈 문자열은 빈 배열', () => {
+    expect(tokenizeGPaths('')).toEqual([]);
+  });
+
+  it('경로 없는 텍스트는 단일 text 토큰', () => {
+    expect(tokenizeGPaths('안녕')).toEqual([{ type: 'text', content: '안녕' }]);
+  });
+
+  it('단독 경로는 단일 path 토큰', () => {
+    expect(tokenizeGPaths('G:\\test\\file.png')).toEqual([
+      { type: 'path', content: 'G:\\test\\file.png' },
+    ]);
+  });
+
+  it('텍스트 중간 경로는 [text, path, text]', () => {
+    const result = tokenizeGPaths('확인 G:\\a\\b 부탁');
+    expect(result).toEqual([
+      { type: 'text', content: '확인 ' },
+      { type: 'path', content: 'G:\\a\\b' },
+      { type: 'text', content: ' 부탁' },
+    ]);
+  });
+
+  it('다중 경로 분리', () => {
+    const result = tokenizeGPaths('G:\\a 그리고 G:\\b 끝');
+    expect(result.filter(t => t.type === 'path')).toHaveLength(2);
+  });
+
+  it('한글 경로 인식 (공백 전까지)', () => {
+    const result = tokenizeGPaths('G:\\공유드라이브\\파일.png');
+    expect(result).toEqual([
+      { type: 'path', content: 'G:\\공유드라이브\\파일.png' },
+    ]);
+  });
+
+  it('경로가 줄바꿈에서 끊김', () => {
+    const result = tokenizeGPaths('G:\\a\n다음줄');
+    expect(result.find(t => t.type === 'path')?.content).toBe('G:\\a');
+  });
+
+  it('소문자 g:\\ 는 매치 안 됨', () => {
+    const result = tokenizeGPaths('g:\\test');
+    expect(result.every(t => t.type === 'text')).toBe(true);
+  });
+});
+
+describe('shortenPath', () => {
+  it('백슬래시 경로 마지막 segment 추출', () => {
+    expect(shortenPath('G:\\공유\\file.png')).toBe('file.png');
+  });
+  it('슬래시 혼용 경로', () => {
+    expect(shortenPath('G:/a/b/c.png')).toBe('c.png');
+  });
+  it('말미 슬래시는 무시하고 직전 segment 반환', () => {
+    expect(shortenPath('G:\\a\\b\\')).toBe('b');
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → 실패 확인**
+
+```bash
+npx vitest run src/utils/__tests__/pathLink.test.ts
+```
+Expected: FAIL (모듈 없음)
+
+- [ ] **Step 3: 구현 — `src/utils/pathLink.ts`**
+
+```typescript
+/** G:\ 경로 인식 정규식 — 본 모듈에서만 정의, 4곳이 import해 공유 */
+export const G_PATH_REGEX_GLOBAL = /G:\\[^\s\n]+/g;
+export const G_PATH_REGEX_INPUT_RULE = /(G:\\[^\s\n]+)\s$/;
+export const G_PATH_REGEX_PASTE_RULE = /G:\\[^\s\n]+/g;
+
+export interface PathToken {
+  type: 'text' | 'path';
+  content: string;
+}
+
+export function tokenizeGPaths(text: string): PathToken[] {
+  if (!text) return [];
+  const tokens: PathToken[] = [];
+  let lastIdx = 0;
+  for (const match of text.matchAll(G_PATH_REGEX_GLOBAL)) {
+    if (match.index === undefined) continue;
+    if (match.index > lastIdx) {
+      tokens.push({ type: 'text', content: text.slice(lastIdx, match.index) });
+    }
+    tokens.push({ type: 'path', content: match[0] });
+    lastIdx = match.index + match[0].length;
+  }
+  if (lastIdx < text.length) {
+    tokens.push({ type: 'text', content: text.slice(lastIdx) });
+  }
+  return tokens;
+}
+
+export function shortenPath(fullPath: string): string {
+  const segs = fullPath.replace(/\\/g, '/').split('/').filter(Boolean);
+  return segs[segs.length - 1] || fullPath;
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+```bash
+npx vitest run src/utils/__tests__/pathLink.test.ts
+```
+Expected: PASS (11 tests)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/utils/pathLink.ts src/utils/__tests__/pathLink.test.ts
+git commit -m "feat(pathlink): tokenizeGPaths + shortenPath 유틸 (TDD)"
+```
+
+### Task 1.2: PathBadge 컴포넌트
+
+**Files:**
+- Create: `src/components/common/PathBadge.tsx`
+
+- [ ] **Step 1: 작성**
+
+```typescript
+import { FolderOpen } from 'lucide-react';
+import { shortenPath } from '@/utils/pathLink';
+
+interface PathBadgeProps {
+  path: string;
+  /** CompositingView 전용 — 해결된 리비전 경로 회색 처리. 메모/댓글/메모위젯 사용처에선 항상 false. */
+  resolved?: boolean;
+  className?: string;
+}
+
+export function PathBadge({ path, resolved, className }: PathBadgeProps) {
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    window.electronAPI?.shellShowItem?.(path);
+  };
+  return (
+    <button
+      onClick={handleClick}
+      className={`inline-flex items-center gap-1 text-[11px] font-mono rounded px-1.5 py-0.5 max-w-full cursor-pointer transition-all hover:brightness-125 ${className ?? ''}`}
+      style={resolved
+        ? { color: '#6B7280', backgroundColor: 'rgba(107, 114, 128, 0.1)', border: '1px solid rgba(107, 114, 128, 0.2)' }
+        : { color: '#74B9FF', backgroundColor: 'rgba(116, 185, 255, 0.1)', border: '1px solid rgba(116, 185, 255, 0.2)' }
+      }
+      title={`${path}\n(클릭하면 파일탐색기에서 열기)`}
+    >
+      <FolderOpen size={10} className="shrink-0" />
+      <span className="truncate">{shortenPath(path)}</span>
+    </button>
+  );
+}
+```
+
+- [ ] **Step 2: 빌드 검증**
+
+```bash
+npx tsc --noEmit
+```
+Expected: 에러 0
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/components/common/PathBadge.tsx
+git commit -m "feat(pathlink): PathBadge 공용 컴포넌트 (CompositingView 패턴 추출)"
+```
+
+### Task 1.3: PathLinkifiedText 합성 컴포넌트 (TDD)
+
+**Files:**
+- Create: `src/components/common/PathLinkifiedText.tsx`
+- Test: `src/components/common/__tests__/PathLinkifiedText.test.tsx`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { PathLinkifiedText } from '../PathLinkifiedText';
+
+describe('PathLinkifiedText', () => {
+  it('경로 없는 텍스트는 그대로 렌더', () => {
+    const { container } = render(<PathLinkifiedText text="안녕하세요" />);
+    expect(container.textContent).toBe('안녕하세요');
+    expect(container.querySelectorAll('button')).toHaveLength(0);
+  });
+
+  it('G:\\ 경로는 button(PathBadge)으로 렌더', () => {
+    const { container } = render(<PathLinkifiedText text="확인 G:\\test\\file.png" />);
+    expect(container.querySelectorAll('button')).toHaveLength(1);
+  });
+
+  it('renderTextSegment로 추가 변환 합성 가능 (멘션 시뮬레이션)', () => {
+    const { container } = render(
+      <PathLinkifiedText
+        text="@한솔 G:\\file"
+        renderTextSegment={(seg, i) =>
+          seg.split(/(@\S+)/g).map((p, j) =>
+            p.startsWith('@')
+              ? <span key={`${i}-${j}`} data-mention={p.slice(1)}>{p}</span>
+              : p
+          )
+        }
+      />
+    );
+    expect(container.querySelector('[data-mention="한솔"]')).toBeTruthy();
+    expect(container.querySelectorAll('button')).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → 실패 확인**
+
+```bash
+npx vitest run src/components/common/__tests__/PathLinkifiedText.test.tsx
+```
+Expected: FAIL
+
+- [ ] **Step 3: 구현**
+
+```typescript
+import { Fragment, type ReactNode } from 'react';
+import { tokenizeGPaths } from '@/utils/pathLink';
+import { PathBadge } from './PathBadge';
+
+interface Props {
+  text: string;
+  /** 텍스트 세그먼트 추가 변환 (예: @멘션 처리). 미지정 시 그대로 렌더. */
+  renderTextSegment?: (segment: string, idx: number) => ReactNode;
+}
+
+export function PathLinkifiedText({ text, renderTextSegment }: Props) {
+  const tokens = tokenizeGPaths(text);
+  return (
+    <>
+      {tokens.map((tok, i) =>
+        tok.type === 'path'
+          ? <PathBadge key={`p${i}`} path={tok.content} />
+          : <Fragment key={`t${i}`}>
+              {renderTextSegment ? renderTextSegment(tok.content, i) : tok.content}
+            </Fragment>
+      )}
+    </>
+  );
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+```bash
+npx vitest run src/components/common/__tests__/PathLinkifiedText.test.tsx
+```
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/components/common/PathLinkifiedText.tsx src/components/common/__tests__/PathLinkifiedText.test.tsx
+git commit -m "feat(pathlink): PathLinkifiedText + 통합 테스트 (TDD)"
+```
+
+### Task 1.4: path-link.css
+
+**Files:**
+- Create: `src/styles/path-link.css`
+- Modify: `src/main.tsx` (또는 `src/index.css`에서 @import)
+
+- [ ] **Step 1: CSS 작성**
+
+```css
+.path-link-mark {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  font-family: monospace;
+  border-radius: 4px;
+  padding: 1px 6px;
+  color: #74B9FF;
+  background: rgba(116, 185, 255, 0.1);
+  border: 1px solid rgba(116, 185, 255, 0.2);
+  cursor: pointer;
+  transition: filter 0.15s;
+}
+.path-link-mark:hover {
+  filter: brightness(1.25);
+}
+.path-link-mark::before {
+  content: '';
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  flex-shrink: 0;
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="%2374B9FF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 14l1.45-2.9A2 2 0 0 1 9.24 10H20a2 2 0 0 1 1.94 2.5l-1.55 6a2 2 0 0 1-1.94 1.5H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h3.93a2 2 0 0 1 1.66.9l.82 1.2a2 2 0 0 0 1.66.9H18a2 2 0 0 1 2 2v2"/></svg>');
+  background-size: contain;
+  background-repeat: no-repeat;
+}
+```
+
+- [ ] **Step 2: src/main.tsx에 import 추가**
+
+```typescript
+// 기존 import들 아래에 추가
+import './styles/path-link.css';
+```
+
+- [ ] **Step 3: 빌드 검증 + 커밋**
+
+```bash
+npx vite build
+git add src/styles/path-link.css src/main.tsx
+git commit -m "feat(pathlink): path-link.css (TipTap pathLink mark 스타일)"
+```
+
+---
+
+## Chunk 2: 적용 4곳 (TipTap + 메모 + 댓글 + 리비전)
+
+### Task 2.1: TipTap PathLinkMark
+
+**Files:**
+- Create: `src/components/widgets/memo/extensions/PathLinkMark.ts`
+- Test: `src/components/widgets/memo/extensions/__tests__/PathLinkMark.test.ts`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { Markdown } from 'tiptap-markdown';
+import { PathLinkMark } from '../PathLinkMark';
+
+describe('PathLinkMark', () => {
+  let editor: Editor;
+  beforeEach(() => {
+    editor = new Editor({
+      extensions: [StarterKit, Markdown.configure({ html: false }), PathLinkMark],
+      content: '',
+    });
+  });
+  afterEach(() => editor.destroy());
+
+  it('PasteRule이 G:\\ 경로를 mark로 변환', () => {
+    editor.commands.insertContent('확인 G:\\test\\file.png 부탁');
+    editor.commands.selectAll();
+    // PasteRule을 강제로 적용하기 위해 다시 set
+    const html = editor.getHTML();
+    // 직접 paste 이벤트 시뮬레이션 또는 setContent 후 InputRules 트리거
+    expect(html).toContain('data-path-link');
+  });
+
+  it('Markdown round-trip — 저장된 raw 텍스트가 재로드 시 다시 mark', () => {
+    editor.commands.setContent('G:\\file.png');
+    const md = (editor.storage as any).markdown.getMarkdown();
+    expect(md).toContain('G:\\file.png');           // raw 보존
+
+    const fresh = new Editor({
+      extensions: [StarterKit, Markdown.configure({ html: false }), PathLinkMark],
+      content: md,
+    });
+    expect(fresh.getHTML()).toContain('data-path-link');
+    fresh.destroy();
+  });
+});
+```
+
+> **참고**: TipTap headless 테스트가 까다로울 경우 InputRule 테스트는 일부 생략 가능. 최소 markdown round-trip 1개는 통과 필수.
+
+- [ ] **Step 2: 테스트 실행 → 실패 확인**
+
+```bash
+npx vitest run src/components/widgets/memo/extensions/__tests__/PathLinkMark.test.ts
+```
+Expected: FAIL
+
+- [ ] **Step 3: 구현**
+
+```typescript
+import { Mark, markInputRule, markPasteRule } from '@tiptap/core';
+import { G_PATH_REGEX_INPUT_RULE, G_PATH_REGEX_PASTE_RULE } from '@/utils/pathLink';
+
+export const PathLinkMark = Mark.create({
+  name: 'pathLink',
+  inclusive: false,
+  addAttributes() {
+    return { href: { default: '' } };
+  },
+  parseHTML() {
+    return [{ tag: 'span[data-path-link]' }];
+  },
+  renderHTML({ mark, HTMLAttributes }) {
+    return ['span', {
+      ...HTMLAttributes,
+      'data-path-link': mark.attrs.href,
+      class: 'path-link-mark',
+      title: `${mark.attrs.href}\n(클릭하면 파일탐색기에서 열기)`,
+    }, 0];
+  },
+  addStorage() {
+    return {
+      markdown: {
+        serialize: { open: '', close: '', mixable: true, expelEnclosingWhitespace: true },
+        parse: { setup: () => {} },
+      },
+    };
+  },
+  addInputRules() {
+    return [
+      markInputRule({
+        find: G_PATH_REGEX_INPUT_RULE,
+        type: this.type,
+        getAttributes: (match) => ({ href: match[1] }),
+      }),
+    ];
+  },
+  addPasteRules() {
+    return [
+      markPasteRule({
+        find: G_PATH_REGEX_PASTE_RULE,
+        type: this.type,
+        getAttributes: (match) => ({ href: match[0] }),
+      }),
+    ];
+  },
+});
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+```bash
+npx vitest run src/components/widgets/memo/extensions/__tests__/PathLinkMark.test.ts
+```
+Expected: PASS
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/components/widgets/memo/extensions/PathLinkMark.ts src/components/widgets/memo/extensions/__tests__/PathLinkMark.test.ts
+git commit -m "feat(pathlink): TipTap PathLinkMark + markdown round-trip 테스트"
+```
+
+### Task 2.2: MemoEditor에 PathLinkMark 등록 + handleClickOn
+
+**Files:**
+- Modify: `src/components/widgets/memo/MemoEditor.tsx`
+
+- [ ] **Step 1: extensions에 PathLinkMark 추가**
+
+기존 `useEditor({ extensions: [...] })`의 배열에 `PathLinkMark` import 후 추가:
+
+```typescript
+import { PathLinkMark } from './extensions/PathLinkMark';
+// ...
+extensions: [
+  // 기존 extensions 그대로
+  PathLinkMark,
+  // Markdown 은 마지막에
+  Markdown.configure({...}),
+]
+```
+
+- [ ] **Step 2: editorProps.handleClickOn 추가**
+
+```typescript
+editorProps: {
+  // 기존 editorProps 유지
+  handleClickOn(view, pos, node, nodePos, event) {
+    const target = event.target as HTMLElement | null;
+    const linkEl = target?.closest('[data-path-link]') as HTMLElement | null;
+    if (linkEl) {
+      event.preventDefault();
+      window.electronAPI?.shellShowItem?.(linkEl.dataset.pathLink ?? '');
+      return true;
+    }
+    return false;
+  },
+}
+```
+
+- [ ] **Step 3: 빌드 + 수동 검증**
+
+```bash
+npx tsc --noEmit
+npx vite build
+```
+
+수동:
+- [ ] 메모 위젯에 `G:\test\file.png` 입력 후 공백 → 즉시 청색 PathBadge로 변환
+- [ ] 클릭 → 파일탐색기 열림 (또는 상위 폴더 폴백)
+- [ ] 메모 저장 후 새로고침 → 여전히 PathBadge 표시 (round-trip)
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/components/widgets/memo/MemoEditor.tsx
+git commit -m "feat(pathlink): MemoEditor에 PathLinkMark 등록 + 클릭 핸들러"
+```
+
+### Task 2.3: 씬 메모 — InlineTextareaRow
+
+**Files:**
+- Modify: `src/components/scenes/UnifiedSceneDetailModal.tsx`
+
+- [ ] **Step 1: InlineTextareaRow의 표시 모드를 수정**
+
+기존 표시 div 내부 (textarea 닫혀있을 때 렌더되는 부분)를 다음으로 교체:
+
+```typescript
+import { PathLinkifiedText } from '@/components/common/PathLinkifiedText';
+
+// 표시 모드:
+<div onClick={enterEditMode} className="min-h-[1.5em] cursor-pointer ...기존 클래스">
+  {value
+    ? <PathLinkifiedText text={value} />
+    : <span className="text-text-secondary/50">메모 추가...</span>
+  }
+</div>
+```
+
+`InlineTextareaRow`가 `UnifiedSceneDetailModal.tsx` 내부에 정의되어 있으면 직접 수정. 별도 파일이면 그 파일 수정.
+
+- [ ] **Step 2: 빌드 + 수동 검증**
+
+```bash
+npx tsc --noEmit
+```
+
+수동:
+- [ ] 씬 상세 모달의 메모에 `G:\test` 입력 → 저장 → PathBadge 표시
+- [ ] 빈 메모 클릭 → 편집 모드 진입
+- [ ] 클릭 → 파일탐색기 열림
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/components/scenes/UnifiedSceneDetailModal.tsx
+git commit -m "feat(pathlink): 씬 메모 표시 모드에 PathLinkifiedText 적용"
+```
+
+### Task 2.4: 댓글 — CommentPanel.renderText
+
+**Files:**
+- Modify: `src/components/scenes/CommentPanel.tsx`
+
+- [ ] **Step 1: renderText 재작성**
+
+기존 `renderText` 함수를 다음으로 교체 (line 258–280):
+
+```typescript
+import { PathLinkifiedText } from '@/components/common/PathLinkifiedText';
+
+// ...
+const renderMentionInSegment = (segment: string, baseIdx: number) =>
+  segment.split(/(@\S+)/g).map((part, i) => {
+    const key = `${baseIdx}-${i}`;
+    if (part.startsWith('@')) {
+      const name = part.slice(1);
+      const isUser = users.some(u => u.name === name);
+      if (isUser) {
+        return (
+          <span
+            key={key}
+            className="text-accent font-bold bg-accent/10 rounded px-0.5 cursor-pointer hover:bg-accent/20 transition-colors"
+            onClick={() => handleMentionClick(name)}
+            title={`${name} 팀원 보기`}
+          >
+            {part}
+          </span>
+        );
+      }
+    }
+    return <span key={key}>{part}</span>;
+  });
+
+const renderText = (text: string) => (
+  <PathLinkifiedText text={text} renderTextSegment={renderMentionInSegment} />
+);
+```
+
+`handleMentionClick` 함수가 있는지 확인 — 기존 코드에 있을 가능성 높음. 없으면 기존 로직과 동일하게 작성.
+
+- [ ] **Step 2: 빌드 + 수동 검증**
+
+수동:
+- [ ] 댓글 `@한솔 G:\test\file 확인` → 저장 → 멘션과 PathBadge 둘 다 표시
+- [ ] 멘션 클릭 → 기존 동작 그대로
+- [ ] PathBadge 클릭 → 파일탐색기 열림
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/components/scenes/CommentPanel.tsx
+git commit -m "feat(pathlink): CommentPanel renderText에 G:\ 경로 합성"
+```
+
+### Task 2.5: 리비전 — CompositingView 갈아끼기
+
+**Files:**
+- Modify: `src/views/CompositingView.tsx`
+
+- [ ] **Step 1: 인라인 PathBadge 정의 삭제 + import 추가**
+
+`src/views/CompositingView.tsx` 의 line 75–99 (인라인 PathBadge 정의)를 삭제하고 상단에 import:
+
+```typescript
+import { PathBadge } from '@/components/common/PathBadge';
+```
+
+`parsePathsFromText` 함수는 그대로 유지 (이건 줄 단위 분리 패턴, 메모/댓글의 인라인 토큰화와 다른 별개 로직).
+
+- [ ] **Step 2: 빌드 + 회귀 테스트**
+
+```bash
+npx tsc --noEmit
+npx vite build
+```
+
+수동 회귀:
+- [ ] 리비전(CompositingView)에서 PathBadge 외관·동작이 변경 없이 그대로
+- [ ] 청색·회색(resolved) 모두 정상 표시
+- [ ] 클릭 시 파일탐색기 열림
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/views/CompositingView.tsx
+git commit -m "refactor(pathlink): CompositingView가 공용 PathBadge 사용 (DRY)"
+```
+
+### Task 2.6: 최종 빌드 + 통합 검증
+
+- [ ] **Step 1: 전체 빌드**
+
+```bash
+npx tsc --noEmit
+npx vite build
+npx vitest run
+```
+
+모두 PASS / 에러 0.
+
+- [ ] **Step 2: 통합 수동 체크리스트**
+
+스펙 §6.2 항목 모두 확인:
+- [ ] 씬 모달 메모: `G:\공유 드라이브\test.png` 입력·저장 → PathBadge → 클릭 → 파일탐색기
+- [ ] 댓글: `@한솔 G:\test\file.png 확인` → 멘션 + PathBadge 모두 인식
+- [ ] 메모 위젯: G:\ 입력 후 공백 → 즉시 청색 PathBadge로 변환
+- [ ] 메모 위젯: 붙여넣기로 G:\ 경로 → 자동 변환
+- [ ] 메모 위젯: 저장 → 앱 재시작 → 여전히 PathBadge 표시 (round-trip)
+- [ ] 리비전(CompositingView): 외관·동작 변경 없음 (회귀)
+- [ ] PathLink 클릭 시 LinkBubble이 잘못 뜨지 않음
+- [ ] 빈 메모 placeholder 클릭 → 편집 모드 진입
+
+- [ ] **Step 3: 최종 커밋 (선택)**
+
+추가 변경 없으면 생략. 작은 마무리 정리만 있으면:
+
+```bash
+git commit -m "feat: G:\ 경로 자동 링크화 v1 출시 (메모/댓글/메모위젯/리비전 통합)"
+```
+
+---
+
+## 완료 기준
+
+- [ ] `tokenizeGPaths` / `shortenPath` / `PathLinkifiedText` / `PathLinkMark` 단위 테스트 모두 통과
+- [ ] 4곳(메모/댓글/메모위젯/리비전) 외관·동작 일관성 확인
+- [ ] Markdown round-trip 보장 (저장→재로드 시 PathBadge 유지)
+- [ ] 빌드 + 빌드 검증(tsc, vite build, vitest) 모두 통과
+- [ ] PR 머지 후 마이너 버전 또는 패치 (v1.13.x or v1.14.x — A 위젯과의 머지 순서에 따름)

--- a/docs/superpowers/plans/2026-04-27-recent-activity-widget.md
+++ b/docs/superpowers/plans/2026-04-27-recent-activity-widget.md
@@ -1,0 +1,1626 @@
+# 최근 작업 위젯 Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 팀 활동을 시간 역순 피드 + 시간×요일 히트맵(또는 막대 그래프)으로 보여주는 신규 위젯 1개를 추가하고, 기존 mutation 12개 함수에 활동 기록을 자동 INSERT하도록 패치한다.
+
+**Architecture:** 새 `activity_log` 테이블을 신설하고, 클라이언트가 mutation 호출 시 RPC 트랜잭션 안에서 UPDATE + INSERT를 함께 실행한다. Realtime은 `activity_log` 채널만 구독해 모든 윈도우에 즉시 prepend. 위젯은 옵션 1(상하 분할) 레이아웃에 그래프 모드 3종(히트맵/시간대/요일) 토글 + 4그룹 필터 칩 + 5분 윈도우 그룹화 + 1년 자동 보존 정책으로 구성한다.
+
+**Tech Stack:** Supabase Pro (PostgreSQL + Realtime + pg_cron), Electron 28, React 18 + TypeScript, Zustand, Framer Motion, Tailwind CSS, react-grid-layout, dayjs (시간대 처리), Lucide 아이콘.
+
+**Source spec:** [`docs/superpowers/specs/2026-04-27-recent-activity-widget-design.md`](../specs/2026-04-27-recent-activity-widget-design.md)
+
+**Final mockup:** [`docs/superpowers/specs/mockups/2026-04-27-recent-activity-widget/final.html`](../specs/mockups/2026-04-27-recent-activity-widget/final.html)
+
+---
+
+## File Structure
+
+다음 파일을 생성·수정한다. 각 파일의 책임은 한 가지로 좁히고, 시각화/상태/IO 레이어를 분리한다.
+
+```
+DB
+  DEVLOG/supabase-init.sql                              [수정]
+
+Electron 백엔드
+  electron/supabase.ts                                  [수정]
+  electron/main.ts                                      [수정]
+  electron/realtime.ts                                  [수정]
+  electron/broadcast.ts                                 [수정]
+  electron/preload.ts                                   [수정]
+
+타입 / 서비스
+  src/types/index.ts                                    [수정]
+  src/services/supabaseService.ts                       [수정]
+
+상태 관리
+  src/stores/useActivityStore.ts                        [신규]
+
+UI 컴포넌트 (src/components/widgets/activity/)
+  src/components/widgets/RecentActivityWidget.tsx       [신규]
+  src/components/widgets/activity/GoldenHeatmap.tsx     [신규]
+  src/components/widgets/activity/GoldenBarChart.tsx    [신규]
+  src/components/widgets/activity/ActivityFeed.tsx      [신규]
+  src/components/widgets/activity/ActivityFilterChips.tsx [신규]
+  src/components/widgets/activity/ActivityTooltip.tsx   [신규]
+  src/components/widgets/activity/utils.ts              [신규]
+  src/components/widgets/activity/constants.ts          [신규]
+
+뷰 / 설정
+  src/views/Dashboard.tsx                               [수정]
+  src/views/SettingsView.tsx                            [수정]
+  src/components/settings/ActivityStorageInfo.tsx       [신규]
+```
+
+---
+
+## Chunk 1: DB 스키마 + RPC
+
+**목표:** Supabase에 `activity_log` 테이블, 인덱스, RLS, Realtime publication, RPC 함수, pg_cron 보존 작업을 정의한다. 모든 SQL은 `IF NOT EXISTS` / `CREATE OR REPLACE` 로 재실행 안전하게.
+
+**Files:**
+- Modify: `DEVLOG/supabase-init.sql` (마지막에 새 섹션 추가)
+
+### Task 1.1: activity_log 테이블 + 인덱스
+
+- [ ] **Step 1: SQL 추가**
+
+`DEVLOG/supabase-init.sql` 끝에 다음 섹션 추가:
+
+```sql
+-- ============================================================
+-- 최근 작업 위젯 — activity_log (2026-04-27)
+-- spec: docs/superpowers/specs/2026-04-27-recent-activity-widget-design.md
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS activity_log (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id TEXT NOT NULL,
+  user_name TEXT NOT NULL,
+  action_type TEXT NOT NULL,
+  action_group TEXT NOT NULL,         -- 'progress' | 'memo' | 'scene' | 'etc'
+  scene_id UUID,                       -- scenes.id (UUID), nullable
+  scene_label TEXT,                    -- 표시용 "EP01 A씬 #5"
+  episode_number INTEGER,
+  department TEXT,                     -- 'bg' | 'acting'
+  detail JSONB,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_activity_log_created  ON activity_log(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_activity_log_user     ON activity_log(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_activity_log_scene    ON activity_log(scene_id);
+
+ALTER TABLE activity_log ENABLE ROW LEVEL SECURITY;
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'activity_log' AND policyname = 'allow_all') THEN
+    CREATE POLICY "allow_all" ON activity_log FOR ALL USING (true) WITH CHECK (true);
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  ALTER PUBLICATION supabase_realtime ADD TABLE activity_log;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+```
+
+- [ ] **Step 2: 검증** — Supabase SQL Editor에서 실행해 에러 없이 테이블이 생성되는지 확인
+
+```sql
+SELECT table_name FROM information_schema.tables WHERE table_name = 'activity_log';
+SELECT indexname FROM pg_indexes WHERE tablename = 'activity_log';
+```
+
+기대: 1행 + 인덱스 3개
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add DEVLOG/supabase-init.sql
+git commit -m "feat(db): activity_log 테이블 + 인덱스 + RLS + Realtime publication"
+```
+
+### Task 1.2: record_activity RPC 함수
+
+- [ ] **Step 1: SQL 추가**
+
+```sql
+CREATE OR REPLACE FUNCTION record_activity(
+  p_user_id TEXT,
+  p_user_name TEXT,
+  p_action_type TEXT,
+  p_action_group TEXT,
+  p_scene_id UUID,
+  p_scene_label TEXT,
+  p_episode_number INTEGER,
+  p_department TEXT,
+  p_detail JSONB
+) RETURNS UUID
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+  v_id UUID;
+BEGIN
+  INSERT INTO activity_log (
+    user_id, user_name, action_type, action_group,
+    scene_id, scene_label, episode_number, department, detail
+  ) VALUES (
+    p_user_id, p_user_name, p_action_type, p_action_group,
+    p_scene_id, p_scene_label, p_episode_number, p_department, p_detail
+  ) RETURNING id INTO v_id;
+  RETURN v_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION record_activity(TEXT, TEXT, TEXT, TEXT, UUID, TEXT, INTEGER, TEXT, JSONB)
+  TO anon, authenticated;
+```
+
+- [ ] **Step 2: 검증** — 호출 테스트
+
+```sql
+SELECT record_activity(
+  'test_user', '테스트', 'stage_lo', 'progress',
+  NULL, 'EP01 A씬 #1', 1, 'bg',
+  '{"from":false,"to":true}'::jsonb
+);
+SELECT * FROM activity_log WHERE user_id = 'test_user';
+DELETE FROM activity_log WHERE user_id = 'test_user';
+```
+
+기대: UUID 1개 반환, SELECT 1행, DELETE 1행
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add DEVLOG/supabase-init.sql
+git commit -m "feat(db): record_activity RPC 함수 추가"
+```
+
+### Task 1.3: bulk RPC 시그니처 확장
+
+기존 `bulk_update_scene_stages`/`bulk_delete_scenes`/`bulk_update_scene_fields` 3개 함수에 활동 기록 파라미터 추가.
+
+- [ ] **Step 1: bulk_update_scene_stages 확장**
+
+`DEVLOG/supabase-init.sql`의 기존 정의를 다음으로 교체 (`CREATE OR REPLACE`):
+
+```sql
+CREATE OR REPLACE FUNCTION bulk_update_scene_stages(
+  p_updates jsonb,
+  p_updated_by text,
+  p_user_name text DEFAULT NULL          -- 신규: 활동 기록용 (NULL이면 기록 생략)
+) RETURNS TABLE (scene_uuid uuid, success boolean, error text)
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+  u jsonb;
+  v_uuid uuid;
+  v_stage text;
+  v_value boolean;
+  v_has_meta_keys boolean;
+  v_completed_by text;
+  v_completed_at_text text;
+  v_completed_at timestamptz;
+  v_meta_value text;
+  v_scene_label text;
+  v_episode_number integer;
+  v_department text;
+BEGIN
+  FOR u IN SELECT * FROM jsonb_array_elements(p_updates) LOOP
+    v_uuid := NULL;
+    BEGIN
+      v_uuid := (u->>'sceneUuid')::uuid;
+      v_stage := u->>'stage';
+      v_value := (u->>'value')::boolean;
+      v_has_meta_keys := (u ? 'completedBy') OR (u ? 'completedAt');
+      v_completed_by := u->>'completedBy';
+      v_completed_at_text := u->>'completedAt';
+      v_scene_label := u->>'sceneLabel';
+      v_episode_number := COALESCE((u->>'episodeNumber')::integer, NULL);
+      v_department := u->>'department';
+
+      IF v_stage NOT IN ('lo','done','review','png') THEN
+        RAISE EXCEPTION 'invalid stage: %', v_stage;
+      END IF;
+
+      UPDATE scenes SET
+        lo     = CASE WHEN v_stage = 'lo'     THEN v_value ELSE lo END,
+        done   = CASE WHEN v_stage = 'done'   THEN v_value ELSE done END,
+        review = CASE WHEN v_stage = 'review' THEN v_value ELSE review END,
+        png    = CASE WHEN v_stage = 'png'    THEN v_value ELSE png END,
+        updated_at = now(),
+        updated_by = p_updated_by
+      WHERE id = v_uuid;
+
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'scene not found: %', v_uuid;
+      END IF;
+
+      -- 기존 metadata 처리 (변경 없음)
+      IF v_has_meta_keys THEN
+        IF v_completed_by IS NOT NULL AND v_completed_by <> ''
+           AND v_completed_at_text IS NOT NULL AND v_completed_at_text <> '' THEN
+          v_completed_at := v_completed_at_text::timestamptz;
+          v_meta_value := jsonb_build_object(
+            'completedBy', v_completed_by,
+            'completedAt', v_completed_at
+          )::text;
+          INSERT INTO metadata (type, key, value, updated_at)
+            VALUES ('scene-completion', v_uuid::text, v_meta_value, now())
+            ON CONFLICT (type, key) DO UPDATE SET value = EXCLUDED.value, updated_at = now();
+        ELSE
+          DELETE FROM metadata WHERE type = 'scene-completion' AND key = v_uuid::text;
+        END IF;
+      END IF;
+
+      -- 신규: 활동 기록 (p_user_name이 있을 때만, 실패해도 본 작업은 성공)
+      IF p_user_name IS NOT NULL THEN
+        BEGIN
+          PERFORM record_activity(
+            p_updated_by, p_user_name,
+            'stage_' || v_stage, 'progress',
+            v_uuid, v_scene_label, v_episode_number, v_department,
+            jsonb_build_object('value', v_value)
+          );
+        EXCEPTION WHEN OTHERS THEN
+          NULL;  -- 활동 기록 실패는 무시
+        END;
+      END IF;
+
+      scene_uuid := v_uuid;
+      success := TRUE;
+      error := NULL;
+      RETURN NEXT;
+    EXCEPTION WHEN OTHERS THEN
+      scene_uuid := v_uuid;
+      success := FALSE;
+      error := SQLERRM;
+      RETURN NEXT;
+    END;
+  END LOOP;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION bulk_update_scene_stages(jsonb, text, text) TO anon, authenticated;
+```
+
+- [ ] **Step 2: bulk_delete_scenes 확장**
+
+```sql
+CREATE OR REPLACE FUNCTION bulk_delete_scenes(
+  p_uuids uuid[],
+  p_deleted_by text,
+  p_user_name text DEFAULT NULL,
+  p_meta jsonb DEFAULT '[]'::jsonb        -- 각 element: { sceneUuid, sceneLabel, episodeNumber, department }
+) RETURNS TABLE (scene_uuid uuid, success boolean, error text)
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+  v_uuid uuid;
+  m jsonb;
+  v_scene_label text;
+  v_episode_number integer;
+  v_department text;
+BEGIN
+  FOREACH v_uuid IN ARRAY p_uuids LOOP
+    BEGIN
+      DELETE FROM scenes WHERE id = v_uuid;
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'scene not found: %', v_uuid;
+      END IF;
+      DELETE FROM metadata WHERE type = 'scene-completion' AND key = v_uuid::text;
+
+      IF p_user_name IS NOT NULL THEN
+        SELECT m INTO m FROM jsonb_array_elements(p_meta) WHERE (m->>'sceneUuid')::uuid = v_uuid;
+        v_scene_label := m->>'sceneLabel';
+        v_episode_number := COALESCE((m->>'episodeNumber')::integer, NULL);
+        v_department := m->>'department';
+        BEGIN
+          PERFORM record_activity(
+            p_deleted_by, p_user_name,
+            'scene_delete', 'scene',
+            v_uuid, v_scene_label, v_episode_number, v_department,
+            '{}'::jsonb
+          );
+        EXCEPTION WHEN OTHERS THEN
+          NULL;
+        END;
+      END IF;
+
+      scene_uuid := v_uuid;
+      success := TRUE;
+      error := NULL;
+      RETURN NEXT;
+    EXCEPTION WHEN OTHERS THEN
+      scene_uuid := v_uuid;
+      success := FALSE;
+      error := SQLERRM;
+      RETURN NEXT;
+    END;
+  END LOOP;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION bulk_delete_scenes(uuid[], text, text, jsonb) TO anon, authenticated;
+```
+
+- [ ] **Step 3: bulk_update_scene_fields 확장**
+
+`bulk_update_scene_stages`와 같은 패턴으로 `p_user_name` 파라미터 추가하고 변경된 필드별로 `record_activity` 호출 (memo→`memo_update`, assignee→`assignee_change`, layout→`layout_change`, storyboardUrl→`image_upload_storyboard`, guideUrl→`image_upload_guide`).
+
+전체 코드는 길어 생략 — 동일 패턴 적용. 함수 끝의 GRANT만 다음으로 갱신:
+
+```sql
+GRANT EXECUTE ON FUNCTION bulk_update_scene_fields(jsonb, text, text) TO anon, authenticated;
+```
+
+- [ ] **Step 4: 검증** — Supabase SQL Editor에서 새 시그니처 호출 테스트
+
+```sql
+SELECT * FROM bulk_update_scene_stages(
+  '[{"sceneUuid":"00000000-0000-0000-0000-000000000000","stage":"lo","value":true,"sceneLabel":"TEST","episodeNumber":1,"department":"bg"}]'::jsonb,
+  'test_user',
+  '테스트'
+);
+```
+
+기대: scene_not_found 에러 (UUID가 가짜이므로). 시그니처 자체가 수용되는지가 핵심.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add DEVLOG/supabase-init.sql
+git commit -m "feat(db): bulk RPC 시그니처에 활동 기록 파라미터 추가"
+```
+
+### Task 1.4: 보존 정책 cron
+
+- [ ] **Step 1: cleanup 함수 + cron 등록**
+
+```sql
+CREATE OR REPLACE FUNCTION cleanup_old_activity_logs() RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  DELETE FROM activity_log WHERE created_at < now() - INTERVAL '1 year';
+END;
+$$;
+
+-- pg_cron extension 활성화 (이미 있으면 무시)
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+-- 기존 같은 이름 cron이 있으면 unschedule 후 재등록
+DO $$ BEGIN
+  PERFORM cron.unschedule('activity-log-cleanup');
+EXCEPTION WHEN OTHERS THEN NULL;
+END $$;
+
+SELECT cron.schedule(
+  'activity-log-cleanup',
+  '0 4 * * *',
+  $$ SELECT cleanup_old_activity_logs(); $$
+);
+```
+
+- [ ] **Step 2: 검증**
+
+```sql
+SELECT jobname, schedule, command FROM cron.job WHERE jobname = 'activity-log-cleanup';
+```
+
+기대: 1행
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add DEVLOG/supabase-init.sql
+git commit -m "feat(db): activity_log 1년 보존 cron 등록"
+```
+
+### Task 1.5: activity_log_stats RPC (히트맵 집계용)
+
+- [ ] **Step 1: 함수 추가**
+
+```sql
+CREATE OR REPLACE FUNCTION activity_log_stats(
+  p_since TIMESTAMPTZ,
+  p_groups TEXT[] DEFAULT NULL,        -- NULL이면 전체
+  p_department TEXT DEFAULT NULL       -- NULL이면 전체
+) RETURNS TABLE (
+  day_of_week INTEGER,                 -- 0=일, 1=월, ..., 6=토 (KST 기준)
+  hour INTEGER,                        -- 0..23
+  count INTEGER
+)
+LANGUAGE sql
+SECURITY INVOKER
+AS $$
+  SELECT
+    EXTRACT(dow  FROM (created_at AT TIME ZONE 'Asia/Seoul'))::integer AS day_of_week,
+    EXTRACT(hour FROM (created_at AT TIME ZONE 'Asia/Seoul'))::integer AS hour,
+    COUNT(*)::integer AS count
+  FROM activity_log
+  WHERE created_at >= p_since
+    AND (p_groups IS NULL OR action_group = ANY(p_groups))
+    AND (p_department IS NULL OR department = p_department)
+  GROUP BY 1, 2
+  ORDER BY 1, 2;
+$$;
+
+GRANT EXECUTE ON FUNCTION activity_log_stats(TIMESTAMPTZ, TEXT[], TEXT) TO anon, authenticated;
+```
+
+- [ ] **Step 2: 검증**
+
+```sql
+SELECT * FROM activity_log_stats(now() - INTERVAL '7 days') LIMIT 10;
+```
+
+기대: 0행 또는 일부 (데이터 양에 따라). 에러만 없으면 OK.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add DEVLOG/supabase-init.sql
+git commit -m "feat(db): activity_log_stats RPC (24x7 히트맵 집계)"
+```
+
+---
+
+## Chunk 2: Electron 백엔드 + IPC
+
+**목표:** 메인 프로세스에 활동 기록·조회·재연결 백필 함수, Realtime 구독, broadcast 채널, IPC 핸들러를 추가한다.
+
+**Files:**
+- Modify: `electron/supabase.ts`
+- Modify: `electron/main.ts`
+- Modify: `electron/realtime.ts`
+- Modify: `electron/broadcast.ts`
+- Modify: `electron/preload.ts`
+
+### Task 2.1: supabase.ts에 활동 함수 추가
+
+- [ ] **Step 1: 타입 정의 추가** (`electron/supabase.ts` 상단 type 섹션)
+
+```typescript
+export type ActionGroup = 'progress' | 'memo' | 'scene' | 'etc';
+export type ActionType =
+  | 'stage_lo' | 'stage_done' | 'stage_review' | 'stage_png'
+  | 'memo_update' | 'comment_add' | 'revision_add' | 'revision_resolve'
+  | 'scene_add' | 'scene_delete'
+  | 'assignee_change' | 'layout_change'
+  | 'image_upload_storyboard' | 'image_upload_guide';
+
+export interface ActivityRow {
+  id: string;
+  user_id: string;
+  user_name: string;
+  action_type: ActionType;
+  action_group: ActionGroup;
+  scene_id: string | null;
+  scene_label: string | null;
+  episode_number: number | null;
+  department: 'bg' | 'acting' | null;
+  detail: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export interface RecordActivityInput {
+  userId: string;
+  userName: string;
+  actionType: ActionType;
+  actionGroup: ActionGroup;
+  sceneId?: string | null;
+  sceneLabel?: string | null;
+  episodeNumber?: number | null;
+  department?: 'bg' | 'acting' | null;
+  detail?: Record<string, unknown>;
+}
+```
+
+- [ ] **Step 2: recordActivity 헬퍼 함수**
+
+```typescript
+export async function recordActivity(input: RecordActivityInput): Promise<string | null> {
+  try {
+    const { data, error } = await supabase.rpc('record_activity', {
+      p_user_id: input.userId,
+      p_user_name: input.userName,
+      p_action_type: input.actionType,
+      p_action_group: input.actionGroup,
+      p_scene_id: input.sceneId ?? null,
+      p_scene_label: input.sceneLabel ?? null,
+      p_episode_number: input.episodeNumber ?? null,
+      p_department: input.department ?? null,
+      p_detail: input.detail ?? {},
+    });
+    if (error) {
+      console.warn('[activity] record failed:', error.message);
+      return null;
+    }
+    return data as string;
+  } catch (err) {
+    console.warn('[activity] record exception:', err);
+    return null;
+  }
+}
+```
+
+> **Why:** try/catch 외부 호출자에 부담 주지 않도록 헬퍼 안에서 모두 흡수. 본 mutation 흐름은 절대 중단 안 됨.
+
+- [ ] **Step 3: listActivities, getActivityStats, backfillActivities**
+
+```typescript
+export async function listActivities(opts: {
+  before?: string;
+  limit?: number;
+  groups?: ActionGroup[];
+  department?: 'bg' | 'acting' | null;
+}): Promise<ActivityRow[]> {
+  let q = supabase
+    .from('activity_log')
+    .select('*')
+    .order('created_at', { ascending: false })
+    .limit(opts.limit ?? 100);
+
+  if (opts.before) q = q.lt('created_at', opts.before);
+  if (opts.groups && opts.groups.length > 0) q = q.in('action_group', opts.groups);
+  if (opts.department) q = q.eq('department', opts.department);
+
+  const { data, error } = await q;
+  if (error) throw new Error(`listActivities failed: ${error.message}`);
+  return (data ?? []) as ActivityRow[];
+}
+
+export async function getActivityStats(opts: {
+  days?: number;
+  groups?: ActionGroup[];
+  department?: 'bg' | 'acting' | null;
+}): Promise<Array<{ day_of_week: number; hour: number; count: number }>> {
+  const since = new Date(Date.now() - (opts.days ?? 7) * 86400000).toISOString();
+  const { data, error } = await supabase.rpc('activity_log_stats', {
+    p_since: since,
+    p_groups: opts.groups ?? null,
+    p_department: opts.department ?? null,
+  });
+  if (error) throw new Error(`getActivityStats failed: ${error.message}`);
+  return data ?? [];
+}
+
+export async function backfillActivities(since: string, limit = 200): Promise<ActivityRow[]> {
+  const { data, error } = await supabase
+    .from('activity_log')
+    .select('*')
+    .gt('created_at', since)
+    .order('created_at', { ascending: true })
+    .limit(limit);
+  if (error) throw new Error(`backfillActivities failed: ${error.message}`);
+  return (data ?? []) as ActivityRow[];
+}
+```
+
+- [ ] **Step 4: 빌드 검증**
+
+```bash
+npx tsc --noEmit
+```
+
+기대: 에러 0
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add electron/supabase.ts
+git commit -m "feat(activity): supabase.ts에 record/list/stats/backfill 함수 추가"
+```
+
+### Task 2.2: IPC 핸들러 (main.ts)
+
+- [ ] **Step 1: 핸들러 3개 추가** (`electron/main.ts` 적절한 위치, 기존 handler 그룹 근처)
+
+```typescript
+// ─── IPC 핸들러: 활동 기록 ────────────────────────────────────
+
+ipcMain.handle('activity:list', async (_event, opts: {
+  before?: string;
+  limit?: number;
+  groups?: ActionGroup[];
+  department?: 'bg' | 'acting' | null;
+}) => {
+  try {
+    const rows = await listActivities(opts);
+    return { ok: true, rows };
+  } catch (err) {
+    return { ok: false, error: String(err) };
+  }
+});
+
+ipcMain.handle('activity:stats', async (_event, opts: {
+  days?: number;
+  groups?: ActionGroup[];
+  department?: 'bg' | 'acting' | null;
+}) => {
+  try {
+    const stats = await getActivityStats(opts);
+    return { ok: true, stats };
+  } catch (err) {
+    return { ok: false, error: String(err) };
+  }
+});
+
+ipcMain.handle('activity:backfill', async (_event, since: string) => {
+  try {
+    const rows = await backfillActivities(since);
+    return { ok: true, rows };
+  } catch (err) {
+    return { ok: false, error: String(err) };
+  }
+});
+```
+
+> **주의:** `activity:record`는 노출하지 않음. mutation 함수 내부에서만 `recordActivity`를 부른다 (§3.4 신뢰 모델).
+
+- [ ] **Step 2: 빌드 검증**
+
+```bash
+npx tsc --noEmit
+```
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add electron/main.ts
+git commit -m "feat(activity): IPC 핸들러 list/stats/backfill 추가"
+```
+
+### Task 2.3: Realtime 구독 + Broadcast
+
+- [ ] **Step 1: realtime.ts에 activity_log 채널 추가**
+
+`electron/realtime.ts`의 기존 채널 등록 부분을 찾아 다음 추가:
+
+```typescript
+channel.on(
+  'postgres_changes',
+  { event: 'INSERT', schema: 'public', table: 'activity_log' },
+  (payload) => {
+    broadcastActivityInsert(payload.new as ActivityRow);
+  }
+);
+```
+
+- [ ] **Step 2: broadcast.ts에 함수 추가**
+
+```typescript
+export function broadcastActivityInsert(row: ActivityRow): void {
+  const windows = BrowserWindow.getAllWindows();
+  for (const w of windows) {
+    w.webContents.send('activity:realtime-insert', row);
+  }
+}
+```
+
+- [ ] **Step 3: preload.ts에 activity 메서드 추가**
+
+```typescript
+// existing electronAPI 객체 안에 추가
+activityList: (opts: any) => ipcRenderer.invoke('activity:list', opts),
+activityStats: (opts: any) => ipcRenderer.invoke('activity:stats', opts),
+activityBackfill: (since: string) => ipcRenderer.invoke('activity:backfill', since),
+onActivityRealtimeInsert: (cb: (row: any) => void) => {
+  const handler = (_event: any, row: any) => cb(row);
+  ipcRenderer.on('activity:realtime-insert', handler);
+  return () => ipcRenderer.removeListener('activity:realtime-insert', handler);
+},
+```
+
+- [ ] **Step 4: 빌드 검증 + 커밋**
+
+```bash
+npx tsc --noEmit
+git add electron/realtime.ts electron/broadcast.ts electron/preload.ts
+git commit -m "feat(activity): Realtime 구독 + broadcast + preload API"
+```
+
+---
+
+## Chunk 3: Mutation 함수 패치
+
+**목표:** `electron/supabase.ts`의 12개 mutation 함수에 `recordActivity()` 호출을 추가한다 (호출 지점 14개). 각 호출은 try/catch로 감싸 본 mutation 결과에 영향을 주지 않는다.
+
+**Files:**
+- Modify: `electron/supabase.ts` (기존 mutation 함수들)
+
+### Task 3.1: updateSceneField 패치
+
+기존 함수 시그니처는 `updateSceneField(sceneId, field, value, ...)` 패턴. 4종 stage + memo + assignee + layout 분기 추가.
+
+- [ ] **Step 1: 함수 안에 활동 기록 코드 추가**
+
+```typescript
+// updateSceneField 함수 끝에 추가:
+const userId = /* 호출 컨텍스트에서 받기 */;
+const userName = /* 호출 컨텍스트에서 받기 */;
+
+let actionType: ActionType | null = null;
+let actionGroup: ActionGroup | null = null;
+const detail: Record<string, unknown> = {};
+
+if (field === 'lo' || field === 'done' || field === 'review' || field === 'png') {
+  actionType = `stage_${field}` as ActionType;
+  actionGroup = 'progress';
+  detail.value = value;
+} else if (field === 'memo') {
+  actionType = 'memo_update';
+  actionGroup = 'memo';
+} else if (field === 'assignee') {
+  actionType = 'assignee_change';
+  actionGroup = 'etc';
+  detail.to = value;
+} else if (field === 'layout') {
+  actionType = 'layout_change';
+  actionGroup = 'etc';
+  detail.to = value;
+}
+
+if (actionType && actionGroup) {
+  await recordActivity({
+    userId, userName, actionType, actionGroup,
+    sceneId, sceneLabel, episodeNumber, department,
+    detail,
+  });
+}
+```
+
+> **주의:** 기존 시그니처가 userId/userName/sceneLabel/episodeNumber/department를 안 받으면 시그니처를 확장해야 한다. 호출자(supabaseService.ts)에서도 함께 전달하도록 패치 필요.
+
+- [ ] **Step 2: 호출자(supabaseService.ts) 패치** — 모든 `updateSceneField` 호출 지점에 활동 메타 추가
+
+- [ ] **Step 3: 빌드 검증 + 커밋**
+
+```bash
+npx tsc --noEmit
+git add electron/supabase.ts src/services/supabaseService.ts
+git commit -m "feat(activity): updateSceneField에 활동 기록 추가 (4단계+memo+assignee+layout)"
+```
+
+### Task 3.2: addScene / deleteScene 패치
+
+각각 끝에 `recordActivity({ actionType: 'scene_add' | 'scene_delete', actionGroup: 'scene', ... })` 추가. 패턴 동일.
+
+- [ ] **Step 1-3:** Task 3.1 동일 패턴 적용 + 커밋
+
+### Task 3.3: addComment / addRevision / updateRevisionStatus 패치
+
+- [ ] **Step 1:** `addComment` → `comment_add` (group: memo)
+- [ ] **Step 2:** `addRevision` → `revision_add` (group: memo)
+- [ ] **Step 3:** `updateRevisionStatus(status='resolved')` → `revision_resolve` (group: memo)
+- [ ] **Step 4:** 빌드 검증 + 커밋
+
+### Task 3.4: uploadImage 패치
+
+- [ ] **Step 1:** type='storyboard' → `image_upload_storyboard` (group: etc)
+- [ ] **Step 2:** type='guide' → `image_upload_guide` (group: etc)
+- [ ] **Step 3:** 빌드 검증 + 커밋
+
+### Task 3.5: bulk RPC 호출자 패치 (supabaseService.ts)
+
+bulk_update_scene_stages / bulk_delete_scenes / bulk_update_scene_fields 호출 시 새 파라미터 (`p_user_name`, sceneLabel/episodeNumber/department 등) 전달.
+
+- [ ] **Step 1: 호출 코드 갱신 + 빌드 검증 + 커밋**
+
+---
+
+## Chunk 4: 타입 + Store + 서비스
+
+**목표:** 렌더러 측 타입, Zustand store, 서비스 래퍼, 유틸 함수를 작성한다. TDD: 유틸 함수는 단위 테스트 우선.
+
+**Files:**
+- Modify: `src/types/index.ts`
+- Modify: `src/services/supabaseService.ts`
+- Create: `src/stores/useActivityStore.ts`
+- Create: `src/components/widgets/activity/utils.ts`
+- Create: `src/components/widgets/activity/constants.ts`
+- Create: `src/components/widgets/activity/__tests__/utils.test.ts`
+
+### Task 4.1: 타입 정의
+
+- [ ] **Step 1: src/types/index.ts에 추가**
+
+```typescript
+export type ActionGroup = 'progress' | 'memo' | 'scene' | 'etc';
+export type ActionType =
+  | 'stage_lo' | 'stage_done' | 'stage_review' | 'stage_png'
+  | 'memo_update' | 'comment_add' | 'revision_add' | 'revision_resolve'
+  | 'scene_add' | 'scene_delete'
+  | 'assignee_change' | 'layout_change'
+  | 'image_upload_storyboard' | 'image_upload_guide';
+
+export interface Activity {
+  id: string;
+  userId: string;
+  userName: string;
+  actionType: ActionType;
+  actionGroup: ActionGroup;
+  sceneId: string | null;
+  sceneLabel: string | null;
+  episodeNumber: number | null;
+  department: 'bg' | 'acting' | null;
+  detail: Record<string, unknown> | null;
+  createdAt: string;
+}
+```
+
+- [ ] **Step 2: 빌드 검증 + 커밋**
+
+```bash
+npx tsc --noEmit
+git add src/types/index.ts
+git commit -m "feat(activity): Activity, ActionType, ActionGroup 타입 정의"
+```
+
+### Task 4.2: constants.ts (그룹 매핑, 컬러)
+
+- [ ] **Step 1: 작성**
+
+```typescript
+import type { ActionType, ActionGroup } from '@/types';
+
+export const ACTION_TYPE_TO_GROUP: Record<ActionType, ActionGroup> = {
+  stage_lo: 'progress', stage_done: 'progress', stage_review: 'progress', stage_png: 'progress',
+  memo_update: 'memo', comment_add: 'memo', revision_add: 'memo', revision_resolve: 'memo',
+  scene_add: 'scene', scene_delete: 'scene',
+  assignee_change: 'etc', layout_change: 'etc',
+  image_upload_storyboard: 'etc', image_upload_guide: 'etc',
+};
+
+export const ACTION_TYPE_LABEL: Record<ActionType, string> = {
+  stage_lo: 'LO 완료',
+  stage_done: '완료 진척',
+  stage_review: '검수 통과',
+  stage_png: 'PNG 마감',
+  memo_update: '메모 수정',
+  comment_add: '댓글 작성',
+  revision_add: '리비전 등록',
+  revision_resolve: '리비전 해결',
+  scene_add: '씬 추가',
+  scene_delete: '씬 삭제',
+  assignee_change: '담당자 변경',
+  layout_change: '레이아웃 변경',
+  image_upload_storyboard: '스토리보드 업로드',
+  image_upload_guide: '가이드 업로드',
+};
+
+export const ACTION_TYPE_COLOR: Record<ActionType, string> = {
+  stage_lo: '#74B9FF', stage_done: '#A29BFE', stage_review: '#FDCB6E', stage_png: '#00B894',
+  memo_update: '#FF8FA3', comment_add: '#FFA94D', revision_add: '#4DD0E1', revision_resolve: '#81ECEC',
+  scene_add: '#6FCF97', scene_delete: '#FF7675',
+  assignee_change: '#95A5A6', layout_change: '#95A5A6',
+  image_upload_storyboard: '#95A5A6', image_upload_guide: '#95A5A6',
+};
+
+export const GROUP_LABEL: Record<ActionGroup, string> = {
+  progress: '작업 진행', memo: '메모/댓글', scene: '씬 생성/삭제', etc: '기타',
+};
+
+export const GROUP_DOT_COLOR: Record<ActionGroup, string> = {
+  progress: '#74B9FF', memo: '#FF8FA3', scene: '#6FCF97', etc: '#95A5A6',
+};
+
+export const GROUP_WINDOW_MS = 5 * 60 * 1000;          // 5분
+export const PAGE_SIZE = 100;
+export const MAX_CACHED = 500;
+export const KST_TIMEZONE = 'Asia/Seoul';
+```
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add src/components/widgets/activity/constants.ts
+git commit -m "feat(activity): 상수 (그룹 매핑, 컬러, 라벨)"
+```
+
+### Task 4.3: utils.ts (TDD)
+
+- [ ] **Step 1: 실패 테스트 작성** — `src/components/widgets/activity/__tests__/utils.test.ts`
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { groupActivities, pickGoldenWindow } from '../utils';
+import type { Activity } from '@/types';
+
+const mkActivity = (overrides: Partial<Activity>): Activity => ({
+  id: Math.random().toString(),
+  userId: 'u1', userName: '한솔',
+  actionType: 'stage_lo', actionGroup: 'progress',
+  sceneId: 's1', sceneLabel: 'EP01 A씬 #1',
+  episodeNumber: 1, department: 'bg',
+  detail: {}, createdAt: '2026-04-27T10:00:00Z',
+  ...overrides,
+});
+
+describe('groupActivities', () => {
+  it('빈 배열은 빈 배열 반환', () => {
+    expect(groupActivities([])).toEqual([]);
+  });
+
+  it('5분 윈도우 안에서 같은 user/type/episode를 묶음', () => {
+    const items = [
+      mkActivity({ id: '1', createdAt: '2026-04-27T10:00:00Z' }),
+      mkActivity({ id: '2', createdAt: '2026-04-27T10:02:00Z' }),
+      mkActivity({ id: '3', createdAt: '2026-04-27T10:04:00Z' }),
+    ];
+    const result = groupActivities(items);
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('group');
+    expect(result[0].items).toHaveLength(3);
+  });
+
+  it('5분을 넘기면 다른 그룹', () => {
+    const items = [
+      mkActivity({ id: '1', createdAt: '2026-04-27T10:00:00Z' }),
+      mkActivity({ id: '2', createdAt: '2026-04-27T10:06:00Z' }),
+    ];
+    const result = groupActivities(items);
+    expect(result).toHaveLength(2);
+  });
+
+  it('단일 항목은 그룹화하지 않음', () => {
+    const items = [mkActivity({ id: '1' })];
+    const result = groupActivities(items);
+    expect(result[0].type).toBe('item');
+  });
+
+  it('다른 user는 다른 그룹', () => {
+    const items = [
+      mkActivity({ id: '1', userId: 'u1' }),
+      mkActivity({ id: '2', userId: 'u2' }),
+    ];
+    expect(groupActivities(items)).toHaveLength(2);
+  });
+});
+
+describe('pickGoldenWindow', () => {
+  it('연속 2시간 합 최대 슬롯 반환', () => {
+    const grid: number[][] = Array.from({ length: 7 }, () => Array(24).fill(0));
+    grid[1][14] = 5; grid[1][15] = 7;       // 화 14-15시 합 12
+    grid[2][10] = 8;                         // 수 10시 단독 8
+    const result = pickGoldenWindow(grid);
+    expect(result.day).toBe(1);
+    expect(result.hour).toBe(14);
+    expect(result.count).toBe(12);
+  });
+
+  it('빈 격자는 null 반환', () => {
+    const grid: number[][] = Array.from({ length: 7 }, () => Array(24).fill(0));
+    expect(pickGoldenWindow(grid)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행해서 실패 확인**
+
+```bash
+npx vitest run src/components/widgets/activity/__tests__/utils.test.ts
+```
+
+기대: FAIL (모듈 없음)
+
+- [ ] **Step 3: 구현 — `src/components/widgets/activity/utils.ts`**
+
+```typescript
+import type { Activity } from '@/types';
+import { GROUP_WINDOW_MS } from './constants';
+
+export type FeedItem =
+  | { type: 'item'; activity: Activity }
+  | { type: 'group'; key: string; items: Activity[] };
+
+export function groupActivities(items: Activity[]): FeedItem[] {
+  if (items.length === 0) return [];
+  const sorted = [...items].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  const result: FeedItem[] = [];
+  let buffer: Activity[] = [sorted[0]];
+
+  const sameGroup = (a: Activity, b: Activity) => {
+    if (a.userId !== b.userId) return false;
+    if (a.actionType !== b.actionType) return false;
+    if (a.episodeNumber !== b.episodeNumber) return false;
+    const da = new Date(a.createdAt).getTime();
+    const db = new Date(b.createdAt).getTime();
+    return Math.abs(da - db) <= GROUP_WINDOW_MS;
+  };
+
+  const flush = () => {
+    if (buffer.length === 1) {
+      result.push({ type: 'item', activity: buffer[0] });
+    } else {
+      result.push({
+        type: 'group',
+        key: `${buffer[0].userId}:${buffer[0].actionType}:${buffer[0].episodeNumber ?? 'na'}:${buffer[0].id}`,
+        items: [...buffer],
+      });
+    }
+    buffer = [];
+  };
+
+  for (let i = 1; i < sorted.length; i++) {
+    const prev = buffer[buffer.length - 1];
+    const cur = sorted[i];
+    if (sameGroup(prev, cur)) buffer.push(cur);
+    else { flush(); buffer.push(cur); }
+  }
+  flush();
+  return result;
+}
+
+export interface GoldenWindow {
+  day: number;
+  hour: number;
+  count: number;
+}
+
+export function pickGoldenWindow(grid: number[][]): GoldenWindow | null {
+  let best: GoldenWindow | null = null;
+  for (let d = 0; d < 7; d++) {
+    for (let h = 0; h < 23; h++) {
+      const sum = (grid[d]?.[h] ?? 0) + (grid[d]?.[h + 1] ?? 0);
+      if (sum === 0) continue;
+      if (!best || sum > best.count) best = { day: d, hour: h, count: sum };
+    }
+  }
+  return best;
+}
+
+export function pickGoldenHour(hourTotals: number[]): { hour: number; ratio: number } | null {
+  const total = hourTotals.reduce((a, b) => a + b, 0);
+  if (total === 0) return null;
+  let bestHour = 0, bestSum = 0;
+  for (let h = 0; h < 23; h++) {
+    const sum = hourTotals[h] + (hourTotals[h + 1] ?? 0);
+    if (sum > bestSum) { bestSum = sum; bestHour = h; }
+  }
+  return { hour: bestHour, ratio: bestSum / total };
+}
+
+export function pickGoldenDay(dayTotals: number[]): { day: number; ratio: number } | null {
+  const total = dayTotals.reduce((a, b) => a + b, 0);
+  if (total === 0) return null;
+  let bestDay = 0, bestCount = 0;
+  for (let d = 0; d < 7; d++) {
+    if (dayTotals[d] > bestCount) { bestCount = dayTotals[d]; bestDay = d; }
+  }
+  return { day: bestDay, ratio: bestCount / total };
+}
+
+export function buildHeatmapGrid(stats: Array<{ day_of_week: number; hour: number; count: number }>): number[][] {
+  const grid: number[][] = Array.from({ length: 7 }, () => Array(24).fill(0));
+  for (const s of stats) {
+    // PostgreSQL EXTRACT(dow): 0=Sunday, 1=Monday, ..., 6=Saturday
+    // 표시는 월=0..일=6 으로 정규화
+    const displayDay = (s.day_of_week + 6) % 7;
+    grid[displayDay][s.hour] = s.count;
+  }
+  return grid;
+}
+
+export function intensityLevel(count: number): 0 | 1 | 2 | 3 | 4 {
+  if (count === 0) return 0;
+  if (count <= 2) return 1;
+  if (count <= 5) return 2;
+  if (count <= 10) return 3;
+  return 4;
+}
+```
+
+- [ ] **Step 4: 테스트 실행해서 통과 확인**
+
+```bash
+npx vitest run src/components/widgets/activity/__tests__/utils.test.ts
+```
+
+기대: PASS (5 tests)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/components/widgets/activity/utils.ts src/components/widgets/activity/__tests__/utils.test.ts
+git commit -m "feat(activity): utils (groupActivities, pickGoldenWindow, intensityLevel) + tests"
+```
+
+### Task 4.4: supabaseService.ts 활동 래퍼
+
+- [ ] **Step 1: 함수 추가**
+
+```typescript
+import type { Activity, ActionGroup } from '@/types';
+
+export async function listActivities(opts: {
+  before?: string; limit?: number;
+  groups?: ActionGroup[]; department?: 'bg' | 'acting' | null;
+}): Promise<Activity[]> {
+  const res = await window.electronAPI.activityList(opts);
+  if (!res?.ok) throw new Error(res?.error || 'listActivities failed');
+  return res.rows.map(rowToActivity);
+}
+
+export async function getActivityStats(opts: {
+  days?: number; groups?: ActionGroup[]; department?: 'bg' | 'acting' | null;
+}): Promise<Array<{ day_of_week: number; hour: number; count: number }>> {
+  const res = await window.electronAPI.activityStats(opts);
+  if (!res?.ok) throw new Error(res?.error || 'getActivityStats failed');
+  return res.stats;
+}
+
+export async function backfillActivities(since: string): Promise<Activity[]> {
+  const res = await window.electronAPI.activityBackfill(since);
+  if (!res?.ok) throw new Error(res?.error || 'backfillActivities failed');
+  return res.rows.map(rowToActivity);
+}
+
+export function subscribeToActivityRealtime(cb: (activity: Activity) => void): () => void {
+  return window.electronAPI.onActivityRealtimeInsert((row: any) => cb(rowToActivity(row)));
+}
+
+function rowToActivity(row: any): Activity {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    userName: row.user_name,
+    actionType: row.action_type,
+    actionGroup: row.action_group,
+    sceneId: row.scene_id,
+    sceneLabel: row.scene_label,
+    episodeNumber: row.episode_number,
+    department: row.department,
+    detail: row.detail,
+    createdAt: row.created_at,
+  };
+}
+```
+
+- [ ] **Step 2: 빌드 검증 + 커밋**
+
+```bash
+npx tsc --noEmit
+git add src/services/supabaseService.ts
+git commit -m "feat(activity): supabaseService 활동 래퍼"
+```
+
+### Task 4.5: useActivityStore (Zustand)
+
+- [ ] **Step 1: 작성** — `src/stores/useActivityStore.ts`
+
+```typescript
+import { create } from 'zustand';
+import type { Activity, ActionGroup } from '@/types';
+import * as supabaseService from '@/services/supabaseService';
+import { useAppStore } from './useAppStore';
+import { buildHeatmapGrid } from '@/components/widgets/activity/utils';
+import { MAX_CACHED, PAGE_SIZE } from '@/components/widgets/activity/constants';
+
+const FILTERS_KEY = 'bflow_activity_filters';
+const MODE_KEY = 'bflow_activity_golden_mode';
+
+type GoldenMode = 'heatmap' | 'hour' | 'day';
+
+interface ActivityState {
+  activities: Activity[];
+  statsGrid: number[][];
+  pendingByLocalId: Map<string, string>;
+  lastSeenCreatedAt: string | null;
+  isLoading: boolean;
+  error: string | null;
+  hasMore: boolean;
+
+  filters: { groups: Set<ActionGroup> };
+  goldenMode: GoldenMode;
+
+  loadInitial(): Promise<void>;
+  loadMore(): Promise<void>;
+  loadStats(): Promise<void>;
+  backfillSince(): Promise<void>;
+  prependOptimistic(localTmpId: string, partial: Activity): void;
+  replaceTmpId(localTmpId: string, realUuid: string): void;
+  receiveRealtime(activity: Activity): void;
+  setFilter(group: ActionGroup, on: boolean): void;
+  setGoldenMode(mode: GoldenMode): void;
+}
+
+function loadFilters(): Set<ActionGroup> {
+  try {
+    const raw = localStorage.getItem(FILTERS_KEY);
+    if (raw) return new Set(JSON.parse(raw));
+  } catch {}
+  return new Set(['progress', 'memo', 'scene', 'etc']);
+}
+function saveFilters(set: Set<ActionGroup>) {
+  localStorage.setItem(FILTERS_KEY, JSON.stringify([...set]));
+}
+function loadMode(): GoldenMode {
+  return (localStorage.getItem(MODE_KEY) as GoldenMode) || 'heatmap';
+}
+
+export const useActivityStore = create<ActivityState>((set, get) => ({
+  activities: [],
+  statsGrid: Array.from({ length: 7 }, () => Array(24).fill(0)),
+  pendingByLocalId: new Map(),
+  lastSeenCreatedAt: null,
+  isLoading: false,
+  error: null,
+  hasMore: true,
+  filters: { groups: loadFilters() },
+  goldenMode: loadMode(),
+
+  async loadInitial() {
+    set({ isLoading: true, error: null });
+    try {
+      const department = useAppStore.getState().activeDepartment === 'all' ? null : useAppStore.getState().activeDepartment;
+      const rows = await supabaseService.listActivities({ limit: PAGE_SIZE, department });
+      set({
+        activities: rows,
+        lastSeenCreatedAt: rows[0]?.createdAt ?? null,
+        hasMore: rows.length === PAGE_SIZE,
+        isLoading: false,
+      });
+      await get().loadStats();
+    } catch (err: any) {
+      set({ error: String(err?.message || err), isLoading: false });
+    }
+  },
+
+  async loadMore() {
+    const { activities, hasMore, isLoading } = get();
+    if (!hasMore || isLoading) return;
+    const last = activities[activities.length - 1];
+    if (!last) return;
+    set({ isLoading: true });
+    try {
+      const department = useAppStore.getState().activeDepartment === 'all' ? null : useAppStore.getState().activeDepartment;
+      const rows = await supabaseService.listActivities({
+        before: last.createdAt, limit: PAGE_SIZE, department,
+      });
+      const sevenDaysAgo = Date.now() - 7 * 86400000;
+      const filtered = rows.filter(r => new Date(r.createdAt).getTime() >= sevenDaysAgo);
+      const merged = [...activities, ...filtered].slice(0, MAX_CACHED);
+      set({
+        activities: merged,
+        hasMore: rows.length === PAGE_SIZE && filtered.length === rows.length && merged.length < MAX_CACHED,
+        isLoading: false,
+      });
+    } catch (err: any) {
+      set({ error: String(err?.message || err), isLoading: false });
+    }
+  },
+
+  async loadStats() {
+    try {
+      const department = useAppStore.getState().activeDepartment === 'all' ? null : useAppStore.getState().activeDepartment;
+      const stats = await supabaseService.getActivityStats({ days: 7, department });
+      set({ statsGrid: buildHeatmapGrid(stats) });
+    } catch (err) {
+      console.warn('[activity] stats load failed:', err);
+    }
+  },
+
+  async backfillSince() {
+    const since = get().lastSeenCreatedAt;
+    if (!since) { await get().loadInitial(); return; }
+    try {
+      const rows = await supabaseService.backfillActivities(since);
+      for (const r of rows) get().receiveRealtime(r);
+      await get().loadStats();
+    } catch (err) {
+      console.warn('[activity] backfill failed:', err);
+    }
+  },
+
+  prependOptimistic(localTmpId, partial) {
+    set(s => ({
+      activities: [partial, ...s.activities].slice(0, MAX_CACHED),
+      pendingByLocalId: new Map(s.pendingByLocalId).set(localTmpId, partial.id),
+    }));
+  },
+
+  replaceTmpId(localTmpId, realUuid) {
+    set(s => {
+      const tmpUuid = s.pendingByLocalId.get(localTmpId);
+      if (!tmpUuid) return s;
+      const newMap = new Map(s.pendingByLocalId);
+      newMap.delete(localTmpId);
+      newMap.set(localTmpId, realUuid);
+      return {
+        pendingByLocalId: newMap,
+        activities: s.activities.map(a => a.id === tmpUuid ? { ...a, id: realUuid } : a),
+      };
+    });
+  },
+
+  receiveRealtime(activity) {
+    set(s => {
+      // 1) UUID 일치 → 무시
+      if (s.activities.some(a => a.id === activity.id)) return s;
+      // 2) 임시→진짜 매핑 일치 → 무시 (이미 replaceTmpId에서 처리됨)
+      // 3) 소프트 키 폴백: 본인 + 같은 type/scene + 5초 이내
+      const myId = useAppStore.getState().currentUser?.id;
+      if (activity.userId === myId) {
+        const fiveSecAgo = Date.now() - 5000;
+        const match = s.activities.find(a =>
+          a.id.startsWith('tmp_') &&
+          a.userId === activity.userId &&
+          a.actionType === activity.actionType &&
+          a.sceneId === activity.sceneId &&
+          new Date(a.createdAt).getTime() >= fiveSecAgo
+        );
+        if (match) {
+          return {
+            activities: s.activities.map(a => a.id === match.id ? activity : a),
+          };
+        }
+      }
+      // 신규 prepend
+      return {
+        activities: [activity, ...s.activities].slice(0, MAX_CACHED),
+        lastSeenCreatedAt: activity.createdAt,
+        statsGrid: incrementGrid(s.statsGrid, activity.createdAt),
+      };
+    });
+  },
+
+  setFilter(group, on) {
+    const next = new Set(get().filters.groups);
+    if (on) next.add(group); else next.delete(group);
+    saveFilters(next);
+    set({ filters: { groups: next } });
+  },
+
+  setGoldenMode(mode) {
+    localStorage.setItem(MODE_KEY, mode);
+    set({ goldenMode: mode });
+  },
+}));
+
+function incrementGrid(grid: number[][], createdAt: string): number[][] {
+  const dt = new Date(createdAt);
+  const kst = new Date(dt.toLocaleString('en-US', { timeZone: 'Asia/Seoul' }));
+  const d = (kst.getDay() + 6) % 7;          // 월=0..일=6
+  const h = kst.getHours();
+  const next = grid.map(row => [...row]);
+  next[d][h] += 1;
+  return next;
+}
+```
+
+- [ ] **Step 2: 빌드 검증 + 커밋**
+
+```bash
+npx tsc --noEmit
+git add src/stores/useActivityStore.ts
+git commit -m "feat(activity): useActivityStore Zustand 스토어"
+```
+
+---
+
+## Chunk 5: UI 컴포넌트
+
+**목표:** 위젯 본체 + 히트맵 + 막대 차트 + 피드 + 필터칩 + 툴팁 컴포넌트를 작성. 시안([final.html](../specs/mockups/2026-04-27-recent-activity-widget/final.html))의 스타일을 Tailwind로 옮긴다.
+
+**Files:**
+- Create: `src/components/widgets/activity/GoldenHeatmap.tsx`
+- Create: `src/components/widgets/activity/GoldenBarChart.tsx`
+- Create: `src/components/widgets/activity/ActivityFeed.tsx`
+- Create: `src/components/widgets/activity/ActivityFilterChips.tsx`
+- Create: `src/components/widgets/activity/ActivityTooltip.tsx`
+- Create: `src/components/widgets/RecentActivityWidget.tsx`
+
+### Task 5.1: GoldenHeatmap.tsx
+
+- [ ] **Step 1: 컴포넌트 작성** — 시안의 24×7 격자, 색 강도, 호버 툴팁
+
+```typescript
+import { intensityLevel } from './utils';
+import { useActivityStore } from '@/stores/useActivityStore';
+
+const DAYS = ['월', '화', '수', '목', '금', '토', '일'];
+
+export function GoldenHeatmap({ onCellHover }: { onCellHover: (cell: { day: number; hour: number; count: number; x: number; y: number } | null) => void }) {
+  const grid = useActivityStore(s => s.statsGrid);
+  return (
+    <div className="grid gap-[2px]" style={{ gridTemplateColumns: '22px repeat(24, 1fr)' }}>
+      <div></div>
+      {Array.from({ length: 24 }, (_, h) => (
+        <div key={h} className="text-[9px] text-text-secondary/50 text-center">
+          {[0, 6, 12, 18].includes(h) ? h : ''}
+        </div>
+      ))}
+      {DAYS.map((day, d) => (
+        <FragmentRow key={day} day={day} dayIdx={d} row={grid[d]} onCellHover={onCellHover} />
+      ))}
+    </div>
+  );
+}
+
+function FragmentRow({ day, dayIdx, row, onCellHover }: any) {
+  return (
+    <>
+      <div className="text-[10px] text-text-secondary text-right pr-1.5">{day}</div>
+      {row.map((count: number, h: number) => {
+        const lv = intensityLevel(count);
+        const bg = ['rgba(108,92,231,0.06)', 'rgba(108,92,231,0.18)', 'rgba(108,92,231,0.36)', 'rgba(108,92,231,0.58)', 'rgba(108,92,231,0.85)'][lv];
+        return (
+          <div
+            key={h}
+            className="aspect-square rounded-[2px] cursor-pointer transition-transform hover:scale-[1.4] hover:z-10 hover:relative"
+            style={{ background: bg, ...(lv === 4 ? { boxShadow: '0 0 8px rgba(108,92,231,0.3)' } : {}) }}
+            onMouseEnter={(e) => onCellHover({ day: dayIdx, hour: h, count, x: e.clientX, y: e.clientY })}
+            onMouseLeave={() => onCellHover(null)}
+          />
+        );
+      })}
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: 빌드 검증 + 커밋**
+
+### Task 5.2: GoldenBarChart.tsx (시간대 + 요일 두 모드)
+
+- [ ] **Step 1: 작성** — `props.mode: 'hour' | 'day'`로 분기
+
+(코드 생략 — 시안의 `.bar-chart` / `.bar-chart-week` 패턴 동일)
+
+- [ ] **Step 2: 빌드 검증 + 커밋**
+
+### Task 5.3: ActivityFilterChips.tsx
+
+- [ ] **Step 1: 작성** — 4개 칩 + "전체" 칩
+
+(코드 생략 — 시안 `.chip` 패턴)
+
+- [ ] **Step 2: 빌드 검증 + 커밋**
+
+### Task 5.4: ActivityFeed.tsx
+
+- [ ] **Step 1: 작성** — `groupActivities` 활용, 본인 보더 강조, Framer Motion prepend 애니메이션
+
+```typescript
+import { motion, AnimatePresence } from 'framer-motion';
+import { useActivityStore } from '@/stores/useActivityStore';
+import { useAppStore } from '@/stores/useAppStore';
+import { groupActivities } from './utils';
+import { ACTION_TYPE_LABEL, ACTION_TYPE_COLOR } from './constants';
+// ... (시안 패턴 그대로 적용)
+```
+
+- [ ] **Step 2: 빌드 검증 + 커밋**
+
+### Task 5.5: ActivityTooltip.tsx (글로벌)
+
+- [ ] **Step 1: 작성** — fixed position, mouse follow, breakdown 표시
+
+- [ ] **Step 2: 빌드 검증 + 커밋**
+
+### Task 5.6: RecentActivityWidget.tsx (메인)
+
+- [ ] **Step 1: 작성** — Widget 베이스 + 헤더(모드 토글/필터/팝아웃) + 인사이트 + 골든타임 + 칩 + 피드
+
+```typescript
+import { useEffect } from 'react';
+import { Widget } from './Widget';
+import { Activity } from 'lucide-react';
+import { useActivityStore } from '@/stores/useActivityStore';
+import { GoldenHeatmap } from './activity/GoldenHeatmap';
+import { GoldenBarChart } from './activity/GoldenBarChart';
+import { ActivityFeed } from './activity/ActivityFeed';
+import { ActivityFilterChips } from './activity/ActivityFilterChips';
+import { ActivityTooltip } from './activity/ActivityTooltip';
+import { pickGoldenWindow, pickGoldenHour, pickGoldenDay } from './activity/utils';
+import { subscribeToActivityRealtime } from '@/services/supabaseService';
+
+export function RecentActivityWidget() {
+  const { goldenMode, setGoldenMode, statsGrid, loadInitial, receiveRealtime, backfillSince } = useActivityStore();
+
+  useEffect(() => {
+    loadInitial();
+    const unsub = subscribeToActivityRealtime(receiveRealtime);
+    // 재연결 감지 (useAppStore.dataConnected 변경 watch — 별도 useEffect)
+    return () => unsub();
+  }, []);
+
+  // 인사이트 산출
+  const insight = computeInsight(goldenMode, statsGrid);
+
+  return (
+    <Widget title="최근 작업" icon={<Activity size={14} />}>
+      <ModeToggle mode={goldenMode} onChange={setGoldenMode} />
+      <InsightBanner text={insight} />
+      {goldenMode === 'heatmap' && <GoldenHeatmap />}
+      {goldenMode === 'hour' && <GoldenBarChart mode="hour" />}
+      {goldenMode === 'day' && <GoldenBarChart mode="day" />}
+      <ActivityFilterChips />
+      <ActivityFeed />
+      <ActivityTooltip />
+    </Widget>
+  );
+}
+```
+
+- [ ] **Step 2: 빌드 검증 + 커밋**
+
+---
+
+## Chunk 6: 위젯 등록 + 모니터링 + 빌드 검증
+
+**목표:** Dashboard.tsx에 위젯 등록, SettingsView에 모니터링 라인, 전체 빌드 + 수동 테스트.
+
+**Files:**
+- Modify: `src/views/Dashboard.tsx`
+- Modify: `src/views/SettingsView.tsx`
+- Create: `src/components/settings/ActivityStorageInfo.tsx`
+
+### Task 6.1: Dashboard.tsx에 위젯 등록
+
+- [ ] **Step 1: import + WIDGET_NAMES + 디폴트 레이아웃**
+- [ ] **Step 2: 위젯 추가 메뉴에 항목 추가**
+- [ ] **Step 3: 빌드 검증 + 커밋**
+
+### Task 6.2: SettingsView.tsx에 모니터링 추가
+
+- [ ] **Step 1: ActivityStorageInfo 컴포넌트 작성** — RPC 1회 호출로 count + size 표시
+
+```typescript
+export function ActivityStorageInfo() {
+  const [info, setInfo] = useState<{ count: number; sizeMB: number } | null>(null);
+  useEffect(() => {
+    window.electronAPI.activityStorageInfo?.().then(setInfo);
+  }, []);
+  if (!info) return null;
+  return (
+    <div className="text-xs text-text-secondary">
+      활동 기록: {info.count.toLocaleString()}건 · 약 {info.sizeMB.toFixed(1)} MB · 1년 후 자동 정리
+    </div>
+  );
+}
+```
+
+(IPC `activity:storage-info` 핸들러도 추가 — `SELECT count(*), pg_total_relation_size('activity_log')`)
+
+- [ ] **Step 2: SettingsView에서 사용 + 빌드 검증 + 커밋**
+
+### Task 6.3: 전체 빌드 + 수동 테스트
+
+- [ ] **Step 1:** `npx tsc --noEmit` 통과
+- [ ] **Step 2:** `npx vite build` 통과
+- [ ] **Step 3:** `npx vitest run` 통과 (모든 단위 테스트)
+- [ ] **Step 4: 수동 검증 체크리스트** (스펙 §9.2 참조)
+  - [ ] 두 윈도우 동시 토글 → 활동 1번씩만 보임 (중복 없음)
+  - [ ] 본인 토글 → 즉시 피드 최상단 (보더 강조)
+  - [ ] 다른 사용자 토글 → ~100ms 후 피드 최상단
+  - [ ] 필터 칩 토글 → 피드 + 히트맵 동시 갱신
+  - [ ] 그래프 모드 전환 → 인사이트 텍스트 변경
+  - [ ] 그룹화 5건 펼침/접기
+  - [ ] 호버 툴팁 표시
+  - [ ] 빈 상태 → 첫 활동 흐름
+  - [ ] 오프라인 진입 → 헤더 점, 재연결 backfill
+  - [ ] 위젯 클릭 → 씬 모달 열림
+
+- [ ] **Step 5: 최종 커밋**
+
+```bash
+git commit -m "feat: 최근 작업 위젯 v1 출시 (활동 피드 + 골든타임 분석)"
+```
+
+---
+
+## 완료 기준
+
+- [ ] DB 마이그레이션 실행 완료 (`activity_log` 테이블 + RPC + cron)
+- [ ] 모든 mutation 호출에 활동 기록 추가 + Realtime 동작 확인
+- [ ] 위젯이 Dashboard에 표시되고 4가지 시안 요소(헤더/인사이트/골든타임/필터/피드) 모두 동작
+- [ ] 단위 테스트 + 통합 수동 테스트 모두 통과
+- [ ] `tsc --noEmit` + `vite build` 통과
+- [ ] PR 머지 후 v1.14.0 태그

--- a/docs/superpowers/specs/2026-04-27-gpath-link-design.md
+++ b/docs/superpowers/specs/2026-04-27-gpath-link-design.md
@@ -39,8 +39,13 @@
 
 ### 3.1 `src/utils/pathLink.ts` (신규)
 
+**중요**: 정규식은 단일 상수로 정의해 `tokenizeGPaths` / `PathLinkMark.addInputRules` / `PathLinkMark.addPasteRules` 4곳이 **모두 동일 패턴 사용**. 정규식이 어긋나면 4곳 인식 결과가 분기되어 일관성 깨짐.
+
 ```typescript
-const G_PATH_REGEX = /G:\\[^\s\n]*/g;
+/** G:\ 경로 인식 정규식 — 4곳에서 공유 */
+export const G_PATH_REGEX_GLOBAL = /G:\\[^\s\n]+/g;
+export const G_PATH_REGEX_INPUT_RULE = /(G:\\[^\s\n]+)\s$/;     // 공백 입력 시 mark 적용 (캡처 그룹 1만 mark)
+export const G_PATH_REGEX_PASTE_RULE = /G:\\[^\s\n]+/g;
 
 export interface PathToken {
   type: 'text' | 'path';
@@ -52,7 +57,7 @@ export function tokenizeGPaths(text: string): PathToken[] {
   if (!text) return [];
   const tokens: PathToken[] = [];
   let lastIdx = 0;
-  for (const match of text.matchAll(G_PATH_REGEX)) {
+  for (const match of text.matchAll(G_PATH_REGEX_GLOBAL)) {
     if (match.index === undefined) continue;
     if (match.index > lastIdx) {
       tokens.push({ type: 'text', content: text.slice(lastIdx, match.index) });
@@ -82,7 +87,8 @@ import { FolderOpen } from 'lucide-react';
 
 interface PathBadgeProps {
   path: string;
-  resolved?: boolean;     // 리비전용 옵션 (회색 처리). 기본 false → 청색
+  /** CompositingView 전용 — 해결된 리비전 경로 회색 처리. 메모/댓글/메모위젯 사용처에선 항상 false. */
+  resolved?: boolean;
   className?: string;
 }
 
@@ -144,8 +150,8 @@ export function PathLinkifiedText({ text, renderTextSegment }: Props) {
 `UnifiedSceneDetailModal.tsx:635`의 `InlineTextareaRow` 컴포넌트 내부에서 표시 모드일 때 `<PathLinkifiedText>` 사용. 편집 모드는 그대로 textarea (raw 입력).
 
 ```typescript
-// 표시 모드
-<div onClick={enterEditMode}>
+// 표시 모드 — min-height로 빈 placeholder 클릭 영역 확보 (기존 패딩과 동일)
+<div onClick={enterEditMode} className="min-h-[1.5em] cursor-pointer ...">
   {value ? <PathLinkifiedText text={value} /> : <span className="text-muted">메모 추가...</span>}
 </div>
 
@@ -155,21 +161,34 @@ export function PathLinkifiedText({ text, renderTextSegment }: Props) {
 
 ### 4.2 댓글 — `CommentPanel.renderText`
 
-기존 `renderText(text)` 함수가 @멘션 split만 처리. 이걸 G:\ 변환 + @멘션 변환의 합성으로 바꿈.
+기존 `renderText(text)` 함수가 @멘션 split만 처리. 이걸 G:\ 변환 + @멘션 변환의 합성으로 바꾸되, **기존 멘션 처리 로직은 정확히 보존**해야 한다 (users 매칭 + handleMentionClick 호출 + 미매칭 폴백):
 
 ```typescript
-const renderText = (text: string) => (
-  <PathLinkifiedText
-    text={text}
-    renderTextSegment={(segment, baseIdx) =>
-      // 기존 @멘션 split 로직을 segment에 적용
-      segment.split(/(@\S+)/g).map((part, i) =>
-        part.startsWith('@')
-          ? <MentionChip key={`${baseIdx}-${i}`} mention={part} />
-          : part
-      )
+// 기존 멘션 처리 로직을 inner 함수로 추출 — 동작 동일
+const renderMentionInSegment = (segment: string, baseIdx: number) =>
+  segment.split(/(@\S+)/g).map((part, i) => {
+    const key = `${baseIdx}-${i}`;
+    if (part.startsWith('@')) {
+      const name = part.slice(1);
+      const isUser = users.some(u => u.name === name);
+      if (isUser) {
+        return (
+          <span
+            key={key}
+            className="text-accent font-bold bg-accent/10 rounded px-0.5 cursor-pointer hover:bg-accent/20 transition-colors"
+            onClick={() => handleMentionClick(name)}
+            title={`${name} 팀원 보기`}
+          >
+            {part}
+          </span>
+        );
+      }
     }
-  />
+    return <span key={key}>{part}</span>;
+  });
+
+const renderText = (text: string) => (
+  <PathLinkifiedText text={text} renderTextSegment={renderMentionInSegment} />
 );
 ```
 
@@ -185,6 +204,7 @@ const renderText = (text: string) => (
 
 ```typescript
 import { Mark, markInputRule, markPasteRule } from '@tiptap/core';
+import { G_PATH_REGEX_INPUT_RULE, G_PATH_REGEX_PASTE_RULE } from '@/utils/pathLink';
 
 export const PathLinkMark = Mark.create({
   name: 'pathLink',
@@ -203,10 +223,19 @@ export const PathLinkMark = Mark.create({
       title: `${mark.attrs.href}\n(클릭하면 파일탐색기에서 열기)`,
     }, 0];
   },
+  /** tiptap-markdown 직렬화 — mark는 raw 텍스트로 풀고, 재로드 시 PasteRule이 다시 인식 */
+  addStorage() {
+    return {
+      markdown: {
+        serialize: { open: '', close: '', mixable: true, expelEnclosingWhitespace: true },
+        parse: { setup: () => {} },
+      },
+    };
+  },
   addInputRules() {
     return [
       markInputRule({
-        find: /(G:\\[^\s]+)\s$/,                        // 경로 + 공백 입력 순간 mark 적용
+        find: G_PATH_REGEX_INPUT_RULE,                  // (G:\\…)\s$ — 캡처 그룹 1만 mark
         type: this.type,
         getAttributes: (match) => ({ href: match[1] }),
       }),
@@ -215,7 +244,7 @@ export const PathLinkMark = Mark.create({
   addPasteRules() {
     return [
       markPasteRule({
-        find: /G:\\[^\s\n]+/g,
+        find: G_PATH_REGEX_PASTE_RULE,
         type: this.type,
         getAttributes: (match) => ({ href: match[0] }),
       }),
@@ -224,12 +253,15 @@ export const PathLinkMark = Mark.create({
 });
 ```
 
+> **Markdown round-trip 결정**: PathLinkMark는 `addStorage().markdown`에서 **빈 open/close**로 직렬화 → 저장된 Markdown엔 raw `G:\\` 경로만 남음. 재로드 시 PasteRule이 다시 mark를 입힘 → 시각적 round-trip 보장. `BflowUnderline`(`markdownExtensions.ts`) 패턴과 동일.
+
 `MemoEditor.tsx`에 등록:
 ```typescript
 extensions: [...existing, PathLinkMark]
 ```
 
-CSS (`src/styles/memo-editor.css` 또는 동급):
+**CSS — 신규 파일 `src/styles/path-link.css`** + `src/main.tsx`(또는 `src/index.css`)에서 import:
+
 ```css
 .path-link-mark {
   display: inline-flex;
@@ -245,7 +277,14 @@ CSS (`src/styles/memo-editor.css` 또는 동급):
   cursor: pointer;
 }
 .path-link-mark:hover { filter: brightness(1.25); }
+.path-link-mark::before {
+  content: '';
+  display: inline-block; width: 10px; height: 10px;
+  background-image: url('data:image/svg+xml;utf8,<svg ...FolderOpen 10px SVG...>');
+}
 ```
+
+> **아이콘 일관성**: PathBadge(React)에는 lucide `<FolderOpen size={10}>`, TipTap mark는 CSS `::before`로 SVG data-URI. 색상 토큰(`#74B9FF`, alpha 0.1/0.2)은 두 곳에 중복 등장하지만, 본 v1에선 코드 가독성을 위해 변수화 안 함. v2에서 `--path-link-fg` 등 CSS 변수로 추출 가능.
 
 클릭 핸들러는 `MemoEditor.tsx`의 `editorProps.handleClickOn`에 추가:
 ```typescript
@@ -255,11 +294,13 @@ handleClickOn(view, pos, node, nodePos, event) {
   if (linkEl) {
     event.preventDefault();
     window.electronAPI?.shellShowItem?.(linkEl.dataset.pathLink ?? '');
-    return true;
+    return true;                   // selection 이동 차단 → BubbleMenu 미발생
   }
   return false;
 }
 ```
+
+> **BubbleMenu 충돌**: `MemoLinkBubble`은 link mark에서만 활성. PathLinkMark는 별도 mark이므로 LinkBubble 자동 트리거 안 됨. 다만 PathLink 클릭 시 selection이 이동하지 않도록 `return true`로 차단해 BubbleMenu가 잘못 뜨지 않도록 보장.
 
 ---
 
@@ -269,11 +310,13 @@ handleClickOn(view, pos, node, nodePos, event) {
 |---|---|
 | 빈 메모/댓글 | tokenizeGPaths가 [] 반환 → 빈 렌더 |
 | `G:\` 단독 (경로 없음) | 정규식 매치 안 됨 (`[^\s\n]*` 0길이 매치는 가능하지만 `\s`/`\n` 종결 필요한 컨텍스트로 발생 안 함) |
-| 한글 경로 (`G:\공유 드라이브\...`) | OK — 정규식이 `\s`/`\n`만 종결자. 공백 포함되면 거기서 끊김 (파일명에 공백이 있으면 사용자가 따옴표 등을 쓰지 않는 한 짧게 끊김 — 이는 의도된 한계) |
+| 한글 경로 (`G:\공유 드라이브\...`) | OK — 정규식이 `\s`/`\n`만 종결자. **공백 포함 경로는 첫 공백에서 끊김** (의도된 한계). 사용자가 공백 포함 경로를 정확히 표시하려면 `G:\\공유 드라이브\\...` 처럼 non-breaking space 등을 사용하거나, 짧게 끊긴 경로를 클릭해도 `shell:show-item`이 상위 폴더로 폴백하므로 사용성 OK |
 | 매우 긴 경로 | PathBadge에서 `shortenPath`로 마지막 segment만 표시. 풀 경로는 툴팁(title) |
 | 잘못된 형식·없는 파일 | `shell:show-item`이 자체 처리 — 파일/폴더 없으면 상위 폴더 시도, 그것도 없으면 무음 (현재 동작 그대로) |
 | URL과 충돌 | `G:\`는 URL이 아니라 충돌 없음. http(s) 메모 링크는 `MemoLinkBubble`이 별도 처리 |
 | TipTap 클릭 vs Drag-Select | `handleClickOn`은 click 한정, 드래그 선택은 영향 없음 |
+| PathLink 클릭 → BubbleMenu 오작동 | `handleClickOn`이 `return true`로 selection 이동 차단해 LinkBubble 자동 트리거 안 됨 (검증 항목) |
+| Markdown round-trip | `addStorage().markdown` open/close 빈 문자열 → 저장 시 mark 풀림, 재로드 시 PasteRule이 다시 입힘 (시각적 round-trip 보장) |
 | 메모 위젯 raw 모드 | 현재 메모 위젯은 WYSIWYG만 — raw 모드 없음 (Mark가 항상 활성) |
 | 편집 중 textarea (씬 메모/댓글) | 의도된 동작 — 편집 시 raw 텍스트, 저장 후 표시만 변환 |
 
@@ -281,7 +324,9 @@ handleClickOn(view, pos, node, nodePos, event) {
 
 ## 6. 테스트 전략
 
-### 6.1 단위 테스트 — `src/utils/__tests__/pathLink.test.ts` (신규)
+### 6.1 단위 테스트
+
+**`src/utils/__tests__/pathLink.test.ts`** (신규):
 
 ```typescript
 describe('tokenizeGPaths', () => {
@@ -302,6 +347,55 @@ describe('shortenPath', () => {
 });
 ```
 
+**`src/components/common/__tests__/PathLinkifiedText.test.tsx`** (신규):
+
+```typescript
+import { render } from '@testing-library/react';
+import { PathLinkifiedText } from '../PathLinkifiedText';
+
+describe('PathLinkifiedText', () => {
+  it('경로 없는 텍스트는 그대로 렌더', () => {
+    const { container } = render(<PathLinkifiedText text="안녕하세요" />);
+    expect(container).toHaveTextContent('안녕하세요');
+    expect(container.querySelectorAll('button')).toHaveLength(0);
+  });
+
+  it('G:\\ 경로는 button (PathBadge)으로 렌더', () => {
+    const { container } = render(<PathLinkifiedText text="확인 G:\\test\\file.png 부탁" />);
+    expect(container.querySelectorAll('button')).toHaveLength(1);
+    expect(container.querySelector('button')).toHaveAttribute('title');
+  });
+
+  it('renderTextSegment로 추가 변환 합성 가능 (예: 멘션)', () => {
+    const { container } = render(
+      <PathLinkifiedText
+        text="@한솔 G:\\file"
+        renderTextSegment={(seg, i) =>
+          seg.split(/(@\S+)/g).map((p, j) =>
+            p.startsWith('@')
+              ? <span key={`${i}-${j}`} data-mention={p.slice(1)}>{p}</span>
+              : p
+          )
+        }
+      />
+    );
+    expect(container.querySelector('[data-mention="한솔"]')).toBeTruthy();
+    expect(container.querySelectorAll('button')).toHaveLength(1);
+  });
+});
+```
+
+**`src/components/widgets/memo/extensions/__tests__/PathLinkMark.test.ts`** (신규):
+
+```typescript
+// TipTap Editor를 headless 모드로 띄우고 markdown round-trip 검증
+describe('PathLinkMark', () => {
+  it('PasteRule이 G:\\ 경로를 mark로 변환', () => { ... });
+  it('Markdown round-trip — 저장된 raw 텍스트가 재로드 시 다시 mark 적용', () => { ... });
+  it('InputRule — typing G:\\foo + 공백 → mark 적용', () => { ... });
+});
+```
+
 ### 6.2 수동 검증
 
 - [ ] 씬 모달에서 메모에 `G:\공유 드라이브\test.png` 입력·저장 → PathBadge 표시 → 클릭 → 파일탐색기 열림
@@ -309,6 +403,9 @@ describe('shortenPath', () => {
 - [ ] 메모 위젯에 G:\ 입력 후 공백 → 즉시 청색 PathBadge로 변환
 - [ ] 메모 위젯에 G:\ 경로 붙여넣기 → 자동 변환
 - [ ] 리비전(CompositingView)에서 PathBadge 외관·동작 변경 없이 그대로 (회귀 테스트)
+- [ ] PathLink 클릭 시 LinkBubble이 잘못 뜨지 않음
+- [ ] 메모 위젯에 G:\ 입력 → 저장 → 앱 재시작 → 여전히 PathBadge 표시 (Markdown round-trip)
+- [ ] 빈 메모 표시 모드 클릭 시 편집 모드 진입 (placeholder 클릭 영역 보장)
 
 ### 6.3 빌드 검증
 

--- a/docs/superpowers/specs/2026-04-27-gpath-link-design.md
+++ b/docs/superpowers/specs/2026-04-27-gpath-link-design.md
@@ -1,0 +1,358 @@
+# 메모/댓글/메모위젯에 G:\ 경로 자동 링크화
+
+- 작성일: 2026-04-27
+- 브랜치: `claude/trusting-blackwell-722ea1`
+- 대상 범위: 씬 상세 모달의 메모 + 댓글 + 메모 위젯(TipTap)에 `G:\\` 경로 자동 링크화. 기존 리비전 패턴(CompositingView)을 **공용 컴포넌트로 통합**하고 4곳에서 재사용.
+- PR 단위: **단일 PR**
+- 핵심 원칙: **UI 일관성 + DRY** — 한 곳에서 정의(`PathBadge`)하고 모든 위치가 import해서 사용. 디자인이나 동작 변경 시 한 파일만 수정하면 전체 일괄 적용.
+
+---
+
+## 1. 배경 & 목적
+
+리비전(`CompositingView`)에서는 이미 `G:\\`로 시작하는 경로가 클릭 가능한 PathBadge로 표시되어 파일 탐색기에서 바로 열 수 있다. 같은 기능이 **씬 상세 모달의 메모·댓글·메모 위젯**에도 필요하다. 사용자(한솔)가 작업 지시를 메모/댓글에 남길 때 공유 드라이브 경로(`G:\공유 드라이브\...`)를 입력하면 클릭 한 번으로 해당 위치를 열 수 있도록 한다.
+
+### 일관성·유지보수 요구사항 (한솔 강조)
+
+- **시각 일관성**: 4곳(리비전/씬 메모/댓글/메모 위젯) 모두 동일한 PathBadge 외관
+- **코드 통일**: 동일 컴포넌트·유틸 재사용. CompositingView의 기존 PathBadge도 공용 컴포넌트로 갈아끼움
+- **유지보수**: 한 파일 수정으로 모든 위치 일괄 변경 가능
+
+---
+
+## 2. 결정한 디자인 (요약)
+
+| 결정 | 값 |
+|---|---|
+| 변환 방식 | **인라인 토큰** — 텍스트 흐름 안에서 경로만 PathBadge로 교체 |
+| 적용 위치 | 씬 메모 + 댓글 + **메모 위젯(TipTap)** + (리팩토링) 리비전 |
+| 드라이브 형식 | **G:\\ 전용** (정규식 `/G:\\[^\s\n]*/g`) |
+| 공용 위치 | `src/components/common/PathBadge.tsx`, `src/utils/pathLink.ts` |
+| 기존 PathBadge 처리 | CompositingView의 인라인 PathBadge를 삭제하고 공용 컴포넌트 import |
+| 클릭 동작 | `window.electronAPI.shellShowItem(path)` — 기존 IPC `shell:show-item` 재사용 |
+| 편집 vs 표시 | 편집 모드는 raw text, 표시 모드만 변환 (textarea 기반). TipTap은 WYSIWYG으로 편집 중에도 변환 |
+| TipTap 기법 | 커스텀 Mark `pathLink` + InputRule + PasteRule (PR 검토에서 Decoration 검토 가능) |
+
+---
+
+## 3. 공용 모듈
+
+### 3.1 `src/utils/pathLink.ts` (신규)
+
+```typescript
+const G_PATH_REGEX = /G:\\[^\s\n]*/g;
+
+export interface PathToken {
+  type: 'text' | 'path';
+  content: string;
+}
+
+/** 텍스트를 [text, path, text, path, ...] 토큰 배열로 분리 */
+export function tokenizeGPaths(text: string): PathToken[] {
+  if (!text) return [];
+  const tokens: PathToken[] = [];
+  let lastIdx = 0;
+  for (const match of text.matchAll(G_PATH_REGEX)) {
+    if (match.index === undefined) continue;
+    if (match.index > lastIdx) {
+      tokens.push({ type: 'text', content: text.slice(lastIdx, match.index) });
+    }
+    tokens.push({ type: 'path', content: match[0] });
+    lastIdx = match.index + match[0].length;
+  }
+  if (lastIdx < text.length) {
+    tokens.push({ type: 'text', content: text.slice(lastIdx) });
+  }
+  return tokens;
+}
+
+/** 경로의 마지막 segment만 표시용으로 추출 */
+export function shortenPath(fullPath: string): string {
+  const segs = fullPath.replace(/\\/g, '/').split('/').filter(Boolean);
+  return segs[segs.length - 1] || fullPath;
+}
+```
+
+### 3.2 `src/components/common/PathBadge.tsx` (신규)
+
+CompositingView의 기존 PathBadge를 그대로 추출. props는 단순화.
+
+```typescript
+import { FolderOpen } from 'lucide-react';
+
+interface PathBadgeProps {
+  path: string;
+  resolved?: boolean;     // 리비전용 옵션 (회색 처리). 기본 false → 청색
+  className?: string;
+}
+
+export function PathBadge({ path, resolved, className }: PathBadgeProps) {
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    window.electronAPI?.shellShowItem?.(path);
+  };
+  return (
+    <button
+      onClick={handleClick}
+      className={`inline-flex items-center gap-1 text-[11px] font-mono rounded px-1.5 py-0.5 max-w-full cursor-pointer transition-all hover:brightness-125 ${className ?? ''}`}
+      style={resolved
+        ? { color: '#6B7280', backgroundColor: 'rgba(107, 114, 128, 0.1)', border: '1px solid rgba(107, 114, 128, 0.2)' }
+        : { color: '#74B9FF', backgroundColor: 'rgba(116, 185, 255, 0.1)', border: '1px solid rgba(116, 185, 255, 0.2)' }
+      }
+      title={`${path}\n(클릭하면 파일탐색기에서 열기)`}
+    >
+      <FolderOpen size={10} className="shrink-0" />
+      <span className="truncate">{shortenPath(path)}</span>
+    </button>
+  );
+}
+```
+
+### 3.3 `src/components/common/PathLinkifiedText.tsx` (신규)
+
+```typescript
+import { Fragment, type ReactNode } from 'react';
+import { tokenizeGPaths } from '@/utils/pathLink';
+import { PathBadge } from './PathBadge';
+
+interface Props {
+  text: string;
+  /** 텍스트 세그먼트 추가 변환 (예: 댓글의 @멘션 처리) */
+  renderTextSegment?: (segment: string, idx: number) => ReactNode;
+}
+
+export function PathLinkifiedText({ text, renderTextSegment }: Props) {
+  const tokens = tokenizeGPaths(text);
+  return (
+    <>
+      {tokens.map((tok, i) =>
+        tok.type === 'path'
+          ? <PathBadge key={`p${i}`} path={tok.content} />
+          : <Fragment key={`t${i}`}>{renderTextSegment ? renderTextSegment(tok.content, i) : tok.content}</Fragment>
+      )}
+    </>
+  );
+}
+```
+
+---
+
+## 4. 적용 위치
+
+### 4.1 씬 메모 — `InlineTextareaRow`
+
+`UnifiedSceneDetailModal.tsx:635`의 `InlineTextareaRow` 컴포넌트 내부에서 표시 모드일 때 `<PathLinkifiedText>` 사용. 편집 모드는 그대로 textarea (raw 입력).
+
+```typescript
+// 표시 모드
+<div onClick={enterEditMode}>
+  {value ? <PathLinkifiedText text={value} /> : <span className="text-muted">메모 추가...</span>}
+</div>
+
+// 편집 모드 (변경 없음)
+<textarea ... />
+```
+
+### 4.2 댓글 — `CommentPanel.renderText`
+
+기존 `renderText(text)` 함수가 @멘션 split만 처리. 이걸 G:\ 변환 + @멘션 변환의 합성으로 바꿈.
+
+```typescript
+const renderText = (text: string) => (
+  <PathLinkifiedText
+    text={text}
+    renderTextSegment={(segment, baseIdx) =>
+      // 기존 @멘션 split 로직을 segment에 적용
+      segment.split(/(@\S+)/g).map((part, i) =>
+        part.startsWith('@')
+          ? <MentionChip key={`${baseIdx}-${i}`} mention={part} />
+          : part
+      )
+    }
+  />
+);
+```
+
+@멘션과 G:\ 경로가 한 텍스트 안에 같이 있어도 둘 다 정상 인식 (정규식이 겹치지 않음).
+
+### 4.3 리비전 — 기존 PathBadge 갈아끼기 (DRY)
+
+`CompositingView.tsx`의 인라인 `PathBadge` 정의(line 75–99)를 삭제하고 공용 컴포넌트 import. `parsePathsFromText`도 그대로 유지하지만 PathBadge만 교체. 외관·동작은 픽셀 단위로 동일.
+
+### 4.4 메모 위젯 (TipTap) — `pathLink` Mark
+
+`src/components/widgets/memo/extensions/PathLinkMark.ts` (신규):
+
+```typescript
+import { Mark, markInputRule, markPasteRule } from '@tiptap/core';
+
+export const PathLinkMark = Mark.create({
+  name: 'pathLink',
+  inclusive: false,                    // 경로 끝에서 typing 시 mark 자동 종료
+  addAttributes() {
+    return { href: { default: '' } };
+  },
+  parseHTML() {
+    return [{ tag: 'span[data-path-link]' }];
+  },
+  renderHTML({ mark, HTMLAttributes }) {
+    return ['span', {
+      ...HTMLAttributes,
+      'data-path-link': mark.attrs.href,
+      class: 'path-link-mark',
+      title: `${mark.attrs.href}\n(클릭하면 파일탐색기에서 열기)`,
+    }, 0];
+  },
+  addInputRules() {
+    return [
+      markInputRule({
+        find: /(G:\\[^\s]+)\s$/,                        // 경로 + 공백 입력 순간 mark 적용
+        type: this.type,
+        getAttributes: (match) => ({ href: match[1] }),
+      }),
+    ];
+  },
+  addPasteRules() {
+    return [
+      markPasteRule({
+        find: /G:\\[^\s\n]+/g,
+        type: this.type,
+        getAttributes: (match) => ({ href: match[0] }),
+      }),
+    ];
+  },
+});
+```
+
+`MemoEditor.tsx`에 등록:
+```typescript
+extensions: [...existing, PathLinkMark]
+```
+
+CSS (`src/styles/memo-editor.css` 또는 동급):
+```css
+.path-link-mark {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  font-family: monospace;
+  border-radius: 4px;
+  padding: 1px 6px;
+  color: #74B9FF;
+  background: rgba(116, 185, 255, 0.1);
+  border: 1px solid rgba(116, 185, 255, 0.2);
+  cursor: pointer;
+}
+.path-link-mark:hover { filter: brightness(1.25); }
+```
+
+클릭 핸들러는 `MemoEditor.tsx`의 `editorProps.handleClickOn`에 추가:
+```typescript
+handleClickOn(view, pos, node, nodePos, event) {
+  const target = event.target as HTMLElement | null;
+  const linkEl = target?.closest('[data-path-link]') as HTMLElement | null;
+  if (linkEl) {
+    event.preventDefault();
+    window.electronAPI?.shellShowItem?.(linkEl.dataset.pathLink ?? '');
+    return true;
+  }
+  return false;
+}
+```
+
+---
+
+## 5. 에지 케이스
+
+| 케이스 | 처리 |
+|---|---|
+| 빈 메모/댓글 | tokenizeGPaths가 [] 반환 → 빈 렌더 |
+| `G:\` 단독 (경로 없음) | 정규식 매치 안 됨 (`[^\s\n]*` 0길이 매치는 가능하지만 `\s`/`\n` 종결 필요한 컨텍스트로 발생 안 함) |
+| 한글 경로 (`G:\공유 드라이브\...`) | OK — 정규식이 `\s`/`\n`만 종결자. 공백 포함되면 거기서 끊김 (파일명에 공백이 있으면 사용자가 따옴표 등을 쓰지 않는 한 짧게 끊김 — 이는 의도된 한계) |
+| 매우 긴 경로 | PathBadge에서 `shortenPath`로 마지막 segment만 표시. 풀 경로는 툴팁(title) |
+| 잘못된 형식·없는 파일 | `shell:show-item`이 자체 처리 — 파일/폴더 없으면 상위 폴더 시도, 그것도 없으면 무음 (현재 동작 그대로) |
+| URL과 충돌 | `G:\`는 URL이 아니라 충돌 없음. http(s) 메모 링크는 `MemoLinkBubble`이 별도 처리 |
+| TipTap 클릭 vs Drag-Select | `handleClickOn`은 click 한정, 드래그 선택은 영향 없음 |
+| 메모 위젯 raw 모드 | 현재 메모 위젯은 WYSIWYG만 — raw 모드 없음 (Mark가 항상 활성) |
+| 편집 중 textarea (씬 메모/댓글) | 의도된 동작 — 편집 시 raw 텍스트, 저장 후 표시만 변환 |
+
+---
+
+## 6. 테스트 전략
+
+### 6.1 단위 테스트 — `src/utils/__tests__/pathLink.test.ts` (신규)
+
+```typescript
+describe('tokenizeGPaths', () => {
+  it('빈 문자열은 빈 배열', ...);
+  it('경로 없는 텍스트는 단일 text 토큰', ...);
+  it('단독 경로는 단일 path 토큰', ...);
+  it('텍스트 중간 경로는 [text, path, text]', ...);
+  it('다중 경로 분리', ...);
+  it('한글 경로 인식', ...);
+  it('경로가 줄바꿈에서 끊김', ...);
+  it('대소문자 g (소문자) 는 매치 안 됨', ...);  // G:\ 만 (대문자)
+});
+
+describe('shortenPath', () => {
+  it('백슬래시 경로 마지막 segment 추출', ...);
+  it('슬래시 혼용', ...);
+  it('말미 슬래시 무시', ...);
+});
+```
+
+### 6.2 수동 검증
+
+- [ ] 씬 모달에서 메모에 `G:\공유 드라이브\test.png` 입력·저장 → PathBadge 표시 → 클릭 → 파일탐색기 열림
+- [ ] 댓글에 `@한솔 G:\test\file.png 확인` → @멘션과 PathBadge 둘 다 인식
+- [ ] 메모 위젯에 G:\ 입력 후 공백 → 즉시 청색 PathBadge로 변환
+- [ ] 메모 위젯에 G:\ 경로 붙여넣기 → 자동 변환
+- [ ] 리비전(CompositingView)에서 PathBadge 외관·동작 변경 없이 그대로 (회귀 테스트)
+
+### 6.3 빌드 검증
+
+- `npx tsc --noEmit` 통과
+- `npx vite build` 통과
+- `npx vitest run` 통과
+
+---
+
+## 7. 작업 범위
+
+### 신규 파일
+
+| 경로 | 책임 |
+|---|---|
+| `src/utils/pathLink.ts` | `tokenizeGPaths`, `shortenPath` |
+| `src/utils/__tests__/pathLink.test.ts` | 유닛 테스트 |
+| `src/components/common/PathBadge.tsx` | 공용 PathBadge |
+| `src/components/common/PathLinkifiedText.tsx` | 텍스트 + 경로 합성 렌더 |
+| `src/components/widgets/memo/extensions/PathLinkMark.ts` | TipTap Mark |
+
+### 수정 파일
+
+| 경로 | 변경 |
+|---|---|
+| `src/views/CompositingView.tsx` | 인라인 PathBadge 삭제, 공용 import. `parsePathsFromText`는 유지 |
+| `src/components/scenes/UnifiedSceneDetailModal.tsx` | `InlineTextareaRow` 표시 모드에 `PathLinkifiedText` 사용 |
+| `src/components/scenes/CommentPanel.tsx` | `renderText` → `PathLinkifiedText`로 합성 |
+| `src/components/widgets/memo/MemoEditor.tsx` | extensions에 `PathLinkMark` 등록 + `handleClickOn` 추가 |
+| `src/styles/memo-editor.css` (또는 인접 css) | `.path-link-mark` 스타일 |
+
+---
+
+## 8. 결정 이력 (Q&A)
+
+1. **변환 방식**: 인라인 토큰 / 줄 단위 분리 / 하이브리드 → **인라인 토큰**
+2. **적용 범위**: 씬 모달만 / + 메모 위젯 / + 그 외 텍스트 → **+ 메모 위젯 포함**
+3. **드라이브 형식**: G:\\만 / 모든 드라이브 / + UNC → **G:\\ 전용**
+4. **추가 강조** (한솔): UI 일관성 + 유지보수성 — 공용 컴포넌트 1곳에서 정의, 4곳 재사용
+
+---
+
+## 9. 후속 작업 (out of scope)
+
+- 다른 드라이브(`X:\`, `D:\`) 또는 UNC 경로 (`\\\\server\\...`) 인식 — 필요해지면 정규식 확장
+- 화이트보드/개인 일정 메모 등 다른 텍스트 영역 — 같은 공용 컴포넌트 import 한 줄이면 됨
+- 깨진 경로 표시 처리 (파일이 없는 경로를 시각적으로 회색 표시) — 사전 검증이 비싸 v1엔 제외

--- a/docs/superpowers/specs/2026-04-27-recent-activity-widget-design.md
+++ b/docs/superpowers/specs/2026-04-27-recent-activity-widget-design.md
@@ -57,7 +57,7 @@ CREATE TABLE IF NOT EXISTS activity_log (
 
   user_id TEXT NOT NULL,                -- 누가 (users.id 참조, 단 FK는 안 검 — 신뢰 모델은 §3.4)
   user_name TEXT NOT NULL,              -- 표시용 (조인 비용 ↓, 이름 변경되어도 옛 기록은 옛 이름)
-  action_type TEXT NOT NULL,            -- 13종 enum (아래 §3.2)
+  action_type TEXT NOT NULL,            -- 14종 enum (아래 §3.2)
   action_group TEXT NOT NULL,           -- 'progress' | 'memo' | 'scene' | 'etc' (필터 4그룹)
 
   scene_id UUID,                        -- scenes.id (UUID, nullable). 주의: comments.scene_id는 TEXT라 다름. 본 테이블은 UUID 통일.
@@ -80,7 +80,7 @@ CREATE POLICY "allow_all" ON activity_log FOR ALL USING (true) WITH CHECK (true)
 ALTER PUBLICATION supabase_realtime ADD TABLE activity_log;
 ```
 
-### 3.2 13종 `action_type` enum
+### 3.2 14종 `action_type` enum
 
 | # | 그룹 | type 값 | 발생 시점 | 픽토그램 컬러 |
 |---|---|---|---|---|
@@ -99,7 +99,7 @@ ALTER PUBLICATION supabase_realtime ADD TABLE activity_log;
 | 13 | **etc** | `image_upload_storyboard` | 스토리보드 이미지 업로드 | 회색 |
 | 14 | **etc** | `image_upload_guide` | 가이드 이미지 업로드 | 회색 |
 
-> 정정: 표 행은 14이지만 그 중 `image_upload_storyboard`/`image_upload_guide`는 한 헬퍼(`uploadImage`)에서 분기하므로 **호출 지점 14개 / type 14개**로 일관 유지. 머리말의 "13종"은 **그룹 분류 기준**(progress 4 + memo 4 + scene 2 + etc 4 = 14)이 아닌 의도된 값. 위 표대로 14종으로 통일하고 머리말·§2를 14로 정정.
+> 합계: action_type 14종 = progress 4 + memo 4 + scene 2 + etc 4. mutation 함수 12개에서 분기를 통해 호출 지점 14개로 매핑(§4.2 표 참조).
 
 ### 3.3 보존 정책 — 1년 자동 정리
 

--- a/docs/superpowers/specs/2026-04-27-recent-activity-widget-design.md
+++ b/docs/superpowers/specs/2026-04-27-recent-activity-widget-design.md
@@ -2,10 +2,14 @@
 
 - 작성일: 2026-04-27
 - 브랜치: `claude/trusting-blackwell-722ea1`
-- 대상 범위: 신규 위젯 1개 + 신규 테이블/RPC + 12개 mutation 함수에 활동 기록 호출 추가
+- 대상 범위: 신규 위젯 1개 + 신규 테이블/RPC + 기존 mutation 코드에 활동 기록 헬퍼 호출 추가
+- 용어 정의:
+  - **action_type 13종** — 활동 종류 enum 값
+  - **호출 지점 14개** — `recordActivity()` 헬퍼를 부르는 코드 위치 (단계 4종은 `updateSceneField` 1개 함수 안에 분기, 이미지 2종은 1개 핸들러 안에 분기)
+  - **수정 대상 함수 12개** — `electron/supabase.ts`에서 손대는 함수 개수
 - PR 단위: **단일 PR** (Phase 9-7 또는 v1.14.0)
 - 시안 미리보기: `docs/superpowers/specs/mockups/2026-04-27-recent-activity-widget/final.html`
-- 참고: Supabase Pro 플랜 기준 (2026-04-22 업그레이드 완료)
+- 인프라: **Supabase Pro 플랜** (2026-04-22 업그레이드 완료, DB 8GB / pg_cron 사용 가능)
 
 ---
 
@@ -29,7 +33,7 @@ Studio JBBJ 팀이 BG/액팅 작업을 하면서 "**다른 동료들이 지금 �
 |---|---|---|
 | 용도 | 팀 소셜 피드 | 한솔 결정 (다른 옵션: 매니저 모니터링/본인 회고/통합) |
 | 레이아웃 | 옵션 1 — 상하 분할 (히트맵 위 / 피드 아래) | 4가지 시안 비교 후 선택 |
-| 추적 종류 | **13종** | 작업 4 + 메모/댓글/리비전 4 + 씬 add/del 2 + 기타 4 |
+| 추적 종류 | **14종** | 작업 4 + 메모/댓글/리비전 4 + 씬 add/del 2 + 기타 4 (담당자/레이아웃/스토리보드 업로드/가이드 업로드) |
 | 출시 방식 | **깨끗하게 시작** (백필 없음) | DB 변경 최소, 출시 후 자동 누적 |
 | 데이터 경로 | **앱 INSERT + RPC 트랜잭션** | 디버깅 용이, 표시 라벨 같이 저장 |
 | 그래프 모드 | **3가지 토글** (히트맵 / 시간대 막대 / 요일 막대) | 한솔 보강 요청 |
@@ -51,12 +55,12 @@ Studio JBBJ 팀이 BG/액팅 작업을 하면서 "**다른 동료들이 지금 �
 CREATE TABLE IF NOT EXISTS activity_log (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 
-  user_id TEXT NOT NULL,                -- 누가
+  user_id TEXT NOT NULL,                -- 누가 (users.id 참조, 단 FK는 안 검 — 신뢰 모델은 §3.4)
   user_name TEXT NOT NULL,              -- 표시용 (조인 비용 ↓, 이름 변경되어도 옛 기록은 옛 이름)
   action_type TEXT NOT NULL,            -- 13종 enum (아래 §3.2)
   action_group TEXT NOT NULL,           -- 'progress' | 'memo' | 'scene' | 'etc' (필터 4그룹)
 
-  scene_id UUID,                        -- 어떤 씬 (nullable: 씬 외 활동도 가능 — 향후 확장)
+  scene_id UUID,                        -- scenes.id (UUID, nullable). 주의: comments.scene_id는 TEXT라 다름. 본 테이블은 UUID 통일.
   scene_label TEXT,                     -- 표시용: "EP01 A씬 #5"
   episode_number INTEGER,               -- 통계/필터용
   department TEXT,                      -- 'bg' | 'acting'
@@ -78,21 +82,24 @@ ALTER PUBLICATION supabase_realtime ADD TABLE activity_log;
 
 ### 3.2 13종 `action_type` enum
 
-| 그룹 | type 값 | 발생 시점 | 픽토그램 컬러 |
-|---|---|---|---|
-| **progress** | `stage_lo`         | LO 체크박스 ON/OFF | LO `#74B9FF` |
-| **progress** | `stage_done`       | 완료 체크박스 ON/OFF | 완료 `#A29BFE` |
-| **progress** | `stage_review`     | 검수 체크박스 ON/OFF | 검수 `#FDCB6E` |
-| **progress** | `stage_png`        | PNG 체크박스 ON/OFF | PNG `#00B894` |
-| **memo** | `memo_update`      | 씬 메모 변경 | 분홍 `#FF8FA3` |
-| **memo** | `comment_add`      | 댓글 작성 | 주황 `#FFA94D` |
-| **memo** | `revision_add`     | 리비전 등록 | 시안 `#4DD0E1` |
-| **memo** | `revision_resolve` | 리비전 해결 | 시안-밝음 `#81ECEC` |
-| **scene** | `scene_add`        | 씬 추가 | 초록 `#6FCF97` |
-| **scene** | `scene_delete`     | 씬 삭제 | 빨강 `#FF7675` |
-| **etc** | `assignee_change`  | 담당자 변경 | 회색 `#95A5A6` |
-| **etc** | `layout_change`    | 레이아웃ID 변경 | 회색 |
-| **etc** | `image_upload_storyboard` / `image_upload_guide` | 이미지 업로드 | 회색 |
+| # | 그룹 | type 값 | 발생 시점 | 픽토그램 컬러 |
+|---|---|---|---|---|
+| 1 | **progress** | `stage_lo`         | LO 체크박스 ON/OFF | LO `#74B9FF` |
+| 2 | **progress** | `stage_done`       | 완료 체크박스 ON/OFF | 완료 `#A29BFE` |
+| 3 | **progress** | `stage_review`     | 검수 체크박스 ON/OFF | 검수 `#FDCB6E` |
+| 4 | **progress** | `stage_png`        | PNG 체크박스 ON/OFF | PNG `#00B894` |
+| 5 | **memo** | `memo_update`      | 씬 메모 변경 | 분홍 `#FF8FA3` |
+| 6 | **memo** | `comment_add`      | 댓글 작성 | 주황 `#FFA94D` |
+| 7 | **memo** | `revision_add`     | 리비전 등록 | 시안 `#4DD0E1` |
+| 8 | **memo** | `revision_resolve` | 리비전 해결 | 시안-밝음 `#81ECEC` |
+| 9 | **scene** | `scene_add`        | 씬 추가 | 초록 `#6FCF97` |
+| 10 | **scene** | `scene_delete`     | 씬 삭제 | 빨강 `#FF7675` |
+| 11 | **etc** | `assignee_change`  | 담당자 변경 | 회색 `#95A5A6` |
+| 12 | **etc** | `layout_change`    | 레이아웃ID 변경 | 회색 |
+| 13 | **etc** | `image_upload_storyboard` | 스토리보드 이미지 업로드 | 회색 |
+| 14 | **etc** | `image_upload_guide` | 가이드 이미지 업로드 | 회색 |
+
+> 정정: 표 행은 14이지만 그 중 `image_upload_storyboard`/`image_upload_guide`는 한 헬퍼(`uploadImage`)에서 분기하므로 **호출 지점 14개 / type 14개**로 일관 유지. 머리말의 "13종"은 **그룹 분류 기준**(progress 4 + memo 4 + scene 2 + etc 4 = 14)이 아닌 의도된 값. 위 표대로 14종으로 통일하고 머리말·§2를 14로 정정.
 
 ### 3.3 보존 정책 — 1년 자동 정리
 
@@ -108,10 +115,14 @@ $$;
 -- pg_cron 사용 (Supabase Pro 활성화됨)
 SELECT cron.schedule(
   'activity-log-cleanup',
-  '0 4 * * *',                          -- 매일 새벽 4시
+  '0 4 * * *',                          -- 매일 새벽 4시 (KST 13시)
   $$ SELECT cleanup_old_activity_logs(); $$
 );
 ```
+
+### 3.4 신뢰 모델 (RLS `allow_all`)
+
+기존 `comments`/`comp_revisions`와 동일하게 `allow_all` 정책. 즉 **anon key로 임의 user_id 위변조 가능**한 상태. v1은 신뢰 환경(스튜디오 사내 사용)으로 가정하고 현행 유지. **Supabase Auth 도입 시점(별도 스펙)에 `auth.uid() = user_id` 정책으로 강화 예정.**
 
 ---
 
@@ -153,30 +164,60 @@ GRANT EXECUTE ON FUNCTION record_activity(...) TO anon, authenticated;
 
 ### 4.2 mutation 함수 패치 — `electron/supabase.ts`
 
-다음 12개 함수 끝에 `recordActivity()` 호출 추가 (try/catch로 감싸서 본 mutation은 실패시키지 않음):
+**수정 대상 함수 12개 / 호출 지점 14개** (단계 4종은 `updateSceneField` 1개 함수 내 분기, 이미지 2종은 1개 핸들러 내 분기). 각 호출 지점 끝에 `recordActivity()` 호출 추가하되 **try/catch로 감싸서 본 mutation은 실패시키지 않음**:
 
-| 함수 | action_type |
-|---|---|
-| `updateSceneField(stage='lo')` | `stage_lo` |
-| `updateSceneField(stage='done')` | `stage_done` |
-| `updateSceneField(stage='review')` | `stage_review` |
-| `updateSceneField(stage='png')` | `stage_png` |
-| `updateSceneField(field='memo')` | `memo_update` |
-| `updateSceneField(field='assignee')` | `assignee_change` |
-| `updateSceneField(field='layout')` | `layout_change` |
-| `addScene` | `scene_add` |
-| `deleteScene` | `scene_delete` |
-| `addComment` | `comment_add` |
-| `addRevision` | `revision_add` |
-| `updateRevisionStatus(='resolved')` | `revision_resolve` |
-| `uploadImage(type='storyboard')` | `image_upload_storyboard` |
-| `uploadImage(type='guide')` | `image_upload_guide` |
+| 함수 | 분기 | action_type |
+|---|---|---|
+| `updateSceneField` | stage='lo' | `stage_lo` |
+| `updateSceneField` | stage='done' | `stage_done` |
+| `updateSceneField` | stage='review' | `stage_review` |
+| `updateSceneField` | stage='png' | `stage_png` |
+| `updateSceneField` | field='memo' | `memo_update` |
+| `updateSceneField` | field='assignee' | `assignee_change` |
+| `updateSceneField` | field='layout' | `layout_change` |
+| `addScene` | — | `scene_add` |
+| `deleteScene` | — | `scene_delete` |
+| `addComment` | — | `comment_add` |
+| `addRevision` | — | `revision_add` |
+| `updateRevisionStatus` | status='resolved' | `revision_resolve` |
+| `uploadImage` | type='storyboard' | `image_upload_storyboard` |
+| `uploadImage` | type='guide' | `image_upload_guide` |
 
-bulk RPC 함수(`bulk_update_scene_stages` 등) 안에서도 각 row 단위로 활동을 INSERT하도록 수정 (트리거 없이 RPC 내부에서 처리).
+### 4.3 bulk RPC 함수 활동 기록 — 파라미터 명세
 
-### 4.3 자기 변경 dedupe
+기존 `bulk_update_scene_stages`/`bulk_delete_scenes`/`bulk_update_scene_fields`는 클라이언트가 호출하는 `SECURITY INVOKER` RPC. 활동 기록을 추가하려면 **호출자가 user_id/user_name과 row별 표시 라벨을 함께 보내야** 한다.
 
-낙관적 prepend의 임시 ID(`tmp_*`)를 RPC 응답의 진짜 UUID로 교체. Realtime 이벤트가 같은 UUID면 store에서 무시.
+**수정 후 시그니처** (예: `bulk_update_scene_stages`):
+
+```sql
+CREATE OR REPLACE FUNCTION bulk_update_scene_stages(
+  p_updates jsonb,                     -- 각 element: { sceneUuid, stage, value, sceneLabel, episodeNumber, department, ... }
+  p_updated_by text,
+  p_user_name text                     -- 신규 파라미터 (활동 표시용)
+) RETURNS TABLE (scene_uuid uuid, success boolean, error text)
+```
+
+`p_updates` jsonb element에 `sceneLabel`, `episodeNumber`, `department` 추가. RPC 내부 루프에서 UPDATE 성공한 row마다 `INSERT INTO activity_log (...)` 직접 실행 (`record_activity` 함수 호출 또는 `INSERT` 인라인). 한 row의 활동 기록 실패는 본 작업 결과에 영향 주지 않도록 inner BEGIN/EXCEPTION 블록으로 분리.
+
+### 4.4 자기 변경 dedupe — 정확한 알고리즘
+
+useActivityStore에 다음 추가:
+
+```typescript
+interface ActivityStore {
+  ...
+  pendingByLocalId: Map<string, string>;   // localTmpId → 진짜 UUID
+
+  prependOptimistic(localTmpId: string, partial: Activity): void;  // 낙관적 prepend
+  replaceTmpId(localTmpId: string, realUuid: string): void;        // RPC 응답 후 ID 교체
+  receiveRealtime(activity: Activity): void;                       // dedupe 로직 적용
+}
+```
+
+**dedupe 우선순위**:
+1. **UUID 일치** — 이미 store에 같은 `id`가 있으면 무시 (가장 강한 키)
+2. **임시→진짜 매핑 일치** — `pendingByLocalId`에 이미 매핑된 UUID면 무시
+3. **소프트 키 폴백** — 본인의 활동이고 `(user_id, action_type, scene_id)` 동일 + `created_at` 차이 5초 이내면 임시 row를 진짜 row로 교체 (타임아웃 또는 RPC 에러로 매핑이 누락된 경우 안전망)
 
 ---
 
@@ -191,7 +232,7 @@ bulk RPC 함수(`bulk_update_scene_stages` 등) 안에서도 각 row 단위로 �
 | 아이콘 | Lucide `Activity` |
 | 그리드 디폴트 | width 6 / height 8 |
 | 등록 위치 | `Dashboard.tsx`의 위젯 배열 + `WIDGET_NAMES` 상수 |
-| 부서 모드 | BG/액팅/통합 모두 동일 (department 컬럼 필터) |
+| 부서 모드 | **앱 전역 부서 모드(`useAppStore.activeDepartment`)에 종속**. 위젯 자체 부서 토글 없음. BG-only/액팅-only 화면에서는 자동으로 그 부서만 필터, 통합 모드에서는 BG+액팅 합산 |
 
 ### 5.2 헤더
 
@@ -310,23 +351,30 @@ bulk RPC 함수(`bulk_update_scene_stages` 등) 안에서도 각 row 단위로 �
 
 ```typescript
 interface ActivityStore {
-  activities: Activity[];                  // 시간 역순, 최대 500
+  activities: Activity[];                       // 시간 역순, 최대 500
+  statsGrid: number[][];                        // 7×24 히트맵 격자 (서버에서 fetch)
+  pendingByLocalId: Map<string, string>;        // 낙관적 row 매핑 (§4.4)
+  lastSeenCreatedAt: string | null;             // Realtime backfill 기준점
   isLoading: boolean;
   error: string | null;
   hasMore: boolean;
+
   filters: {
     groups: Set<'progress' | 'memo' | 'scene' | 'etc'>;
-    department: 'all' | 'bg' | 'acting';
+    // department는 useAppStore.activeDepartment에서 가져옴, 본 store에 저장하지 않음
   };
   goldenMode: 'heatmap' | 'hour' | 'day';
 
   // 액션
   loadInitial(): Promise<void>;
   loadMore(): Promise<void>;
-  prepend(activity: Activity): void;       // Realtime
-  applyDelta(payload: RealtimePayload): void;
-  setFilter(group: ..., on: boolean): void;
-  setGoldenMode(mode: ...): void;
+  loadStats(): Promise<void>;                   // activity:stats RPC
+  backfillSince(createdAt: string): Promise<void>;  // 재연결 시
+  prependOptimistic(localTmpId: string, partial: Activity): void;
+  replaceTmpId(localTmpId: string, realUuid: string): void;
+  receiveRealtime(activity: Activity): void;    // dedupe 로직 적용
+  setFilter(group: ActionGroup, on: boolean): void;
+  setGoldenMode(mode: 'heatmap' | 'hour' | 'day'): void;
 }
 ```
 
@@ -350,17 +398,30 @@ interface ActivityStore {
   → Supabase Realtime 이벤트
   → electron/realtime.ts 수신
   → broadcast.ts → 모든 윈도우에 전파
-  → useActivityStore.prepend(newItem) (UUID 중복 체크 후)
+  → useActivityStore.receiveRealtime(newItem) (§4.4 dedupe 적용)
   → 피드 최상단에 Framer Motion 진입 애니메이션
   → 히트맵 해당 셀 강도 +1 (로컬 재계산)
 
 [자기 변경]
-  체크박스 토글 → 낙관적 prepend (tmp_*) → RPC 응답으로 진짜 UUID 교체
-  Realtime 같은 UUID 이벤트는 store dedupe 로직으로 무시
+  체크박스 토글
+  → useActivityStore.prependOptimistic(tmpId, partial)
+  → RPC 호출 → 응답 UUID 받음 → replaceTmpId(tmpId, realUuid)
+  → Realtime 같은 UUID 이벤트 도착 → dedupe로 무시
+  → RPC 에러 시: 일정 시간 뒤 소프트 키 폴백으로 매칭 시도, 그래도 안 맞으면 임시 row 제거
+
+[Realtime 재연결 backfill]
+  WebSocket 끊김 → useAppStore.dataConnected = false (헤더 점)
+  재연결(SUBSCRIBED 콜백)
+    → IPC 'activity:backfill' { since: lastSeenCreatedAt }
+    → activity_log WHERE created_at > since ORDER BY created_at ASC LIMIT 200
+    → 각 row를 receiveRealtime() 호출 (dedupe 적용)
+    → lastSeenCreatedAt 갱신
+    → 통계 격자(useActivityStore.statsGrid) 다시 fetch (activity:stats)
 
 [페이지네이션]
   피드 끝 도달 → loadMore() → IPC { before: oldestCreatedAt, limit: 50 }
-  → 7일 경계 도달 시 hasMore: false
+  → 7일 경계 도달 또는 누적 500건 도달 중 먼저 닿는 쪽에서 hasMore: false
+  → 그 시점에 "이전 활동은 자동 정리되었습니다" 안내 (v1)
 ```
 
 ### 6.3 그룹화 알고리즘
@@ -395,9 +456,13 @@ function pickGoldenDay(dayTotals: number[]): {day, ratio}
 
 | 채널 | 역할 |
 |---|---|
-| `activity:list` | 페이지네이션 조회 |
-| `activity:record` | RPC `record_activity` 호출 래퍼 |
-| `activity:stats` | 1주일치 히트맵용 집계 (옵션, 클라이언트 계산이면 생략 가능) |
+| `activity:list` | 페이지네이션 조회 (최근 100건, before 커서) |
+| `activity:stats` | **필수** — 7일치 24×7 격자 집계 (서버 사이드, GROUP BY day_of_week, hour) |
+| `activity:backfill` | Realtime 재연결 시 누락분 fetch (`created_at > lastSeenAt`) |
+
+**`activity:record` IPC 채널은 노출하지 않음.** 활동 기록은 `electron/supabase.ts` 내부의 `recordActivity()` 헬퍼로만 호출되며, 각 mutation 함수가 직접 사용. 렌더러가 임의로 활동을 기록할 경로를 제거해 §3.4 신뢰 모델 위반을 줄임.
+
+**`activity:stats` 필수 사유**: 활발한 시기엔 7일치 활동이 클라이언트 캐시 한도(500건)를 초과할 수 있어, 클라이언트 사이드 집계는 부정확. 서버에서 `GROUP BY EXTRACT(dow FROM created_at AT TIME ZONE 'Asia/Seoul'), EXTRACT(hour FROM created_at AT TIME ZONE 'Asia/Seoul')` 으로 정확한 24×7 격자 반환.
 
 ---
 
@@ -415,15 +480,16 @@ function pickGoldenDay(dayTotals: number[]): {day, ratio}
 - 씬 삭제 → `scene_id`는 FK 없으므로 그대로 남음, 클릭 시 토스트 후 모달 닫힘
 - 아카이브된 에피소드 활동도 표시 (필터로 제외 가능, v2)
 
-### 7.3 성능 추정
+### 7.3 성능 추정 (Supabase Pro 플랜)
 
 | 시나리오 | 측정/추정 | 대응 |
 |---|---|---|
-| 활동량 (팀 20명, 50건/인/일) | 1,000건/일 = 26만건/년 | 1년 보존 정책으로 제한 |
-| DB 용량 | row 약 400 bytes → 약 100MB/년 | 무료 한도 500MB의 20% |
-| 위젯 첫 로드 | <100ms | 인덱스 효율 |
-| 체크박스 토글 지연 | +5–10ms | RPC INSERT 1건 |
-| Realtime 메시지 | 2만/일 (1000건 × 20접속) | Pro 한도 200만/일의 1% |
+| 활동량 (팀 20명, 50건/인/일) | 1,000건/일 = 26만건/년 | 1년 보존 정책으로 제한 (cron) |
+| DB 용량 | row 약 400 bytes → 약 100MB/년 | Pro 한도 8GB의 1.25%/년, 1년 보존이면 영구 안정 |
+| 위젯 첫 로드 | <100ms | 3개 인덱스로 최근 100건 + 7일 stats GROUP BY 빠름 |
+| 체크박스 토글 지연 | +5–10ms | RPC INSERT 1건 (try/catch로 본 mutation 실패 안 시킴) |
+| Realtime 메시지 | 2만/일 (1000건 × 20접속) | Pro 한도 250만/일의 1% |
+| Realtime 재연결 backfill | 끊김 N분 후 재연결 시 N분치 fetch 1회 | RPC 1회, 보통 < 50건 |
 
 ### 7.4 사이즈 모니터링
 
@@ -525,7 +591,7 @@ function pickGoldenDay(dayTotals: number[]): {day, ratio}
 3. **활동 범위**: 진척만 / 진척+소통 / 픽토그램 다양화 → **그룹화된 픽토그램**
 4. **골든타임 형태**: 히트맵 / 시간대 막대 / 사람별 카드 / 텍스트 → **히트맵** (+ 후속 요청으로 막대 모드 추가)
 5. **레이아웃**: 상하 분할 / 탭 / 좌우 분할 / 분리 위젯 → **상하 분할**
-6. **추적 종류**: 성과만 / 성과+소통 / 성과+소통+설정 → **전부 (12종 → 13종)**
+6. **추적 종류**: 성과만 / 성과+소통 / 성과+소통+설정 → **전부 14종 action_type / 14개 호출 지점 / 12개 mutation 함수 손봄** (씬 삭제 추가, 이미지 업로드 2종 분리)
 7. **출시 시점 데이터**: 풍부 백필 / 진척만 백필 / 깨끗한 시작 → **깨끗한 시작**
 8. **기록 경로**: 트리거 / 앱 INSERT+RPC / 기존 테이블 UNION → **앱 INSERT+RPC**
 9. **추가 보강** (한솔 요청): 그래프 3모드 + 4그룹 필터 + 툴팁 강화 + 1년 보존

--- a/docs/superpowers/specs/2026-04-27-recent-activity-widget-design.md
+++ b/docs/superpowers/specs/2026-04-27-recent-activity-widget-design.md
@@ -1,0 +1,546 @@
+# 최근 작업 위젯 — 활동 피드 + 골든타임 분석
+
+- 작성일: 2026-04-27
+- 브랜치: `claude/trusting-blackwell-722ea1`
+- 대상 범위: 신규 위젯 1개 + 신규 테이블/RPC + 12개 mutation 함수에 활동 기록 호출 추가
+- PR 단위: **단일 PR** (Phase 9-7 또는 v1.14.0)
+- 시안 미리보기: `docs/superpowers/specs/mockups/2026-04-27-recent-activity-widget/final.html`
+- 참고: Supabase Pro 플랜 기준 (2026-04-22 업그레이드 완료)
+
+---
+
+## 1. 배경 & 목적
+
+Studio JBBJ 팀이 BG/액팅 작업을 하면서 "**다른 동료들이 지금 뭘 하고 있는지**"를 자연스럽게 인지할 수단이 부족하다. 슬랙처럼 앱을 항상 띄워두는 사용 패턴이지만, 정작 진행률 카드·차트만으로는 "지영이 방금 무슨 씬을 끝냈고, 민수가 어떤 댓글을 남겼는지" 같은 **사회적 인지(social presence)** 가 약하다.
+
+또한 한솔(매니저)은 "팀이 언제 가장 활발한지"를 데이터로 알고 싶어 한다. 회의 시간대 회피, 집중 시간 보호 결정에 활용하기 위함.
+
+### 핵심 사용자 시나리오
+
+1. **모두가 보는 소셜 피드** — 누가 LO를 끝냈고 누가 메모를 달았는지 시간 역순으로 흐름 확인. 동기부여·협업 촉진.
+2. **팀 골든타임 분석** — 1주일 단위로 가장 활발한 시간대를 시각화. 회의·집중 시간 결정에 참고.
+3. **본인 활동 회고 (이차적)** — 본인 활동도 같이 보임. 피드에서 본인 항목은 좌측 보더로 약하게 강조.
+
+---
+
+## 2. 결정한 디자인 (요약)
+
+| 결정 | 값 | 근거 |
+|---|---|---|
+| 용도 | 팀 소셜 피드 | 한솔 결정 (다른 옵션: 매니저 모니터링/본인 회고/통합) |
+| 레이아웃 | 옵션 1 — 상하 분할 (히트맵 위 / 피드 아래) | 4가지 시안 비교 후 선택 |
+| 추적 종류 | **13종** | 작업 4 + 메모/댓글/리비전 4 + 씬 add/del 2 + 기타 4 |
+| 출시 방식 | **깨끗하게 시작** (백필 없음) | DB 변경 최소, 출시 후 자동 누적 |
+| 데이터 경로 | **앱 INSERT + RPC 트랜잭션** | 디버깅 용이, 표시 라벨 같이 저장 |
+| 그래프 모드 | **3가지 토글** (히트맵 / 시간대 막대 / 요일 막대) | 한솔 보강 요청 |
+| 필터 | **4그룹 칩** (작업 진행 / 메모·댓글 / 씬 생성·삭제 / 기타) | 한솔 명시 분류 |
+| 그룹화 | 같은 사람 + 같은 종류 + 같은 씬 + **5분 윈도우** | 자잘한 토글 묶기 |
+| 본인 강조 | 좌측 보더 + "(나)" 라벨 | 사회적 인지 / 자기 식별 |
+| 보존 정책 | **1년 자동 정리** (cron) | DB ~100MB/년 안정, 무료 플랜 5년 안전 |
+| 모니터링 | 설정 화면에 "활동 N건 · X MB" 한 줄 | 한솔 직접 상태 확인 |
+| Realtime | INSERT 즉시 prepend + UUID dedupe | 기존 broadcast.ts 패턴 |
+| 클릭 동작 | 항목 클릭 → 씬 상세 모달 (`UnifiedSceneDetailModal`) | 자연스러운 흐름 |
+
+---
+
+## 3. 데이터 모델
+
+### 3.1 신규 테이블: `activity_log`
+
+```sql
+CREATE TABLE IF NOT EXISTS activity_log (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  user_id TEXT NOT NULL,                -- 누가
+  user_name TEXT NOT NULL,              -- 표시용 (조인 비용 ↓, 이름 변경되어도 옛 기록은 옛 이름)
+  action_type TEXT NOT NULL,            -- 13종 enum (아래 §3.2)
+  action_group TEXT NOT NULL,           -- 'progress' | 'memo' | 'scene' | 'etc' (필터 4그룹)
+
+  scene_id UUID,                        -- 어떤 씬 (nullable: 씬 외 활동도 가능 — 향후 확장)
+  scene_label TEXT,                     -- 표시용: "EP01 A씬 #5"
+  episode_number INTEGER,               -- 통계/필터용
+  department TEXT,                      -- 'bg' | 'acting'
+
+  detail JSONB,                         -- 자유 메타 (예: { from: false, to: true })
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_activity_log_created  ON activity_log(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_activity_log_user     ON activity_log(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_activity_log_scene    ON activity_log(scene_id);
+
+ALTER TABLE activity_log ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "allow_all" ON activity_log FOR ALL USING (true) WITH CHECK (true);
+
+-- Realtime 활성화
+ALTER PUBLICATION supabase_realtime ADD TABLE activity_log;
+```
+
+### 3.2 13종 `action_type` enum
+
+| 그룹 | type 값 | 발생 시점 | 픽토그램 컬러 |
+|---|---|---|---|
+| **progress** | `stage_lo`         | LO 체크박스 ON/OFF | LO `#74B9FF` |
+| **progress** | `stage_done`       | 완료 체크박스 ON/OFF | 완료 `#A29BFE` |
+| **progress** | `stage_review`     | 검수 체크박스 ON/OFF | 검수 `#FDCB6E` |
+| **progress** | `stage_png`        | PNG 체크박스 ON/OFF | PNG `#00B894` |
+| **memo** | `memo_update`      | 씬 메모 변경 | 분홍 `#FF8FA3` |
+| **memo** | `comment_add`      | 댓글 작성 | 주황 `#FFA94D` |
+| **memo** | `revision_add`     | 리비전 등록 | 시안 `#4DD0E1` |
+| **memo** | `revision_resolve` | 리비전 해결 | 시안-밝음 `#81ECEC` |
+| **scene** | `scene_add`        | 씬 추가 | 초록 `#6FCF97` |
+| **scene** | `scene_delete`     | 씬 삭제 | 빨강 `#FF7675` |
+| **etc** | `assignee_change`  | 담당자 변경 | 회색 `#95A5A6` |
+| **etc** | `layout_change`    | 레이아웃ID 변경 | 회색 |
+| **etc** | `image_upload_storyboard` / `image_upload_guide` | 이미지 업로드 | 회색 |
+
+### 3.3 보존 정책 — 1년 자동 정리
+
+```sql
+CREATE OR REPLACE FUNCTION cleanup_old_activity_logs() RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  DELETE FROM activity_log WHERE created_at < now() - INTERVAL '1 year';
+END;
+$$;
+
+-- pg_cron 사용 (Supabase Pro 활성화됨)
+SELECT cron.schedule(
+  'activity-log-cleanup',
+  '0 4 * * *',                          -- 매일 새벽 4시
+  $$ SELECT cleanup_old_activity_logs(); $$
+);
+```
+
+---
+
+## 4. 기록 경로 — 앱 INSERT + RPC 트랜잭션
+
+### 4.1 공통 RPC 함수
+
+```sql
+CREATE OR REPLACE FUNCTION record_activity(
+  p_user_id TEXT,
+  p_user_name TEXT,
+  p_action_type TEXT,
+  p_action_group TEXT,
+  p_scene_id UUID,
+  p_scene_label TEXT,
+  p_episode_number INTEGER,
+  p_department TEXT,
+  p_detail JSONB
+) RETURNS UUID
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+  v_id UUID;
+BEGIN
+  INSERT INTO activity_log (
+    user_id, user_name, action_type, action_group,
+    scene_id, scene_label, episode_number, department, detail
+  ) VALUES (
+    p_user_id, p_user_name, p_action_type, p_action_group,
+    p_scene_id, p_scene_label, p_episode_number, p_department, p_detail
+  ) RETURNING id INTO v_id;
+  RETURN v_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION record_activity(...) TO anon, authenticated;
+```
+
+### 4.2 mutation 함수 패치 — `electron/supabase.ts`
+
+다음 12개 함수 끝에 `recordActivity()` 호출 추가 (try/catch로 감싸서 본 mutation은 실패시키지 않음):
+
+| 함수 | action_type |
+|---|---|
+| `updateSceneField(stage='lo')` | `stage_lo` |
+| `updateSceneField(stage='done')` | `stage_done` |
+| `updateSceneField(stage='review')` | `stage_review` |
+| `updateSceneField(stage='png')` | `stage_png` |
+| `updateSceneField(field='memo')` | `memo_update` |
+| `updateSceneField(field='assignee')` | `assignee_change` |
+| `updateSceneField(field='layout')` | `layout_change` |
+| `addScene` | `scene_add` |
+| `deleteScene` | `scene_delete` |
+| `addComment` | `comment_add` |
+| `addRevision` | `revision_add` |
+| `updateRevisionStatus(='resolved')` | `revision_resolve` |
+| `uploadImage(type='storyboard')` | `image_upload_storyboard` |
+| `uploadImage(type='guide')` | `image_upload_guide` |
+
+bulk RPC 함수(`bulk_update_scene_stages` 등) 안에서도 각 row 단위로 활동을 INSERT하도록 수정 (트리거 없이 RPC 내부에서 처리).
+
+### 4.3 자기 변경 dedupe
+
+낙관적 prepend의 임시 ID(`tmp_*`)를 RPC 응답의 진짜 UUID로 교체. Realtime 이벤트가 같은 UUID면 store에서 무시.
+
+---
+
+## 5. UI 구조 — 위젯 본체
+
+### 5.1 메타데이터
+
+| 항목 | 값 |
+|---|---|
+| widget id | `recent-activity` |
+| 타이틀 | "최근 작업" |
+| 아이콘 | Lucide `Activity` |
+| 그리드 디폴트 | width 6 / height 8 |
+| 등록 위치 | `Dashboard.tsx`의 위젯 배열 + `WIDGET_NAMES` 상수 |
+| 부서 모드 | BG/액팅/통합 모두 동일 (department 컬럼 필터) |
+
+### 5.2 헤더
+
+기존 위젯 글래스 헤더 패턴 + 추가 도구:
+
+- **모드 토글 3개** (히트맵 / 시간대 / 요일) — 우측 정렬, 작은 사이즈, 토글 시 `localStorage` 저장
+- **필터 버튼** (`Filter` 아이콘) — 클릭 시 13종 개별 토글 드롭다운 (선택)
+- **팝아웃 버튼** (기존 패턴)
+
+### 5.3 인사이트 배너
+
+히트맵/그래프 바로 위에 액센트 컬러 배너 1줄. 모드별 자동 산출 문구:
+
+- 히트맵: `"이번 주 가장 활발: {요일} {N}–{N+2}시 ({합계}건)"` — 연속 2시간 합 최대 슬롯
+- 시간대 막대: `"하루 중 정점: 오후 {N}–{N+2}시 ({비율}%)"` — 24시간 합산 후 정점 슬롯
+- 요일 막대: `"주중 정점: {요일} (전체의 {비율}%)"` — 7일 합산 후 정점 요일
+
+데이터 < 20건이면 **"기록을 모으는 중입니다"** 폴백.
+
+### 5.4 골든타임 시각화
+
+#### 히트맵 (24×7 격자)
+
+- 가로 24시간 / 세로 7요일
+- 5단계 색 강도: `0건(회색 6%) → 1–2건(18%) → 3–5건(36%) → 6–10건(58%) → 11+건(85% + glow)`
+- 시간 라벨은 `0 / 6 / 12 / 18` 4개만
+- 셀 호버 시 툴팁: `"{요일} {시}시 · {건수}건 / 작업 X · 메모 Y · 씬 Z · 기타 W"` (그룹별 분포)
+
+#### 시간대 막대 (0–23시)
+
+- 24개 막대, 요일 합산
+- 액센트 그라데이션 (`#6C5CE7` → `#A29BFE`)
+- 호버 시 굵기 변화 + 툴팁 `"{시}시 · {건수}건"`
+
+#### 요일 막대 (월–일)
+
+- 7개 막대, 시간 합산
+- 정점 요일은 노란색 그라데이션 (`#FDCB6E` → `#FFE5A0`)
+- 호버 시 툴팁 `"{요일}요일 · {건수}건"`
+
+### 5.5 4그룹 필터 칩
+
+```
+[ 전체 N ] [ ● 작업 진행 N ] [ ● 메모/댓글 N ] [ ● 씬 생성/삭제 N ] [ ● 기타 N ]
+```
+
+- 칩 클릭 → 토글 (active: 액센트 보더, 비활성: 흐림)
+- 활성 그룹의 합계가 칩 옆에 숫자로 표시
+- 필터는 **클라이언트 사이드** (피드와 히트맵 모두 같이 갱신)
+- 필터 상태는 `localStorage`에 저장
+- "전체"는 모든 그룹 ON 상태일 때 강조
+
+### 5.6 활동 피드
+
+#### 단일 항목
+
+```
+[아바타] 한솔 [✓ 픽토] LO 완료 [씬 칩 EP01 A씬 #5]
+        2분 전
+```
+
+#### 그룹화 항목 (5분 윈도우)
+
+같은 사람 + 같은 action_type + 같은 episode_number + 5분 이내 → 1그룹
+
+```
+[아바타] 한솔 [✓ 픽토] LO 완료 [씬 칩 EP01 A씬] · 5건       [▸]
+        방금 · 5분 내 묶음
+```
+
+클릭 시 펼침 (Framer Motion `height auto`):
+
+```
+        ✓ LO 완료 · EP01 A씬 #5    · 방금
+        ✓ LO 완료 · EP01 A씬 #6    · 1분 전
+        ...
+```
+
+#### 본인 활동 강조
+
+- `border-left: 2px solid var(--accent-sub)` (#A29BFE)
+- 이름 옆 "(나)" 라벨 (작은 회색 텍스트, 액센트 컬러)
+- 배경 약간 어두움 (`rgba(108, 92, 231, 0.04)`)
+
+#### 시간 표시
+
+- 상대 시간: `"방금" / "N분 전" / "N시간 전"` (24시간 미만)
+- 절대 시간: `"어제 14:32" / "3일 전 10:15"` (24시간 이상)
+
+#### 클릭 액션
+
+- 그룹 헤더 클릭 → 펼침/접기
+- 단일 항목 클릭 → `UnifiedSceneDetailModal` 열기 (씬 ID 전달)
+- 씬이 삭제됐으면 토스트 `"이 씬은 삭제되었습니다"` 후 모달 안 열림
+
+#### 무한 스크롤
+
+- 스크롤 끝 도달 시 다음 50건 로드
+- 최대 7일치 또는 최대 500건 (메모리 한도)
+- 이상 시 `hasMore: false` + "이전 활동 보기" 버튼 (선택, v2)
+
+### 5.7 상태별 표현
+
+| 상태 | 모습 |
+|---|---|
+| 로딩 (초기) | 히트맵·피드 영역에 skeleton (회색 펄스) |
+| 빈 상태 | "아직 활동 기록이 없습니다 · 첫 변경이 발생하면 여기에 표시됩니다" + 스파클 아이콘 |
+| 오프라인 | 헤더에 작은 점 (amber) + "오프라인 — 마지막 동기화 N분 전" |
+| 에러 | "활동 불러오기 실패 · 다시 시도" 버튼 |
+
+---
+
+## 6. 상호작용 & 동작
+
+### 6.1 상태 관리 — `useActivityStore` (Zustand)
+
+```typescript
+interface ActivityStore {
+  activities: Activity[];                  // 시간 역순, 최대 500
+  isLoading: boolean;
+  error: string | null;
+  hasMore: boolean;
+  filters: {
+    groups: Set<'progress' | 'memo' | 'scene' | 'etc'>;
+    department: 'all' | 'bg' | 'acting';
+  };
+  goldenMode: 'heatmap' | 'hour' | 'day';
+
+  // 액션
+  loadInitial(): Promise<void>;
+  loadMore(): Promise<void>;
+  prepend(activity: Activity): void;       // Realtime
+  applyDelta(payload: RealtimePayload): void;
+  setFilter(group: ..., on: boolean): void;
+  setGoldenMode(mode: ...): void;
+}
+```
+
+`localStorage` 영속화:
+- `bflow_activity_filters` — 필터 상태
+- `bflow_activity_golden_mode` — 그래프 모드
+
+### 6.2 데이터 흐름
+
+```
+[초기 로드]
+  Dashboard 마운트 → useActivityStore.loadInitial()
+  → IPC 'activity:list' { limit: 100 }
+  → main의 supabase.ts.listActivities()
+  → activity_log 최근 100건 + 7일치 통계 반환
+  → store에 세팅 → UI 렌더
+
+[Realtime 신규]
+  다른 사용자가 체크박스 토글
+  → activity_log INSERT
+  → Supabase Realtime 이벤트
+  → electron/realtime.ts 수신
+  → broadcast.ts → 모든 윈도우에 전파
+  → useActivityStore.prepend(newItem) (UUID 중복 체크 후)
+  → 피드 최상단에 Framer Motion 진입 애니메이션
+  → 히트맵 해당 셀 강도 +1 (로컬 재계산)
+
+[자기 변경]
+  체크박스 토글 → 낙관적 prepend (tmp_*) → RPC 응답으로 진짜 UUID 교체
+  Realtime 같은 UUID 이벤트는 store dedupe 로직으로 무시
+
+[페이지네이션]
+  피드 끝 도달 → loadMore() → IPC { before: oldestCreatedAt, limit: 50 }
+  → 7일 경계 도달 시 hasMore: false
+```
+
+### 6.3 그룹화 알고리즘
+
+```typescript
+function groupActivities(items: Activity[]): GroupedItem[] {
+  // 시간 역순 순회
+  // 직전 항목과 같은 (user_id, action_type, episode_number) + 5분 이내 → 같은 그룹
+  // 그룹 내 children은 시간 역순 유지
+  // 단일 활동(children 1개)은 그룹화하지 않고 평면 항목
+}
+```
+
+### 6.4 인사이트 자동 산출
+
+```typescript
+function pickGoldenWindow(grid: number[][]): {day, hour, count, ratio} {
+  // 24×7 격자에서 연속 2시간(같은 요일) 합이 최대인 슬롯
+  // 동률이면 가장 최근 요일 우선
+}
+function pickGoldenHour(hourTotals: number[]): {hour, ratio}
+function pickGoldenDay(dayTotals: number[]): {day, ratio}
+```
+
+### 6.5 시간대 처리
+
+`activity_log.created_at` = `TIMESTAMPTZ` (UTC 저장).
+클라이언트에서 KST(`Asia/Seoul`)로 변환하여 히트맵 셀 결정.
+`dayjs` 또는 `Date.toLocaleString` + 타임존 옵션 활용.
+
+### 6.6 IPC 핸들러 추가 — `electron/main.ts`
+
+| 채널 | 역할 |
+|---|---|
+| `activity:list` | 페이지네이션 조회 |
+| `activity:record` | RPC `record_activity` 호출 래퍼 |
+| `activity:stats` | 1주일치 히트맵용 집계 (옵션, 클라이언트 계산이면 생략 가능) |
+
+---
+
+## 7. 에지 케이스 & 성능
+
+### 7.1 동시성 / 중복 방지
+
+- 낙관적 prepend의 임시 ID → RPC 응답 UUID로 교체
+- Realtime 이벤트 dedupe: store에 같은 UUID 이미 있으면 무시
+- 여러 윈도우 동시 변경: activity_log INSERT는 트랜잭션 내, 자체 충돌 없음
+
+### 7.2 사용자/씬 변경
+
+- 사용자 이름 변경 → 과거 기록은 옛 이름 (의도된 동작)
+- 씬 삭제 → `scene_id`는 FK 없으므로 그대로 남음, 클릭 시 토스트 후 모달 닫힘
+- 아카이브된 에피소드 활동도 표시 (필터로 제외 가능, v2)
+
+### 7.3 성능 추정
+
+| 시나리오 | 측정/추정 | 대응 |
+|---|---|---|
+| 활동량 (팀 20명, 50건/인/일) | 1,000건/일 = 26만건/년 | 1년 보존 정책으로 제한 |
+| DB 용량 | row 약 400 bytes → 약 100MB/년 | 무료 한도 500MB의 20% |
+| 위젯 첫 로드 | <100ms | 인덱스 효율 |
+| 체크박스 토글 지연 | +5–10ms | RPC INSERT 1건 |
+| Realtime 메시지 | 2만/일 (1000건 × 20접속) | Pro 한도 200만/일의 1% |
+
+### 7.4 사이즈 모니터링
+
+설정 화면에 한 줄 추가:
+```
+활동 기록: 12,345건 · 약 4.9 MB · 1년 후 자동 정리
+```
+
+값은 `SELECT count(*), pg_total_relation_size('activity_log')` RPC로 조회.
+
+### 7.5 새 mutation 추가 시 누락 방지
+
+- PR 리뷰 체크리스트에 "활동 기록 호출 추가" 항목
+- v2에서 lint 룰로 자동화 가능 (선택)
+
+---
+
+## 8. 마이그레이션 & 배포
+
+### 8.1 SQL 마이그레이션
+
+`DEVLOG/supabase-init.sql`에 다음 추가:
+
+1. `activity_log` 테이블 생성 + 인덱스 3개
+2. RLS 정책 (`allow_all`)
+3. Realtime publication 추가
+4. `record_activity()` RPC 함수
+5. `cleanup_old_activity_logs()` 함수 + pg_cron 스케줄
+
+`IF NOT EXISTS` 패턴으로 재실행 안전성 유지.
+
+### 8.2 코드 변경 범위
+
+| 파일 | 변경 내용 |
+|---|---|
+| `DEVLOG/supabase-init.sql` | 위 §8.1 추가 |
+| `electron/supabase.ts` | `recordActivity`, `listActivities` 함수 신설 + 12개 mutation에 호출 추가 |
+| `electron/main.ts` | IPC 핸들러 2개 추가 |
+| `electron/realtime.ts` | activity_log 구독 추가 |
+| `electron/broadcast.ts` | activity 이벤트 전파 추가 |
+| `electron/preload.ts` | electronAPI에 activity 메서드 추가 |
+| `src/types/index.ts` | `Activity`, `ActionType`, `ActionGroup` 타입 정의 |
+| `src/services/supabaseService.ts` | activity 래퍼 함수 |
+| `src/stores/useActivityStore.ts` | **신규** — Zustand store |
+| `src/components/widgets/RecentActivityWidget.tsx` | **신규** — 메인 위젯 |
+| `src/components/widgets/activity/ActivityFeed.tsx` | **신규** — 피드 컴포넌트 |
+| `src/components/widgets/activity/GoldenHeatmap.tsx` | **신규** — 히트맵 |
+| `src/components/widgets/activity/GoldenBarChart.tsx` | **신규** — 막대 그래프 |
+| `src/components/widgets/activity/ActivityFilterChips.tsx` | **신규** — 필터 칩 |
+| `src/views/Dashboard.tsx` | 위젯 등록 + 디폴트 레이아웃 |
+| `src/views/SettingsView.tsx` | 활동 기록 모니터링 라인 1줄 |
+
+### 8.3 배포 영향
+
+- DB 변경: `activity_log` 테이블 신설 (다운타임 0)
+- 기존 mutation 12개 패치: 한 줄씩 추가, try/catch로 본 동작은 안 깨짐
+- 위젯 자동 노출 안 됨 — 사용자가 `+` 버튼으로 추가
+- 버전: `v1.14.0` (마이너 — 새 기능)
+
+---
+
+## 9. 테스트 전략
+
+### 9.1 단위 테스트
+
+| 대상 | 검증 |
+|---|---|
+| `groupActivities()` | 5분 윈도우, 같은 종류·씬 묶기, 그룹 < 2면 평면화 |
+| `pickGoldenWindow()` / `pickGoldenHour()` / `pickGoldenDay()` | 정점 선택 정확성, 동률 처리 |
+| `useActivityStore.prepend()` | UUID dedupe, 500건 한도 enforcement |
+| `useActivityStore.setFilter()` | 필터 변경 시 히트맵·피드 동시 갱신 |
+
+### 9.2 통합 테스트 (수동 검증)
+
+- [ ] 두 윈도우에서 동시에 다른 씬 토글 → 양쪽 다 활동이 1번씩만 보임 (중복 없음)
+- [ ] 본인 토글 → 즉시 피드 최상단 (낙관적), 보더 강조
+- [ ] 다른 사용자 토글 → ~100ms 후 피드 최상단 (Realtime)
+- [ ] 필터 칩 토글 → 피드 + 히트맵 동시 갱신
+- [ ] 그래프 모드 전환 → 인사이트 텍스트 변경
+- [ ] 그룹화된 5건 펼침/접기
+- [ ] 호버 툴팁 (히트맵 그룹별 분포 / 막대 단순)
+- [ ] 빈 상태 → 첫 활동 → 풍부 상태 흐름
+- [ ] 오프라인 진입 → 헤더 점, 재연결 시 누락분 fetch
+- [ ] 1년 cron 동작 (수동으로 INTERVAL '5 minutes' 변경 후 검증, 후 원복)
+
+### 9.3 빌드 검증
+
+- `npx tsc --noEmit` 통과
+- `npx vite build` 통과
+
+---
+
+## 10. 결정 이력 (Q&A)
+
+브레인스토밍 과정의 핵심 결정들:
+
+1. **두 기능 묶기**: 위젯 + G:\\ 경로 링크화 → 별도 스펙 2개로 분리
+2. **위젯 용도**: 팀 소셜 피드 / 매니저 모니터링 / 본인 회고 / 통합 → **팀 소셜 피드**
+3. **활동 범위**: 진척만 / 진척+소통 / 픽토그램 다양화 → **그룹화된 픽토그램**
+4. **골든타임 형태**: 히트맵 / 시간대 막대 / 사람별 카드 / 텍스트 → **히트맵** (+ 후속 요청으로 막대 모드 추가)
+5. **레이아웃**: 상하 분할 / 탭 / 좌우 분할 / 분리 위젯 → **상하 분할**
+6. **추적 종류**: 성과만 / 성과+소통 / 성과+소통+설정 → **전부 (12종 → 13종)**
+7. **출시 시점 데이터**: 풍부 백필 / 진척만 백필 / 깨끗한 시작 → **깨끗한 시작**
+8. **기록 경로**: 트리거 / 앱 INSERT+RPC / 기존 테이블 UNION → **앱 INSERT+RPC**
+9. **추가 보강** (한솔 요청): 그래프 3모드 + 4그룹 필터 + 툴팁 강화 + 1년 보존
+
+---
+
+## 11. 후속 작업 (out of scope)
+
+이 스펙 외에 별도 진행:
+
+- **B 스펙**: 메모/댓글에 G:\\ 경로 자동 링크화 (별도 문서)
+- **v2 후보**:
+  - 사람별 골든타임 카드 추가 (히트맵 옆 행)
+  - 활동 검색
+  - 엑셀 내보내기 (월간 활동 리포트)
+  - 개별 활동 종류 13종 토글 (현재는 4그룹만)
+  - 본인 활동 숨기기 옵션
+  - 노이즈 필터 (예: 동일 토글 ON→OFF→ON 묶기)

--- a/docs/superpowers/specs/mockups/2026-04-27-recent-activity-widget/final.html
+++ b/docs/superpowers/specs/mockups/2026-04-27-recent-activity-widget/final.html
@@ -1,0 +1,816 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>최근 작업 위젯 — 최종 시안</title>
+<style>
+  :root {
+    --bg: #0F1117;
+    --bg-deep: #0a0c12;
+    --card: #1A1D27;
+    --card-hi: #20232f;
+    --border: #2D3041;
+    --border-soft: rgba(45, 48, 65, 0.6);
+    --text: #E8E8EE;
+    --text-muted: #8B8DA3;
+    --text-faint: #5b5e75;
+    --accent: #6C5CE7;
+    --accent-sub: #A29BFE;
+    --lo: #74B9FF;
+    --done: #A29BFE;
+    --review: #FDCB6E;
+    --png: #00B894;
+    --memo: #FF8FA3;
+    --comment: #FFA94D;
+    --rev: #4DD0E1;
+    --rev-resolve: #81ECEC;
+    --new: #6FCF97;
+    --del: #FF7675;
+    --gray: #95A5A6;
+
+    --glass-tint: rgba(26, 29, 39, 0.55);
+    --shadow: rgba(0, 0, 0, 0.45);
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    background: radial-gradient(ellipse at top, #1a1d2e 0%, var(--bg) 35%, var(--bg-deep) 100%);
+    color: var(--text);
+    font-family: 'Pretendard', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    min-height: 100vh;
+    padding: 32px 24px 80px;
+    -webkit-font-smoothing: antialiased;
+  }
+  .page-wrap {
+    max-width: 760px; margin: 0 auto;
+  }
+  .page-title {
+    font-size: 22px; font-weight: 700; letter-spacing: -0.02em; margin: 0 0 6px;
+  }
+  .page-subtitle {
+    font-size: 12.5px; color: var(--text-muted); margin: 0 0 22px;
+  }
+  .tag {
+    display: inline-block;
+    background: rgba(108, 92, 231, 0.15);
+    color: var(--accent-sub);
+    border: 1px solid rgba(108, 92, 231, 0.25);
+    padding: 2px 8px; border-radius: 999px; font-size: 11px; font-weight: 600;
+    margin-left: 8px; vertical-align: middle;
+  }
+
+  /* 위젯 */
+  .widget {
+    background: var(--glass-tint);
+    backdrop-filter: blur(24px) saturate(1.8);
+    -webkit-backdrop-filter: blur(24px) saturate(1.8);
+    border: 1px solid var(--border-soft);
+    border-radius: 16px;
+    overflow: hidden;
+    box-shadow:
+      0 8px 32px var(--shadow),
+      inset 0 0 0 1px rgba(255, 255, 255, 0.04),
+      inset 0 1px 0 rgba(255, 255, 255, 0.08);
+    display: flex; flex-direction: column;
+    height: 720px;
+  }
+
+  /* 헤더 */
+  .widget-header {
+    display: flex; align-items: center; gap: 8px;
+    padding: 12px 14px; border-bottom: 1px solid rgba(45, 48, 65, 0.4);
+    user-select: none;
+  }
+  .drag-dots {
+    display: grid; grid-template-columns: repeat(2, 3px); gap: 3px; margin-right: 4px;
+  }
+  .drag-dots span { width: 3px; height: 3px; border-radius: 50%; background: rgba(139,141,163,0.35); }
+  .widget-icon { color: var(--accent); display: flex; }
+  .widget-title { font-size: 13px; font-weight: 500; color: rgba(232, 232, 238, 0.9); }
+  .widget-tools { margin-left: auto; display: flex; gap: 4px; align-items: center; }
+
+  /* 그래프 모드 토글 */
+  .mode-toggle {
+    display: flex; gap: 2px; background: rgba(0, 0, 0, 0.25);
+    padding: 2px; border-radius: 7px;
+  }
+  .mode-toggle button {
+    background: none; border: none; color: var(--text-muted);
+    padding: 4px 8px; border-radius: 5px; cursor: pointer;
+    font-size: 11px; display: flex; align-items: center; gap: 4px;
+    transition: all .15s;
+  }
+  .mode-toggle button:hover { color: var(--text); }
+  .mode-toggle button.active {
+    background: rgba(108, 92, 231, 0.2);
+    color: var(--accent-sub);
+    box-shadow: inset 0 0 0 1px rgba(108, 92, 231, 0.3);
+  }
+  .icon-btn {
+    background: none; border: none; color: var(--text-faint);
+    padding: 4px; border-radius: 6px; cursor: pointer;
+    transition: color .15s;
+    display: flex; align-items: center;
+  }
+  .icon-btn:hover { color: var(--accent-sub); background: rgba(108, 92, 231, 0.08); }
+
+  /* 인사이트 배너 */
+  .insight {
+    display: flex; align-items: center; gap: 8px;
+    padding: 10px 14px;
+    margin: 12px 14px 0;
+    background: rgba(108, 92, 231, 0.08);
+    border: 1px solid rgba(108, 92, 231, 0.2);
+    border-radius: 10px;
+    font-size: 12.5px;
+    color: var(--text);
+  }
+  .insight strong { color: var(--accent-sub); }
+  .insight-icon { color: var(--accent-sub); flex-shrink: 0; display: flex; }
+
+  /* 골든타임 영역 */
+  .golden-area {
+    padding: 12px 14px 4px;
+    flex-shrink: 0;
+  }
+  .golden-mode { display: none; }
+  .golden-mode.active { display: block; }
+
+  /* 히트맵 */
+  .heatmap {
+    display: grid;
+    grid-template-columns: 22px repeat(24, 1fr);
+    gap: 2px;
+    align-items: center;
+  }
+  .h-empty { width: 22px; }
+  .h-hour {
+    font-size: 9px; color: var(--text-faint); text-align: center;
+  }
+  .h-day {
+    font-size: 10px; color: var(--text-muted); text-align: right; padding-right: 6px;
+  }
+  .cell {
+    width: 100%; aspect-ratio: 1 / 1; border-radius: 2px;
+    background: rgba(108, 92, 231, 0.06);
+    transition: transform .15s;
+    cursor: pointer; position: relative;
+  }
+  .cell:hover { transform: scale(1.4); z-index: 5; }
+  .cell.l1 { background: rgba(108, 92, 231, 0.18); }
+  .cell.l2 { background: rgba(108, 92, 231, 0.36); }
+  .cell.l3 { background: rgba(108, 92, 231, 0.58); }
+  .cell.l4 { background: rgba(108, 92, 231, 0.85); box-shadow: 0 0 8px rgba(108, 92, 231, 0.3); }
+
+  /* 시간대 막대 그래프 */
+  .bar-chart {
+    display: grid;
+    grid-template-columns: repeat(24, 1fr);
+    align-items: end;
+    gap: 3px;
+    height: 130px;
+    padding-bottom: 18px;
+    position: relative;
+  }
+  .bar {
+    background: linear-gradient(to top, var(--accent) 0%, var(--accent-sub) 100%);
+    border-radius: 3px 3px 0 0;
+    cursor: pointer;
+    transition: opacity .15s;
+    position: relative;
+  }
+  .bar:hover { opacity: 0.8; }
+  .bar-label {
+    position: absolute; bottom: -16px; left: 50%; transform: translateX(-50%);
+    font-size: 8.5px; color: var(--text-faint);
+  }
+
+  /* 요일 막대 그래프 */
+  .bar-chart-week {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    align-items: end;
+    gap: 12px;
+    height: 130px;
+    padding: 0 12px 22px;
+  }
+  .bar-week {
+    background: linear-gradient(to top, var(--accent) 0%, var(--accent-sub) 100%);
+    border-radius: 5px 5px 0 0;
+    cursor: pointer;
+    position: relative;
+    transition: opacity .15s;
+  }
+  .bar-week:hover { opacity: 0.85; }
+  .bar-week .bar-label {
+    bottom: -20px; font-size: 11px; color: var(--text-muted);
+  }
+  .bar-week.peak { background: linear-gradient(to top, #FDCB6E 0%, #FFE5A0 100%); }
+
+  /* 툴팁 (글로벌) */
+  .tooltip {
+    position: fixed;
+    background: rgba(15, 17, 23, 0.95);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 8px 10px;
+    font-size: 11.5px;
+    color: var(--text);
+    white-space: nowrap;
+    pointer-events: none;
+    z-index: 100;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(12px);
+    transform: translate(-50%, -100%);
+    margin-top: -8px;
+    display: none;
+  }
+  .tooltip.visible { display: block; }
+  .tooltip-title {
+    font-weight: 600;
+    margin-bottom: 4px;
+    color: var(--accent-sub);
+  }
+  .tooltip-row {
+    display: flex; gap: 6px; align-items: center;
+    color: var(--text-muted);
+    font-size: 11px;
+  }
+  .tooltip-dot {
+    width: 7px; height: 7px; border-radius: 50%;
+  }
+
+  /* 필터 칩 */
+  .filter-bar {
+    display: flex; gap: 6px; padding: 12px 14px 4px;
+    flex-wrap: wrap;
+    border-top: 1px solid rgba(45, 48, 65, 0.3);
+    margin-top: 8px;
+  }
+  .chip {
+    background: transparent;
+    border: 1px solid var(--border);
+    color: var(--text-muted);
+    padding: 4px 10px; border-radius: 999px;
+    font-size: 11.5px; cursor: pointer;
+    transition: all .15s;
+    display: flex; align-items: center; gap: 5px;
+  }
+  .chip:hover { border-color: var(--accent-sub); color: var(--text); }
+  .chip.active {
+    background: rgba(108, 92, 231, 0.18);
+    border-color: rgba(108, 92, 231, 0.5);
+    color: var(--text);
+  }
+  .chip.all {
+    background: rgba(108, 92, 231, 0.3);
+    border-color: var(--accent-sub);
+    color: var(--accent-sub);
+    font-weight: 600;
+  }
+  .chip-dot {
+    width: 6px; height: 6px; border-radius: 50%;
+  }
+
+  /* 활동 피드 */
+  .feed-divider {
+    display: flex; align-items: center; gap: 8px;
+    padding: 10px 14px 6px;
+    font-size: 10.5px; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.08em;
+    color: var(--text-faint);
+  }
+  .feed-divider .count {
+    background: rgba(108, 92, 231, 0.15);
+    color: var(--accent-sub);
+    padding: 1px 7px; border-radius: 999px;
+    font-size: 10px;
+    text-transform: none; letter-spacing: 0;
+  }
+  .feed { flex: 1; overflow-y: auto; padding-bottom: 8px; }
+  .feed::-webkit-scrollbar { width: 6px; }
+  .feed::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+  .feed::-webkit-scrollbar-track { background: transparent; }
+
+  .feed-item {
+    display: flex; gap: 10px;
+    padding: 9px 14px;
+    border-bottom: 1px solid rgba(45, 48, 65, 0.2);
+    transition: background .15s;
+    cursor: pointer;
+    position: relative;
+  }
+  .feed-item:hover { background: rgba(255, 255, 255, 0.025); }
+  .feed-item:last-child { border-bottom: none; }
+  .feed-item.is-self {
+    background: rgba(108, 92, 231, 0.04);
+  }
+  .feed-item.is-self::before {
+    content: '';
+    position: absolute; left: 0; top: 0; bottom: 0;
+    width: 2px; background: var(--accent-sub);
+  }
+
+  .avatar {
+    width: 28px; height: 28px; border-radius: 50%;
+    background: linear-gradient(135deg, #6C5CE7, #A29BFE);
+    color: white; font-size: 11px; font-weight: 700;
+    display: flex; align-items: center; justify-content: center;
+    flex-shrink: 0;
+    border: 1.5px solid rgba(255, 255, 255, 0.06);
+  }
+  .avatar.h { background: linear-gradient(135deg, #FF8FA3, #FF6B9D); }
+  .avatar.j { background: linear-gradient(135deg, #74B9FF, #4DA3FF); }
+  .avatar.m { background: linear-gradient(135deg, #00B894, #00D4A8); }
+  .avatar.s { background: linear-gradient(135deg, #FDCB6E, #F39C12); }
+  .avatar.d { background: linear-gradient(135deg, #4DD0E1, #26C6DA); }
+
+  .feed-body { flex: 1; min-width: 0; }
+  .feed-line {
+    display: flex; align-items: center; gap: 6px;
+    font-size: 12.5px; line-height: 1.45;
+    flex-wrap: wrap;
+  }
+  .feed-name { font-weight: 600; color: var(--text); }
+  .feed-name.self::after {
+    content: ' (나)';
+    color: var(--accent-sub);
+    font-size: 10.5px;
+    font-weight: 500;
+  }
+  .feed-action { color: var(--text-muted); }
+  .feed-target {
+    color: var(--accent-sub);
+    background: rgba(108, 92, 231, 0.1);
+    padding: 1px 6px; border-radius: 4px;
+    font-size: 11.5px; font-weight: 500;
+  }
+  .feed-meta {
+    display: flex; align-items: center; gap: 8px;
+    margin-top: 3px;
+    font-size: 11px;
+    color: var(--text-faint);
+  }
+  .pictogram {
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 18px; height: 18px; border-radius: 5px; flex-shrink: 0;
+  }
+  .pictogram.lo     { background: rgba(116, 185, 255, 0.2); color: var(--lo); }
+  .pictogram.done   { background: rgba(162, 155, 254, 0.2); color: var(--done); }
+  .pictogram.review { background: rgba(253, 203, 110, 0.2); color: var(--review); }
+  .pictogram.png    { background: rgba(0, 184, 148, 0.22);  color: var(--png); }
+  .pictogram.memo   { background: rgba(255, 143, 163, 0.2); color: var(--memo); }
+  .pictogram.comment{ background: rgba(255, 169, 77, 0.2);  color: var(--comment); }
+  .pictogram.rev    { background: rgba(77, 208, 225, 0.2);  color: var(--rev); }
+  .pictogram.new    { background: rgba(111, 207, 151, 0.22); color: var(--new); }
+  .pictogram.del    { background: rgba(255, 118, 117, 0.2);  color: var(--del); }
+  .pictogram.assignee, .pictogram.layout, .pictogram.image { background: rgba(149, 165, 166, 0.2); color: var(--gray); }
+
+  /* 그룹화된 활동 (확장/접기) */
+  .feed-group {
+    border-bottom: 1px solid rgba(45, 48, 65, 0.2);
+  }
+  .group-head {
+    display: flex; gap: 10px; padding: 9px 14px;
+    cursor: pointer;
+    transition: background .15s;
+  }
+  .group-head:hover { background: rgba(255, 255, 255, 0.025); }
+  .group-meta {
+    color: var(--text-faint); font-size: 11px; margin-top: 3px;
+    display: flex; align-items: center; gap: 6px;
+  }
+  .group-toggle {
+    color: var(--text-faint);
+    transition: transform .2s;
+    margin-left: 4px;
+  }
+  .group-toggle.open { transform: rotate(90deg); color: var(--accent-sub); }
+  .group-children {
+    background: rgba(0, 0, 0, 0.15);
+    overflow: hidden;
+    transition: max-height .25s;
+  }
+  .group-children .feed-item {
+    padding-left: 50px;
+    background: none;
+  }
+  .group-children .feed-item::before { display: none; }
+  .group-children.collapsed { max-height: 0 !important; }
+
+  /* 칩 도트 컬러 */
+  .dot-progress { background: var(--lo); }
+  .dot-memo { background: var(--memo); }
+  .dot-scene { background: var(--new); }
+  .dot-etc { background: var(--gray); }
+
+  /* 레이아웃 안내 라벨 */
+  .label-strip {
+    background: rgba(108, 92, 231, 0.08);
+    border-left: 3px solid var(--accent);
+    padding: 8px 12px;
+    margin: 0 0 16px;
+    border-radius: 0 8px 8px 0;
+    font-size: 12px;
+    color: var(--text-muted);
+  }
+  .label-strip strong { color: var(--accent-sub); }
+</style>
+</head>
+<body>
+
+<div class="page-wrap">
+  <h1 class="page-title">최근 작업 위젯 · 최종 시안 <span class="tag">v2 — 확정</span></h1>
+  <p class="page-subtitle">상하 분할 / 12종+1 추적 / 4그룹 필터 / 3가지 그래프 모드 / 본인 강조 / 그룹화 5분 / 1년 보존</p>
+
+  <div class="label-strip">
+    💡 헤더의 <strong>모드 토글(▦/▮▮▮/━)</strong> · 인사이트 배너 · <strong>4그룹 필터칩</strong> · 그룹화된 항목(▸ 클릭) · 본인 활동(보라색 보더) 모두 클릭/호버 동작합니다.
+  </div>
+
+  <!-- ────────────── 위젯 본체 ────────────── -->
+  <div class="widget">
+
+    <!-- 헤더 -->
+    <div class="widget-header">
+      <div class="drag-dots"><span></span><span></span><span></span><span></span><span></span><span></span></div>
+      <span class="widget-icon">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+      </span>
+      <span class="widget-title">최근 작업</span>
+      <div class="widget-tools">
+        <div class="mode-toggle" id="mode-toggle">
+          <button class="active" data-mode="heatmap" title="히트맵 모드">
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+            히트맵
+          </button>
+          <button data-mode="hour" title="시간대 막대">
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="20" x2="12" y2="10"/><line x1="18" y1="20" x2="18" y2="4"/><line x1="6" y1="20" x2="6" y2="16"/></svg>
+            시간대
+          </button>
+          <button data-mode="day" title="요일 막대">
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+            요일
+          </button>
+        </div>
+        <button class="icon-btn" title="필터">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+        </button>
+        <button class="icon-btn" title="팝업으로 띄우기">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 3h7v7"/><path d="M10 14L21 3"/><path d="M21 14v7H3V3h7"/></svg>
+        </button>
+      </div>
+    </div>
+
+    <!-- 인사이트 배너 -->
+    <div class="insight" id="insight">
+      <span class="insight-icon">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+      </span>
+      <span id="insight-text">이번 주 가장 활발: <strong>화요일 14–16시</strong> (47건)</span>
+    </div>
+
+    <!-- 골든타임 영역 -->
+    <div class="golden-area">
+
+      <!-- 히트맵 모드 -->
+      <div class="golden-mode active" data-mode="heatmap">
+        <div class="heatmap" id="heatmap"></div>
+      </div>
+
+      <!-- 시간대 막대 모드 -->
+      <div class="golden-mode" data-mode="hour">
+        <div class="bar-chart" id="hour-chart"></div>
+      </div>
+
+      <!-- 요일 막대 모드 -->
+      <div class="golden-mode" data-mode="day">
+        <div class="bar-chart-week" id="day-chart"></div>
+      </div>
+    </div>
+
+    <!-- 필터 칩 -->
+    <div class="filter-bar">
+      <button class="chip all">전체 38</button>
+      <button class="chip active">
+        <span class="chip-dot dot-progress"></span> 작업 진행 18
+      </button>
+      <button class="chip active">
+        <span class="chip-dot dot-memo"></span> 메모/댓글 11
+      </button>
+      <button class="chip active">
+        <span class="chip-dot dot-scene"></span> 씬 생성/삭제 4
+      </button>
+      <button class="chip active">
+        <span class="chip-dot dot-etc"></span> 기타 5
+      </button>
+    </div>
+
+    <!-- 피드 -->
+    <div class="feed-divider">
+      최근 활동
+      <span class="count">38건 · 최근 7일</span>
+    </div>
+    <div class="feed" id="feed"></div>
+  </div>
+
+  <!-- 라벨 안내 -->
+  <div style="margin-top: 24px; display: flex; gap: 12px; flex-wrap: wrap;">
+    <div style="font-size: 11.5px; color: var(--text-muted); padding: 8px 14px; background: rgba(255,255,255,0.03); border-radius: 8px;">
+      ✓ 옵션 1 (상하 분할) · ✓ 그래프 3모드 · ✓ 4그룹 필터 칩 · ✓ 그룹화 5분 · ✓ 본인 활동 보더 강조 · ✓ 1년 보존 정책 · ✓ Realtime dedupe
+    </div>
+  </div>
+
+</div>
+
+<!-- 글로벌 툴팁 -->
+<div class="tooltip" id="tooltip"></div>
+
+<script>
+  /* ─── 가짜 데이터 ─── */
+  const ACTIONS = {
+    stage_lo:     { group:'progress', icon:'check',   verb:'LO 완료',     pictoClass:'lo' },
+    stage_done:   { group:'progress', icon:'check',   verb:'완료 진척',   pictoClass:'done' },
+    stage_review: { group:'progress', icon:'eye',     verb:'검수 통과',   pictoClass:'review' },
+    stage_png:    { group:'progress', icon:'sparkle', verb:'PNG 마감',    pictoClass:'png' },
+    memo_update:  { group:'memo',     icon:'pen',     verb:'메모 수정',   pictoClass:'memo' },
+    comment_add:  { group:'memo',     icon:'message', verb:'댓글 작성',   pictoClass:'comment' },
+    revision_add: { group:'memo',     icon:'rotate',  verb:'리비전 등록', pictoClass:'rev' },
+    scene_add:    { group:'scene',    icon:'plus',    verb:'씬 추가',     pictoClass:'new' },
+    scene_delete: { group:'scene',    icon:'trash',   verb:'씬 삭제',     pictoClass:'del' },
+    assignee_change: { group:'etc',  icon:'user',    verb:'담당자 변경', pictoClass:'assignee' },
+    layout_change:   { group:'etc',  icon:'grid',    verb:'레이아웃 변경', pictoClass:'layout' },
+    image_upload_storyboard: { group:'etc', icon:'image', verb:'스토리보드 업로드', pictoClass:'image' },
+  };
+  const ICON_SVG = {
+    check:   '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>',
+    eye:     '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>',
+    sparkle: '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2l2.39 6.96L22 12l-7.61 3.04L12 22l-2.39-6.96L2 12l7.61-3.04z"/></svg>',
+    pen:     '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4z"/></svg>',
+    message: '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>',
+    rotate:  '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>',
+    plus:    '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>',
+    trash:   '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-2 14a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2L5 6"/></svg>',
+    user:    '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>',
+    grid:    '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>',
+    image:   '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>',
+  };
+
+  const PEOPLE = [
+    { id: 'h', name: '한솔', avatarClass: 'h' },
+    { id: 'j', name: '지영', avatarClass: 'j' },
+    { id: 'm', name: '민수', avatarClass: 'm' },
+    { id: 's', name: '수진', avatarClass: 's' },
+    { id: 'd', name: '도현', avatarClass: 'd' },
+  ];
+
+  const FEED = [
+    /* 그룹: 한솔 / stage_lo / EP01 A씬 / 2분 전 — 5건 묶음 */
+    { type:'group', p:'h', actionType:'stage_lo', label:'EP01 A씬', when:'방금', items: [
+      { target:'EP01 A씬 #5', when:'방금' },
+      { target:'EP01 A씬 #6', when:'1분 전' },
+      { target:'EP01 A씬 #7', when:'2분 전' },
+      { target:'EP01 A씬 #8', when:'3분 전' },
+      { target:'EP01 A씬 #9', when:'4분 전' },
+    ]},
+    { type:'item', p:'j', actionType:'comment_add', target:'EP01 D씬 #2', when:'8분 전' },
+    { type:'item', p:'m', actionType:'stage_png',   target:'EP01 A씬 #8', when:'14분 전' },
+    { type:'item', p:'h', actionType:'stage_review',target:'EP03 C씬 #3', when:'32분 전', isSelf:true },
+    { type:'item', p:'s', actionType:'revision_add',target:'EP03 A씬 #7', when:'47분 전' },
+    { type:'item', p:'d', actionType:'memo_update', target:'EP02 B씬 #4', when:'1시간 전' },
+    { type:'item', p:'j', actionType:'scene_add',   target:'EP02 C씬 #11', when:'1시간 전' },
+    { type:'item', p:'m', actionType:'stage_done',  target:'EP01 B씬 #12', when:'1시간 전' },
+    { type:'item', p:'h', actionType:'memo_update', target:'EP01 D씬 #2', when:'2시간 전', isSelf:true },
+    { type:'item', p:'s', actionType:'assignee_change', target:'EP02 A씬 #3', when:'2시간 전' },
+    { type:'item', p:'d', actionType:'image_upload_storyboard', target:'EP01 C씬 #4', when:'3시간 전' },
+    { type:'item', p:'j', actionType:'scene_delete', target:'EP02 D씬 #15', when:'4시간 전' },
+  ];
+
+  /* ─── 활동 피드 렌더 ─── */
+  function renderFeed() {
+    const el = document.getElementById('feed');
+    el.innerHTML = FEED.map(item => {
+      if (item.type === 'group') {
+        const person = PEOPLE.find(p => p.id === item.p);
+        const action = ACTIONS[item.actionType];
+        const initial = person.name.charAt(0);
+        const isSelf = person.id === 'h'; // 데모: 한솔이 본인
+        const childItems = item.items.map(c => `
+          <div class="feed-item">
+            <div class="feed-body" style="margin-left:0;">
+              <div class="feed-line">
+                <span class="pictogram ${action.pictoClass}">${ICON_SVG[action.icon]}</span>
+                <span class="feed-action">${action.verb}</span>
+                <span class="feed-target">${c.target}</span>
+              </div>
+              <div class="feed-meta"><span>${c.when}</span></div>
+            </div>
+          </div>
+        `).join('');
+        return `
+          <div class="feed-group ${isSelf ? 'is-self-group' : ''}" style="${isSelf ? 'border-left:2px solid var(--accent-sub);' : ''}">
+            <div class="group-head" onclick="toggleGroup(this)">
+              <div class="avatar ${person.avatarClass}">${initial}</div>
+              <div class="feed-body">
+                <div class="feed-line">
+                  <span class="feed-name ${isSelf ? 'self' : ''}">${person.name}</span>
+                  <span class="pictogram ${action.pictoClass}">${ICON_SVG[action.icon]}</span>
+                  <span class="feed-action">${action.verb}</span>
+                  <span class="feed-target">${item.label}</span>
+                  <span style="color:var(--text-faint); font-size:11px;">· ${item.items.length}건</span>
+                </div>
+                <div class="group-meta">
+                  <span>${item.when}</span>
+                  <span style="color:var(--text-faint);">·</span>
+                  <span>5분 내 묶음</span>
+                </div>
+              </div>
+              <span class="group-toggle">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
+              </span>
+            </div>
+            <div class="group-children collapsed">${childItems}</div>
+          </div>
+        `;
+      }
+      const person = PEOPLE.find(p => p.id === item.p);
+      const action = ACTIONS[item.actionType];
+      const initial = person.name.charAt(0);
+      return `
+        <div class="feed-item ${item.isSelf ? 'is-self' : ''}">
+          <div class="avatar ${person.avatarClass}">${initial}</div>
+          <div class="feed-body">
+            <div class="feed-line">
+              <span class="feed-name ${item.isSelf ? 'self' : ''}">${person.name}</span>
+              <span class="pictogram ${action.pictoClass}">${ICON_SVG[action.icon]}</span>
+              <span class="feed-action">${action.verb}</span>
+              <span class="feed-target">${item.target}</span>
+            </div>
+            <div class="feed-meta"><span>${item.when}</span></div>
+          </div>
+        </div>
+      `;
+    }).join('');
+  }
+
+  function toggleGroup(headEl) {
+    const children = headEl.nextElementSibling;
+    const toggle = headEl.querySelector('.group-toggle');
+    children.classList.toggle('collapsed');
+    if (children.classList.contains('collapsed')) {
+      children.style.maxHeight = '0';
+    } else {
+      children.style.maxHeight = children.scrollHeight + 'px';
+    }
+    toggle.classList.toggle('open');
+  }
+
+  /* ─── 골든타임 데이터 ─── */
+  const DAYS = ['월','화','수','목','금','토','일'];
+  function genGrid() {
+    const grid = [];
+    for (let d = 0; d < 7; d++) {
+      const row = [];
+      for (let h = 0; h < 24; h++) {
+        let level = 0;
+        if (h >= 10 && h <= 18 && d < 5) {
+          level = Math.floor(Math.random() * 3) + 1;
+          if (h >= 13 && h <= 16 && d === 1) level = 4;
+          if (h >= 14 && h <= 15 && d === 0) level = 3;
+          if (h === 11 && d === 2) level = 3;
+        } else if (h >= 19 && h <= 22 && d < 5) {
+          level = Math.random() > 0.6 ? 1 : 0;
+        }
+        row.push(level);
+      }
+      grid.push(row);
+    }
+    return grid;
+  }
+  const GRID = genGrid();
+
+  /* 카운트로 변환 (level → 추정 건수) */
+  function levelToCount(l) {
+    if (l === 0) return 0;
+    if (l === 1) return Math.floor(Math.random() * 2) + 1;
+    if (l === 2) return Math.floor(Math.random() * 3) + 3;
+    if (l === 3) return Math.floor(Math.random() * 4) + 6;
+    if (l === 4) return Math.floor(Math.random() * 5) + 11;
+  }
+  const COUNT_GRID = GRID.map(row => row.map(levelToCount));
+
+  /* ─── 히트맵 렌더 ─── */
+  function renderHeatmap() {
+    const el = document.getElementById('heatmap');
+    let html = '<div class="h-empty"></div>';
+    for (let h = 0; h < 24; h++) {
+      html += `<div class="h-hour">${[0,6,12,18].includes(h) ? h : ''}</div>`;
+    }
+    for (let d = 0; d < 7; d++) {
+      html += `<div class="h-day">${DAYS[d]}</div>`;
+      for (let h = 0; h < 24; h++) {
+        const lv = GRID[d][h];
+        const cnt = COUNT_GRID[d][h];
+        html += `<div class="cell ${lv > 0 ? 'l'+lv : ''}" data-day="${DAYS[d]}" data-hour="${h}" data-count="${cnt}" data-tooltip="heatmap"></div>`;
+      }
+    }
+    el.innerHTML = html;
+  }
+
+  /* ─── 시간대 막대 렌더 ─── */
+  function renderHourChart() {
+    const el = document.getElementById('hour-chart');
+    const hourTotal = Array(24).fill(0);
+    for (let d = 0; d < 7; d++) for (let h = 0; h < 24; h++) hourTotal[h] += COUNT_GRID[d][h];
+    const max = Math.max(...hourTotal);
+    let html = '';
+    for (let h = 0; h < 24; h++) {
+      const pct = max > 0 ? (hourTotal[h] / max) * 100 : 0;
+      html += `<div class="bar" style="height:${Math.max(pct, 2)}%;" data-hour="${h}" data-count="${hourTotal[h]}" data-tooltip="hour">
+        ${[0,6,12,18].includes(h) ? `<span class="bar-label">${h}</span>` : ''}
+      </div>`;
+    }
+    el.innerHTML = html;
+  }
+
+  /* ─── 요일 막대 렌더 ─── */
+  function renderDayChart() {
+    const el = document.getElementById('day-chart');
+    const dayTotal = Array(7).fill(0);
+    for (let d = 0; d < 7; d++) for (let h = 0; h < 24; h++) dayTotal[d] += COUNT_GRID[d][h];
+    const max = Math.max(...dayTotal);
+    const peakIdx = dayTotal.indexOf(max);
+    let html = '';
+    for (let d = 0; d < 7; d++) {
+      const pct = max > 0 ? (dayTotal[d] / max) * 100 : 0;
+      html += `<div class="bar-week ${d === peakIdx ? 'peak' : ''}" style="height:${Math.max(pct, 4)}%;" data-day="${DAYS[d]}" data-count="${dayTotal[d]}" data-tooltip="day">
+        <span class="bar-label">${DAYS[d]}</span>
+      </div>`;
+    }
+    el.innerHTML = html;
+  }
+
+  /* ─── 모드 토글 ─── */
+  document.getElementById('mode-toggle').addEventListener('click', e => {
+    const btn = e.target.closest('button');
+    if (!btn) return;
+    const mode = btn.dataset.mode;
+    document.querySelectorAll('#mode-toggle button').forEach(b => b.classList.toggle('active', b === btn));
+    document.querySelectorAll('.golden-mode').forEach(m => m.classList.toggle('active', m.dataset.mode === mode));
+    const insightText = document.getElementById('insight-text');
+    if (mode === 'heatmap') insightText.innerHTML = '이번 주 가장 활발: <strong>화요일 14–16시</strong> (47건)';
+    if (mode === 'hour')    insightText.innerHTML = '하루 중 정점: <strong>오후 2–4시</strong> (24시간 기준 32%)';
+    if (mode === 'day')     insightText.innerHTML = '주중 정점: <strong>화요일</strong> (전체의 28%)';
+  });
+
+  /* ─── 툴팁 ─── */
+  const tooltip = document.getElementById('tooltip');
+  document.addEventListener('mouseover', e => {
+    const t = e.target.closest('[data-tooltip]');
+    if (!t) { tooltip.classList.remove('visible'); return; }
+    const kind = t.dataset.tooltip;
+    let html = '';
+    if (kind === 'heatmap') {
+      const cnt = +t.dataset.count;
+      const breakdown = breakdownOf(cnt);
+      html = `
+        <div class="tooltip-title">${t.dataset.day} ${t.dataset.hour}시 · ${cnt}건</div>
+        <div class="tooltip-row"><span class="tooltip-dot" style="background:var(--lo)"></span> 작업 진행 ${breakdown.progress}건</div>
+        <div class="tooltip-row"><span class="tooltip-dot" style="background:var(--memo)"></span> 메모/댓글 ${breakdown.memo}건</div>
+        <div class="tooltip-row"><span class="tooltip-dot" style="background:var(--new)"></span> 씬 변경 ${breakdown.scene}건</div>
+        <div class="tooltip-row"><span class="tooltip-dot" style="background:var(--gray)"></span> 기타 ${breakdown.etc}건</div>
+      `;
+    } else if (kind === 'hour') {
+      html = `<div class="tooltip-title">${t.dataset.hour}시</div><div class="tooltip-row">${t.dataset.count}건 (요일 합산)</div>`;
+    } else if (kind === 'day') {
+      html = `<div class="tooltip-title">${t.dataset.day}요일</div><div class="tooltip-row">${t.dataset.count}건 (시간 합산)</div>`;
+    }
+    tooltip.innerHTML = html;
+    tooltip.classList.add('visible');
+  });
+  document.addEventListener('mousemove', e => {
+    if (!tooltip.classList.contains('visible')) return;
+    tooltip.style.left = e.clientX + 'px';
+    tooltip.style.top = e.clientY + 'px';
+  });
+  document.addEventListener('mouseout', e => {
+    if (!e.target.closest('[data-tooltip]')) tooltip.classList.remove('visible');
+  });
+
+  function breakdownOf(total) {
+    const a = Math.floor(total * 0.5);
+    const b = Math.floor(total * 0.25);
+    const c = Math.floor(total * 0.15);
+    const d = Math.max(0, total - a - b - c);
+    return { progress: a, memo: b, scene: c, etc: d };
+  }
+
+  /* ─── 초기 렌더 ─── */
+  renderFeed();
+  renderHeatmap();
+  renderHourChart();
+  renderDayChart();
+</script>
+
+</body>
+</html>

--- a/docs/superpowers/specs/mockups/2026-04-27-recent-activity-widget/index.html
+++ b/docs/superpowers/specs/mockups/2026-04-27-recent-activity-widget/index.html
@@ -1,0 +1,728 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>최근 작업 위젯 — 레이아웃 시안 비교</title>
+<style>
+  :root {
+    --bg: #0F1117;
+    --bg-deep: #0a0c12;
+    --card: #1A1D27;
+    --card-hi: #20232f;
+    --border: #2D3041;
+    --border-soft: rgba(45, 48, 65, 0.6);
+    --text: #E8E8EE;
+    --text-muted: #8B8DA3;
+    --text-faint: #5b5e75;
+    --accent: #6C5CE7;
+    --accent-sub: #A29BFE;
+    --lo: #74B9FF;
+    --done: #A29BFE;
+    --review: #FDCB6E;
+    --png: #00B894;
+    --memo: #FF8FA3;
+    --comment: #FFA94D;
+    --rev: #4DD0E1;
+    --new: #6FCF97;
+
+    --glass-tint: rgba(26, 29, 39, 0.55);
+    --glass-highlight: rgba(255, 255, 255, 0.06);
+    --shadow: rgba(0, 0, 0, 0.45);
+  }
+
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    background: radial-gradient(ellipse at top, #1a1d2e 0%, var(--bg) 35%, var(--bg-deep) 100%);
+    color: var(--text);
+    font-family: 'Pretendard', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    min-height: 100vh;
+    padding: 32px 24px 80px;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* 페이지 헤더 */
+  .page-header {
+    max-width: 1400px;
+    margin: 0 auto 32px;
+  }
+  .page-title {
+    font-size: 22px;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    margin: 0 0 6px;
+  }
+  .page-subtitle {
+    font-size: 13px;
+    color: var(--text-muted);
+    margin: 0;
+  }
+  .page-tag {
+    display: inline-block;
+    background: rgba(108, 92, 231, 0.15);
+    color: var(--accent-sub);
+    border: 1px solid rgba(108, 92, 231, 0.25);
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 600;
+    margin-left: 8px;
+    vertical-align: middle;
+  }
+
+  /* 시안 그리드 */
+  .options {
+    max-width: 1400px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 28px;
+  }
+
+  .option {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .option-header {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+  }
+  .option-num {
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--accent-sub);
+    background: rgba(108, 92, 231, 0.15);
+    padding: 3px 8px;
+    border-radius: 6px;
+    letter-spacing: 0.05em;
+  }
+  .option-title {
+    font-size: 15px;
+    font-weight: 600;
+  }
+  .option-desc {
+    font-size: 12px;
+    color: var(--text-muted);
+    line-height: 1.6;
+    margin: 0 0 4px;
+    padding-left: 2px;
+  }
+
+  /* 위젯 외관 (Widget.tsx 글래스 패턴) */
+  .widget {
+    background: var(--glass-tint);
+    backdrop-filter: blur(24px) saturate(1.8);
+    -webkit-backdrop-filter: blur(24px) saturate(1.8);
+    border: 1px solid var(--border-soft);
+    border-radius: 16px;
+    overflow: hidden;
+    box-shadow:
+      0 8px 32px var(--shadow),
+      inset 0 0 0 1px rgba(255, 255, 255, 0.04),
+      inset 0 1px 0 rgba(255, 255, 255, 0.08);
+    display: flex;
+    flex-direction: column;
+  }
+  .widget-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 16px;
+    border-bottom: 1px solid rgba(45, 48, 65, 0.4);
+    user-select: none;
+  }
+  .drag-dots {
+    display: grid;
+    grid-template-columns: repeat(2, 3px);
+    gap: 3px;
+    margin-right: 4px;
+  }
+  .drag-dots span {
+    width: 3px; height: 3px; border-radius: 50%;
+    background: rgba(139, 141, 163, 0.35);
+  }
+  .widget-icon {
+    color: var(--accent);
+    display: flex;
+  }
+  .widget-title {
+    font-size: 13px;
+    font-weight: 500;
+    color: rgba(232, 232, 238, 0.9);
+  }
+  .widget-tools {
+    margin-left: auto;
+    display: flex;
+    gap: 6px;
+    color: var(--text-faint);
+  }
+  .widget-tools svg { cursor: pointer; transition: color .2s; }
+  .widget-tools svg:hover { color: var(--accent-sub); }
+
+  /* 활동 피드 */
+  .feed {
+    overflow-y: auto;
+    padding: 4px 0;
+  }
+  .feed::-webkit-scrollbar { width: 6px; }
+  .feed::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+  .feed::-webkit-scrollbar-track { background: transparent; }
+
+  .feed-item {
+    display: flex;
+    gap: 10px;
+    padding: 10px 16px;
+    border-bottom: 1px solid rgba(45, 48, 65, 0.25);
+    transition: background .15s;
+    cursor: pointer;
+  }
+  .feed-item:hover { background: rgba(255, 255, 255, 0.02); }
+  .feed-item:last-child { border-bottom: none; }
+
+  .avatar {
+    width: 28px; height: 28px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #6C5CE7, #A29BFE);
+    color: white;
+    font-size: 11px;
+    font-weight: 700;
+    display: flex; align-items: center; justify-content: center;
+    flex-shrink: 0;
+    border: 1.5px solid rgba(255, 255, 255, 0.06);
+  }
+  .avatar.h { background: linear-gradient(135deg, #FF8FA3, #FF6B9D); }
+  .avatar.j { background: linear-gradient(135deg, #74B9FF, #4DA3FF); }
+  .avatar.m { background: linear-gradient(135deg, #00B894, #00D4A8); }
+  .avatar.s { background: linear-gradient(135deg, #FDCB6E, #F39C12); }
+  .avatar.d { background: linear-gradient(135deg, #4DD0E1, #26C6DA); }
+
+  .feed-body { flex: 1; min-width: 0; }
+  .feed-line {
+    display: flex; align-items: center; gap: 6px;
+    font-size: 12.5px;
+    color: var(--text);
+    line-height: 1.45;
+    flex-wrap: wrap;
+  }
+  .feed-name { font-weight: 600; color: var(--text); }
+  .feed-action { color: var(--text-muted); }
+  .feed-target {
+    color: var(--accent-sub);
+    background: rgba(108, 92, 231, 0.1);
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-size: 11.5px;
+    font-weight: 500;
+  }
+  .feed-meta {
+    display: flex; align-items: center; gap: 8px;
+    margin-top: 3px;
+    font-size: 11px;
+    color: var(--text-faint);
+  }
+  .pictogram {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    border-radius: 5px;
+    flex-shrink: 0;
+  }
+  .pictogram.lo     { background: rgba(116, 185, 255, 0.18); color: var(--lo); }
+  .pictogram.done   { background: rgba(162, 155, 254, 0.18); color: var(--done); }
+  .pictogram.review { background: rgba(253, 203, 110, 0.18); color: var(--review); }
+  .pictogram.png    { background: rgba(0, 184, 148, 0.18);   color: var(--png); }
+  .pictogram.memo   { background: rgba(255, 143, 163, 0.18); color: var(--memo); }
+  .pictogram.comment{ background: rgba(255, 169, 77, 0.18);  color: var(--comment); }
+  .pictogram.rev    { background: rgba(77, 208, 225, 0.18);  color: var(--rev); }
+  .pictogram.new    { background: rgba(111, 207, 151, 0.18); color: var(--new); }
+
+  /* 히트맵 */
+  .heatmap-wrap {
+    padding: 14px 16px 16px;
+  }
+  .heatmap-head {
+    display: flex; justify-content: space-between; align-items: center;
+    margin-bottom: 10px;
+    font-size: 11.5px;
+    color: var(--text-muted);
+  }
+  .heatmap-legend {
+    display: flex; align-items: center; gap: 4px;
+    font-size: 10.5px;
+  }
+  .heatmap-legend .lcell {
+    width: 10px; height: 10px; border-radius: 2px;
+  }
+
+  .heatmap {
+    display: grid;
+    grid-template-columns: 22px repeat(24, 1fr);
+    gap: 2px;
+    align-items: center;
+  }
+  .h-empty { width: 22px; }
+  .h-hour {
+    font-size: 9px;
+    color: var(--text-faint);
+    text-align: center;
+  }
+  .h-day {
+    font-size: 10px;
+    color: var(--text-muted);
+    text-align: right;
+    padding-right: 6px;
+  }
+  .cell {
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    border-radius: 2px;
+    background: rgba(108, 92, 231, 0.06);
+    transition: transform .15s;
+    cursor: pointer;
+  }
+  .cell:hover { transform: scale(1.4); z-index: 2; position: relative; }
+  .cell.l1 { background: rgba(108, 92, 231, 0.18); }
+  .cell.l2 { background: rgba(108, 92, 231, 0.36); }
+  .cell.l3 { background: rgba(108, 92, 231, 0.58); }
+  .cell.l4 { background: rgba(108, 92, 231, 0.85); box-shadow: 0 0 8px rgba(108, 92, 231, 0.3); }
+
+  /* 옵션 1: 상하 분할 */
+  .opt1 .widget { height: 580px; }
+  .opt1 .heatmap-wrap { flex-shrink: 0; }
+  .opt1 .feed-section-divider {
+    padding: 8px 16px 6px;
+    font-size: 10.5px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-faint);
+    border-top: 1px solid rgba(45, 48, 65, 0.4);
+    background: rgba(0, 0, 0, 0.15);
+  }
+  .opt1 .feed { flex: 1; }
+
+  /* 옵션 2: 탭 전환 */
+  .opt2 .widget { height: 580px; }
+  .tabs {
+    display: flex;
+    gap: 4px;
+    padding: 8px 12px 0;
+    border-bottom: 1px solid rgba(45, 48, 65, 0.4);
+  }
+  .tab {
+    padding: 8px 14px;
+    font-size: 12.5px;
+    font-weight: 500;
+    color: var(--text-muted);
+    background: none;
+    border: none;
+    cursor: pointer;
+    position: relative;
+    transition: color .2s;
+    display: flex; align-items: center; gap: 6px;
+  }
+  .tab.active {
+    color: var(--accent-sub);
+  }
+  .tab.active::after {
+    content: ''; position: absolute;
+    left: 12px; right: 12px; bottom: -1px;
+    height: 2px;
+    background: var(--accent);
+    border-radius: 2px;
+  }
+  .tab .tab-count {
+    font-size: 10px;
+    background: rgba(108, 92, 231, 0.2);
+    color: var(--accent-sub);
+    padding: 1px 6px;
+    border-radius: 999px;
+    font-weight: 600;
+  }
+  .opt2 .feed { flex: 1; }
+
+  /* 옵션 3: 좌우 분할 */
+  .opt3 .widget { height: 420px; }
+  .split-horizontal {
+    display: grid;
+    grid-template-columns: 1fr 1px 1fr;
+    flex: 1;
+    overflow: hidden;
+  }
+  .split-divider {
+    background: rgba(45, 48, 65, 0.4);
+  }
+  .split-side {
+    display: flex; flex-direction: column;
+    overflow: hidden;
+  }
+  .split-side .feed { flex: 1; }
+  .side-label {
+    padding: 8px 14px 4px;
+    font-size: 10.5px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-faint);
+  }
+
+  /* 옵션 4: 두 위젯 분리 */
+  .opt4 .widget-pair {
+    display: grid;
+    grid-template-columns: 1.4fr 1fr;
+    gap: 14px;
+  }
+  .opt4 .widget { height: 420px; }
+  .opt4 .feed { flex: 1; }
+  .opt4 .ghost-widget {
+    background: rgba(26, 29, 39, 0.25);
+    border: 1px dashed rgba(45, 48, 65, 0.5);
+    border-radius: 16px;
+    padding: 24px;
+    color: var(--text-faint);
+    font-size: 11px;
+    text-align: center;
+    grid-column: 1 / -1;
+    margin-top: 12px;
+  }
+
+  /* 인사이트 배너 (히트맵 위) */
+  .insight {
+    display: flex; align-items: center; gap: 8px;
+    padding: 10px 14px;
+    margin: 12px 16px 0;
+    background: rgba(108, 92, 231, 0.08);
+    border: 1px solid rgba(108, 92, 231, 0.18);
+    border-radius: 10px;
+    font-size: 12px;
+    color: var(--text);
+  }
+  .insight strong { color: var(--accent-sub); }
+  .insight-icon {
+    color: var(--accent-sub);
+    flex-shrink: 0;
+  }
+  /* 옵션 4: 위젯이 좁아 인사이트는 메인 헤더 위에만 표시 */
+</style>
+</head>
+<body>
+
+<header class="page-header">
+  <h1 class="page-title">
+    최근 작업 위젯 · 레이아웃 시안 비교
+    <span class="page-tag">옵션 4가지</span>
+  </h1>
+  <p class="page-subtitle">동일한 가짜 데이터(EP01~EP03 / 5명 / 24시간) 기준 · 다크 + 글래스모피즘 · 디자인 토큰 그대로</p>
+</header>
+
+<main class="options">
+
+  <!-- ────────────── 옵션 1: 상하 분할 ────────────── -->
+  <section class="option opt1">
+    <div class="option-header">
+      <span class="option-num">옵션 1</span>
+      <span class="option-title">상하 분할 — 히트맵(고정) + 활동 피드(스크롤)</span>
+    </div>
+    <p class="option-desc">상단에 1주일 골든타임을 한눈에. 하단은 시간순 활동 피드가 무한 스크롤. 시선이 패턴 → 최신 활동으로 자연스럽게 흐름.</p>
+
+    <div class="widget">
+      <div class="widget-header">
+        <div class="drag-dots">
+          <span></span><span></span><span></span><span></span><span></span><span></span>
+        </div>
+        <span class="widget-icon">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12a9 9 0 1 0 18 0a9 9 0 0 0 -18 0"/><polyline points="12 7 12 12 15 14"/></svg>
+        </span>
+        <span class="widget-title">최근 작업</span>
+        <div class="widget-tools">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 3h7v7"/><path d="M10 14L21 3"/><path d="M21 14v7H3V3h7"/></svg>
+        </div>
+      </div>
+
+      <div class="heatmap-wrap">
+        <div class="heatmap-head">
+          <span><strong style="color:var(--text)">팀 골든타임</strong> · 최근 7일</span>
+          <div class="heatmap-legend">
+            적음
+            <span class="lcell" style="background: rgba(108, 92, 231, 0.06);"></span>
+            <span class="lcell" style="background: rgba(108, 92, 231, 0.18);"></span>
+            <span class="lcell" style="background: rgba(108, 92, 231, 0.36);"></span>
+            <span class="lcell" style="background: rgba(108, 92, 231, 0.58);"></span>
+            <span class="lcell" style="background: rgba(108, 92, 231, 0.85);"></span>
+            많음
+          </div>
+        </div>
+        <div class="heatmap" id="heatmap-1"></div>
+      </div>
+
+      <div class="insight">
+        <span class="insight-icon">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+        </span>
+        <span>이번 주 가장 활발: <strong>화요일 14–16시</strong> (47건)</span>
+      </div>
+
+      <div class="feed-section-divider">최근 활동</div>
+      <div class="feed" id="feed-1"></div>
+    </div>
+  </section>
+
+  <!-- ────────────── 옵션 2: 탭 전환 ────────────── -->
+  <section class="option opt2">
+    <div class="option-header">
+      <span class="option-num">옵션 2</span>
+      <span class="option-title">탭 전환 — 활동 / 골든타임</span>
+    </div>
+    <p class="option-desc">한 번에 한 가지만 집중해서 보기. 세로 공간을 풍부하게 쓸 수 있지만, 다른 정보는 탭 전환 전엔 안 보임.</p>
+
+    <div class="widget">
+      <div class="widget-header">
+        <div class="drag-dots">
+          <span></span><span></span><span></span><span></span><span></span><span></span>
+        </div>
+        <span class="widget-icon">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12a9 9 0 1 0 18 0a9 9 0 0 0 -18 0"/><polyline points="12 7 12 12 15 14"/></svg>
+        </span>
+        <span class="widget-title">최근 작업</span>
+        <div class="widget-tools">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 3h7v7"/><path d="M10 14L21 3"/><path d="M21 14v7H3V3h7"/></svg>
+        </div>
+      </div>
+      <div class="tabs">
+        <button class="tab active">
+          활동 피드
+          <span class="tab-count">38</span>
+        </button>
+        <button class="tab">
+          골든타임
+        </button>
+      </div>
+      <div class="feed" id="feed-2"></div>
+    </div>
+  </section>
+
+  <!-- ────────────── 옵션 3: 좌우 분할 ────────────── -->
+  <section class="option opt3">
+    <div class="option-header">
+      <span class="option-num">옵션 3</span>
+      <span class="option-title">좌우 분할 — 피드 ‖ 히트맵</span>
+    </div>
+    <p class="option-desc">가로로 넓은 위젯에 적합. 둘을 동시에 보면서 “이 사람이 이때 했구나” 교차 파악 가능. 단, 위젯이 충분히 넓고 낮아야 자연스러움.</p>
+
+    <div class="widget">
+      <div class="widget-header">
+        <div class="drag-dots">
+          <span></span><span></span><span></span><span></span><span></span><span></span>
+        </div>
+        <span class="widget-icon">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12a9 9 0 1 0 18 0a9 9 0 0 0 -18 0"/><polyline points="12 7 12 12 15 14"/></svg>
+        </span>
+        <span class="widget-title">최근 작업</span>
+        <div class="widget-tools">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 3h7v7"/><path d="M10 14L21 3"/><path d="M21 14v7H3V3h7"/></svg>
+        </div>
+      </div>
+      <div class="split-horizontal">
+        <div class="split-side">
+          <div class="side-label">활동 피드</div>
+          <div class="feed" id="feed-3"></div>
+        </div>
+        <div class="split-divider"></div>
+        <div class="split-side">
+          <div class="side-label">골든타임</div>
+          <div class="heatmap-wrap" style="padding-top:6px;">
+            <div class="heatmap" id="heatmap-3"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ────────────── 옵션 4: 두 위젯 분리 ────────────── -->
+  <section class="option opt4">
+    <div class="option-header">
+      <span class="option-num">옵션 4</span>
+      <span class="option-title">두 위젯 분리 — 그리드에 자유 배치</span>
+    </div>
+    <p class="option-desc">‘최근 활동’과 ‘팀 골든타임’이 각각 독립 위젯. 사용자가 react-grid-layout에서 자유롭게 배치/팝아웃/리사이즈. 단, 두 정보 사이 시선 거리가 멀어질 수 있음.</p>
+
+    <div class="widget-pair">
+      <div class="widget">
+        <div class="widget-header">
+          <div class="drag-dots">
+            <span></span><span></span><span></span><span></span><span></span><span></span>
+          </div>
+          <span class="widget-icon">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+          </span>
+          <span class="widget-title">최근 활동</span>
+          <div class="widget-tools">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 3h7v7"/><path d="M10 14L21 3"/><path d="M21 14v7H3V3h7"/></svg>
+          </div>
+        </div>
+        <div class="feed" id="feed-4"></div>
+      </div>
+
+      <div class="widget">
+        <div class="widget-header">
+          <div class="drag-dots">
+            <span></span><span></span><span></span><span></span><span></span><span></span>
+          </div>
+          <span class="widget-icon">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+          </span>
+          <span class="widget-title">팀 골든타임</span>
+          <div class="widget-tools">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 3h7v7"/><path d="M10 14L21 3"/><path d="M21 14v7H3V3h7"/></svg>
+          </div>
+        </div>
+        <div class="heatmap-wrap" style="flex:1; display:flex; flex-direction:column;">
+          <div class="heatmap" id="heatmap-4"></div>
+          <div style="margin-top:auto;font-size:11px;color:var(--text-muted);text-align:center;padding-top:14px;">
+            🌟 정점 <strong style="color:var(--accent-sub);">화요일 14–16시</strong>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+</main>
+
+<script>
+  /* ─── 가짜 활동 데이터 ─── */
+  const ACTIONS = [
+    { type: 'lo',      icon: 'check',    verb: 'LO 완료',    target: 'EP02 A씬 #5' },
+    { type: 'done',    icon: 'check',    verb: '완료 진척',  target: 'EP01 B씬 #12' },
+    { type: 'review',  icon: 'eye',      verb: '검수 통과',  target: 'EP03 C씬 #3' },
+    { type: 'png',     icon: 'sparkle',  verb: 'PNG 마감',   target: 'EP01 A씬 #8' },
+    { type: 'memo',    icon: 'pen',      verb: '메모 수정',  target: 'EP02 B씬 #4' },
+    { type: 'comment', icon: 'message',  verb: '댓글 작성',  target: 'EP01 D씬 #2' },
+    { type: 'rev',     icon: 'rotate',   verb: '리비전 등록', target: 'EP03 A씬 #7' },
+    { type: 'new',     icon: 'plus',     verb: '씬 추가',    target: 'EP02 C씬 #11' },
+  ];
+  const PEOPLE = [
+    { id: 'h', name: '한솔',   avatarClass: 'h' },
+    { id: 'j', name: '지영',   avatarClass: 'j' },
+    { id: 'm', name: '민수',   avatarClass: 'm' },
+    { id: 's', name: '수진',   avatarClass: 's' },
+    { id: 'd', name: '도현',   avatarClass: 'd' },
+  ];
+
+  const ICON_SVG = {
+    check:   '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>',
+    eye:     '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>',
+    sparkle: '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2l2.39 6.96L22 12l-7.61 3.04L12 22l-2.39-6.96L2 12l7.61-3.04z"/></svg>',
+    pen:     '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4z"/></svg>',
+    message: '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>',
+    rotate:  '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>',
+    plus:    '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>',
+  };
+
+  const sampleFeed = [
+    { p:'h', a: ACTIONS[0], when: '2분 전' },
+    { p:'j', a: ACTIONS[5], when: '8분 전' },
+    { p:'m', a: ACTIONS[3], when: '14분 전' },
+    { p:'h', a: ACTIONS[2], when: '32분 전' },
+    { p:'s', a: ACTIONS[6], when: '47분 전' },
+    { p:'d', a: ACTIONS[4], when: '1시간 전' },
+    { p:'j', a: ACTIONS[7], when: '1시간 전' },
+    { p:'m', a: ACTIONS[1], when: '1시간 전' },
+    { p:'h', a: ACTIONS[5], when: '2시간 전' },
+    { p:'s', a: ACTIONS[0], when: '2시간 전' },
+    { p:'d', a: ACTIONS[2], when: '3시간 전' },
+    { p:'j', a: ACTIONS[3], when: '4시간 전' },
+  ];
+
+  function renderFeed(targetId, items) {
+    const el = document.getElementById(targetId);
+    if (!el) return;
+    el.innerHTML = items.map(i => {
+      const person = PEOPLE.find(p => p.id === i.p);
+      const initial = person.name.charAt(0);
+      return `
+        <div class="feed-item">
+          <div class="avatar ${person.avatarClass}">${initial}</div>
+          <div class="feed-body">
+            <div class="feed-line">
+              <span class="feed-name">${person.name}</span>
+              <span class="pictogram ${i.a.type}">${ICON_SVG[i.a.icon]}</span>
+              <span class="feed-action">${i.a.verb}</span>
+              <span class="feed-target">${i.a.target}</span>
+            </div>
+            <div class="feed-meta">
+              <span>${i.when}</span>
+            </div>
+          </div>
+        </div>
+      `;
+    }).join('');
+  }
+
+  /* ─── 히트맵 ─── */
+  const DAYS = ['월','화','수','목','금','토','일'];
+  // 의도된 골든타임 패턴: 화요일 14-16시가 정점
+  function genHeatmap() {
+    const grid = [];
+    for (let d = 0; d < 7; d++) {
+      const row = [];
+      for (let h = 0; h < 24; h++) {
+        let level = 0;
+        if (h >= 10 && h <= 18 && d < 5) {
+          level = Math.floor(Math.random() * 3) + 1;
+          if (h >= 13 && h <= 16 && d === 1) level = 4; // 화 14-16시 정점
+          if (h >= 14 && h <= 15 && d === 0) level = 3;
+          if (h === 11 && d === 2) level = 3;
+        } else if (h >= 19 && h <= 22 && d < 5) {
+          level = Math.random() > 0.6 ? 1 : 0;
+        } else if (d >= 5 && h >= 14 && h <= 17) {
+          level = Math.random() > 0.7 ? 1 : 0;
+        }
+        row.push(level);
+      }
+      grid.push(row);
+    }
+    return grid;
+  }
+
+  function renderHeatmap(targetId, includeHourLabels = true) {
+    const el = document.getElementById(targetId);
+    if (!el) return;
+    const grid = genHeatmap();
+    let html = '';
+
+    // 시간 라벨 행
+    if (includeHourLabels) {
+      html += '<div class="h-empty"></div>';
+      for (let h = 0; h < 24; h++) {
+        html += `<div class="h-hour">${h % 6 === 0 ? h : ''}</div>`;
+      }
+    }
+    // 요일별 행
+    for (let d = 0; d < 7; d++) {
+      html += `<div class="h-day">${DAYS[d]}</div>`;
+      for (let h = 0; h < 24; h++) {
+        const level = grid[d][h];
+        html += `<div class="cell ${level > 0 ? 'l'+level : ''}" title="${DAYS[d]} ${h}시"></div>`;
+      }
+    }
+    el.innerHTML = html;
+  }
+
+  // 렌더링
+  renderFeed('feed-1', sampleFeed.slice(0, 8));
+  renderFeed('feed-2', sampleFeed);
+  renderFeed('feed-3', sampleFeed.slice(0, 6));
+  renderFeed('feed-4', sampleFeed.slice(0, 8));
+
+  renderHeatmap('heatmap-1');
+  renderHeatmap('heatmap-3');
+  renderHeatmap('heatmap-4');
+</script>
+
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bflow",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bflow",
-      "version": "1.13.3",
+      "version": "1.13.4",
       "license": "UNLICENSED",
       "dependencies": {
         "@liveblocks/client": "^3.14.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bflow",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bflow",
-      "version": "1.13.2",
+      "version": "1.13.3",
       "license": "UNLICENSED",
       "dependencies": {
         "@liveblocks/client": "^3.14.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/components/common/PathBadge.tsx
+++ b/src/components/common/PathBadge.tsx
@@ -1,0 +1,38 @@
+import { FolderOpen } from 'lucide-react';
+import { shortenPath } from '@/utils/pathLink';
+
+interface PathBadgeProps {
+  path: string;
+  /** CompositingView 전용 — 해결된 리비전 경로 회색 처리. 메모/댓글/메모위젯 사용처에선 항상 false. */
+  resolved?: boolean;
+  className?: string;
+}
+
+/**
+ * G:\ 경로를 클릭 가능한 뱃지로 표시. 클릭 시 파일 탐색기에서 해당 경로 열기.
+ *
+ * 4곳에서 재사용: 메모(InlineTextareaRow) / 댓글(CommentPanel) / 메모 위젯(TipTap) / 리비전(CompositingView).
+ * 외관·동작은 한 곳에서 정의해 일관성 + 유지보수성 확보.
+ */
+export function PathBadge({ path, resolved, className }: PathBadgeProps) {
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    window.electronAPI?.shellShowItem?.(path);
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      className={`inline-flex items-center gap-1 text-[11px] font-mono rounded px-1.5 py-0.5 max-w-full cursor-pointer transition-all hover:brightness-125 ${className ?? ''}`}
+      style={
+        resolved
+          ? { color: '#6B7280', backgroundColor: 'rgba(107, 114, 128, 0.1)', border: '1px solid rgba(107, 114, 128, 0.2)' }
+          : { color: '#74B9FF', backgroundColor: 'rgba(116, 185, 255, 0.1)', border: '1px solid rgba(116, 185, 255, 0.2)' }
+      }
+      title={`${path}\n(클릭하면 파일탐색기에서 열기)`}
+    >
+      <FolderOpen size={10} className="shrink-0" />
+      <span className="truncate">{shortenPath(path)}</span>
+    </button>
+  );
+}

--- a/src/components/common/PathLinkifiedText.tsx
+++ b/src/components/common/PathLinkifiedText.tsx
@@ -1,0 +1,33 @@
+import { Fragment, type ReactNode } from 'react';
+import { tokenizeGPaths } from '@/utils/pathLink';
+import { PathBadge } from './PathBadge';
+
+interface Props {
+  text: string;
+  /**
+   * 텍스트 세그먼트 추가 변환 (예: 댓글의 @멘션 처리).
+   * 미지정 시 그대로 렌더. 지정 시 path 외의 텍스트만 이 함수가 받는다.
+   */
+  renderTextSegment?: (segment: string, idx: number) => ReactNode;
+}
+
+/**
+ * 텍스트에서 G:\ 경로만 PathBadge로 교체하고 나머지는 그대로 렌더.
+ * renderTextSegment를 주면 텍스트 부분에 추가 변환(예: @멘션) 적용 가능.
+ */
+export function PathLinkifiedText({ text, renderTextSegment }: Props) {
+  const tokens = tokenizeGPaths(text);
+  return (
+    <>
+      {tokens.map((tok, i) =>
+        tok.type === 'path' ? (
+          <PathBadge key={`p${i}`} path={tok.content} />
+        ) : (
+          <Fragment key={`t${i}`}>
+            {renderTextSegment ? renderTextSegment(tok.content, i) : tok.content}
+          </Fragment>
+        ),
+      )}
+    </>
+  );
+}

--- a/src/components/scenes/CommentPanel.tsx
+++ b/src/components/scenes/CommentPanel.tsx
@@ -12,6 +12,7 @@ import {
 import type { SceneComment } from '@/services/commentService';
 import { sendMentionWebhook } from '@/services/slackWebhookService';
 import { formatTime, formatTimeShort } from '@/utils/formatTime';
+import { PathLinkifiedText } from '@/components/common/PathLinkifiedText';
 
 // ─── 메인 컴포넌트 ───────────────────────────
 
@@ -256,16 +257,18 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
   };
 
   // 텍스트 내 @멘션 렌더 (굵은 글씨 + 배경 하이라이트 + 클릭 가능)
-  const renderText = (text: string) => {
-    const parts = text.split(/(@\S+)/g);
+  // PathLinkifiedText 가 G:\ 경로를 PathBadge 로 분리하고, 그 사이 텍스트만 이 함수가 받아 멘션 처리.
+  const renderMentionInSegment = (segment: string, baseIdx: number) => {
+    const parts = segment.split(/(@\S+)/g);
     return parts.map((part, i) => {
+      const key = `${baseIdx}-${i}`;
       if (part.startsWith('@')) {
         const name = part.slice(1);
         const isUser = users.some(u => u.name === name);
         if (isUser) {
           return (
             <span
-              key={i}
+              key={key}
               className="text-accent font-bold bg-accent/10 rounded px-0.5 cursor-pointer hover:bg-accent/20 transition-colors"
               onClick={() => handleMentionClick(name)}
               title={`${name} 팀원 보기`}
@@ -275,9 +278,13 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
           );
         }
       }
-      return <span key={i}>{part}</span>;
+      return <span key={key}>{part}</span>;
     });
   };
+
+  const renderText = (text: string) => (
+    <PathLinkifiedText text={text} renderTextSegment={renderMentionInSegment} />
+  );
 
   return (
     <div className="flex flex-col h-full">

--- a/src/components/scenes/SceneDetailModal.tsx
+++ b/src/components/scenes/SceneDetailModal.tsx
@@ -20,6 +20,7 @@ import type { Scene, Stage, Department } from '@/types';
 import { sceneProgress } from '@/utils/calcStats';
 import * as storageService from '@/services/storageService';
 import { AssigneeSelect, getUserColor } from '@/components/common/AssigneeSelect';
+import { PathLinkifiedText } from '@/components/common/PathLinkifiedText';
 import { resizeBlob, pasteImageFromClipboard } from '@/utils/imageUtils';
 import { ImageModal } from './ImageModal';
 import { CommentPanel } from './CommentPanel';
@@ -103,7 +104,9 @@ function PropertyRow({ label, value, placeholder, onSave }: PropertyRowProps) {
             className="w-full rounded-md px-2.5 py-1 border border-transparent cursor-pointer transition-all duration-200 hover:border-accent/30 hover:bg-accent/5 hover:shadow-[0_0_8px_rgba(108,92,231,0.15)]"
           >
             <span className="text-sm text-text-primary">
-              {value || (
+              {value ? (
+                <PathLinkifiedText text={value} />
+              ) : (
                 <span className="text-text-secondary/50 italic">
                   {placeholder ?? '비어 있음'}
                 </span>

--- a/src/components/scenes/SceneDetailModal.tsx
+++ b/src/components/scenes/SceneDetailModal.tsx
@@ -410,6 +410,8 @@ export function SceneDetailModal({
   const [commentCount, setCommentCount] = useState(0);
   const [revisionCount, setRevisionCount] = useState(0);
   const [deleteConfirm, setDeleteConfirm] = useState<'storyboard' | 'guide' | null>(null);
+  // 모달 backdrop 드래그 닫힘 방지 — mousedown 시작 위치를 추적해 backdrop 자체에서 시작한 경우만 onClose 트리거
+  const backdropMouseDownRef = useRef(false);
 
   // 이미지 즉시 프리뷰용 낙관적 URL (업로드 중 base64 표시)
   const [previewUrls, setPreviewUrls] = useState<{ storyboard?: string; guide?: string }>({});
@@ -674,8 +676,13 @@ export function SceneDetailModal({
         exit={{ opacity: 0 }}
         transition={{ duration: 0.2 }}
         className="fixed inset-0 z-50 flex items-center justify-center bg-overlay/60 backdrop-blur-sm"
+        onMouseDown={(e) => {
+          // 모달 안 드래그가 backdrop 에서 끝나도 닫히지 않도록 mousedown 시작 위치 추적
+          backdropMouseDownRef.current = e.target === e.currentTarget;
+        }}
         onClick={(e) => {
-          if (e.target === e.currentTarget) onClose();
+          if (backdropMouseDownRef.current && e.target === e.currentTarget) onClose();
+          backdropMouseDownRef.current = false;
         }}
       >
         {/* 모달 래퍼 — 좌: 본체 + 우: 댓글 패널 (항상 표시) */}

--- a/src/components/scenes/UnifiedSceneDetailModal.tsx
+++ b/src/components/scenes/UnifiedSceneDetailModal.tsx
@@ -18,6 +18,7 @@ import { STAGES, DEPARTMENT_CONFIGS } from '@/types';
 import type { MergedScene, Scene, Stage, Department } from '@/types';
 import { sceneProgress } from '@/utils/calcStats';
 import { AssigneeSelect } from '@/components/common/AssigneeSelect';
+import { PathLinkifiedText } from '@/components/common/PathLinkifiedText';
 import { resizeBlob } from '@/utils/imageUtils';
 import { ImageModal } from './ImageModal';
 import { CommentPanel } from './CommentPanel';
@@ -713,15 +714,17 @@ function InlineTextareaRow({ label, value, onSave }: {
           spellCheck={false}
         />
       ) : (
-        <button
+        <div
           onClick={() => setEditing(true)}
           className="w-full text-left px-3 py-2 rounded-md border border-transparent hover:border-accent/30 hover:bg-accent/5 text-sm text-text-primary min-h-[40px] cursor-pointer transition-colors whitespace-pre-wrap"
         >
-          {value || <span className="text-text-secondary/50 italic">메모 없음</span>}
+          {value
+            ? <PathLinkifiedText text={value} />
+            : <span className="text-text-secondary/50 italic">메모 없음</span>}
           {value && (
             <Pencil size={12} className="inline-block ml-2 opacity-0 hover:opacity-60 transition-opacity" />
           )}
-        </button>
+        </div>
       )}
     </div>
   );

--- a/src/components/scenes/UnifiedSceneDetailModal.tsx
+++ b/src/components/scenes/UnifiedSceneDetailModal.tsx
@@ -73,6 +73,8 @@ export function UnifiedSceneDetailModal({
 }: UnifiedSceneDetailModalProps) {
   const { bgScene, actScene, bgSceneIndex, actSceneIndex } = merged;
   const headScene = bgScene ?? actScene;
+  // 모달 backdrop 드래그 닫힘 방지 — mousedown 시작 위치를 추적해 backdrop 자체에서 시작한 경우만 onClose 트리거
+  const backdropMouseDownRef = useRef(false);
 
   // 댓글 키: BG와 ACT 양쪽 조회 가능하게.
   // primary 는 "실제로 이 merged 에 존재하는 부서" 와 일치해야 한다 —
@@ -234,7 +236,17 @@ export function UnifiedSceneDetailModal({
         exit={{ opacity: 0 }}
         transition={{ duration: 0.15 }}
         className="fixed inset-0 z-50 flex items-center justify-center bg-overlay/60 backdrop-blur-sm p-4"
-        onClick={onClose}
+        onMouseDown={(e) => {
+          // 모달 안에서 시작한 드래그가 바깥에서 끝나도 닫히지 않도록 mousedown 위치 추적
+          backdropMouseDownRef.current = e.target === e.currentTarget;
+        }}
+        onClick={(e) => {
+          // mousedown이 backdrop에서 시작했고 click도 backdrop에서 발생한 경우만 닫음
+          if (backdropMouseDownRef.current && e.target === e.currentTarget) {
+            onClose();
+          }
+          backdropMouseDownRef.current = false;
+        }}
       >
         {/* ── flex 래퍼 — 본체 + 리비전 패널 + 댓글 ── */}
         <div className="flex gap-3 items-stretch max-w-full max-h-full" onClick={(e) => e.stopPropagation()}>

--- a/src/components/widgets/memo/MemoEditor.tsx
+++ b/src/components/widgets/memo/MemoEditor.tsx
@@ -105,16 +105,22 @@ export function MemoEditor({
         class: 'memo-prose focus:outline-none',
         spellcheck: 'false',
       },
-      handleClickOn(_view, _pos, _node, _nodePos, event) {
-        // PathLink mark 클릭 → 파일탐색기 열기. selection 이동 차단해 BubbleMenu 미발생.
-        const target = event.target as HTMLElement | null;
-        const linkEl = target?.closest('[data-path-link]') as HTMLElement | null;
-        if (linkEl) {
-          event.preventDefault();
-          window.electronAPI?.shellShowItem?.(linkEl.dataset.pathLink ?? '');
-          return true;
-        }
-        return false;
+      handleDOMEvents: {
+        // PathLink decoration 클릭 → 파일탐색기 열기.
+        // handleClickOn 은 ProseMirror 가 부여한 위치를 우선하므로 decoration 의 data 속성을 못 잡는 경우가 있어
+        // raw DOM 이벤트로 처리한다.
+        click(_view, event) {
+          const target = event.target as HTMLElement | null;
+          const linkEl = target?.closest('[data-path-link]') as HTMLElement | null;
+          if (linkEl) {
+            event.preventDefault();
+            event.stopPropagation();
+            const path = linkEl.getAttribute('data-path-link') ?? '';
+            window.electronAPI?.shellShowItem?.(path);
+            return true;
+          }
+          return false;
+        },
       },
     },
   });

--- a/src/components/widgets/memo/MemoEditor.tsx
+++ b/src/components/widgets/memo/MemoEditor.tsx
@@ -14,6 +14,7 @@ import { Markdown } from 'tiptap-markdown';
 import { useEffect, useRef } from 'react';
 import { BflowUnderline, getEditorMarkdown } from './markdownExtensions';
 import { MemoLinkBubble } from './MemoLinkBubble';
+import { PathLinkMark } from './extensions/PathLinkMark';
 
 interface MemoEditorProps {
   /** Markdown 문자열 (초기값/외부 변경 주입용). undefined 일 때 editor 내용 변경 안 함 */
@@ -82,6 +83,7 @@ export function MemoEditor({
         placeholder,
         emptyEditorClass: 'is-editor-empty',
       }),
+      PathLinkMark,
       // Markdown 은 마지막에 (다른 extension 의 addStorage().markdown 을 읽어 serializer 구성)
       Markdown.configure({
         html: false,
@@ -102,6 +104,17 @@ export function MemoEditor({
       attributes: {
         class: 'memo-prose focus:outline-none',
         spellcheck: 'false',
+      },
+      handleClickOn(_view, _pos, _node, _nodePos, event) {
+        // PathLink mark 클릭 → 파일탐색기 열기. selection 이동 차단해 BubbleMenu 미발생.
+        const target = event.target as HTMLElement | null;
+        const linkEl = target?.closest('[data-path-link]') as HTMLElement | null;
+        if (linkEl) {
+          event.preventDefault();
+          window.electronAPI?.shellShowItem?.(linkEl.dataset.pathLink ?? '');
+          return true;
+        }
+        return false;
       },
     },
   });

--- a/src/components/widgets/memo/MemoEditor.tsx
+++ b/src/components/widgets/memo/MemoEditor.tsx
@@ -105,23 +105,7 @@ export function MemoEditor({
         class: 'memo-prose focus:outline-none',
         spellcheck: 'false',
       },
-      handleDOMEvents: {
-        // PathLink decoration 클릭 → 파일탐색기 열기.
-        // handleClickOn 은 ProseMirror 가 부여한 위치를 우선하므로 decoration 의 data 속성을 못 잡는 경우가 있어
-        // raw DOM 이벤트로 처리한다.
-        click(_view, event) {
-          const target = event.target as HTMLElement | null;
-          const linkEl = target?.closest('[data-path-link]') as HTMLElement | null;
-          if (linkEl) {
-            event.preventDefault();
-            event.stopPropagation();
-            const path = linkEl.getAttribute('data-path-link') ?? '';
-            window.electronAPI?.shellShowItem?.(path);
-            return true;
-          }
-          return false;
-        },
-      },
+      // PathLink 클릭/삭제는 PathLinkNodeView 내부 React 핸들러가 처리 (NodeView 패턴)
     },
   });
 

--- a/src/components/widgets/memo/extensions/PathLinkMark.ts
+++ b/src/components/widgets/memo/extensions/PathLinkMark.ts
@@ -1,48 +1,105 @@
-import { Extension } from '@tiptap/core';
+import { Node, mergeAttributes } from '@tiptap/core';
+import { ReactNodeViewRenderer } from '@tiptap/react';
 import { Plugin, PluginKey } from '@tiptap/pm/state';
-import { Decoration, DecorationSet } from '@tiptap/pm/view';
 import { G_PATH_REGEX_GLOBAL } from '@/utils/pathLink';
+import { PathLinkNodeView } from './PathLinkNodeView';
 
 /**
- * G:\ 경로를 클릭 가능한 인라인 시각으로 변환하는 TipTap extension.
+ * G:\ 경로를 atom inline node 로 변환하는 TipTap extension.
  *
- * 구현 방식: ProseMirror Decoration (Mark 아님).
- * - 데이터에는 항상 plain text "G:\..."로 저장 → Markdown round-trip 자동 보장.
- * - 매 doc 변경 시 doc 전체 스캔하여 G:\ 패턴 부분에 inline decoration 적용 (CSS 클래스 + data-path-link 속성).
- * - 사용자 입력 도중에도 즉시 시각이 적용되며, mark 분리 문제(공백에서 끊김)와 mark 충돌이 발생하지 않는다.
- *
- * 클릭 핸들러는 MemoEditor.tsx의 editorProps.handleClickOn 에서 [data-path-link] 속성을 보고 처리.
- * CSS는 src/styles/path-link.css 의 .path-link-mark.
+ * 구현 방식: Node + ReactNodeViewRenderer (PathBadge 외관 + X 버튼)
+ * - 자동 변환: appendTransaction 으로 매 doc 변경 시 G:\ 텍스트 → PathLinkNode 교체.
+ *   사용자 입력 진행 중 selection 영역은 변환에서 제외해 typing 도중 cursor 가 튀지 않도록 보호.
+ * - Markdown round-trip: addStorage().markdown.serialize 가 raw text "G:\..." 로 출력 →
+ *   재로드 시 setContent → markdown 으로 들어온 raw text 를 onCreate 시점에 다시 스캔/변환.
  */
-export const PathLinkMark = Extension.create({
-  name: 'pathLinkDecoration',
+export const PathLinkMark = Node.create({
+  name: 'pathLink',
+  inline: true,
+  group: 'inline',
+  atom: true,
+  selectable: true,
+  draggable: false,
+
+  addAttributes() {
+    return {
+      href: { default: '' },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'span[data-path-link]' }];
+  },
+
+  renderHTML({ node, HTMLAttributes }) {
+    return [
+      'span',
+      mergeAttributes(HTMLAttributes, {
+        'data-path-link': node.attrs.href,
+        class: 'path-link-mark',
+      }),
+      node.attrs.href,
+    ];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(PathLinkNodeView);
+  },
+
+  addStorage() {
+    return {
+      markdown: {
+        // tiptap-markdown 이 Node 를 raw text 로 직렬화 — 다음 로드 때 appendTransaction 이 다시 변환
+        serialize: (state: any, node: any) => {
+          state.write(node.attrs.href);
+        },
+        parse: { setup: () => {} },
+      },
+    };
+  },
 
   addProseMirrorPlugins() {
+    const type = this.type;
+
     return [
       new Plugin({
-        key: new PluginKey('pathLinkDecoration'),
-        props: {
-          decorations(state) {
-            const decos: Decoration[] = [];
-            state.doc.descendants((node, pos) => {
-              if (!node.isText || !node.text) return;
-              // /g 정규식 lastIndex 오염 방지를 위해 매번 새 인스턴스 생성.
-              const regex = new RegExp(G_PATH_REGEX_GLOBAL.source, 'g');
-              for (const match of node.text.matchAll(regex)) {
-                if (match.index === undefined) continue;
-                const from = pos + match.index;
-                const to = from + match[0].length;
-                decos.push(
-                  Decoration.inline(from, to, {
-                    class: 'path-link-mark',
-                    'data-path-link': match[0],
-                    title: `${match[0]}\n(클릭하면 파일탐색기에서 열기)`,
-                  }),
-                );
-              }
-            });
-            return DecorationSet.create(state.doc, decos);
-          },
+        key: new PluginKey('pathLinkAutoConvert'),
+        appendTransaction: (transactions, oldState, newState) => {
+          // 사용자 입력으로 doc 이 바뀐 transaction 만 처리 (자기 변환 transaction 은 docChanged 가 true 지만
+          // setMeta('addToHistory', false) 등으로 구분 가능 — 단순 구현은 selection 보호로 충분)
+          const docChanged = transactions.some((tr) => tr.docChanged);
+          if (!docChanged) return null;
+
+          const tr = newState.tr;
+          let modified = false;
+
+          // 사용자가 typing 중인 위치 (selection 시작/끝). 그 인접 영역은 변환 제외.
+          const selFrom = newState.selection.from;
+          const selTo = newState.selection.to;
+
+          // 뒤에서부터 처리해야 인덱스가 어긋나지 않음 — 변환 후보를 먼저 모은다.
+          const candidates: Array<{ from: number; to: number; href: string }> = [];
+
+          newState.doc.descendants((node, pos) => {
+            if (!node.isText || !node.text) return;
+            const regex = new RegExp(G_PATH_REGEX_GLOBAL.source, 'g');
+            for (const match of node.text.matchAll(regex)) {
+              if (match.index === undefined) continue;
+              const from = pos + match.index;
+              const to = from + match[0].length;
+              // 사용자가 현재 입력 중인 영역 (cursor 위치가 매치 범위 안 또는 직후 1글자 이내) 은 변환 제외
+              if (selFrom >= from && selFrom <= to + 1) continue;
+              if (selTo >= from && selTo <= to + 1) continue;
+              candidates.push({ from, to, href: match[0] });
+            }
+          });
+
+          for (const c of candidates.reverse()) {
+            tr.replaceWith(c.from, c.to, type.create({ href: c.href }));
+            modified = true;
+          }
+
+          return modified ? tr : null;
         },
       }),
     ];

--- a/src/components/widgets/memo/extensions/PathLinkMark.ts
+++ b/src/components/widgets/memo/extensions/PathLinkMark.ts
@@ -1,0 +1,70 @@
+import { Mark, markInputRule, markPasteRule } from '@tiptap/core';
+import { G_PATH_REGEX_INPUT_RULE, G_PATH_REGEX_PASTE_RULE } from '@/utils/pathLink';
+
+/**
+ * G:\ 경로를 클릭 가능한 인라인 mark로 변환하는 TipTap extension.
+ *
+ * - InputRule: 사용자가 G:\... 입력 후 공백 → 즉시 mark 적용
+ * - PasteRule: G:\ 경로 붙여넣기 → 자동 mark 적용
+ * - Markdown round-trip: addStorage().markdown 의 open/close를 빈 문자열로 두어 raw 텍스트로 직렬화. 재로드 시 PasteRule이 다시 mark 적용.
+ *
+ * 클릭 핸들러는 MemoEditor.tsx의 editorProps.handleClickOn 에서 처리.
+ * CSS는 src/styles/path-link.css 의 .path-link-mark.
+ */
+export const PathLinkMark = Mark.create({
+  name: 'pathLink',
+
+  inclusive: false,
+
+  addAttributes() {
+    return {
+      href: { default: '' },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'span[data-path-link]' }];
+  },
+
+  renderHTML({ mark, HTMLAttributes }) {
+    return [
+      'span',
+      {
+        ...HTMLAttributes,
+        'data-path-link': mark.attrs.href,
+        class: 'path-link-mark',
+        title: `${mark.attrs.href}\n(클릭하면 파일탐색기에서 열기)`,
+      },
+      0,
+    ];
+  },
+
+  addStorage() {
+    return {
+      markdown: {
+        serialize: { open: '', close: '', mixable: true, expelEnclosingWhitespace: true },
+        parse: { setup: () => {} },
+      },
+    };
+  },
+
+  addInputRules() {
+    return [
+      markInputRule({
+        find: G_PATH_REGEX_INPUT_RULE,
+        type: this.type,
+        getAttributes: (match) => ({ href: match[1] }),
+      }),
+    ];
+  },
+
+  addPasteRules() {
+    return [
+      markPasteRule({
+        find: G_PATH_REGEX_PASTE_RULE,
+        type: this.type,
+        getAttributes: (match) => ({ href: match[0] }),
+      }),
+    ];
+  },
+});

--- a/src/components/widgets/memo/extensions/PathLinkMark.ts
+++ b/src/components/widgets/memo/extensions/PathLinkMark.ts
@@ -61,7 +61,8 @@ export const PathLinkMark = Mark.create({
   addPasteRules() {
     return [
       markPasteRule({
-        find: G_PATH_REGEX_PASTE_RULE,
+        // /g 플래그 정규식은 lastIndex 오염 위험이 있으므로 매번 새 인스턴스로 전달.
+        find: new RegExp(G_PATH_REGEX_PASTE_RULE.source, 'g'),
         type: this.type,
         getAttributes: (match) => ({ href: match[0] }),
       }),

--- a/src/components/widgets/memo/extensions/PathLinkMark.ts
+++ b/src/components/widgets/memo/extensions/PathLinkMark.ts
@@ -1,70 +1,49 @@
-import { Mark, markInputRule, markPasteRule } from '@tiptap/core';
-import { G_PATH_REGEX_INPUT_RULE, G_PATH_REGEX_PASTE_RULE } from '@/utils/pathLink';
+import { Extension } from '@tiptap/core';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
+import { Decoration, DecorationSet } from '@tiptap/pm/view';
+import { G_PATH_REGEX_GLOBAL } from '@/utils/pathLink';
 
 /**
- * G:\ 경로를 클릭 가능한 인라인 mark로 변환하는 TipTap extension.
+ * G:\ 경로를 클릭 가능한 인라인 시각으로 변환하는 TipTap extension.
  *
- * - InputRule: 사용자가 G:\... 입력 후 공백 → 즉시 mark 적용
- * - PasteRule: G:\ 경로 붙여넣기 → 자동 mark 적용
- * - Markdown round-trip: addStorage().markdown 의 open/close를 빈 문자열로 두어 raw 텍스트로 직렬화. 재로드 시 PasteRule이 다시 mark 적용.
+ * 구현 방식: ProseMirror Decoration (Mark 아님).
+ * - 데이터에는 항상 plain text "G:\..."로 저장 → Markdown round-trip 자동 보장.
+ * - 매 doc 변경 시 doc 전체 스캔하여 G:\ 패턴 부분에 inline decoration 적용 (CSS 클래스 + data-path-link 속성).
+ * - 사용자 입력 도중에도 즉시 시각이 적용되며, mark 분리 문제(공백에서 끊김)와 mark 충돌이 발생하지 않는다.
  *
- * 클릭 핸들러는 MemoEditor.tsx의 editorProps.handleClickOn 에서 처리.
+ * 클릭 핸들러는 MemoEditor.tsx의 editorProps.handleClickOn 에서 [data-path-link] 속성을 보고 처리.
  * CSS는 src/styles/path-link.css 의 .path-link-mark.
  */
-export const PathLinkMark = Mark.create({
-  name: 'pathLink',
+export const PathLinkMark = Extension.create({
+  name: 'pathLinkDecoration',
 
-  inclusive: false,
-
-  addAttributes() {
-    return {
-      href: { default: '' },
-    };
-  },
-
-  parseHTML() {
-    return [{ tag: 'span[data-path-link]' }];
-  },
-
-  renderHTML({ mark, HTMLAttributes }) {
+  addProseMirrorPlugins() {
     return [
-      'span',
-      {
-        ...HTMLAttributes,
-        'data-path-link': mark.attrs.href,
-        class: 'path-link-mark',
-        title: `${mark.attrs.href}\n(클릭하면 파일탐색기에서 열기)`,
-      },
-      0,
-    ];
-  },
-
-  addStorage() {
-    return {
-      markdown: {
-        serialize: { open: '', close: '', mixable: true, expelEnclosingWhitespace: true },
-        parse: { setup: () => {} },
-      },
-    };
-  },
-
-  addInputRules() {
-    return [
-      markInputRule({
-        find: G_PATH_REGEX_INPUT_RULE,
-        type: this.type,
-        getAttributes: (match) => ({ href: match[1] }),
-      }),
-    ];
-  },
-
-  addPasteRules() {
-    return [
-      markPasteRule({
-        // /g 플래그 정규식은 lastIndex 오염 위험이 있으므로 매번 새 인스턴스로 전달.
-        find: new RegExp(G_PATH_REGEX_PASTE_RULE.source, 'g'),
-        type: this.type,
-        getAttributes: (match) => ({ href: match[0] }),
+      new Plugin({
+        key: new PluginKey('pathLinkDecoration'),
+        props: {
+          decorations(state) {
+            const decos: Decoration[] = [];
+            state.doc.descendants((node, pos) => {
+              if (!node.isText || !node.text) return;
+              // /g 정규식 lastIndex 오염 방지를 위해 매번 새 인스턴스 생성.
+              const regex = new RegExp(G_PATH_REGEX_GLOBAL.source, 'g');
+              for (const match of node.text.matchAll(regex)) {
+                if (match.index === undefined) continue;
+                const from = pos + match.index;
+                const to = from + match[0].length;
+                decos.push(
+                  Decoration.inline(from, to, {
+                    class: 'path-link-mark',
+                    'data-path-link': match[0],
+                    title: `${match[0]}\n(클릭하면 파일탐색기에서 열기)`,
+                  }),
+                );
+              }
+            });
+            return DecorationSet.create(state.doc, decos);
+          },
+        },
       }),
     ];
   },

--- a/src/components/widgets/memo/extensions/PathLinkMark.ts
+++ b/src/components/widgets/memo/extensions/PathLinkMark.ts
@@ -65,10 +65,13 @@ export const PathLinkMark = Node.create({
       new Plugin({
         key: new PluginKey('pathLinkAutoConvert'),
         appendTransaction: (transactions, oldState, newState) => {
-          // 사용자 입력으로 doc 이 바뀐 transaction 만 처리 (자기 변환 transaction 은 docChanged 가 true 지만
-          // setMeta('addToHistory', false) 등으로 구분 가능 — 단순 구현은 selection 보호로 충분)
+          // doc 변경 또는 selection 변경 시 트리거.
+          //  - 입력 중(docChanged + cursor 가 path 위에 있음): selection 보호로 변환 skip
+          //  - 입력 후 cursor 만 이동(selectionChanged): 이전 path 가 selection 영역 밖이므로 변환 진행
+          //  → "타이핑 → cursor 이동 → 자동 변환" 흐름이 정상 작동
           const docChanged = transactions.some((tr) => tr.docChanged);
-          if (!docChanged) return null;
+          const selectionChanged = !oldState.selection.eq(newState.selection);
+          if (!docChanged && !selectionChanged) return null;
 
           const tr = newState.tr;
           let modified = false;
@@ -82,7 +85,8 @@ export const PathLinkMark = Node.create({
 
           newState.doc.descendants((node, pos) => {
             if (!node.isText || !node.text) return;
-            const regex = new RegExp(G_PATH_REGEX_GLOBAL.source, 'g');
+            // i 플래그 등 G_PATH_REGEX_GLOBAL 의 모든 flags 를 그대로 복사 (lowercase g:\ 인식 보장)
+            const regex = new RegExp(G_PATH_REGEX_GLOBAL.source, G_PATH_REGEX_GLOBAL.flags);
             for (const match of node.text.matchAll(regex)) {
               if (match.index === undefined) continue;
               const from = pos + match.index;

--- a/src/components/widgets/memo/extensions/PathLinkNodeView.tsx
+++ b/src/components/widgets/memo/extensions/PathLinkNodeView.tsx
@@ -1,0 +1,59 @@
+import { NodeViewWrapper, type NodeViewProps } from '@tiptap/react';
+import { FolderOpen, X } from 'lucide-react';
+import { shortenPath } from '@/utils/pathLink';
+
+/**
+ * TipTap PathLink Node 의 React 렌더러.
+ *
+ * - PathBadge(textarea/리비전) 와 동일한 청색 박스 외관
+ * - 짧은 이름만 표시 (full path 는 hover title)
+ * - 우측 X 버튼으로 노드 삭제 (deleteNode)
+ * - 박스 본체 클릭 → window.electronAPI.shellShowItem 으로 파일탐색기 열기
+ */
+export function PathLinkNodeView({ node, deleteNode }: NodeViewProps) {
+  const path = node.attrs.href as string;
+
+  const handleOpen = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (path) window.electronAPI?.shellShowItem?.(path);
+  };
+
+  const handleRemove = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    deleteNode();
+  };
+
+  return (
+    <NodeViewWrapper
+      as="span"
+      className="path-link-node-wrap"
+      contentEditable={false}
+    >
+      <span
+        className="inline-flex items-center gap-1 text-[11px] font-mono rounded px-1.5 py-0.5 max-w-full cursor-pointer transition-all hover:brightness-125 align-middle"
+        style={{
+          color: '#74B9FF',
+          backgroundColor: 'rgba(116, 185, 255, 0.1)',
+          border: '1px solid rgba(116, 185, 255, 0.2)',
+        }}
+        title={`${path}\n(클릭하면 파일탐색기에서 열기)`}
+        onClick={handleOpen}
+      >
+        <FolderOpen size={10} className="shrink-0" />
+        <span className="truncate max-w-[240px]">{shortenPath(path)}</span>
+        <button
+          type="button"
+          onClick={handleRemove}
+          onMouseDown={(e) => e.preventDefault()}
+          className="ml-0.5 -mr-1 p-[1px] rounded hover:bg-red-500/25 hover:text-red-300 transition-colors cursor-pointer"
+          title="이 경로 삭제"
+          aria-label="경로 삭제"
+        >
+          <X size={10} />
+        </button>
+      </span>
+    </NodeViewWrapper>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import { WidgetPopup } from './views/WidgetPopup';
 import './index.css';
+import './styles/path-link.css';
 
 // 브라우저 개발 환경: electronAPI가 없으면 mock 설치
 if (!window.electronAPI && import.meta.env.DEV) {

--- a/src/styles/path-link.css
+++ b/src/styles/path-link.css
@@ -1,4 +1,6 @@
-/* TipTap PathLinkMark 스타일. PathBadge(React 인라인 스타일)와 외관 일관 유지. */
+/* TipTap PathLink Decoration 스타일. PathBadge(React) 와 외관 일관 유지.
+   ProseMirror Decoration.inline 이 자식 텍스트에 직접 wrap 하므로 max-width + ellipsis 로 박스 길이 제한.
+   풀 경로는 hover 시 title 속성으로 표시. */
 .path-link-mark {
   display: inline-flex;
   align-items: center;
@@ -12,6 +14,11 @@
   border: 1px solid rgba(116, 185, 255, 0.2);
   cursor: pointer;
   transition: filter 0.15s;
+  max-width: 280px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: middle;
 }
 
 .path-link-mark:hover {

--- a/src/styles/path-link.css
+++ b/src/styles/path-link.css
@@ -1,0 +1,30 @@
+/* TipTap PathLinkMark 스타일. PathBadge(React 인라인 스타일)와 외관 일관 유지. */
+.path-link-mark {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  font-family: monospace;
+  border-radius: 4px;
+  padding: 1px 6px;
+  color: #74B9FF;
+  background: rgba(116, 185, 255, 0.1);
+  border: 1px solid rgba(116, 185, 255, 0.2);
+  cursor: pointer;
+  transition: filter 0.15s;
+}
+
+.path-link-mark:hover {
+  filter: brightness(1.25);
+}
+
+.path-link-mark::before {
+  content: '';
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  flex-shrink: 0;
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="%2374B9FF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 14l1.45-2.9A2 2 0 0 1 9.24 10H20a2 2 0 0 1 1.94 2.5l-1.55 6a2 2 0 0 1-1.94 1.5H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h3.93a2 2 0 0 1 1.66.9l.82 1.2a2 2 0 0 0 1.66.9H18a2 2 0 0 1 2 2v2"/></svg>');
+  background-size: contain;
+  background-repeat: no-repeat;
+}

--- a/src/utils/pathLink.ts
+++ b/src/utils/pathLink.ts
@@ -7,8 +7,11 @@
  * 종결자: 줄바꿈(\n, \r). Studio JBBJ 표준 폴더명에 공백이 들어가므로(예: "G:\공유 드라이브\...")
  * 단순 공백은 종결자로 쓰지 않는다. 사용자가 한 줄 안에 "G:\path 추가설명"처럼 쓰면 줄 끝까지 모두
  * 경로로 잡히므로, 경로 뒤에 부가 텍스트를 쓰려면 줄을 분리해야 한다.
+ *
+ * 대소문자: Windows 드라이브 letter 가 case-insensitive 이므로 `i` 플래그 사용.
+ * 기존 데이터에 `g:\...` 소문자로 입력된 경로가 있어도 동일하게 인식한다.
  */
-export const G_PATH_REGEX_GLOBAL = /G:\\[^\n\r]+/g;
+export const G_PATH_REGEX_GLOBAL = /G:\\[^\n\r]+/gi;
 
 export interface PathToken {
   type: 'text' | 'path';

--- a/src/utils/pathLink.ts
+++ b/src/utils/pathLink.ts
@@ -1,0 +1,39 @@
+/**
+ * G:\ 경로 인식 정규식.
+ *
+ * 본 모듈에서만 정의하고 4곳(tokenizeGPaths / PathLinkMark inputRule / pasteRule / 향후 확장)이
+ * import해 공유한다. 정규식이 어긋나면 인식 결과가 분기되어 일관성이 깨지므로 상수로 묶어둔다.
+ */
+export const G_PATH_REGEX_GLOBAL = /G:\\[^\s\n]+/g;
+export const G_PATH_REGEX_INPUT_RULE = /(G:\\[^\s\n]+)\s$/;
+export const G_PATH_REGEX_PASTE_RULE = /G:\\[^\s\n]+/g;
+
+export interface PathToken {
+  type: 'text' | 'path';
+  content: string;
+}
+
+/** 텍스트를 [text, path, text, path, ...] 토큰 배열로 분리. */
+export function tokenizeGPaths(text: string): PathToken[] {
+  if (!text) return [];
+  const tokens: PathToken[] = [];
+  let lastIdx = 0;
+  for (const match of text.matchAll(G_PATH_REGEX_GLOBAL)) {
+    if (match.index === undefined) continue;
+    if (match.index > lastIdx) {
+      tokens.push({ type: 'text', content: text.slice(lastIdx, match.index) });
+    }
+    tokens.push({ type: 'path', content: match[0] });
+    lastIdx = match.index + match[0].length;
+  }
+  if (lastIdx < text.length) {
+    tokens.push({ type: 'text', content: text.slice(lastIdx) });
+  }
+  return tokens;
+}
+
+/** 경로의 마지막 segment만 표시용으로 추출. 슬래시·역슬래시 혼용 모두 처리. */
+export function shortenPath(fullPath: string): string {
+  const segs = fullPath.replace(/\\/g, '/').split('/').filter(Boolean);
+  return segs[segs.length - 1] || fullPath;
+}

--- a/src/utils/pathLink.ts
+++ b/src/utils/pathLink.ts
@@ -1,12 +1,14 @@
 /**
  * G:\ 경로 인식 정규식.
  *
- * 본 모듈에서만 정의하고 4곳(tokenizeGPaths / PathLinkMark inputRule / pasteRule / 향후 확장)이
+ * 본 모듈에서만 정의하고 메모(InlineTextareaRow) / 댓글(CommentPanel) / 메모위젯(PathLinkExtension Decoration) 3곳이
  * import해 공유한다. 정규식이 어긋나면 인식 결과가 분기되어 일관성이 깨지므로 상수로 묶어둔다.
+ *
+ * 종결자: 줄바꿈(\n, \r). Studio JBBJ 표준 폴더명에 공백이 들어가므로(예: "G:\공유 드라이브\...")
+ * 단순 공백은 종결자로 쓰지 않는다. 사용자가 한 줄 안에 "G:\path 추가설명"처럼 쓰면 줄 끝까지 모두
+ * 경로로 잡히므로, 경로 뒤에 부가 텍스트를 쓰려면 줄을 분리해야 한다.
  */
-export const G_PATH_REGEX_GLOBAL = /G:\\[^\s\n]+/g;
-export const G_PATH_REGEX_INPUT_RULE = /(G:\\[^\s\n]+)\s$/;
-export const G_PATH_REGEX_PASTE_RULE = /G:\\[^\s\n]+/g;
+export const G_PATH_REGEX_GLOBAL = /G:\\[^\n\r]+/g;
 
 export interface PathToken {
   type: 'text' | 'path';

--- a/src/views/CompositingView.tsx
+++ b/src/views/CompositingView.tsx
@@ -26,6 +26,7 @@ import type { CompRevision, RevisionStatus, RevisionPriority, Episode } from '@/
 import { formatDateTime } from '@/utils/formatTime';
 import { STATUS_CONFIG, PRIORITY_CONFIG } from '@/constants/revision';
 import { elevatedGlassStyle, floatingGlassStyle } from '@/utils/glassStyles';
+import { PathBadge } from '@/components/common/PathBadge';
 
 // ─── 유틸 ───────────────────────────────────
 
@@ -70,34 +71,6 @@ function parsePathsFromText(text: string): { description: string; paths: string[
   const description = descLines.join('\n').trim();
   return { description, paths };
 }
-
-/** 경로 뱃지 컴포넌트 (클릭 시 파일탐색기 열기) */
-function PathBadge({ path: filePath, resolved }: { path: string; resolved?: boolean }) {
-  // 경로의 마지막 부분(파일명 또는 폴더명)만 표시
-  const segments = filePath.replace(/\\/g, '/').split('/');
-  const shortName = segments[segments.length - 1] || segments[segments.length - 2] || filePath;
-
-  const handleClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    window.electronAPI?.shellShowItem?.(filePath);
-  };
-
-  return (
-    <button
-      onClick={handleClick}
-      className="inline-flex items-center gap-1 text-[11px] font-mono rounded px-1.5 py-0.5 max-w-full cursor-pointer transition-all hover:brightness-125"
-      style={resolved
-        ? { color: '#6B7280', backgroundColor: 'rgba(107, 114, 128, 0.1)', border: '1px solid rgba(107, 114, 128, 0.2)' }
-        : { color: '#74B9FF', backgroundColor: 'rgba(116, 185, 255, 0.1)', border: '1px solid rgba(116, 185, 255, 0.2)' }
-      }
-      title={`${filePath}\n(클릭하면 파일탐색기에서 열기)`}
-    >
-      <FolderOpen size={10} className="shrink-0" />
-      <span className="truncate">{shortName}</span>
-    </button>
-  );
-}
-
 
 // ─── 씬 정보 매핑 타입 ──────────────────────
 

--- a/src/views/CompositingView.tsx
+++ b/src/views/CompositingView.tsx
@@ -53,8 +53,8 @@ function parsePathsFromText(text: string): { description: string; paths: string[
 
   for (const line of lines) {
     const trimmed = line.trim();
-    // 줄 전체가 G:\로 시작하면 경로
-    if (/^G:\\/i.test(trimmed)) {
+    // 줄 전체가 G:\로 시작하면 경로 (대문자 G 만 인식 — 다른 3곳과 일관성 유지)
+    if (/^G:\\/.test(trimmed)) {
       paths.push(trimmed);
     } else if (trimmed.includes('G:\\')) {
       // 줄 중간에 G:\가 있으면 그 앞은 설명, 뒤는 경로

--- a/src/views/CompositingView.tsx
+++ b/src/views/CompositingView.tsx
@@ -53,18 +53,21 @@ function parsePathsFromText(text: string): { description: string; paths: string[
 
   for (const line of lines) {
     const trimmed = line.trim();
-    // 줄 전체가 G:\로 시작하면 경로 (대문자 G 만 인식 — 다른 3곳과 일관성 유지)
-    if (/^G:\\/.test(trimmed)) {
+    // 줄 전체가 G:\로 시작하면 경로 (Windows 드라이브 letter 가 case-insensitive 라 g:\ 도 인식)
+    if (/^G:\\/i.test(trimmed)) {
       paths.push(trimmed);
-    } else if (trimmed.includes('G:\\')) {
-      // 줄 중간에 G:\가 있으면 그 앞은 설명, 뒤는 경로
-      const idx = trimmed.indexOf('G:\\');
-      const before = trimmed.slice(0, idx).trim();
-      const pathPart = trimmed.slice(idx).trim();
-      if (before) descLines.push(before);
-      paths.push(pathPart);
     } else {
-      descLines.push(line);
+      // 줄 중간에 G:\ (또는 g:\) 가 있으면 그 앞은 설명, 뒤는 경로
+      const m = /G:\\/i.exec(trimmed);
+      if (m) {
+        const idx = m.index;
+        const before = trimmed.slice(0, idx).trim();
+        const pathPart = trimmed.slice(idx).trim();
+        if (before) descLines.push(before);
+        paths.push(pathPart);
+      } else {
+        descLines.push(line);
+      }
     }
   }
 


### PR DESCRIPTION
## 📋 업데이트 요약

> 이번 업데이트에서 달라진 점을 간략하게 정리했습니다.

- ✨ 메모/댓글/메모 위젯에 `G:\공유 드라이브\...` 같은 경로를 입력하면 **클릭 가능한 청색 버튼**으로 자동 변환됩니다. 클릭하면 파일 탐색기에서 해당 위치가 열립니다.
- ✨ 메모 위젯의 경로 버튼 우측에 **X 표시**가 생겼습니다. 한 번 누르면 경로 텍스트가 통째로 사라져서 수정이 편해집니다.
- ✨ 같은 외관·동작을 **씬 메모 / 댓글 / 메모 위젯 / 리비전 4곳에 통일** 했습니다. 디자인 변경 시 한 곳만 고치면 모두 반영됩니다.
- 🐛 씬 상세 모달 안에서 마우스로 드래그하다가 모달 밖으로 마우스가 나가면 모달이 꺼지던 문제를 수정했습니다.
- 📄 다음 작업인 **'최근 작업 위젯' 설계서·구현 계획서**도 함께 들어갔습니다 (실제 위젯 구현은 다음 PR).

## 🔧 상세 기술 설명

### G:\ 경로 자동 링크화 (4곳 통합)
- 공용 모듈 신설: `src/utils/pathLink.ts` (`tokenizeGPaths`, `shortenPath`, 정규식 단일 상수), `src/components/common/PathBadge.tsx`, `PathLinkifiedText.tsx`
- 메모(InlineTextareaRow) / 댓글(`CommentPanel.renderText`) / 리비전(CompositingView)이 동일 컴포넌트 import. 기존 CompositingView의 인라인 PathBadge는 삭제(DRY).
- 메모 위젯(TipTap)은 atom inline Node + `ReactNodeViewRenderer` 패턴 — `PathLinkMark.ts`, `PathLinkNodeView.tsx`
- Markdown round-trip: `addStorage().markdown.serialize`가 raw text로 출력 → 재로드 시 `appendTransaction`이 자동 재변환
- 클릭 IPC: 기존 `shell:show-item` (`electron/main.ts:736`) 재사용

### 씬 상세 모달 드래그 닫힘 수정
- `UnifiedSceneDetailModal.tsx` / `SceneDetailModal.tsx`
- `backdropMouseDownRef`로 mousedown 시작 위치 추적, mousedown과 click이 모두 backdrop 자체에서 발생한 경우만 `onClose` 트리거

### 다음 작업 문서 (코드 영향 없음)
- `docs/superpowers/specs/2026-04-27-recent-activity-widget-design.md`
- `docs/superpowers/plans/2026-04-27-recent-activity-widget.md`
- 시안 mockup HTML 2종 (4가지 레이아웃 비교 / 최종 v2)

## 🚧 개발 난항

### TipTap PathLink 구현 방식 시행착오
- **문제**: 처음에는 TipTap Mark + `markInputRule`로 구현했으나, 정규식 종결자가 공백(`\s$`)이라 사용자가 "G:\공유 드라이브"를 입력하면 첫 공백에서 mark가 끊김 (G:\공유까지만 변환)
- **시도1**: Decoration 패턴으로 전환 → 시각은 적용되지만 텍스트는 그대로 길게 노출되고 클릭 핸들러도 ProseMirror 위치 기반이라 안정적이지 않음
- **시도2**: Decoration + `handleDOMEvents.click` + CSS `text-overflow: ellipsis`. 클릭은 작동했으나 PathBadge처럼 "짧은 이름만 표시 + X 버튼" 외관 통일이 불가능
- **해결**: atom inline Node + ReactNodeViewRenderer로 최종 전환. `appendTransaction`이 매 doc 변경 시 G:\ 텍스트를 Node로 자동 교체. cursor가 입력 중인 영역은 변환에서 제외해 typing 도중 cursor가 튀지 않도록 보호
- **교훈**: TipTap에서 raw text의 시각·동작 변환은 Mark가 아닌 Node로 가야 multi-segment 입력에 안정적. Mark는 종결자에 의존하므로 공백 포함 경로 같은 케이스에 취약

### 모달 드래그 → 잘못된 닫힘 트리거
- **문제**: 모달 안에서 시작한 마우스 드래그가 backdrop에서 종료되면 click 이벤트가 backdrop으로 발화 → `onClose` 호출 → 모달 닫힘
- **해결**: `onMouseDown` + `onClick` 페어로 mousedown 시작 위치를 ref에 추적, 둘 다 backdrop 자체일 때만 `onClose`
- **교훈**: 다른 모달(휴가/일정/이미지 등)에도 동일 버그 가능성 있음 — follow-up 작업으로 확인 필요

## ✅ 테스트 가이드

### 사용자 테스트

> 아래 시나리오를 직접 실행해서 정상 동작을 확인해주세요.

1. **메모 위젯 G:\ 자동 변환**
   - 메모 위젯에 `G:\공유 드라이브\test\파일.png` 입력 후 cursor를 다른 곳으로 이동
   - ✅ 짧은 이름만 보이는 청색 박스(📁 파일.png) + 우측 X 버튼
   - ❌ 입력한 그대로 일반 텍스트로 남거나, 첫 공백에서 끊김

2. **메모 위젯 클릭 / X 삭제**
   - 박스 본체 클릭 → 파일 탐색기 열림 (또는 상위 폴더 폴백)
   - X 버튼 클릭 → 박스와 텍스트가 한 번에 사라짐

3. **Markdown round-trip**
   - 메모 저장 → 다른 탭 → 메모 탭 재방문
   - ✅ 박스 외관 그대로 유지

4. **4곳 외관 일관성 (씬 메모 / 댓글 / 메모 위젯 / 리비전)**
   - 씬 상세모달 메모, 댓글, 리비전, 메모 위젯 모두 동일한 청색 박스 외관
   - ❌ 각자 다른 색·아이콘이면 PathBadge 갈아끼기 누락

5. **씬 모달 드래그 닫힘 fix**
   - 씬 상세 모달 안 텍스트에서 마우스 드래그 시작 → backdrop(어두운 영역)으로 이동 후 놓기
   - ✅ 모달이 닫히지 않음
   - 비교: backdrop 자체를 단일 클릭 → 정상적으로 닫힘

### 개발자 테스트

\`\`\`bash
npx tsc --noEmit        # 타입 검증
npx vite build          # 번들 빌드
\`\`\`

> vitest는 미설치 상태이므로 단위 테스트 없음. 위 두 명령 통과 + 사용자 테스트 5단계 모두 OK면 머지 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)