### PR TITLE
[v1.14.1] 히트맵 호버 툴팁 — 그룹별 카운트 표시

### DIFF
--- a/DEVLOG/supabase-init.sql
+++ b/DEVLOG/supabase-init.sql
@@ -479,8 +479,10 @@ $$;
 GRANT EXECUTE ON FUNCTION record_activity(TEXT, TEXT, TEXT, TEXT, UUID, TEXT, INTEGER, TEXT, JSONB)
   TO anon, authenticated;
 
--- 3. activity_log_stats RPC (히트맵 24x7 격자 집계)
+-- 3. activity_log_stats RPC (히트맵 24x7 격자 집계 + 그룹별 카운트)
 -- KST 기준으로 day_of_week / hour 추출 (PostgreSQL EXTRACT(dow): 0=일 ~ 6=토)
+-- v1.14.1: 그룹별 카운트(progress/memo/scene/etc) 추가 — 히트맵 셀 호버 툴팁용
+DROP FUNCTION IF EXISTS activity_log_stats(TIMESTAMPTZ, TEXT[], TEXT);
 CREATE OR REPLACE FUNCTION activity_log_stats(
   p_since TIMESTAMPTZ,
   p_groups TEXT[] DEFAULT NULL,        -- NULL이면 전체
@@ -488,7 +490,11 @@ CREATE OR REPLACE FUNCTION activity_log_stats(
 ) RETURNS TABLE (
   day_of_week INTEGER,
   hour INTEGER,
-  count INTEGER
+  count INTEGER,
+  count_progress INTEGER,
+  count_memo INTEGER,
+  count_scene INTEGER,
+  count_etc INTEGER
 )
 LANGUAGE sql
 SECURITY INVOKER
@@ -496,7 +502,11 @@ AS $$
   SELECT
     EXTRACT(dow  FROM (created_at AT TIME ZONE 'Asia/Seoul'))::integer AS day_of_week,
     EXTRACT(hour FROM (created_at AT TIME ZONE 'Asia/Seoul'))::integer AS hour,
-    COUNT(*)::integer AS count
+    COUNT(*)::integer AS count,
+    COUNT(*) FILTER (WHERE action_group = 'progress')::integer AS count_progress,
+    COUNT(*) FILTER (WHERE action_group = 'memo')::integer     AS count_memo,
+    COUNT(*) FILTER (WHERE action_group = 'scene')::integer    AS count_scene,
+    COUNT(*) FILTER (WHERE action_group = 'etc')::integer      AS count_etc
   FROM activity_log
   WHERE created_at >= p_since
     AND (p_groups IS NULL OR action_group = ANY(p_groups))

--- a/electron/supabase.ts
+++ b/electron/supabase.ts
@@ -1712,11 +1712,21 @@ export async function listActivities(opts: {
   return (data ?? []) as ActivityRow[];
 }
 
+export interface ActivityStatBucket {
+  day_of_week: number;
+  hour: number;
+  count: number;
+  count_progress: number;
+  count_memo: number;
+  count_scene: number;
+  count_etc: number;
+}
+
 export async function getActivityStats(opts: {
   days?: number;
   groups?: ActionGroup[];
   department?: 'bg' | 'acting' | null;
-}): Promise<Array<{ day_of_week: number; hour: number; count: number }>> {
+}): Promise<ActivityStatBucket[]> {
   const since = new Date(Date.now() - (opts.days ?? 7) * 86400000).toISOString();
   const { data, error } = await supabase.rpc('activity_log_stats', {
     p_since: since,
@@ -1724,7 +1734,7 @@ export async function getActivityStats(opts: {
     p_department: opts.department ?? null,
   });
   if (error) throw new Error(`getActivityStats failed: ${error.message}`);
-  return (data ?? []) as Array<{ day_of_week: number; hour: number; count: number }>;
+  return (data ?? []) as ActivityStatBucket[];
 }
 
 export async function backfillActivities(since: string, limit = 200): Promise<ActivityRow[]> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bflow",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bflow",
-      "version": "1.14.0",
+      "version": "1.14.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@liveblocks/client": "^3.14.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/components/widgets/RecentActivityWidget.tsx
+++ b/src/components/widgets/RecentActivityWidget.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { Activity, Clock, Filter, Grid3x3, BarChart3 } from 'lucide-react';
+import { Activity, Clock, Grid3x3, BarChart3 } from 'lucide-react';
 import { Widget } from './Widget';
 import { useActivityStore, type GoldenMode } from '@/stores/useActivityStore';
 import { useAppStore } from '@/stores/useAppStore';
@@ -8,15 +8,20 @@ import { GoldenHeatmap } from './activity/GoldenHeatmap';
 import { GoldenBarChart } from './activity/GoldenBarChart';
 import { ActivityFilterChips } from './activity/ActivityFilterChips';
 import { ActivityFeed } from './activity/ActivityFeed';
-import { pickGoldenWindow, pickGoldenHour, pickGoldenDay, dayLabel } from './activity/utils';
+import { pickGoldenWindow, pickGoldenHour, pickGoldenDay, dayLabel, EMPTY_GROUPED_COUNT, type GroupedCount } from './activity/utils';
+import { GROUP_LABEL, GROUP_DOT_COLOR } from './activity/constants';
 import { subscribeToActivityRealtime } from '@/services/supabaseService';
+import type { ActionGroup } from '@/types';
 
 interface TooltipState {
   visible: boolean;
-  text: string;
+  title: string;
+  cell: GroupedCount;
   x: number;
   y: number;
 }
+
+const TOOLTIP_GROUP_ORDER: ActionGroup[] = ['progress', 'memo', 'scene', 'etc'];
 
 export function RecentActivityWidget() {
   const {
@@ -28,7 +33,16 @@ export function RecentActivityWidget() {
     receiveRealtime,
   } = useActivityStore();
 
-  const [tooltip, setTooltip] = useState<TooltipState>({ visible: false, text: '', x: 0, y: 0 });
+  const [tooltip, setTooltip] = useState<TooltipState>({
+    visible: false,
+    title: '',
+    cell: { ...EMPTY_GROUPED_COUNT },
+    x: 0,
+    y: 0,
+  });
+
+  const hideTooltip = () =>
+    setTooltip({ visible: false, title: '', cell: { ...EMPTY_GROUPED_COUNT }, x: 0, y: 0 });
 
   // 대시보드 부서 필터 변경 시 활동 + statsGrid 자동 재로드 (Codex P2).
   // useActivityStore 의 store action 은 stable reference 라 useEffect 가 재실행되지 않으므로
@@ -56,14 +70,14 @@ export function RecentActivityWidget() {
     }
     if (goldenMode === 'hour') {
       const hourTotals = new Array(24).fill(0);
-      for (let d = 0; d < 7; d++) for (let h = 0; h < 24; h++) hourTotals[h] += statsGrid[d][h];
+      for (let d = 0; d < 7; d++) for (let h = 0; h < 24; h++) hourTotals[h] += statsGrid[d][h].total;
       const r = pickGoldenHour(hourTotals);
       if (!r) return '활동 기록이 부족합니다';
       return `하루 중 정점: ${r.hour}–${r.hour + 2}시 (24시간 기준 ${Math.round(r.ratio * 100)}%)`;
     }
     // day
     const dayTotals = new Array(7).fill(0);
-    for (let d = 0; d < 7; d++) for (let h = 0; h < 24; h++) dayTotals[d] += statsGrid[d][h];
+    for (let d = 0; d < 7; d++) for (let h = 0; h < 24; h++) dayTotals[d] += statsGrid[d][h].total;
     const r = pickGoldenDay(dayTotals);
     if (!r) return '활동 기록이 부족합니다';
     return `주중 정점: ${dayLabel(r.day)}요일 (전체의 ${Math.round(r.ratio * 100)}%)`;
@@ -87,10 +101,11 @@ export function RecentActivityWidget() {
           {goldenMode === 'heatmap' && (
             <GoldenHeatmap
               onCellHover={(info) => {
-                if (!info) { setTooltip({ visible: false, text: '', x: 0, y: 0 }); return; }
+                if (!info) { hideTooltip(); return; }
                 setTooltip({
                   visible: true,
-                  text: `${dayLabel(info.day)} ${info.hour}시 · ${info.count}건`,
+                  title: `${dayLabel(info.day)} ${info.hour}시`,
+                  cell: info.cell,
                   x: info.x, y: info.y,
                 });
               }}
@@ -100,8 +115,8 @@ export function RecentActivityWidget() {
             <GoldenBarChart
               mode="hour"
               onBarHover={(info) => {
-                if (!info) { setTooltip({ visible: false, text: '', x: 0, y: 0 }); return; }
-                setTooltip({ visible: true, text: `${info.label} · ${info.count}건`, x: info.x, y: info.y });
+                if (!info) { hideTooltip(); return; }
+                setTooltip({ visible: true, title: info.label, cell: info.cell, x: info.x, y: info.y });
               }}
             />
           )}
@@ -109,8 +124,8 @@ export function RecentActivityWidget() {
             <GoldenBarChart
               mode="day"
               onBarHover={(info) => {
-                if (!info) { setTooltip({ visible: false, text: '', x: 0, y: 0 }); return; }
-                setTooltip({ visible: true, text: `${info.label} · ${info.count}건`, x: info.x, y: info.y });
+                if (!info) { hideTooltip(); return; }
+                setTooltip({ visible: true, title: info.label, cell: info.cell, x: info.x, y: info.y });
               }}
             />
           )}
@@ -131,7 +146,7 @@ export function RecentActivityWidget() {
             위젯의 backdrop-filter 가 만든 stacking context 안에 갇히지 않음 */}
         {tooltip.visible && createPortal(
           <div
-            className="fixed z-[9999] bg-bg-card/95 border border-bg-border rounded-lg px-2.5 py-1.5 text-[11.5px] text-text-primary pointer-events-none shadow-xl backdrop-blur-md"
+            className="fixed z-[9999] bg-bg-card/95 border border-bg-border rounded-lg px-2.5 py-2 text-[11.5px] text-text-primary pointer-events-none shadow-xl backdrop-blur-md min-w-[120px]"
             style={{
               left: tooltip.x,
               top: tooltip.y,
@@ -139,7 +154,29 @@ export function RecentActivityWidget() {
               whiteSpace: 'nowrap',
             }}
           >
-            {tooltip.text}
+            <div className="font-semibold text-accent-sub mb-1.5">
+              {tooltip.title} <span className="text-text-secondary font-normal">· 총 {tooltip.cell.total}건</span>
+            </div>
+            {tooltip.cell.total === 0 ? (
+              <div className="text-text-secondary text-[11px]">활동 없음</div>
+            ) : (
+              <div className="flex flex-col gap-[3px]">
+                {TOOLTIP_GROUP_ORDER.map((g) => {
+                  const c = tooltip.cell[g];
+                  if (c === 0) return null;
+                  return (
+                    <div key={g} className="flex items-center gap-1.5 text-[11px] text-text-secondary">
+                      <span
+                        className="w-[7px] h-[7px] rounded-full flex-shrink-0"
+                        style={{ background: GROUP_DOT_COLOR[g] }}
+                      />
+                      <span>{GROUP_LABEL[g]}</span>
+                      <span className="text-text-primary ml-auto pl-2">{c}</span>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
           </div>,
           document.body,
         )}

--- a/src/components/widgets/activity/GoldenBarChart.tsx
+++ b/src/components/widgets/activity/GoldenBarChart.tsx
@@ -1,10 +1,17 @@
 import { useMemo } from 'react';
 import { useActivityStore } from '@/stores/useActivityStore';
-import { dayLabel } from './utils';
+import { dayLabel, addGroupedCount, EMPTY_GROUPED_COUNT, type GroupedCount } from './utils';
+
+export interface BarHoverInfo {
+  label: string;
+  cell: GroupedCount;
+  x: number;
+  y: number;
+}
 
 interface Props {
   mode: 'hour' | 'day';
-  onBarHover?: (info: { label: string; count: number; x: number; y: number } | null) => void;
+  onBarHover?: (info: BarHoverInfo | null) => void;
 }
 
 const ACCENT_GRADIENT = 'linear-gradient(to top, rgb(var(--color-accent)) 0%, rgb(var(--color-accent-sub)) 100%)';
@@ -14,18 +21,19 @@ const PEAK_GRADIENT = 'linear-gradient(to top, #FDCB6E 0%, #FFE5A0 100%)';
 export function GoldenBarChart({ mode, onBarHover }: Props) {
   const grid = useActivityStore((s) => s.statsGrid);
 
-  const totals = useMemo(() => {
+  /** mode 기준으로 24시간(또는 7요일) 분 그룹별 카운트 합산. */
+  const buckets = useMemo<GroupedCount[]>(() => {
     if (mode === 'hour') {
-      const arr = new Array(24).fill(0);
-      for (let d = 0; d < 7; d++) for (let h = 0; h < 24; h++) arr[h] += grid[d][h];
-      return arr;
-    } else {
-      const arr = new Array(7).fill(0);
-      for (let d = 0; d < 7; d++) for (let h = 0; h < 24; h++) arr[d] += grid[d][h];
+      const arr: GroupedCount[] = Array.from({ length: 24 }, () => ({ ...EMPTY_GROUPED_COUNT }));
+      for (let d = 0; d < 7; d++) for (let h = 0; h < 24; h++) arr[h] = addGroupedCount(arr[h], grid[d][h]);
       return arr;
     }
+    const arr: GroupedCount[] = Array.from({ length: 7 }, () => ({ ...EMPTY_GROUPED_COUNT }));
+    for (let d = 0; d < 7; d++) for (let h = 0; h < 24; h++) arr[d] = addGroupedCount(arr[d], grid[d][h]);
+    return arr;
   }, [grid, mode]);
 
+  const totals = useMemo(() => buckets.map((b) => b.total), [buckets]);
   const max = Math.max(1, ...totals);
   const peakIdx = totals.indexOf(Math.max(...totals));
 
@@ -35,8 +43,8 @@ export function GoldenBarChart({ mode, onBarHover }: Props) {
         className="grid items-end gap-[3px] relative"
         style={{ gridTemplateColumns: 'repeat(24, 1fr)', height: '130px', paddingBottom: '18px' }}
       >
-        {totals.map((count, h) => {
-          const pct = max > 0 ? (count / max) * 100 : 0;
+        {buckets.map((cell, h) => {
+          const pct = max > 0 ? (cell.total / max) * 100 : 0;
           return (
             <div
               key={h}
@@ -48,7 +56,7 @@ export function GoldenBarChart({ mode, onBarHover }: Props) {
               }}
               onMouseEnter={(e) => {
                 const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
-                onBarHover?.({ label: `${h}시`, count, x: rect.left + rect.width / 2, y: rect.top });
+                onBarHover?.({ label: `${h}시`, cell, x: rect.left + rect.width / 2, y: rect.top });
               }}
               onMouseLeave={() => onBarHover?.(null)}
             >
@@ -70,9 +78,9 @@ export function GoldenBarChart({ mode, onBarHover }: Props) {
       className="grid items-end gap-3 px-3"
       style={{ gridTemplateColumns: 'repeat(7, 1fr)', height: '130px', paddingBottom: '22px' }}
     >
-      {totals.map((count, d) => {
-        const pct = max > 0 ? (count / max) * 100 : 0;
-        const isPeak = d === peakIdx && count > 0;
+      {buckets.map((cell, d) => {
+        const pct = max > 0 ? (cell.total / max) * 100 : 0;
+        const isPeak = d === peakIdx && cell.total > 0;
         return (
           <div
             key={d}
@@ -84,7 +92,7 @@ export function GoldenBarChart({ mode, onBarHover }: Props) {
             }}
             onMouseEnter={(e) => {
               const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
-              onBarHover?.({ label: `${dayLabel(d)}요일`, count, x: rect.left + rect.width / 2, y: rect.top });
+              onBarHover?.({ label: `${dayLabel(d)}요일`, cell, x: rect.left + rect.width / 2, y: rect.top });
             }}
             onMouseLeave={() => onBarHover?.(null)}
           >

--- a/src/components/widgets/activity/GoldenBarChart.tsx
+++ b/src/components/widgets/activity/GoldenBarChart.tsx
@@ -45,6 +45,9 @@ export function GoldenBarChart({ mode, onBarHover }: Props) {
       >
         {buckets.map((cell, h) => {
           const pct = max > 0 ? (cell.total / max) * 100 : 0;
+          // 마우스 위치를 그대로 전달 — 툴팁이 커서를 따라다님 (목업과 동일)
+          const reportHover = (e: React.MouseEvent<HTMLDivElement>) =>
+            onBarHover?.({ label: `${h}시`, cell, x: e.clientX, y: e.clientY });
           return (
             <div
               key={h}
@@ -54,10 +57,8 @@ export function GoldenBarChart({ mode, onBarHover }: Props) {
                 background: ACCENT_GRADIENT,
                 transition: 'opacity 0.15s ease, filter 0.15s ease',
               }}
-              onMouseEnter={(e) => {
-                const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
-                onBarHover?.({ label: `${h}시`, cell, x: rect.left + rect.width / 2, y: rect.top });
-              }}
+              onMouseEnter={reportHover}
+              onMouseMove={reportHover}
               onMouseLeave={() => onBarHover?.(null)}
             >
               {[0, 6, 12, 18].includes(h) && (
@@ -81,6 +82,8 @@ export function GoldenBarChart({ mode, onBarHover }: Props) {
       {buckets.map((cell, d) => {
         const pct = max > 0 ? (cell.total / max) * 100 : 0;
         const isPeak = d === peakIdx && cell.total > 0;
+        const reportHover = (e: React.MouseEvent<HTMLDivElement>) =>
+          onBarHover?.({ label: `${dayLabel(d)}요일`, cell, x: e.clientX, y: e.clientY });
         return (
           <div
             key={d}
@@ -90,10 +93,8 @@ export function GoldenBarChart({ mode, onBarHover }: Props) {
               background: isPeak ? PEAK_GRADIENT : ACCENT_GRADIENT,
               transition: 'opacity 0.15s ease, filter 0.15s ease',
             }}
-            onMouseEnter={(e) => {
-              const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
-              onBarHover?.({ label: `${dayLabel(d)}요일`, cell, x: rect.left + rect.width / 2, y: rect.top });
-            }}
+            onMouseEnter={reportHover}
+            onMouseMove={reportHover}
             onMouseLeave={() => onBarHover?.(null)}
           >
             <span className="absolute left-1/2 -translate-x-1/2 -bottom-5 text-[11px] text-text-secondary">

--- a/src/components/widgets/activity/GoldenHeatmap.tsx
+++ b/src/components/widgets/activity/GoldenHeatmap.tsx
@@ -1,8 +1,16 @@
 import { useActivityStore } from '@/stores/useActivityStore';
-import { intensityLevel, intensityBg, intensityGlow, dayLabel } from './utils';
+import { intensityLevel, intensityBg, intensityGlow, dayLabel, type GroupedCount } from './utils';
+
+export interface HeatmapCellHoverInfo {
+  day: number;
+  hour: number;
+  cell: GroupedCount;
+  x: number;
+  y: number;
+}
 
 interface Props {
-  onCellHover?: (info: { day: number; hour: number; count: number; x: number; y: number } | null) => void;
+  onCellHover?: (info: HeatmapCellHoverInfo | null) => void;
 }
 
 export function GoldenHeatmap({ onCellHover }: Props) {
@@ -34,7 +42,7 @@ function DayRow({
   onCellHover,
 }: {
   dayIdx: number;
-  row: number[];
+  row: GroupedCount[];
   onCellHover?: Props['onCellHover'];
 }) {
   return (
@@ -42,15 +50,15 @@ function DayRow({
       <div className="text-[10px] text-text-secondary text-right pr-1.5">
         {dayLabel(dayIdx)}
       </div>
-      {row.map((count, h) => {
-        const lv = intensityLevel(count);
+      {row.map((cell, h) => {
+        const lv = intensityLevel(cell.total);
         const handleEnter = (e: React.MouseEvent<HTMLDivElement>) => {
           // 셀의 화면 좌상단 좌표 사용 — 호버 영역 안에서 마우스 움직여도 툴팁 위치 안정
           const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
           onCellHover?.({
             day: dayIdx,
             hour: h,
-            count,
+            cell,
             x: rect.left + rect.width / 2,
             y: rect.top,
           });

--- a/src/components/widgets/activity/GoldenHeatmap.tsx
+++ b/src/components/widgets/activity/GoldenHeatmap.tsx
@@ -52,15 +52,14 @@ function DayRow({
       </div>
       {row.map((cell, h) => {
         const lv = intensityLevel(cell.total);
-        const handleEnter = (e: React.MouseEvent<HTMLDivElement>) => {
-          // 셀의 화면 좌상단 좌표 사용 — 호버 영역 안에서 마우스 움직여도 툴팁 위치 안정
-          const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
+        // 마우스 위치를 그대로 전달 — 툴팁이 커서를 따라다니도록 (목업과 동일)
+        const reportHover = (e: React.MouseEvent<HTMLDivElement>) => {
           onCellHover?.({
             day: dayIdx,
             hour: h,
             cell,
-            x: rect.left + rect.width / 2,
-            y: rect.top,
+            x: e.clientX,
+            y: e.clientY,
           });
         };
         return (
@@ -72,7 +71,8 @@ function DayRow({
               boxShadow: intensityGlow(lv),
               transition: 'transform 0.15s ease',
             }}
-            onMouseEnter={handleEnter}
+            onMouseEnter={reportHover}
+            onMouseMove={reportHover}
             onMouseLeave={() => onCellHover?.(null)}
           />
         );

--- a/src/components/widgets/activity/utils.ts
+++ b/src/components/widgets/activity/utils.ts
@@ -79,6 +79,31 @@ export function groupActivities(items: Activity[]): FeedItem[] {
   return result;
 }
 
+/**
+ * 그룹별 카운트 묶음 — 한 셀(요일×시간)의 활동을 그룹별로 분해 보관.
+ * v1.14.1 추가: 히트맵 셀 호버 툴팁에서 "작업진행 N건 / 메모·댓글 N건 / 씬 N건 / 기타 N건" 표시용.
+ * total 은 4개 합과 항상 일치 (서버 RPC FILTER 절에서 보장).
+ */
+export interface GroupedCount {
+  total: number;
+  progress: number;
+  memo: number;
+  scene: number;
+  etc: number;
+}
+
+export const EMPTY_GROUPED_COUNT: GroupedCount = { total: 0, progress: 0, memo: 0, scene: 0, etc: 0 };
+
+export function addGroupedCount(a: GroupedCount, b: GroupedCount): GroupedCount {
+  return {
+    total: a.total + b.total,
+    progress: a.progress + b.progress,
+    memo: a.memo + b.memo,
+    scene: a.scene + b.scene,
+    etc: a.etc + b.etc,
+  };
+}
+
 export interface GoldenWindow {
   day: number;
   hour: number;
@@ -86,11 +111,11 @@ export interface GoldenWindow {
 }
 
 /** 24x7 격자에서 연속 2시간 합이 최대인 슬롯. 동률이면 가장 최근 요일 우선. */
-export function pickGoldenWindow(grid: number[][]): GoldenWindow | null {
+export function pickGoldenWindow(grid: GroupedCount[][]): GoldenWindow | null {
   let best: GoldenWindow | null = null;
   for (let d = 0; d < 7; d++) {
     for (let h = 0; h < 23; h++) {
-      const sum = (grid[d]?.[h] ?? 0) + (grid[d]?.[h + 1] ?? 0);
+      const sum = (grid[d]?.[h]?.total ?? 0) + (grid[d]?.[h + 1]?.total ?? 0);
       if (sum === 0) continue;
       if (!best || sum > best.count || (sum === best.count && d > best.day)) {
         best = { day: d, hour: h, count: sum };
@@ -126,14 +151,33 @@ export function pickGoldenDay(dayTotals: number[]): { day: number; ratio: number
 /**
  * stats 결과(PostgreSQL EXTRACT(dow): 0=일~6=토) → 표시용 24x7 격자.
  * 표시 인덱스: 0=월, 1=화, ..., 5=토, 6=일.
+ * v1.14.1: 그룹별 카운트(progress/memo/scene/etc) 포함.
  */
-export function buildHeatmapGrid(stats: Array<{ day_of_week: number; hour: number; count: number }>): number[][] {
-  const grid: number[][] = Array.from({ length: 7 }, () => Array(24).fill(0));
+export interface ActivityStatRow {
+  day_of_week: number;
+  hour: number;
+  count: number;
+  count_progress?: number;
+  count_memo?: number;
+  count_scene?: number;
+  count_etc?: number;
+}
+
+export function buildHeatmapGrid(stats: ActivityStatRow[]): GroupedCount[][] {
+  const grid: GroupedCount[][] = Array.from({ length: 7 }, () =>
+    Array.from({ length: 24 }, () => ({ ...EMPTY_GROUPED_COUNT })),
+  );
   for (const s of stats) {
     // pg dow 0=일,1=월,...,6=토 → 표시 0=월,...,6=일
     const displayDay = (s.day_of_week + 6) % 7;
     if (displayDay >= 0 && displayDay < 7 && s.hour >= 0 && s.hour < 24) {
-      grid[displayDay][s.hour] = s.count;
+      grid[displayDay][s.hour] = {
+        total: s.count,
+        progress: s.count_progress ?? 0,
+        memo: s.count_memo ?? 0,
+        scene: s.count_scene ?? 0,
+        etc: s.count_etc ?? 0,
+      };
     }
   }
   return grid;

--- a/src/services/supabaseService.ts
+++ b/src/services/supabaseService.ts
@@ -517,7 +517,15 @@ export async function getActivityStats(opts: {
   days?: number;
   groups?: ActionGroup[];
   department?: 'bg' | 'acting' | null;
-}): Promise<Array<{ day_of_week: number; hour: number; count: number }>> {
+}): Promise<Array<{
+  day_of_week: number;
+  hour: number;
+  count: number;
+  count_progress: number;
+  count_memo: number;
+  count_scene: number;
+  count_etc: number;
+}>> {
   return await window.electronAPI.activityStats(opts);
 }
 

--- a/src/stores/useActivityStore.ts
+++ b/src/stores/useActivityStore.ts
@@ -3,7 +3,7 @@ import type { Activity, ActionGroup } from '@/types';
 import * as supabaseService from '@/services/supabaseService';
 import { useAppStore } from './useAppStore';
 import { useAuthStore } from './useAuthStore';
-import { buildHeatmapGrid } from '@/components/widgets/activity/utils';
+import { buildHeatmapGrid, EMPTY_GROUPED_COUNT, type GroupedCount } from '@/components/widgets/activity/utils';
 import { MAX_CACHED, PAGE_SIZE } from '@/components/widgets/activity/constants';
 
 const FILTERS_KEY = 'bflow_activity_filters';
@@ -13,7 +13,8 @@ export type GoldenMode = 'heatmap' | 'hour' | 'day';
 
 interface ActivityState {
   activities: Activity[];
-  statsGrid: number[][];
+  /** 24x7 그룹별 카운트 격자 — 히트맵 셀 호버 툴팁이 progress/memo/scene/etc 분해 표시 */
+  statsGrid: GroupedCount[][];
   /** 낙관적 prepend 매핑 — localTmpId → 진짜 UUID. Realtime dedupe 보조 */
   pendingByLocalId: Map<string, string>;
   lastSeenCreatedAt: string | null;
@@ -65,8 +66,8 @@ function getCurrentGroupsForServer(filters: Set<ActionGroup>): ActionGroup[] | u
   return [...filters];
 }
 
-/** stats grid 의 해당 셀 +1 — Realtime 신규 시 즉시 반영 */
-function incrementGrid(grid: number[][], createdAt: string): number[][] {
+/** stats grid 의 해당 셀 +1 — Realtime 신규 시 즉시 반영 (총합 + 그룹별 둘 다 갱신) */
+function incrementGrid(grid: GroupedCount[][], createdAt: string, group: ActionGroup): GroupedCount[][] {
   const dt = new Date(createdAt);
   // KST 변환 — getTimezoneOffset 은 분 단위
   const kstStr = dt.toLocaleString('en-US', { timeZone: 'Asia/Seoul', hour12: false });
@@ -76,14 +77,18 @@ function incrementGrid(grid: number[][], createdAt: string): number[][] {
   const displayDay = (dow + 6) % 7; // 표시 0=월 ~ 6=일
   const hour = kst.getHours();
   if (displayDay < 0 || displayDay >= 7 || hour < 0 || hour >= 24) return grid;
-  const next = grid.map((row) => [...row]);
-  next[displayDay][hour] += 1;
+  const next = grid.map((row) => row.map((c) => ({ ...c })));
+  const cell = next[displayDay][hour];
+  cell.total += 1;
+  cell[group] += 1;
   return next;
 }
 
 export const useActivityStore = create<ActivityState>((set, get) => ({
   activities: [],
-  statsGrid: Array.from({ length: 7 }, () => Array(24).fill(0)),
+  statsGrid: Array.from({ length: 7 }, () =>
+    Array.from({ length: 24 }, () => ({ ...EMPTY_GROUPED_COUNT })),
+  ),
   pendingByLocalId: new Map(),
   lastSeenCreatedAt: null,
   isLoading: false,
@@ -202,7 +207,7 @@ export const useActivityStore = create<ActivityState>((set, get) => ({
       return {
         activities: newActs,
         lastSeenCreatedAt: activity.createdAt,
-        statsGrid: inActiveGroup ? incrementGrid(s.statsGrid, activity.createdAt) : s.statsGrid,
+        statsGrid: inActiveGroup ? incrementGrid(s.statsGrid, activity.createdAt, activity.actionGroup) : s.statsGrid,
       };
     });
   },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -580,7 +580,15 @@ export interface ElectronAPI {
     days?: number;
     groups?: ('progress' | 'memo' | 'scene' | 'etc')[];
     department?: 'bg' | 'acting' | null;
-  }) => Promise<Array<{ day_of_week: number; hour: number; count: number }>>;
+  }) => Promise<Array<{
+    day_of_week: number;
+    hour: number;
+    count: number;
+    count_progress: number;
+    count_memo: number;
+    count_scene: number;
+    count_etc: number;
+  }>>;
   activityBackfill: (since: string) => Promise<any[]>;
   activityStorageInfo: () => Promise<{ count: number; sizeMB: number }>;
   onActivityRealtimeInsert: (cb: (row: any) => void) => () => void;


### PR DESCRIPTION
## 📋 업데이트 요약

> 이번 업데이트에서 달라진 점을 간략하게 정리했습니다.

- ✨ 최근 작업 위젯의 *히트맵 셀에 마우스를 올리면* 그 시간대 활동을 **작업 진행 / 메모·댓글 / 씬 / 기타** 4그룹으로 나눠 보여줍니다
- ⚡ 시간대 막대(시간대 모드)와 요일 막대(요일 모드) 호버 툴팁도 동일하게 그룹별 분해 표시
- 🎨 목업과 동일한 디자인 — 그룹 색상 점 + 라벨 + 카운트가 정렬된 한 줄로 정돈

## 🔧 상세 기술 설명

### 1. DB RPC 확장 (`activity_log_stats`)
- 기존: `(day_of_week, hour, count)` 한 행 반환
- 변경: `count_progress / count_memo / count_scene / count_etc` 4컬럼 추가 (`COUNT(*) FILTER (WHERE action_group = …)`)
- DROP FUNCTION 후 재생성 (시그니처 변경 시 필수)
- 마이그레이션은 Supabase MCP로 적용 완료

### 2. 타입/저장소 — `GroupedCount` 도입
- `statsGrid` 를 `number[][]` → `GroupedCount[][]` 로 확장 (`{ total, progress, memo, scene, etc }`)
- `EMPTY_GROUPED_COUNT` 상수, `addGroupedCount` 헬퍼 추가
- 관련 파일: `src/components/widgets/activity/utils.ts`, `src/stores/useActivityStore.ts`

### 3. 컴포넌트 — Hover 콜백 정보 확장
- `GoldenHeatmap.HeatmapCellHoverInfo`: `count: number` → `cell: GroupedCount`
- `GoldenBarChart.BarHoverInfo`: 동일하게 `cell` 전달
- `RecentActivityWidget` 툴팁: 단일 텍스트 한 줄 → **타이틀 + 4개 분해 행** (count 0 인 그룹은 숨김)
- 그룹별 색상 점은 `constants.ts` 의 `GROUP_DOT_COLOR` 사용 (BG/액팅 변경 영향 X)

### 4. Realtime 일관성
- `incrementGrid` 가 `actionGroup` 인자를 받아 *총합과 그룹별 둘 다* +1
- 기존 client-only group filter 분기 로직(`inActiveGroup`) 그대로 유지

## 🚧 개발 난항

특이사항 없음. 데이터 흐름이 SQL → IPC → store → UI 로 깔끔히 정렬되어 있어 한 번에 적용.

## ✅ 테스트 가이드

### 사용자 테스트
> 아래 시나리오를 직접 실행해서 정상 동작을 확인해주세요.

1. **히트맵 모드 호버**
   - 대시보드의 *최근 작업* 위젯에서 *히트맵* 모드 선택
   - 색이 진한 셀에 마우스를 올리면 → 셀 위에 툴팁이 뜨고
   - ✅ 기대: `월 14시 · 총 9건` 헤더 + 그룹별 점·라벨·카운트 4줄(있는 그룹만)
   - ❌ 비정상: 총 건수만 한 줄로 표시 (이전 동작)

2. **시간대 / 요일 모드 호버**
   - 모드 토글에서 *시간대* 또는 *요일* 선택 → 막대에 호버
   - ✅ 기대: `14시` 또는 `화요일` 헤더 + 그룹별 4줄

3. **빈 셀 호버**
   - 활동이 없는 회색 셀에 호버
   - ✅ 기대: `활동 없음` 한 줄

### 개발자 테스트
```bash
npm run build:vite   # tsc + vite build, 타입 에러 없음을 확인
```

> Supabase RPC 확인:
> ```sql
> SELECT * FROM activity_log_stats(NOW() - INTERVAL '7 days', NULL, NULL) LIMIT 5;
> ```
> count + count_progress + count_memo + count_scene + count_etc 컬럼이 반환되어야 함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)