### PR TITLE
[v1.15.0] 씬 뷰 UX 폴리싱 + 알림 시스템 강화 + 보안 hotfix

### DIFF
--- a/docs/superpowers/specs/2026-04-28-scenes-ux-polish-design.md
+++ b/docs/superpowers/specs/2026-04-28-scenes-ux-polish-design.md
@@ -1,0 +1,267 @@
+# 씬 뷰 UX 폴리싱 + SEED_USER 보안 hotfix — 디자인 문서
+
+**작성일**: 2026-04-28
+**대상 브랜치**: `feat/scenes-view-ux-polish`
+**대상 버전**: v1.15.0
+**작성자**: 한솔 × Claude
+
+---
+
+## 배경
+
+한솔이 일상 사용 중 부딪히는 씬 뷰 UX 마찰 8가지를 한 묶음으로 해결한다. 추가로 *9번(미리보기 모드) 작업 중 발견한 SEED_USER 실 password 노출 보안 이슈* 도 함께 hotfix 한다 (별도 PR 분리 비효율 — 같은 v1.15.0 에 묶음).
+
+---
+
+## 결정사항 요약 (1차 브레인스토밍 결과)
+
+| 묶음 | 항목 | 한솔 결정 |
+|---|---|---|
+| 🅐 | (1+6) 시트 뷰 셀에 `L#레이아웃번호` 가 안 보임 | 셀 자체에 표시되어야 — *현재 코드는 layoutId 있으면 표시인데 데이터/조건 추가 분석 필요* |
+| 🅑 | (2+3+4) 마지막 본 *뷰 모드 / 에피소드 / 트리 펼침* 상태 기억 | localStorage 로 사용자별 저장 + 씬 뷰 재진입 시 복원 |
+| 🅒 | (5) 시트 뷰 씬 번호 호버 시 더블클릭 어포던스 | **↗ 화살표 아이콘 등장 + 색 강조** |
+| 🅓 | (7) 상단바 *옵션 접기* 동작 | **완전 숨김** — 요약 칩 라인까지 사라짐. 펼치기는 그대로 |
+| 🅔 | (8) 댓글 알림 토스트 + 확인 버튼 | **멘션된 댓글 + 담당 씬 댓글 둘 다** 토스트. 클릭 시 씬 모달 |
+| 🅕 | SEED_USER 실 password 코드 평문 노출 | hotfix — `password=''` + `isInitialPassword=true`. 코드에서 password 제거 |
+
+---
+
+## 섹션 1: 🅐 시트 뷰 레이아웃 표시 (3가지 변경)
+
+한솔의 추가 명확화로 단순 스타일 강화가 아니라 **세 가지 변경**으로 정리:
+
+### 1-A. 시트 뷰 셀에 `L#레이아웃` 항상 표시
+
+**현재**: 시트 뷰는 `sceneGroupMode === 'layout'` (레이아웃별 보기) 일 때만 layoutId 가 그룹 헤더로 노출. *일반 모드(예: episode/part)에서는 시트 뷰 셀 어디에도 layoutId 가 안 보임*. (카드 뷰는 셀 안에 흐리게라도 표시됨 — `ScenesView.tsx:757-761`)
+
+**결정**: 시트 뷰의 *각 행* 에도 layoutId 를 작은 컬럼/뱃지로 항상 표시. sceneGroupMode 와 무관.
+
+**구현 위치**: `src/components/scenes/UnifiedSceneSheetView.tsx` (시트 행 셀 부근, 596 라인 근방)
+
+### 1-B. 레이아웃별 보기 모드의 시트 뷰 = 카드 뷰처럼 섹션 그룹핑
+
+**현재**: `sceneGroupMode === 'layout'` 시 시트 뷰의 그룹핑 처리 분석이 필요 — 카드 뷰는 레이아웃 헤더 + 그 아래 카드들이 *섹션* 으로 명확히 구분되는데, 시트 뷰는 그렇지 않음 (행 사이 구분만 있을 가능성)
+
+**결정**: 시트 뷰의 레이아웃 모드를 *카드 뷰와 동일한 섹션 헤더 + 섹션별 영역 구분* 스타일로 정렬. 헤더에 `L#XX (n개 씬)` 표기, 섹션 사이 visible separator.
+
+**구현 위치**: `src/components/scenes/UnifiedSceneSheetView.tsx` 의 layout 그룹핑 렌더 분기 (라인 285~296 의 "레이아웃 그루핑" 주석 근방)
+
+### 1-C. 레이아웃 글자 자체 스타일 강화
+
+`L#{layoutId}` 라벨이 현재 `text-text-secondary/50 italic 11px` 라 너무 흐림.
+
+**결정**: `text-accent-sub italic 12px font-medium` 정도로 가시성 강화. 카드 뷰(ScenesView 757-761) 와 시트 뷰 모두 동일 적용해 일관성 유지.
+
+### 구현 위치 종합
+
+- `src/views/ScenesView.tsx:757-761` (카드 뷰 셀 — 1-C 스타일)
+- `src/components/scenes/UnifiedSceneSheetView.tsx` 다음 부분:
+  - 시트 행 셀에 layoutId 표시 추가 (1-A)
+  - layout 그룹핑 분기 카드 스타일 정렬 (1-B)
+  - layoutId 라벨 스타일 (1-C)
+
+---
+
+## 섹션 2: 🅑 마지막 상태 기억 (뷰 모드 / 에피소드 / 트리)
+
+### 목표
+
+씬 뷰를 떠나도 다음 진입 시 *마지막으로 보던 상태* 가 그대로 복원.
+
+### 저장 항목 + key
+
+| key | 값 |
+|---|---|
+| `bflow_scenes_view_mode` | `'card'` 또는 `'sheet'` |
+| `bflow_scenes_last_episode` | 에피소드 번호 (number) |
+| `bflow_scenes_tree_open` | `true` 또는 `false` |
+
+브라우저 localStorage 단일 사용자 환경 — 모든 키 사용자별 분리 불필요 (앱이 단일 PC 에서 실행). 만료 없음 (변경 시 즉시 갱신).
+
+### 구현 위치
+
+신규 유틸: `src/utils/scenesViewPersist.ts`
+
+```ts
+const KEYS = {
+  viewMode: 'bflow_scenes_view_mode',
+  lastEpisode: 'bflow_scenes_last_episode',
+  treeOpen: 'bflow_scenes_tree_open',
+} as const;
+
+export function loadPersistedSceneViewMode(): 'card' | 'sheet' | null { /* ... */ }
+export function savePersistedSceneViewMode(mode: 'card' | 'sheet'): void { /* ... */ }
+// 동일 패턴 lastEpisode / treeOpen
+```
+
+### 통합 위치
+
+- `src/views/ScenesView.tsx`:
+  - `sceneViewMode` 초기값을 `loadPersistedSceneViewMode() ?? 'card'` 로
+  - `setSceneViewMode` 시 즉시 `savePersistedSceneViewMode()` 호출
+  - 동일하게 `selectedEpisode` (useAppStore), `treeOpen` (local state)
+- `useAppStore.dashboardDeptFilter` 패턴과 동일 (이미 영속화 패턴 존재 — `src/stores/useAppStore.ts` 참고하면 ZUSTAND PERSIST middleware 가 있는지 확인 필요)
+
+### Edge case
+
+- **에피소드가 삭제됨**: 마지막 본 에피소드 번호가 현재 episodes 목록에 없으면 → 첫 에피소드로 fallback
+- **localStorage 비활성** (사용자 개인정보보호 모드): try/catch 로 무시 + 디폴트 동작
+
+---
+
+## 섹션 3: 🅒 시트 뷰 씬 번호 호버 어포던스
+
+### 결정
+
+호버 시 *씬 번호 글자 옆에 ↗ 화살표 아이콘이 부드럽게 등장* + *글자 색이 액센트로 변경*.
+
+### 구현 위치
+
+`src/views/ScenesView.tsx:750-762` 근방 (씬 번호 셀)
+
+```tsx
+<div className="flex items-center gap-2 min-w-0 group cursor-pointer">
+  <span className="text-sm font-mono text-text-secondary/50 group-hover:text-accent transition-colors">
+    #{...}
+  </span>
+  <span className="text-[15px] font-mono font-bold text-text-primary truncate group-hover:text-accent-sub transition-colors">
+    <HighlightText ... />
+  </span>
+  <ArrowUpRight
+    size={12}
+    className="text-accent opacity-0 group-hover:opacity-100 transition-opacity"
+  />
+  {scene.layoutId && (
+    <span className="...">L#{scene.layoutId}</span>
+  )}
+</div>
+```
+
+`group` + `group-hover:` Tailwind 패턴으로 셀 호버 시 자식 동시 변화. `ArrowUpRight` (lucide-react) 아이콘 사용.
+
+### 동일 적용 위치
+
+- `UnifiedSceneSheetView.tsx` 의 씬 번호 셀
+
+---
+
+## 섹션 4: 🅓 상단바 옵션 접기 = 완전 숨김
+
+### 현재 상태
+
+`src/views/ScenesView.tsx:3245-3262`:
+- 접힌 상태에서 *"현재 옵션 [chip] [chip] ..."* 요약 라인 표시
+- chip 들은 클릭 비활성
+
+### 결정
+
+접힌 상태에서 **요약 라인 자체를 렌더하지 않음** — `AnimatePresence` 의 `sceneControlsCollapsed === true` 분기를 빈 요소(또는 0높이 placeholder) 로 변경.
+
+### 구현 위치
+
+`src/views/ScenesView.tsx:3247-3262` (`sceneControlsCollapsed ? (...요약 라인...) : (...풀 옵션...)`)
+
+수정 후:
+```tsx
+{sceneControlsCollapsed ? null : (
+  <motion.div ...>
+    {/* 풀 옵션 */}
+  </motion.div>
+)}
+```
+
+또는 AnimatePresence 가 한쪽 자식 null 을 처리하므로 단순 조건부 렌더로 변경.
+
+---
+
+## 섹션 5: 🅔 댓글 토스트 (멘션 + 담당 씬)
+
+### 현재 상태 (코드 분석)
+
+`src/utils/notificationHelper.ts:46-60` 의 `dispatchNotification()` 함수가 *이미* sonner 토스트 + "씬 보기" 액션 버튼 + 클릭 시 씬 뷰로 이동을 구현. 즉 인프라는 이미 있음.
+
+### 한솔 의도 추정
+
+한솔이 "토스트 알림 추가"라 한 건 다음 중 하나:
+- (가설 A) 토스트가 이미 뜨는데 *눈에 잘 안 띄어서* 인지 안 됨 → 디자인 강화
+- (가설 B) 트리거 흐름이 누락되어 *멘션/담당 씬 댓글 도착 시 dispatchNotification 호출이 안 됨* → 트리거 추가
+- (가설 C) "확인" 버튼이 라벨이 "씬 보기" 라 직관적이지 않음 → 라벨 변경
+
+### 결정
+
+한솔이 "둘 다 해주세요" — 세 가지 모두 처리:
+
+#### 5-1. 트리거 흐름 보강 (가설 B 가 가장 가능성 높음)
+
+- 댓글 Realtime 수신 시 (`src/services/commentService.ts` 또는 useAppStore 의 댓글 트리거) → 다음 조건 확인:
+  - 댓글에 `@한솔` 같은 멘션 포함 (사용자 이름 정확 매치)
+  - 또는 댓글 대상 씬의 `assignee === currentUser.name`
+- 둘 중 하나면 `dispatchNotification(...)` 호출
+
+구현 위치: `src/services/commentService.ts` 또는 `src/stores/useDataStore.ts` (Realtime 댓글 처리 부분)
+
+#### 5-2. 토스트 라벨 직관화
+
+`dispatchNotification()` 의 action.label `'씬 보기'` → `'확인'` 로 변경. 동작은 동일 (클릭 시 씬 모달 포커스).
+
+#### 5-3. 토스트 시각 강화 (선택)
+
+sonner 의 `duration` 옵션을 늘리거나 (`{ duration: 8000 }`) 색상 액센트 강화. 현재 디폴트 4000ms 인지 확인 후.
+
+### Edge case
+
+- **본인이 작성한 댓글에 본인 이름 멘션** (자체 멘션): 토스트 안 띄움 (자기 댓글에 알림 무의미)
+- **여러 멘션이 한꺼번에 도착**: sonner 가 자체 stack 처리. 별도 처리 불필요
+
+---
+
+## 섹션 6: 🅕 SEED_USER 보안 hotfix
+
+### 문제
+
+`src/services/userService.ts:25-33` 의 `SEED_USER` 상수에 한솔의 실 Supabase admin password (`'1q2w3e4r!A'`) 가 *하드코딩*되어 v1.14.x 빌드된 `.exe` 의 main entry chunk 에 평문으로 노출.
+
+### 결정
+
+```ts
+const SEED_USER: AppUser = {
+  id: '00000000-0000-0000-0000-000000000001',
+  name: '배한솔',
+  slackId: 'U05DFV9UAN5',
+  password: '',                  // ← 빈값으로 변경
+  isInitialPassword: true,       // ← true 로 변경 (변경 강제)
+  createdAt: '2025-01-01T00:00:00.000Z',
+  role: 'admin',
+};
+```
+
+### 운영 영향
+
+- 평상시 (Supabase 사용자 row 살아있는 상태) 에는 SEED_USER fallback 자체가 호출 안 됨 → 영향 없음
+- 빈 사용자 목록에서 시드되더라도 빈 password 로는 로그인 매칭 불가 → 한솔이 Supabase Studio 에서 password 직접 설정 후 로그인
+
+### 한솔에게 안내 필수
+
+PR 본문에 다음 *반드시* 포함:
+> ⚠️ 현재 G드라이브에 배포된 v1.14.1 `.exe` 의 main entry chunk 에 한솔님 admin 의 옛 password 가 평문 노출 중. **즉시 Supabase 에서 새 강한 password 로 변경해주세요** (이미 변경하셨다면 무시).
+
+### 검증
+
+production 빌드 후 `grep -c "1q2w3e4r!A" dist/assets/index-*.js` → **0** 매치 확인.
+
+---
+
+## 비범위 (Out of Scope)
+
+- 9번 (미리보기 모드) — 별도 PR (#42) 폐기 결정에 따라 본 작업에서 제외
+- mock 사용자(11명, '배한솔' 외) password 변경 — 별도 후속 작업
+- 다른 뷰 (에피소드, 인원별 등) 의 마지막 상태 기억 — 본 작업은 *씬 뷰 한정*
+
+---
+
+## 다음 단계
+
+1. 이 spec 에 대한 한솔 검토
+2. 필요 시 1+6번 / 8번 가설 확인 (한솔 화면 캡처 또는 dev server 로 직접 검증)
+3. **구현 계획** 작성 (`writing-plans` 스킬) → 단계별 task 분해 — 또는 spec 검토 후 한솔 동의하에 *plan 단계 생략하고 바로 구현*
+4. 구현 → 빌드 → PR (v1.15.0)

--- a/docs/superpowers/specs/mockups/2026-04-28-scenes-ux-polish/index.html
+++ b/docs/superpowers/specs/mockups/2026-04-28-scenes-ux-polish/index.html
@@ -1,0 +1,414 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8" />
+<title>v1.15.0 씬 뷰 UX 폴리싱 — 디자인 프리뷰</title>
+<style>
+  :root {
+    --bg-primary: #0F1117;
+    --bg-card: #161922;
+    --bg-border: #2A2F3D;
+    --text-primary: #E8EAF0;
+    --text-secondary: #8B92A4;
+    --accent: #6C5CE7;
+    --accent-sub: #A29BFE;
+    --bg-color: #74B9FF;
+    --act-color: #FF6B9D;
+    --status-done: #00D9A0;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; padding: 32px 16px; background: var(--bg-primary);
+    color: var(--text-primary);
+    font-family: -apple-system, "Pretendard", "Segoe UI", sans-serif;
+    font-size: 14px;
+  }
+  h1 { font-size: 22px; margin: 0 0 6px; color: var(--accent-sub); }
+  h2 {
+    font-size: 16px; margin: 36px 0 8px;
+    padding-bottom: 6px; border-bottom: 1px solid var(--bg-border);
+    color: var(--accent-sub);
+  }
+  .subtitle { color: var(--text-secondary); font-size: 13px; margin-bottom: 24px; }
+  .container { max-width: 1100px; margin: 0 auto; }
+  .section-desc {
+    background: rgba(108, 92, 231, 0.08);
+    border-left: 3px solid var(--accent);
+    padding: 10px 14px; margin: 12px 0;
+    border-radius: 0 6px 6px 0;
+    font-size: 13px; line-height: 1.6;
+  }
+  .compare {
+    display: grid; grid-template-columns: 1fr 1fr; gap: 18px; margin: 14px 0;
+  }
+  .compare-block {
+    background: var(--bg-card);
+    border: 1px solid var(--bg-border);
+    border-radius: 8px; padding: 14px;
+  }
+  .compare-label {
+    font-size: 11px; font-weight: 700; letter-spacing: 0.1em;
+    color: var(--text-secondary);
+    margin-bottom: 10px;
+  }
+  .compare-label.before { color: #FF7675; }
+  .compare-label.after { color: var(--status-done); }
+
+  /* ── 시트 뷰 모방 ── */
+  table.sheet {
+    width: 100%; border-collapse: collapse; font-size: 11px;
+    background: rgba(15, 17, 23, 0.6);
+    border-radius: 6px; overflow: hidden;
+  }
+  table.sheet th {
+    background: var(--bg-card);
+    color: var(--text-secondary);
+    font-size: 10px; font-weight: 600; text-align: left;
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--bg-border);
+  }
+  table.sheet td {
+    padding: 5px 8px; border-bottom: 1px solid rgba(42, 47, 61, 0.5);
+    font-family: "JetBrains Mono", monospace; font-size: 11px;
+  }
+  table.sheet tr:nth-child(odd) td { background: rgba(15, 17, 23, 0.3); }
+  table.sheet tr.row-hover td { background: rgba(108, 92, 231, 0.08); }
+
+  /* layoutId 라벨 — 1-C 강화 */
+  .layout-label-old {
+    color: rgba(139, 146, 164, 0.5);
+    font-size: 10px;
+    font-style: italic;
+    margin-left: 4px;
+  }
+  .layout-label-new {
+    color: var(--accent-sub);
+    font-size: 12px;
+    font-style: italic;
+    font-weight: 500;
+    margin-left: 4px;
+  }
+
+  /* 호버 ↗ — 5번 */
+  .scene-cell {
+    display: inline-flex; align-items: center; gap: 6px;
+    color: var(--accent);
+    cursor: pointer;
+  }
+  .scene-cell .arrow {
+    color: var(--accent);
+    opacity: 0;
+    transition: opacity 0.2s;
+    font-size: 11px;
+  }
+  .scene-cell.hovered .arrow { opacity: 1; }
+
+  /* 그룹 헤더 — 1-B 카드 스타일 */
+  .group-header {
+    background: rgba(108, 92, 231, 0.08);
+    border-top: 1px solid rgba(108, 92, 231, 0.3);
+    border-bottom: 1px solid rgba(108, 92, 231, 0.3);
+  }
+  .group-header td {
+    padding: 8px 12px !important;
+    background: transparent !important;
+    border-bottom: none !important;
+  }
+  .group-header-title {
+    font-size: 13px; font-weight: 700; color: var(--accent);
+  }
+  .group-header-meta {
+    font-size: 11px; color: var(--text-secondary); margin-left: 8px;
+  }
+
+  /* 토스트 — 8번 */
+  .toast-container {
+    background: var(--bg-card);
+    border: 1px solid var(--bg-border);
+    border-radius: 10px;
+    padding: 12px 14px;
+    display: flex; align-items: center; gap: 12px;
+    box-shadow: 0 8px 24px rgba(0,0,0,0.3);
+    max-width: 360px;
+  }
+  .toast-icon {
+    width: 32px; height: 32px;
+    background: rgba(108, 92, 231, 0.2);
+    border-radius: 8px;
+    display: flex; align-items: center; justify-content: center;
+    color: var(--accent);
+  }
+  .toast-body {
+    flex: 1;
+  }
+  .toast-title {
+    font-size: 13px; font-weight: 600;
+  }
+  .toast-desc {
+    font-size: 12px; color: var(--text-secondary);
+    margin-top: 2px;
+  }
+  .toast-action {
+    background: var(--accent);
+    color: white;
+    border: none;
+    padding: 6px 12px;
+    border-radius: 6px;
+    font-size: 12px; font-weight: 600;
+    cursor: pointer;
+  }
+  .toast-action.label-old { background: rgba(108, 92, 231, 0.5); }
+
+  /* 상단바 — 7번 */
+  .toolbar-row {
+    background: rgba(15, 17, 23, 0.5);
+    border: 1px solid var(--bg-border);
+    border-radius: 8px;
+    padding: 10px;
+    display: flex; gap: 10px;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+  .chip {
+    background: rgba(42, 47, 61, 0.4);
+    border: 1px solid var(--bg-border);
+    padding: 4px 10px;
+    border-radius: 6px;
+    font-size: 11px;
+  }
+  .chip.active {
+    background: rgba(108, 92, 231, 0.2);
+    border-color: rgba(108, 92, 231, 0.4);
+    color: var(--accent-sub);
+  }
+  .toolbar-summary {
+    background: rgba(42, 47, 61, 0.2);
+    border: 1px solid rgba(42, 47, 61, 0.5);
+    border-radius: 8px;
+    padding: 8px 12px;
+    font-size: 11px;
+    color: var(--text-secondary);
+  }
+  .toolbar-empty {
+    height: 0;
+    padding: 0;
+    border: none;
+    overflow: hidden;
+    /* 그냥 안 보임을 표현 */
+  }
+  .arrow-collapse {
+    color: var(--accent-sub);
+    font-size: 14px;
+    margin-right: 6px;
+  }
+  .collapse-btn {
+    background: rgba(42, 47, 61, 0.4);
+    border: 1px solid var(--bg-border);
+    padding: 6px 12px;
+    border-radius: 6px;
+    color: var(--text-secondary);
+    font-size: 12px;
+    margin-bottom: 8px;
+  }
+  .footnote {
+    color: var(--text-secondary);
+    font-size: 11px;
+    margin-top: 6px;
+    font-style: italic;
+  }
+</style>
+</head>
+<body>
+<div class="container">
+
+<h1>🎨 v1.15.0 씬 뷰 UX 폴리싱 — 디자인 프리뷰</h1>
+<p class="subtitle">한솔 결정 기반의 6가지 변경 + SEED_USER 보안 hotfix. 실 코드 변경 사항을 시각적으로 미리 확인.</p>
+
+<!-- ============================================== -->
+<h2>🅐 (1-A) 시트 뷰 셀에 L#레이아웃 항상 표시</h2>
+<div class="section-desc">
+  <strong>현재</strong>: '레이아웃 별' 보기 모드일 때만 별도 컬럼에 표시. 일반 모드(에피소드 별 등)에서는 어디에도 안 보임.<br>
+  <strong>변경</strong>: 시트 행 의 씬번호 옆에 작은 italic 뱃지로 항상 표시. 보기 모드와 무관.
+</div>
+<div class="compare">
+  <div class="compare-block">
+    <div class="compare-label before">전 (일반 모드 — 레이아웃 안 보임)</div>
+    <table class="sheet">
+      <tr><th>씬번호</th><th>메모</th><th>BG담당</th><th>LO</th><th>완료</th></tr>
+      <tr><td><span class="scene-cell">EP01-A-15</span></td><td>골목 진입</td><td>한솔</td><td>✓</td><td></td></tr>
+      <tr><td><span class="scene-cell">EP01-A-16</span></td><td>벽 그림자</td><td>한솔</td><td>✓</td><td>✓</td></tr>
+      <tr><td><span class="scene-cell">EP01-A-17</span></td><td>달려오는 인물</td><td>윤스</td><td></td><td></td></tr>
+    </table>
+  </div>
+  <div class="compare-block">
+    <div class="compare-label after">후 (셀 안에 L#XX 항상 표시)</div>
+    <table class="sheet">
+      <tr><th>씬번호</th><th>메모</th><th>BG담당</th><th>LO</th><th>완료</th></tr>
+      <tr><td><span class="scene-cell">EP01-A-15<span class="layout-label-new">L#A2</span></span></td><td>골목 진입</td><td>한솔</td><td>✓</td><td></td></tr>
+      <tr><td><span class="scene-cell">EP01-A-16<span class="layout-label-new">L#A2</span></span></td><td>벽 그림자</td><td>한솔</td><td>✓</td><td>✓</td></tr>
+      <tr><td><span class="scene-cell">EP01-A-17<span class="layout-label-new">L#A3</span></span></td><td>달려오는 인물</td><td>윤스</td><td></td><td></td></tr>
+    </table>
+  </div>
+</div>
+
+<!-- ============================================== -->
+<h2>🅐 (1-B) 레이아웃 별 보기 = 카드 뷰처럼 섹션 그룹핑</h2>
+<div class="section-desc">
+  <strong>현재</strong>: 레이아웃 별 보기 시 첫 행에 rowspan 으로 #레이아웃키 라벨 표시 + 다음 그룹 시작에 얇은 separator. 섹션 구분 모호.<br>
+  <strong>변경</strong>: 그룹 시작 직전에 별도 헤더 행 삽입 — <code>L#XX (n개 씬)</code> 표기 + 액센트 색 배경 + 위·아래 액센트 보더. 카드 뷰의 섹션 헤더와 동일한 강도.
+</div>
+<div class="compare">
+  <div class="compare-block">
+    <div class="compare-label before">전 (rowspan 셀 + 얇은 separator)</div>
+    <table class="sheet">
+      <tr><th style="background:rgba(108,92,231,0.05);">레이아웃</th><th>씬번호</th><th>메모</th><th>LO</th></tr>
+      <tr><td rowspan="2" style="text-align:center; color:var(--accent); font-weight:700; border-right:1px solid var(--bg-border);">#A2</td><td>EP01-A-15</td><td>골목 진입</td><td>✓</td></tr>
+      <tr><td>EP01-A-16</td><td>벽 그림자</td><td>✓</td></tr>
+      <tr style="border-top:2px solid var(--bg-border);"><td rowspan="2" style="text-align:center; color:var(--accent); font-weight:700; border-right:1px solid var(--bg-border);">#A3</td><td>EP01-A-17</td><td>달려오는 인물</td><td></td></tr>
+      <tr><td>EP01-A-18</td><td>턴어라운드</td><td></td></tr>
+    </table>
+  </div>
+  <div class="compare-block">
+    <div class="compare-label after">후 (그룹 헤더 행 + 액센트 강조)</div>
+    <table class="sheet">
+      <tr><th>씬번호</th><th>메모</th><th>LO</th></tr>
+      <tr class="group-header"><td colspan="3"><span class="group-header-title">L#A2</span><span class="group-header-meta">2개 씬</span></td></tr>
+      <tr><td>EP01-A-15<span class="layout-label-new">L#A2</span></td><td>골목 진입</td><td>✓</td></tr>
+      <tr><td>EP01-A-16<span class="layout-label-new">L#A2</span></td><td>벽 그림자</td><td>✓</td></tr>
+      <tr class="group-header"><td colspan="3"><span class="group-header-title">L#A3</span><span class="group-header-meta">2개 씬</span></td></tr>
+      <tr><td>EP01-A-17<span class="layout-label-new">L#A3</span></td><td>달려오는 인물</td><td></td></tr>
+      <tr><td>EP01-A-18<span class="layout-label-new">L#A3</span></td><td>턴어라운드</td><td></td></tr>
+    </table>
+  </div>
+</div>
+
+<!-- ============================================== -->
+<h2>🅐 (1-C) 레이아웃 라벨 가시성 강화</h2>
+<div class="section-desc">
+  카드 뷰 셀과 시트 뷰 셀 모두 동일한 강한 스타일 적용 — 일관성 확보.
+</div>
+<div class="compare">
+  <div class="compare-block">
+    <div class="compare-label before">전 (50% 투명 회색 italic 11px)</div>
+    <div style="padding:18px; text-align:center; font-family:monospace;">
+      EP01-A-16
+      <span class="layout-label-old">L#A2</span>
+    </div>
+  </div>
+  <div class="compare-block">
+    <div class="compare-label after">후 (액센트색 italic 12px font-medium)</div>
+    <div style="padding:18px; text-align:center; font-family:monospace;">
+      EP01-A-16
+      <span class="layout-label-new">L#A2</span>
+    </div>
+  </div>
+</div>
+
+<!-- ============================================== -->
+<h2>🅒 (5) 시트 뷰 씬번호 호버 ↗ 어포던스</h2>
+<div class="section-desc">
+  씬 번호에 마우스를 올리면 "더블클릭으로 상세 모달 가능" 단서로 ↗ 화살표 아이콘이 부드럽게 등장.
+</div>
+<div class="compare">
+  <div class="compare-block">
+    <div class="compare-label before">기본 상태</div>
+    <table class="sheet">
+      <tr><th>씬번호</th><th>메모</th></tr>
+      <tr><td><span class="scene-cell">EP01-A-15<span class="arrow">↗</span><span class="layout-label-new">L#A2</span></span></td><td>골목 진입</td></tr>
+      <tr><td><span class="scene-cell">EP01-A-16<span class="arrow">↗</span><span class="layout-label-new">L#A2</span></span></td><td>벽 그림자</td></tr>
+    </table>
+    <div class="footnote">평소엔 ↗ 안 보임</div>
+  </div>
+  <div class="compare-block">
+    <div class="compare-label after">호버 시</div>
+    <table class="sheet">
+      <tr><th>씬번호</th><th>메모</th></tr>
+      <tr class="row-hover"><td><span class="scene-cell hovered">EP01-A-15<span class="arrow">↗</span><span class="layout-label-new">L#A2</span></span></td><td>골목 진입</td></tr>
+      <tr><td><span class="scene-cell">EP01-A-16<span class="arrow">↗</span><span class="layout-label-new">L#A2</span></span></td><td>벽 그림자</td></tr>
+    </table>
+    <div class="footnote">호버한 행에만 ↗ 등장 (fade-in 0.2s)</div>
+  </div>
+</div>
+
+<!-- ============================================== -->
+<h2>🅓 (7) 상단바 옵션 접기 = 완전 숨김</h2>
+<div class="section-desc">
+  <strong>현재</strong>: 접기 누르면 옵션 줄이 사라지지만 *현재 옵션 [chip] [chip] ...* 요약 라인이 남음. 칩은 클릭 비활성이라 잠긴 느낌.<br>
+  <strong>변경</strong>: 요약 라인까지 완전히 사라짐. 펼치기 누르면 원래대로.
+</div>
+<div class="compare">
+  <div class="compare-block">
+    <div class="compare-label before">전 (접기 → 요약 칩 라인 남음)</div>
+    <button class="collapse-btn"><span class="arrow-collapse">⌄</span>옵션 펼치기</button>
+    <div class="toolbar-summary">
+      <span style="font-weight:600; margin-right:6px; letter-spacing:0.1em; color:rgba(139,146,164,0.6);">현재 옵션</span>
+      <span class="chip">작업자: 전체</span>
+      <span class="chip">상태: 진행중</span>
+      <span class="chip">정렬: 번호순 ↑</span>
+      <span class="chip">보기: 시트</span>
+    </div>
+    <div class="footnote">↑ 칩이 클릭 안 됨 — "잠긴 느낌"</div>
+  </div>
+  <div class="compare-block">
+    <div class="compare-label after">후 (접기 → 깨끗하게 사라짐)</div>
+    <button class="collapse-btn"><span class="arrow-collapse">⌄</span>옵션 펼치기</button>
+    <div class="toolbar-empty"></div>
+    <div class="footnote">↑ 옵션 줄 자체가 사라져 화면 공간 절약</div>
+  </div>
+</div>
+
+<!-- ============================================== -->
+<h2>🅔 (8) 댓글 토스트 — '확인' 버튼 + 8초 노출</h2>
+<div class="section-desc">
+  <strong>현재</strong>: 멘션/담당 씬 댓글 도착 시 sonner 토스트 + '씬 보기' 액션 (4초 노출). 트리거는 이미 동작 중 (App.tsx:709-722).<br>
+  <strong>변경</strong>: 라벨 '씬 보기' → '확인' (간결). 노출 시간 4초 → 8초 (한솔이 인지할 시간 확보).
+</div>
+<div class="compare">
+  <div class="compare-block">
+    <div class="compare-label before">전 (라벨 '씬 보기')</div>
+    <div class="toast-container">
+      <div class="toast-icon">💬</div>
+      <div class="toast-body">
+        <div class="toast-title">윤스님이 나를 태그했습니다</div>
+        <div class="toast-desc">EP01-A-17 의 BG 검수 한 번만...</div>
+      </div>
+      <button class="toast-action label-old">씬 보기</button>
+    </div>
+    <div class="footnote">4초 후 자동 사라짐</div>
+  </div>
+  <div class="compare-block">
+    <div class="compare-label after">후 (라벨 '확인' + 8초)</div>
+    <div class="toast-container">
+      <div class="toast-icon">💬</div>
+      <div class="toast-body">
+        <div class="toast-title">윤스님이 나를 태그했습니다</div>
+        <div class="toast-desc">EP01-A-17 의 BG 검수 한 번만...</div>
+      </div>
+      <button class="toast-action">확인</button>
+    </div>
+    <div class="footnote">8초 노출 + 클릭 시 씬 모달 자동 열림</div>
+  </div>
+</div>
+
+<!-- ============================================== -->
+<h2>🅑 (2+3+4) 마지막 상태 기억 (시각 비교 X — 동작 차이)</h2>
+<div class="section-desc">
+  <strong>현재</strong>: 씬 뷰 진입 시 항상 기본값 (카드 뷰 / 첫 에피소드 / 트리 펼침).<br>
+  <strong>변경</strong>: localStorage 에 저장된 마지막 상태로 자동 복원. 한 번 시트 모드 + 트리 접기로 작업하면 다음 진입 때 그대로.
+</div>
+
+<!-- ============================================== -->
+<h2>🅕 SEED_USER 보안 hotfix (시각 비교 X — 빌드 산출물 차이)</h2>
+<div class="section-desc">
+  <strong>현재 v1.14.1 .exe</strong>: 한솔 admin 의 옛 password (<code>1q2w3e4r!A</code>) 가 main entry chunk 에 평문으로 들어가 있음. 누구든 .exe 분석으로 노출 가능.<br>
+  <strong>변경 후 v1.15.0 .exe</strong>: <code>password=''</code>, <code>isInitialPassword=true</code>. 코드에 password 자체가 안 들어감.<br>
+  <strong>한솔 권장</strong>: 실 admin 비밀번호를 새 강한 값으로 변경 (이미 노출된 옛 password 무효화).
+</div>
+
+<div style="margin-top:48px; padding:18px; background: rgba(108, 92, 231, 0.08); border-radius:8px; text-align:center;">
+  <div style="font-size:13px; color:var(--accent-sub);">PR <a href="https://github.com/baehandoridori/Bflow-BGonly/pull/43" style="color:var(--accent-sub);">#43</a> 에 머지 + 빌드/배포 후 BFLOW 앱에서 직접 확인 가능합니다.</div>
+</div>
+
+</div>
+</body>
+</html>

--- a/docs/superpowers/specs/mockups/2026-04-28-scenes-ux-polish/layout-grouping.html
+++ b/docs/superpowers/specs/mockups/2026-04-28-scenes-ux-polish/layout-grouping.html
@@ -1,0 +1,321 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8" />
+<title>(1-B) 레이아웃 별 뷰 그룹 분리 — 5개 시안</title>
+<style>
+  :root {
+    --bg-primary: #0F1117;
+    --bg-card: #161922;
+    --bg-border: #2A2F3D;
+    --text-primary: #E8EAF0;
+    --text-secondary: #8B92A4;
+    --accent: #6C5CE7;
+    --accent-sub: #A29BFE;
+    --accent-bright: #B8AFFF;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; padding: 32px 16px;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    font-family: -apple-system, "Pretendard", "Segoe UI", sans-serif;
+    font-size: 14px;
+  }
+  h1 { font-size: 22px; margin: 0 0 6px; color: var(--accent-sub); }
+  h3 { font-size: 14px; margin: 0 0 4px; color: var(--accent-sub); }
+  .subtitle { color: var(--text-secondary); font-size: 13px; margin-bottom: 24px; line-height: 1.6; }
+  .container { max-width: 1100px; margin: 0 auto; }
+
+  .grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 18px;
+  }
+  .card {
+    background: var(--bg-card);
+    border: 1px solid var(--bg-border);
+    border-radius: 12px;
+    padding: 18px;
+    position: relative;
+  }
+  .card.full { grid-column: span 2; }
+  .card-num {
+    position: absolute; top: 12px; right: 14px;
+    font-size: 10px; font-weight: 700; letter-spacing: 0.1em;
+    color: var(--text-secondary);
+    background: rgba(108, 92, 231, 0.15);
+    padding: 2px 8px; border-radius: 10px;
+  }
+  .card-desc {
+    font-size: 12px; color: var(--text-secondary);
+    margin: 6px 0 14px; line-height: 1.5;
+  }
+
+  /* 공통 시트 스타일 */
+  .sheet {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+    background: rgba(15, 17, 23, 0.6);
+    border-radius: 6px;
+    overflow: hidden;
+    font-size: 11px;
+  }
+  .sheet th {
+    background: var(--bg-card);
+    color: var(--text-secondary);
+    font-size: 10px; font-weight: 600;
+    padding: 6px 10px; text-align: left;
+  }
+  .sheet td {
+    padding: 7px 10px;
+    border-bottom: 1px solid rgba(42, 47, 61, 0.5);
+    font-family: "JetBrains Mono", monospace; font-size: 11px;
+  }
+  .sheet tr:nth-child(odd) td:not(.group-cell) { background: rgba(15, 17, 23, 0.3); }
+  .scene-num { color: var(--accent-bright); font-weight: 600; }
+
+  /* 헤더 행 (모든 시안 공통) */
+  .group-header td {
+    background: rgba(108, 92, 231, 0.12) !important;
+    padding: 8px 12px !important;
+    border-bottom: none !important;
+  }
+  .group-header-title { font-size: 13px; font-weight: 700; color: var(--accent); }
+  .group-header-meta { font-size: 11px; color: var(--text-secondary); margin-left: 8px; }
+
+  /* ======== 시안 1: 그룹 사이 빈 간격 ======== */
+  .style-1 .gap td {
+    background: var(--bg-primary) !important;
+    height: 14px;
+    padding: 0 !important;
+    border-bottom: none !important;
+  }
+  .style-1 .group-header td { border-top: 1px solid rgba(108, 92, 231, 0.3); }
+
+  /* ======== 시안 2: 카드 박스 (각 그룹이 독립 카드) ======== */
+  .style-2 .group-card {
+    background: rgba(15, 17, 23, 0.6);
+    border: 1px solid rgba(108, 92, 231, 0.25);
+    border-radius: 8px;
+    overflow: hidden;
+    margin-bottom: 12px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  }
+  .style-2 .group-card-header {
+    background: rgba(108, 92, 231, 0.15);
+    padding: 8px 12px;
+    border-bottom: 1px solid rgba(108, 92, 231, 0.3);
+  }
+  .style-2 .inner-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 11px;
+  }
+  .style-2 .inner-table td {
+    padding: 7px 10px;
+    border-bottom: 1px solid rgba(42, 47, 61, 0.4);
+    font-family: "JetBrains Mono", monospace;
+  }
+  .style-2 .inner-table tr:last-child td { border-bottom: none; }
+  .style-2 .inner-table tr:nth-child(even) td { background: rgba(15, 17, 23, 0.4); }
+
+  /* ======== 시안 3: 좌측 컬러 바 (그룹마다 같은 색 막대 연결) ======== */
+  .style-3 td.lbar {
+    width: 4px;
+    padding: 0 !important;
+    border-bottom: none !important;
+  }
+  .style-3 .lbar-color1 {
+    background: linear-gradient(180deg, var(--accent), var(--accent-sub)) !important;
+  }
+  .style-3 .lbar-color2 {
+    background: linear-gradient(180deg, #74B9FF, #A29BFE) !important;
+  }
+  .style-3 .lbar-color3 {
+    background: linear-gradient(180deg, #FF8FA3, var(--accent-sub)) !important;
+  }
+  .style-3 .group-end td:not(.lbar) {
+    border-bottom: 2px solid var(--bg-border) !important;
+    padding-bottom: 12px !important;
+  }
+  .style-3 .group-header td:first-child { padding-left: 18px !important; }
+
+  /* ======== 시안 4: 그룹 마지막 행 굵은 보더 + 다음 헤더 강조 ======== */
+  .style-4 .group-end td {
+    border-bottom: 2px solid var(--accent) !important;
+    padding-bottom: 10px !important;
+  }
+  .style-4 .group-header td {
+    background: rgba(108, 92, 231, 0.18) !important;
+    box-shadow: inset 0 -1px 0 var(--accent);
+  }
+  .style-4 .group-header + tr td { padding-top: 10px !important; }
+
+  /* ======== 시안 5: 그룹 번갈아 배경색 + 헤더 강조 ======== */
+  .style-5 tr.group-bg-A td:not(.group-cell) { background: rgba(108, 92, 231, 0.04) !important; }
+  .style-5 tr.group-bg-A:nth-child(odd) td:not(.group-cell) { background: rgba(108, 92, 231, 0.08) !important; }
+  .style-5 tr.group-bg-B td:not(.group-cell) { background: rgba(116, 185, 255, 0.04) !important; }
+  .style-5 tr.group-bg-B:nth-child(odd) td:not(.group-cell) { background: rgba(116, 185, 255, 0.08) !important; }
+  .style-5 tr.group-bg-C td:not(.group-cell) { background: rgba(255, 143, 163, 0.04) !important; }
+  .style-5 tr.group-bg-C:nth-child(odd) td:not(.group-cell) { background: rgba(255, 143, 163, 0.08) !important; }
+
+  .vote {
+    margin-top: 32px;
+    padding: 14px;
+    background: rgba(108, 92, 231, 0.06);
+    border-radius: 8px;
+    text-align: center;
+    color: var(--accent-sub);
+    font-size: 13px;
+  }
+
+  .header-bar {
+    background: rgba(108, 92, 231, 0.08);
+    border-left: 3px solid var(--accent);
+    padding: 12px 16px;
+    border-radius: 0 8px 8px 0;
+    margin: 16px 0 28px;
+    line-height: 1.6;
+    font-size: 13px;
+  }
+  .current-state {
+    background: rgba(255, 118, 117, 0.06);
+    border-left: 3px solid #FF7675;
+    padding: 12px 16px;
+    border-radius: 0 8px 8px 0;
+    margin: 0 0 24px;
+    line-height: 1.6;
+    font-size: 13px;
+  }
+</style>
+</head>
+<body>
+<div class="container">
+
+<h1>📐 (1-B) 레이아웃 별 뷰 그룹 분리 — 5개 시안</h1>
+<p class="subtitle">"셀이 다 이어져있어서 가시화 약함" — 한솔 피드백 반영. 그룹별 시각 분리를 강화하는 5가지 방향.</p>
+
+<div class="current-state">
+  <strong>🔍 현재 구현된 모습</strong>: 그룹 헤더 행 + 그 아래 일반 행들이 셀 간격 동일하게 *연속*. 헤더 행만 액센트 배경이고 행들은 줄무늬만 있음. 그룹 경계가 약함.
+</div>
+
+<div class="header-bar">
+  💡 마음에 드는 시안 번호 (1~5) 알려주세요. 또는 "X번에 이런 부분만 더해" 도 가능합니다.
+</div>
+
+<div class="grid">
+
+  <!-- 시안 1: 빈 간격 -->
+  <div class="card">
+    <span class="card-num">시안 1</span>
+    <h3>📏 그룹 사이 빈 간격 (Spacer)</h3>
+    <p class="card-desc">그룹 끝과 다음 그룹 시작 사이에 14px 높이의 빈 행 삽입. 가장 단순하면서도 효과적.</p>
+    <table class="sheet style-1">
+      <tr><th style="width:100px;">씬번호</th><th>메모</th><th style="width:50px;">LO</th></tr>
+      <tr class="group-header"><td colspan="3"><span class="group-header-title">L#A2</span><span class="group-header-meta">2개 씬</span></td></tr>
+      <tr><td><span class="scene-num">EP01-A-15</span></td><td>골목 진입</td><td>✓</td></tr>
+      <tr><td><span class="scene-num">EP01-A-16</span></td><td>벽 그림자</td><td>✓</td></tr>
+      <tr class="gap"><td colspan="3"></td></tr>
+      <tr class="group-header"><td colspan="3"><span class="group-header-title">L#A3</span><span class="group-header-meta">2개 씬</span></td></tr>
+      <tr><td><span class="scene-num">EP01-A-17</span></td><td>달려오는 인물</td><td></td></tr>
+      <tr><td><span class="scene-num">EP01-A-18</span></td><td>턴어라운드</td><td></td></tr>
+      <tr class="gap"><td colspan="3"></td></tr>
+      <tr class="group-header"><td colspan="3"><span class="group-header-title">L#A4</span><span class="group-header-meta">1개 씬</span></td></tr>
+      <tr><td><span class="scene-num">EP01-A-19</span></td><td>옥상 펜스</td><td>✓</td></tr>
+    </table>
+  </div>
+
+  <!-- 시안 2: 카드 박스 -->
+  <div class="card">
+    <span class="card-num">시안 2</span>
+    <h3>🃏 카드 박스 (Card Container)</h3>
+    <p class="card-desc">각 그룹을 *독립 카드*로 분리. 둥근 모서리 + 보더 + 그림자. 가장 강한 분리.</p>
+    <div class="style-2">
+      <div class="group-card">
+        <div class="group-card-header"><span class="group-header-title">L#A2</span><span class="group-header-meta">2개 씬</span></div>
+        <table class="inner-table">
+          <tr><td style="width:100px;"><span class="scene-num">EP01-A-15</span></td><td>골목 진입</td><td style="width:50px;">✓</td></tr>
+          <tr><td><span class="scene-num">EP01-A-16</span></td><td>벽 그림자</td><td>✓</td></tr>
+        </table>
+      </div>
+      <div class="group-card">
+        <div class="group-card-header"><span class="group-header-title">L#A3</span><span class="group-header-meta">2개 씬</span></div>
+        <table class="inner-table">
+          <tr><td style="width:100px;"><span class="scene-num">EP01-A-17</span></td><td>달려오는 인물</td><td style="width:50px;"></td></tr>
+          <tr><td><span class="scene-num">EP01-A-18</span></td><td>턴어라운드</td><td></td></tr>
+        </table>
+      </div>
+      <div class="group-card">
+        <div class="group-card-header"><span class="group-header-title">L#A4</span><span class="group-header-meta">1개 씬</span></div>
+        <table class="inner-table">
+          <tr><td style="width:100px;"><span class="scene-num">EP01-A-19</span></td><td>옥상 펜스</td><td style="width:50px;">✓</td></tr>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <!-- 시안 3: 좌측 컬러 바 -->
+  <div class="card">
+    <span class="card-num">시안 3</span>
+    <h3>🎨 좌측 컬러 바 (Group Color Bar)</h3>
+    <p class="card-desc">그룹마다 다른 색상의 좌측 막대가 헤더부터 마지막 행까지 *연결*. 시각적 묶음 명확.</p>
+    <table class="sheet style-3">
+      <tr><th style="width:4px;"></th><th style="width:100px;">씬번호</th><th>메모</th><th style="width:50px;">LO</th></tr>
+      <tr class="group-header"><td class="lbar lbar-color1"></td><td colspan="3"><span class="group-header-title">L#A2</span><span class="group-header-meta">2개 씬</span></td></tr>
+      <tr><td class="lbar lbar-color1"></td><td><span class="scene-num">EP01-A-15</span></td><td>골목 진입</td><td>✓</td></tr>
+      <tr class="group-end"><td class="lbar lbar-color1"></td><td><span class="scene-num">EP01-A-16</span></td><td>벽 그림자</td><td>✓</td></tr>
+      <tr class="group-header"><td class="lbar lbar-color2"></td><td colspan="3"><span class="group-header-title">L#A3</span><span class="group-header-meta">2개 씬</span></td></tr>
+      <tr><td class="lbar lbar-color2"></td><td><span class="scene-num">EP01-A-17</span></td><td>달려오는 인물</td><td></td></tr>
+      <tr class="group-end"><td class="lbar lbar-color2"></td><td><span class="scene-num">EP01-A-18</span></td><td>턴어라운드</td><td></td></tr>
+      <tr class="group-header"><td class="lbar lbar-color3"></td><td colspan="3"><span class="group-header-title">L#A4</span><span class="group-header-meta">1개 씬</span></td></tr>
+      <tr><td class="lbar lbar-color3"></td><td><span class="scene-num">EP01-A-19</span></td><td>옥상 펜스</td><td>✓</td></tr>
+    </table>
+  </div>
+
+  <!-- 시안 4: 마지막 행 굵은 보더 -->
+  <div class="card">
+    <span class="card-num">시안 4</span>
+    <h3>📍 그룹 끝 굵은 보더 (Strong Divider)</h3>
+    <p class="card-desc">그룹 마지막 행에 *굵은 액센트 보더* + 헤더에 진한 액센트 배경. 단순 + 명확.</p>
+    <table class="sheet style-4">
+      <tr><th style="width:100px;">씬번호</th><th>메모</th><th style="width:50px;">LO</th></tr>
+      <tr class="group-header"><td colspan="3"><span class="group-header-title">L#A2</span><span class="group-header-meta">2개 씬</span></td></tr>
+      <tr><td><span class="scene-num">EP01-A-15</span></td><td>골목 진입</td><td>✓</td></tr>
+      <tr class="group-end"><td><span class="scene-num">EP01-A-16</span></td><td>벽 그림자</td><td>✓</td></tr>
+      <tr class="group-header"><td colspan="3"><span class="group-header-title">L#A3</span><span class="group-header-meta">2개 씬</span></td></tr>
+      <tr><td><span class="scene-num">EP01-A-17</span></td><td>달려오는 인물</td><td></td></tr>
+      <tr class="group-end"><td><span class="scene-num">EP01-A-18</span></td><td>턴어라운드</td><td></td></tr>
+      <tr class="group-header"><td colspan="3"><span class="group-header-title">L#A4</span><span class="group-header-meta">1개 씬</span></td></tr>
+      <tr class="group-end"><td><span class="scene-num">EP01-A-19</span></td><td>옥상 펜스</td><td>✓</td></tr>
+    </table>
+  </div>
+
+  <!-- 시안 5: 번갈아 배경 -->
+  <div class="card full">
+    <span class="card-num">시안 5</span>
+    <h3>🎨 그룹별 옅은 배경색 (Tinted Group Background)</h3>
+    <p class="card-desc">각 그룹마다 약간 다른 옅은 색조의 배경. 줄무늬는 같은 톤으로 유지. 무지개처럼 부드럽게 분리.</p>
+    <table class="sheet style-5">
+      <tr><th style="width:100px;">씬번호</th><th>메모</th><th style="width:50px;">LO</th></tr>
+      <tr class="group-header"><td colspan="3"><span class="group-header-title">L#A2</span><span class="group-header-meta">2개 씬</span></td></tr>
+      <tr class="group-bg-A"><td><span class="scene-num">EP01-A-15</span></td><td>골목 진입</td><td>✓</td></tr>
+      <tr class="group-bg-A"><td><span class="scene-num">EP01-A-16</span></td><td>벽 그림자</td><td>✓</td></tr>
+      <tr class="group-header"><td colspan="3"><span class="group-header-title">L#A3</span><span class="group-header-meta">2개 씬</span></td></tr>
+      <tr class="group-bg-B"><td><span class="scene-num">EP01-A-17</span></td><td>달려오는 인물</td><td></td></tr>
+      <tr class="group-bg-B"><td><span class="scene-num">EP01-A-18</span></td><td>턴어라운드</td><td></td></tr>
+      <tr class="group-header"><td colspan="3"><span class="group-header-title">L#A4</span><span class="group-header-meta">1개 씬</span></td></tr>
+      <tr class="group-bg-C"><td><span class="scene-num">EP01-A-19</span></td><td>옥상 펜스</td><td>✓</td></tr>
+    </table>
+  </div>
+
+</div>
+
+<div class="vote">
+  ⬆️ 마음에 드는 시안 번호 (1~5) 알려주세요. 조합도 가능 — 예: "1 + 4" 또는 "3에 빈 간격도 추가".
+</div>
+
+</div>
+</body>
+</html>

--- a/docs/superpowers/specs/mockups/2026-04-28-scenes-ux-polish/notification-panel.html
+++ b/docs/superpowers/specs/mockups/2026-04-28-scenes-ux-polish/notification-panel.html
@@ -1,0 +1,461 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8" />
+<title>알림 탭 — 액션 버튼 4개 시안</title>
+<style>
+  :root {
+    --bg-primary: #0F1117;
+    --bg-card: #161922;
+    --bg-border: #2A2F3D;
+    --text-primary: #E8EAF0;
+    --text-secondary: #8B92A4;
+    --accent: #6C5CE7;
+    --accent-sub: #A29BFE;
+    --status-done: #00D9A0;
+    --status-warn: #FDCB6E;
+    --status-danger: #FF7675;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; padding: 32px 16px;
+    background: var(--bg-primary); color: var(--text-primary);
+    font-family: -apple-system, "Pretendard", "Segoe UI", sans-serif;
+    font-size: 14px;
+  }
+  h1 { font-size: 22px; margin: 0 0 6px; color: var(--accent-sub); }
+  h3 { font-size: 14px; margin: 0 0 4px; color: var(--accent-sub); }
+  .subtitle { color: var(--text-secondary); font-size: 13px; margin-bottom: 24px; line-height: 1.6; }
+  .container { max-width: 1100px; margin: 0 auto; }
+  .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
+  .card {
+    background: var(--bg-card);
+    border: 1px solid var(--bg-border);
+    border-radius: 12px;
+    padding: 18px;
+    position: relative;
+  }
+  .card-num {
+    position: absolute; top: 12px; right: 14px;
+    font-size: 10px; font-weight: 700; letter-spacing: 0.1em;
+    color: var(--text-secondary);
+    background: rgba(108, 92, 231, 0.15);
+    padding: 2px 8px; border-radius: 10px;
+  }
+  .card-desc {
+    font-size: 12px; color: var(--text-secondary);
+    margin: 6px 0 14px; line-height: 1.5;
+  }
+  .panel {
+    background: rgba(15, 17, 23, 0.6);
+    border: 1px solid var(--bg-border);
+    border-radius: 8px;
+    padding: 6px;
+    overflow: hidden;
+  }
+  .panel-header {
+    display: flex; justify-content: space-between; align-items: center;
+    padding: 8px 10px 8px 8px;
+    border-bottom: 1px solid var(--bg-border);
+    font-size: 12px;
+    color: var(--text-secondary);
+  }
+  .panel-actions {
+    display: flex; gap: 8px;
+  }
+  .panel-actions button {
+    background: rgba(108, 92, 231, 0.15);
+    color: var(--accent-sub);
+    border: none;
+    padding: 3px 8px;
+    border-radius: 4px;
+    font-size: 10px;
+    cursor: pointer;
+  }
+  .noti-item {
+    display: flex; gap: 8px;
+    padding: 10px 8px;
+    border-radius: 6px;
+    margin: 2px 0;
+    transition: background 0.15s;
+    position: relative;
+  }
+  .noti-item.unread { background: rgba(108, 92, 231, 0.08); }
+  .noti-item:hover { background: rgba(108, 92, 231, 0.12); }
+  .noti-icon {
+    width: 24px; height: 24px;
+    border-radius: 6px;
+    display: flex; align-items: center; justify-content: center;
+    flex-shrink: 0;
+    font-size: 12px;
+  }
+  .noti-icon.comment { background: rgba(108, 92, 231, 0.2); color: var(--accent); }
+  .noti-icon.scene { background: rgba(116, 185, 255, 0.2); color: #74B9FF; }
+  .noti-icon.system { background: rgba(139, 141, 163, 0.2); color: var(--text-secondary); }
+  .noti-body {
+    flex: 1;
+    min-width: 0;
+  }
+  .noti-title { font-size: 12.5px; line-height: 1.4; margin-bottom: 2px; }
+  .noti-desc { font-size: 11.5px; color: var(--text-secondary); line-height: 1.4; }
+  .noti-time { font-size: 10.5px; color: var(--text-secondary); margin-top: 2px; }
+  .unread-dot {
+    width: 6px; height: 6px;
+    background: var(--accent);
+    border-radius: 50%;
+    position: absolute;
+    left: 4px; top: 16px;
+  }
+
+  /* ── 시안 1: 호버 시 액션 fade-in ── */
+  .style-1 .noti-item .actions {
+    display: flex; gap: 4px;
+    align-items: center;
+    opacity: 0;
+    transition: opacity 0.2s;
+  }
+  .style-1 .noti-item:hover .actions { opacity: 1; }
+  .style-1 .actions button {
+    background: rgba(108, 92, 231, 0.15);
+    border: 1px solid rgba(108, 92, 231, 0.3);
+    color: var(--accent-sub);
+    padding: 3px 8px;
+    border-radius: 4px;
+    font-size: 11px;
+    cursor: pointer;
+  }
+  .style-1 .actions button.danger {
+    background: rgba(255, 118, 117, 0.1);
+    border-color: rgba(255, 118, 117, 0.3);
+    color: var(--status-danger);
+  }
+  .style-1 .actions button.read {
+    background: rgba(0, 217, 160, 0.1);
+    border-color: rgba(0, 217, 160, 0.3);
+    color: var(--status-done);
+  }
+
+  /* ── 시안 2: 항상 표시 미니 아이콘 ── */
+  .style-2 .actions { display: flex; gap: 2px; }
+  .style-2 .actions button {
+    background: transparent;
+    border: none;
+    width: 24px; height: 24px;
+    display: flex; align-items: center; justify-content: center;
+    border-radius: 4px;
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 14px;
+    transition: background 0.15s, color 0.15s;
+  }
+  .style-2 .actions button:hover {
+    background: rgba(108, 92, 231, 0.2);
+    color: var(--accent-sub);
+  }
+  .style-2 .actions button.danger:hover {
+    background: rgba(255, 118, 117, 0.15);
+    color: var(--status-danger);
+  }
+  .style-2 .actions button.done:hover {
+    background: rgba(0, 217, 160, 0.15);
+    color: var(--status-done);
+  }
+
+  /* ── 시안 3: 본문 클릭 = 자동 + ⋯ 메뉴 ── */
+  .style-3 .noti-item.clickable { cursor: pointer; }
+  .style-3 .menu-btn {
+    background: transparent;
+    border: none;
+    width: 22px; height: 22px;
+    display: flex; align-items: center; justify-content: center;
+    border-radius: 4px;
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 16px;
+  }
+  .style-3 .menu-btn:hover { background: rgba(108, 92, 231, 0.2); color: var(--accent-sub); }
+  .style-3 .open-menu {
+    position: absolute;
+    right: 8px; top: 32px;
+    background: var(--bg-card);
+    border: 1px solid var(--bg-border);
+    border-radius: 6px;
+    padding: 4px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.4);
+    z-index: 10;
+    min-width: 90px;
+  }
+  .style-3 .open-menu button {
+    background: transparent;
+    border: none;
+    width: 100%;
+    padding: 6px 10px;
+    text-align: left;
+    color: var(--text-primary);
+    font-size: 11.5px;
+    cursor: pointer;
+    border-radius: 4px;
+    display: flex; align-items: center; gap: 6px;
+  }
+  .style-3 .open-menu button:hover { background: rgba(108, 92, 231, 0.15); }
+  .style-3 .open-menu button.danger { color: var(--status-danger); }
+  .style-3 .quick-hint {
+    margin-top: 8px;
+    padding: 6px 8px;
+    background: rgba(108, 92, 231, 0.06);
+    border-radius: 4px;
+    font-size: 10.5px;
+    color: var(--text-secondary);
+    text-align: center;
+  }
+
+  /* ── 시안 4: 좌측 액션 칩 ── */
+  .style-4 .noti-item { padding-left: 4px; }
+  .style-4 .left-chips {
+    display: flex; flex-direction: column; gap: 3px;
+    flex-shrink: 0;
+    margin-top: 2px;
+  }
+  .style-4 .left-chips button {
+    background: rgba(108, 92, 231, 0.12);
+    color: var(--accent-sub);
+    border: none;
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-size: 9.5px;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+  .style-4 .left-chips button:hover { background: rgba(108, 92, 231, 0.25); }
+  .style-4 .left-chips button.danger {
+    background: rgba(255, 118, 117, 0.1);
+    color: var(--status-danger);
+  }
+
+  .vote {
+    margin-top: 32px;
+    padding: 14px;
+    background: rgba(108, 92, 231, 0.06);
+    border-radius: 8px;
+    text-align: center;
+    color: var(--accent-sub);
+    font-size: 13px;
+  }
+</style>
+</head>
+<body>
+<div class="container">
+
+<h1>🔔 알림 탭 액션 버튼 — 4개 시안</h1>
+<p class="subtitle">"씬 보기 / 알림 읽음 / 삭제 버튼 추가" — 한솔 요청. 각 시안마다 어디에 어떻게 배치하느냐가 다름.</p>
+
+<div class="grid">
+
+  <!-- 시안 1 -->
+  <div class="card">
+    <span class="card-num">시안 1</span>
+    <h3>👻 호버 시 액션 Fade-in</h3>
+    <p class="card-desc">평소엔 깔끔하다가, 마우스 올리면 우측에 [씬 보기][읽음][삭제] 3 버튼이 부드럽게 등장. 가독성 우선.</p>
+    <div class="panel style-1">
+      <div class="panel-header"><span>알림 (3)</span><span style="color:var(--accent-sub); cursor:pointer; font-size:11px;">전체 읽음</span></div>
+
+      <div class="noti-item unread">
+        <div class="unread-dot"></div>
+        <div class="noti-icon comment" style="margin-left:8px;">💬</div>
+        <div class="noti-body">
+          <div class="noti-title">윤스님이 나를 태그했습니다</div>
+          <div class="noti-desc">EP01-A-17 의 BG 검수 한 번만...</div>
+          <div class="noti-time">2분 전</div>
+        </div>
+        <div class="actions">
+          <button>씬 보기</button>
+          <button class="read">✓</button>
+          <button class="danger">×</button>
+        </div>
+      </div>
+
+      <div class="noti-item unread">
+        <div class="unread-dot"></div>
+        <div class="noti-icon scene" style="margin-left:8px;">🔄</div>
+        <div class="noti-body">
+          <div class="noti-title">EP01-A-15 — LO ✓</div>
+          <div class="noti-desc">한솔님이 LO 완료 처리</div>
+          <div class="noti-time">14분 전</div>
+        </div>
+        <div class="actions">
+          <button>씬 보기</button>
+          <button class="read">✓</button>
+          <button class="danger">×</button>
+        </div>
+      </div>
+
+      <div class="noti-item">
+        <div class="noti-icon system" style="margin-left:8px;">🔔</div>
+        <div class="noti-body" style="opacity:0.7;">
+          <div class="noti-title">시스템 — 동기화 완료</div>
+          <div class="noti-time">1시간 전</div>
+        </div>
+        <div class="actions">
+          <button class="danger">×</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 시안 2 -->
+  <div class="card">
+    <span class="card-num">시안 2</span>
+    <h3>👁 항상 미니 아이콘 3개</h3>
+    <p class="card-desc">우측에 작은 아이콘 버튼 항상 표시 — 👁(씬 보기) ✓(읽음) ✕(삭제). 호버 시 각 색상 강조. 클릭 1번에 바로 동작.</p>
+    <div class="panel style-2">
+      <div class="panel-header"><span>알림 (3)</span><span style="color:var(--accent-sub); cursor:pointer; font-size:11px;">전체 읽음</span></div>
+
+      <div class="noti-item unread">
+        <div class="unread-dot"></div>
+        <div class="noti-icon comment" style="margin-left:8px;">💬</div>
+        <div class="noti-body">
+          <div class="noti-title">윤스님이 나를 태그했습니다</div>
+          <div class="noti-desc">EP01-A-17 의 BG 검수 한 번만...</div>
+          <div class="noti-time">2분 전</div>
+        </div>
+        <div class="actions">
+          <button title="씬 보기">👁</button>
+          <button class="done" title="읽음">✓</button>
+          <button class="danger" title="삭제">✕</button>
+        </div>
+      </div>
+
+      <div class="noti-item unread">
+        <div class="unread-dot"></div>
+        <div class="noti-icon scene" style="margin-left:8px;">🔄</div>
+        <div class="noti-body">
+          <div class="noti-title">EP01-A-15 — LO ✓</div>
+          <div class="noti-desc">한솔님이 LO 완료 처리</div>
+          <div class="noti-time">14분 전</div>
+        </div>
+        <div class="actions">
+          <button title="씬 보기">👁</button>
+          <button class="done" title="읽음">✓</button>
+          <button class="danger" title="삭제">✕</button>
+        </div>
+      </div>
+
+      <div class="noti-item">
+        <div class="noti-icon system" style="margin-left:8px;">🔔</div>
+        <div class="noti-body" style="opacity:0.7;">
+          <div class="noti-title">시스템 — 동기화 완료</div>
+          <div class="noti-time">1시간 전</div>
+        </div>
+        <div class="actions">
+          <button class="danger" title="삭제">✕</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 시안 3 -->
+  <div class="card">
+    <span class="card-num">시안 3</span>
+    <h3>🎯 본문 클릭 = 자동 + ⋯ 메뉴</h3>
+    <p class="card-desc">알림 본문 클릭 = 자동으로 씬 보기 + 읽음 처리. 우측 ⋯ 버튼 = 메뉴 (삭제/읽음 토글). 가장 깔끔.</p>
+    <div class="panel style-3">
+      <div class="panel-header"><span>알림 (3)</span><span style="color:var(--accent-sub); cursor:pointer; font-size:11px;">전체 읽음</span></div>
+
+      <div class="noti-item unread clickable">
+        <div class="unread-dot"></div>
+        <div class="noti-icon comment" style="margin-left:8px;">💬</div>
+        <div class="noti-body">
+          <div class="noti-title">윤스님이 나를 태그했습니다</div>
+          <div class="noti-desc">EP01-A-17 의 BG 검수 한 번만...</div>
+          <div class="noti-time">2분 전</div>
+        </div>
+        <button class="menu-btn">⋯</button>
+      </div>
+
+      <div class="noti-item unread clickable" style="position:relative;">
+        <div class="unread-dot"></div>
+        <div class="noti-icon scene" style="margin-left:8px;">🔄</div>
+        <div class="noti-body">
+          <div class="noti-title">EP01-A-15 — LO ✓</div>
+          <div class="noti-desc">한솔님이 LO 완료 처리</div>
+          <div class="noti-time">14분 전</div>
+        </div>
+        <button class="menu-btn">⋯</button>
+        <!-- 메뉴 펼친 상태 미리보기 -->
+        <div class="open-menu">
+          <button>👁 씬 보기</button>
+          <button>✓ 읽음</button>
+          <button class="danger">✕ 삭제</button>
+        </div>
+      </div>
+
+      <div class="noti-item clickable">
+        <div class="noti-icon system" style="margin-left:8px;">🔔</div>
+        <div class="noti-body" style="opacity:0.7;">
+          <div class="noti-title">시스템 — 동기화 완료</div>
+          <div class="noti-time">1시간 전</div>
+        </div>
+        <button class="menu-btn">⋯</button>
+      </div>
+      <div class="quick-hint">💡 알림 본문 클릭 시 즉시 씬으로 이동 + 읽음 처리. 삭제 등은 ⋯ 메뉴에서.</div>
+    </div>
+  </div>
+
+  <!-- 시안 4 -->
+  <div class="card">
+    <span class="card-num">시안 4</span>
+    <h3>📌 좌측 액션 칩 (가독성)</h3>
+    <p class="card-desc">알림 좌측에 작은 칩 [보기][읽음][삭제] 항상 표시. 본문 텍스트와 분리되어 가독성 ↑. 알림 자체 클릭 동작 없음.</p>
+    <div class="panel style-4">
+      <div class="panel-header"><span>알림 (3)</span><span style="color:var(--accent-sub); cursor:pointer; font-size:11px;">전체 읽음</span></div>
+
+      <div class="noti-item unread">
+        <div class="left-chips">
+          <button>보기</button>
+          <button>읽음</button>
+          <button class="danger">삭제</button>
+        </div>
+        <div class="noti-icon comment">💬</div>
+        <div class="noti-body">
+          <div class="noti-title">윤스님이 나를 태그했습니다</div>
+          <div class="noti-desc">EP01-A-17 의 BG 검수 한 번만...</div>
+          <div class="noti-time">2분 전</div>
+        </div>
+      </div>
+
+      <div class="noti-item unread">
+        <div class="left-chips">
+          <button>보기</button>
+          <button>읽음</button>
+          <button class="danger">삭제</button>
+        </div>
+        <div class="noti-icon scene">🔄</div>
+        <div class="noti-body">
+          <div class="noti-title">EP01-A-15 — LO ✓</div>
+          <div class="noti-desc">한솔님이 LO 완료 처리</div>
+          <div class="noti-time">14분 전</div>
+        </div>
+      </div>
+
+      <div class="noti-item">
+        <div class="left-chips">
+          <button class="danger">삭제</button>
+        </div>
+        <div class="noti-icon system">🔔</div>
+        <div class="noti-body" style="opacity:0.7;">
+          <div class="noti-title">시스템 — 동기화 완료</div>
+          <div class="noti-time">1시간 전</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<div class="vote">
+  ⬆️ 마음에 드는 시안 번호 (1~4) 알려주세요. 조합 또는 변형도 가능 — 예: "2번에 호버 강조 추가".
+</div>
+
+</div>
+</body>
+</html>

--- a/docs/superpowers/specs/mockups/2026-04-28-scenes-ux-polish/scene-effects.html
+++ b/docs/superpowers/specs/mockups/2026-04-28-scenes-ux-polish/scene-effects.html
@@ -1,0 +1,618 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8" />
+<title>(5) 씬 번호 빛나는 효과 — 6개 시안</title>
+<style>
+  :root {
+    --bg-primary: #0F1117;
+    --bg-card: #161922;
+    --bg-border: #2A2F3D;
+    --text-primary: #E8EAF0;
+    --text-secondary: #8B92A4;
+    --accent: #6C5CE7;
+    --accent-sub: #A29BFE;
+    --accent-bright: #B8AFFF;
+  }
+  @property --gradient-angle {
+    syntax: '<angle>';
+    initial-value: 0deg;
+    inherits: false;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; padding: 32px 16px;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    font-family: -apple-system, "Pretendard", "Segoe UI", sans-serif;
+    font-size: 14px;
+  }
+  h1 { font-size: 22px; margin: 0 0 6px; color: var(--accent-sub); }
+  h3 { font-size: 14px; margin: 0 0 4px; color: var(--accent-sub); }
+  .subtitle {
+    color: var(--text-secondary); font-size: 13px;
+    margin-bottom: 24px; line-height: 1.6;
+  }
+  .container { max-width: 1200px; margin: 0 auto; }
+  .grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+  }
+  .card {
+    background: var(--bg-card);
+    border: 1px solid var(--bg-border);
+    border-radius: 12px;
+    padding: 18px;
+    position: relative;
+  }
+  .card-num {
+    position: absolute; top: 12px; right: 14px;
+    font-size: 10px; font-weight: 700;
+    letter-spacing: 0.1em;
+    color: var(--text-secondary);
+    background: rgba(108, 92, 231, 0.15);
+    padding: 2px 8px; border-radius: 10px;
+  }
+  .card-desc {
+    font-size: 12px; color: var(--text-secondary);
+    margin: 6px 0 18px; line-height: 1.5;
+  }
+  .demo-bar {
+    background: rgba(15, 17, 23, 0.5);
+    border-radius: 8px;
+    padding: 18px 16px;
+    display: flex; gap: 28px; align-items: center;
+    justify-content: center;
+  }
+  .demo-label {
+    font-size: 10px; color: var(--text-secondary);
+    margin-bottom: 6px; text-align: center;
+  }
+  .demo-cell {
+    display: inline-flex; flex-direction: column; gap: 4px;
+  }
+  .scene-text {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 14px; font-weight: 600;
+    cursor: pointer;
+    user-select: none;
+    padding: 4px 8px;
+    position: relative;
+  }
+  .vote {
+    margin-top: 26px;
+    padding: 14px;
+    background: rgba(108, 92, 231, 0.06);
+    border-radius: 8px;
+    text-align: center;
+    color: var(--accent-sub);
+    font-size: 13px;
+  }
+
+  /* ============ 시안 1: 네온 펄스 (Neon Pulse) ============ */
+  .style-1 {
+    color: var(--accent);
+    text-shadow:
+      0 0 4px rgba(108, 92, 231, 0.6),
+      0 0 12px rgba(108, 92, 231, 0.3);
+    animation: pulse1 2.4s ease-in-out infinite;
+    transition: all 0.3s;
+  }
+  .style-1:hover {
+    color: var(--accent-bright);
+    text-shadow:
+      0 0 6px rgba(184, 175, 255, 1),
+      0 0 18px rgba(108, 92, 231, 0.8),
+      0 0 32px rgba(108, 92, 231, 0.4);
+    transform: scale(1.05);
+  }
+  @keyframes pulse1 {
+    0%, 100% { text-shadow: 0 0 4px rgba(108, 92, 231, 0.5), 0 0 10px rgba(108, 92, 231, 0.25); }
+    50% { text-shadow: 0 0 8px rgba(108, 92, 231, 0.8), 0 0 18px rgba(108, 92, 231, 0.45); }
+  }
+
+  /* ============ 시안 2: 에너지 오브 (Energy Orb) ============ */
+  .style-2-wrap {
+    position: relative;
+    display: inline-block;
+    padding: 4px 14px;
+  }
+  .style-2-wrap::before {
+    content: '';
+    position: absolute; inset: 0;
+    border-radius: 100px;
+    background: radial-gradient(ellipse at center,
+      rgba(108, 92, 231, 0.35) 0%,
+      rgba(108, 92, 231, 0.15) 40%,
+      transparent 70%);
+    filter: blur(6px);
+    opacity: 0.7;
+    transition: all 0.4s;
+    z-index: 0;
+    animation: orb-pulse 2.5s ease-in-out infinite;
+  }
+  .style-2-wrap:hover::before {
+    opacity: 1;
+    background: radial-gradient(ellipse at center,
+      rgba(184, 175, 255, 0.7) 0%,
+      rgba(108, 92, 231, 0.4) 40%,
+      transparent 70%);
+    filter: blur(10px);
+    transform: scale(1.3);
+  }
+  .style-2 {
+    color: var(--accent);
+    position: relative; z-index: 1;
+    transition: color 0.3s;
+  }
+  .style-2-wrap:hover .style-2 { color: white; }
+  @keyframes orb-pulse {
+    0%, 100% { opacity: 0.5; transform: scale(0.95); }
+    50% { opacity: 0.85; transform: scale(1.1); }
+  }
+
+  /* ============ 시안 3: 회전 보더 (Rotating Border) ============ */
+  .style-3-wrap {
+    position: relative;
+    display: inline-block;
+    padding: 5px 14px;
+    border-radius: 8px;
+    isolation: isolate;
+  }
+  .style-3-wrap::before {
+    content: '';
+    position: absolute; inset: 0;
+    padding: 1.5px;
+    border-radius: 8px;
+    background: conic-gradient(from var(--gradient-angle),
+      var(--accent), var(--accent-sub), var(--accent-bright),
+      var(--accent-sub), var(--accent));
+    -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+    -webkit-mask-composite: xor;
+            mask-composite: exclude;
+    animation: rotate-border 3s linear infinite;
+    opacity: 0.55;
+    transition: opacity 0.3s;
+  }
+  .style-3-wrap:hover::before {
+    opacity: 1;
+    animation-duration: 1.2s;
+  }
+  .style-3 {
+    color: var(--accent);
+    transition: all 0.3s;
+  }
+  .style-3-wrap:hover .style-3 {
+    color: var(--accent-bright);
+    text-shadow: 0 0 8px rgba(108, 92, 231, 0.6);
+  }
+  @keyframes rotate-border {
+    to { --gradient-angle: 360deg; }
+  }
+
+  /* ============ 시안 4: 스캔 라인 (Scan Line) ============ */
+  .style-4-wrap {
+    position: relative; display: inline-block;
+    padding: 4px 12px;
+    overflow: hidden;
+    border-radius: 6px;
+    background: rgba(108, 92, 231, 0.08);
+  }
+  .style-4-wrap::before {
+    content: '';
+    position: absolute;
+    top: -100%; left: 0; right: 0;
+    height: 30%;
+    background: linear-gradient(180deg,
+      transparent,
+      rgba(184, 175, 255, 0.4),
+      transparent);
+    animation: scanline 2.4s ease-in-out infinite;
+    pointer-events: none;
+  }
+  .style-4-wrap:hover::before {
+    animation-duration: 0.8s;
+  }
+  .style-4 {
+    color: var(--accent-bright);
+    position: relative;
+    text-shadow: 0 0 6px rgba(108, 92, 231, 0.4);
+    transition: text-shadow 0.3s;
+  }
+  .style-4-wrap:hover .style-4 {
+    text-shadow: 0 0 12px rgba(108, 92, 231, 0.9);
+  }
+  @keyframes scanline {
+    0% { top: -30%; }
+    100% { top: 130%; }
+  }
+
+  /* ============ 시안 5: 파티클 모음 (Particle Gather) ============ */
+  .style-5-wrap {
+    position: relative; display: inline-block;
+    padding: 6px 14px;
+  }
+  .style-5 {
+    color: var(--accent);
+    transition: all 0.3s;
+  }
+  .style-5-wrap:hover .style-5 {
+    color: var(--accent-bright);
+    text-shadow: 0 0 8px rgba(108, 92, 231, 0.8);
+  }
+  .particle {
+    position: absolute;
+    width: 4px; height: 4px; border-radius: 50%;
+    background: var(--accent-sub);
+    opacity: 0;
+    pointer-events: none;
+  }
+  .style-5-wrap:hover .particle {
+    animation: particle-gather 0.7s ease-out forwards;
+  }
+  .style-5-wrap .p1 { top: -8px; left: -8px; }
+  .style-5-wrap .p2 { top: -8px; right: -8px; }
+  .style-5-wrap .p3 { bottom: -8px; left: -8px; }
+  .style-5-wrap .p4 { bottom: -8px; right: -8px; }
+  .style-5-wrap .p5 { top: 50%; left: -16px; }
+  .style-5-wrap .p6 { top: 50%; right: -16px; }
+  @keyframes particle-gather {
+    0% { opacity: 0; transform: translate(0, 0) scale(0.5); }
+    50% { opacity: 1; transform: translate(0, 0) scale(1); }
+    100% {
+      opacity: 0;
+      transform: translate(calc(50% - var(--px, 0px)), calc(50% - var(--py, 0px))) scale(0.3);
+    }
+  }
+  .style-5-wrap .p1 { --px: -8px; --py: -8px; }
+  .style-5-wrap .p2 { --px: 8px; --py: -8px; }
+  .style-5-wrap .p3 { --px: -8px; --py: 8px; }
+  .style-5-wrap .p4 { --px: 8px; --py: 8px; }
+  .style-5-wrap .p5 { --px: -16px; --py: 0; }
+  .style-5-wrap .p6 { --px: 16px; --py: 0; }
+
+  /* ============ 시안 6: 마법 광휘 (Magic Glow) ============ */
+  .style-6-wrap {
+    position: relative; display: inline-block;
+    padding: 4px 14px;
+    border-radius: 6px;
+  }
+  .style-6 {
+    background: linear-gradient(120deg,
+      var(--accent) 0%,
+      var(--accent-sub) 50%,
+      var(--accent-bright) 100%);
+    background-size: 200% 100%;
+    -webkit-background-clip: text; background-clip: text;
+    -webkit-text-fill-color: transparent;
+    animation: shimmer 3.5s linear infinite;
+    transition: filter 0.3s;
+  }
+  .style-6-wrap::after {
+    content: '';
+    position: absolute;
+    inset: -2px;
+    border-radius: 8px;
+    background: linear-gradient(120deg, transparent 30%,
+      rgba(184, 175, 255, 0.5) 50%,
+      transparent 70%);
+    background-size: 200% 100%;
+    animation: shimmer 3.5s linear infinite;
+    opacity: 0;
+    transition: opacity 0.3s;
+    z-index: -1;
+    filter: blur(8px);
+  }
+  .style-6-wrap:hover::after { opacity: 1; }
+  .style-6-wrap:hover .style-6 {
+    filter: drop-shadow(0 0 4px rgba(184, 175, 255, 0.8));
+  }
+  @keyframes shimmer {
+    0% { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+  }
+
+  .header-bar {
+    background: rgba(108, 92, 231, 0.08);
+    border-left: 3px solid var(--accent);
+    padding: 12px 16px;
+    border-radius: 0 8px 8px 0;
+    margin: 16px 0 28px;
+    line-height: 1.6;
+    font-size: 13px;
+  }
+</style>
+</head>
+<body>
+<div class="container">
+
+<h1>🎮 (5) 씬 번호 빛나는 효과 — 6개 시안</h1>
+<p class="subtitle">"화살표 말고, 게임 이펙트처럼 빛나는 거" — 한솔 요청 반영. 평소엔 살짝 빛나고, 호버 시 더 강해지는 패턴으로 통일.</p>
+
+<div class="header-bar">
+  💡 <strong>각 카드의 씬 번호 위에 마우스를 올려보세요</strong> — 호버 시 효과가 강해집니다. 마음에 드시는 시안 번호를 알려주세요!
+</div>
+
+<div class="grid">
+
+  <!-- 시안 1 -->
+  <div class="card">
+    <span class="card-num">시안 1</span>
+    <h3>✨ 네온 펄스 (Neon Pulse)</h3>
+    <p class="card-desc">은은한 빛이 자체적으로 펄스. 호버 시 강한 글로우 + 살짝 확대. 깔끔하고 가장 가벼움.</p>
+    <div class="demo-bar">
+      <div class="demo-cell">
+        <div class="demo-label">평소 (자체 펄스)</div>
+        <span class="scene-text style-1">EP01-A-15</span>
+      </div>
+      <div class="demo-cell">
+        <div class="demo-label">호버 (강한 글로우)</div>
+        <span class="scene-text style-1" style="color:var(--accent-bright); text-shadow: 0 0 6px rgba(184, 175, 255, 1), 0 0 18px rgba(108, 92, 231, 0.8), 0 0 32px rgba(108, 92, 231, 0.4); transform: scale(1.05); display: inline-block;">EP01-A-15</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- 시안 2 -->
+  <div class="card">
+    <span class="card-num">시안 2</span>
+    <h3>🔮 에너지 오브 (Energy Orb)</h3>
+    <p class="card-desc">텍스트 뒤에 보라 구슬이 펄스. 호버 시 구슬이 커지고 텍스트 흰색으로. "구슬에 에너지 차는" 그 느낌!</p>
+    <div class="demo-bar">
+      <div class="demo-cell">
+        <div class="demo-label">평소 (구슬 떠다님)</div>
+        <span class="style-2-wrap"><span class="scene-text style-2">EP01-A-15</span></span>
+      </div>
+      <div class="demo-cell">
+        <div class="demo-label">호버 (구슬 활성화)</div>
+        <span class="style-2-wrap" style="--hover:1;"><span class="scene-text style-2">EP01-A-15</span></span>
+      </div>
+    </div>
+  </div>
+
+  <!-- 시안 3 -->
+  <div class="card">
+    <span class="card-num">시안 3</span>
+    <h3>🎯 회전 보더 (Rotating Border)</h3>
+    <p class="card-desc">텍스트 주위에 보라/연보라 그라데이션 보더가 회전. 호버 시 회전 빨라지며 보더 진해짐. 미래적.</p>
+    <div class="demo-bar">
+      <div class="demo-cell">
+        <div class="demo-label">평소 (천천히 회전)</div>
+        <span class="style-3-wrap"><span class="scene-text style-3">EP01-A-15</span></span>
+      </div>
+      <div class="demo-cell">
+        <div class="demo-label">호버 (빠르게 회전)</div>
+        <span class="style-3-wrap"><span class="scene-text style-3">EP01-A-15</span></span>
+      </div>
+    </div>
+  </div>
+
+  <!-- 시안 4 -->
+  <div class="card">
+    <span class="card-num">시안 4</span>
+    <h3>📡 스캔 라인 (Scan Line)</h3>
+    <p class="card-desc">텍스트 위로 빛이 위→아래로 스캔하며 흐름. 호버 시 스캔 속도 3배. 시네마틱한 디지털 느낌.</p>
+    <div class="demo-bar">
+      <div class="demo-cell">
+        <div class="demo-label">평소 (천천히 스캔)</div>
+        <span class="style-4-wrap"><span class="scene-text style-4">EP01-A-15</span></span>
+      </div>
+      <div class="demo-cell">
+        <div class="demo-label">호버 (빠르게 스캔)</div>
+        <span class="style-4-wrap"><span class="scene-text style-4">EP01-A-15</span></span>
+      </div>
+    </div>
+  </div>
+
+  <!-- 시안 5 -->
+  <div class="card">
+    <span class="card-num">시안 5</span>
+    <h3>💫 파티클 모음 (Particle Gather)</h3>
+    <p class="card-desc">호버 시 텍스트 주위에서 작은 점 6개가 가운데로 모여듦. 마치 마법 봉인 푸는 효과.</p>
+    <div class="demo-bar">
+      <div class="demo-cell">
+        <div class="demo-label">평소 (정적)</div>
+        <span class="style-5-wrap"><span class="scene-text style-5">EP01-A-15</span></span>
+      </div>
+      <div class="demo-cell">
+        <div class="demo-label">호버 (파티클 모음)</div>
+        <span class="style-5-wrap">
+          <span class="particle p1"></span>
+          <span class="particle p2"></span>
+          <span class="particle p3"></span>
+          <span class="particle p4"></span>
+          <span class="particle p5"></span>
+          <span class="particle p6"></span>
+          <span class="scene-text style-5">EP01-A-15</span>
+        </span>
+      </div>
+    </div>
+  </div>
+
+  <!-- 시안 6 -->
+  <div class="card">
+    <span class="card-num">시안 6</span>
+    <h3>🌈 마법 광휘 (Magic Glow)</h3>
+    <p class="card-desc">텍스트 자체가 보라→연보라→밝은보라 그라데이션이 흘러감. 호버 시 외부에 빛 띠가 회전. 가장 럭셔리.</p>
+    <div class="demo-bar">
+      <div class="demo-cell">
+        <div class="demo-label">평소 (그라데이션 흐름)</div>
+        <span class="style-6-wrap"><span class="scene-text style-6">EP01-A-15</span></span>
+      </div>
+      <div class="demo-cell">
+        <div class="demo-label">호버 (외부 빛띠 추가)</div>
+        <span class="style-6-wrap"><span class="scene-text style-6">EP01-A-15</span></span>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<div class="vote">
+  ⬆️ 마음에 드는 시안 번호 (1~6) 알려주세요. 또는 "이 시안에 이런 부분만 바꿔서" 도 가능합니다.
+</div>
+
+<!-- ============ 한솔 선택: 1 + 3 합본 ============ -->
+<style>
+  .final-section {
+    margin-top: 56px;
+    padding: 24px;
+    background: linear-gradient(135deg, rgba(108, 92, 231, 0.12), rgba(162, 155, 254, 0.06));
+    border: 1px solid rgba(108, 92, 231, 0.3);
+    border-radius: 12px;
+  }
+  .final-title {
+    font-size: 18px; font-weight: 700;
+    color: var(--accent-bright);
+    margin: 0 0 6px;
+  }
+
+  /* 1+3 합본: 네온 펄스 (text-shadow) + 회전 보더 (conic) */
+  .combo-wrap {
+    position: relative;
+    display: inline-block;
+    padding: 5px 14px;
+    border-radius: 8px;
+    isolation: isolate;
+  }
+  .combo-wrap::before {
+    content: '';
+    position: absolute; inset: 0;
+    padding: 1.5px;
+    border-radius: 8px;
+    background: conic-gradient(from var(--gradient-angle),
+      var(--accent), var(--accent-sub), var(--accent-bright),
+      var(--accent-sub), var(--accent));
+    -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+    -webkit-mask-composite: xor;
+            mask-composite: exclude;
+    animation: rotate-border 3s linear infinite;
+    opacity: 0.55;
+    transition: opacity 0.3s, filter 0.3s;
+  }
+  .combo-wrap:hover::before {
+    opacity: 1;
+    animation-duration: 1.2s;
+    filter: blur(0.5px);
+  }
+  .combo-text {
+    color: var(--accent);
+    font-family: "JetBrains Mono", monospace;
+    font-size: 14px; font-weight: 600;
+    text-shadow:
+      0 0 4px rgba(108, 92, 231, 0.6),
+      0 0 12px rgba(108, 92, 231, 0.3);
+    animation: pulse1 2.4s ease-in-out infinite;
+    transition: all 0.3s;
+    cursor: pointer;
+  }
+  .combo-wrap:hover .combo-text {
+    color: var(--accent-bright);
+    text-shadow:
+      0 0 6px rgba(184, 175, 255, 1),
+      0 0 18px rgba(108, 92, 231, 0.8),
+      0 0 32px rgba(108, 92, 231, 0.4);
+  }
+
+  /* 행 하이라이트 버전 — 같은 효과를 행 전체에 적용 (토스트 클릭 후 2초간) */
+  .row-highlight-table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+    background: rgba(15, 17, 23, 0.6);
+    border-radius: 6px;
+    margin-top: 10px;
+    overflow: hidden;
+  }
+  .row-highlight-table th {
+    background: var(--bg-card);
+    color: var(--text-secondary);
+    font-size: 10px; font-weight: 600;
+    padding: 6px 10px;
+    text-align: left;
+  }
+  .row-highlight-table td {
+    padding: 8px 10px;
+    border-bottom: 1px solid rgba(42, 47, 61, 0.5);
+    font-family: "JetBrains Mono", monospace;
+    font-size: 11px;
+  }
+  .row-highlight-table tr:nth-child(odd) td {
+    background: rgba(15, 17, 23, 0.3);
+  }
+  /* 강조된 행 — 1+3 합본 효과를 행 전체에 */
+  .row-highlight-table tr.highlighted {
+    position: relative;
+    isolation: isolate;
+    animation: row-pulse 2.4s ease-in-out 2;
+    box-shadow:
+      inset 0 0 0 1.5px transparent,
+      0 0 8px rgba(108, 92, 231, 0.4);
+  }
+  .row-highlight-table tr.highlighted td {
+    background: rgba(108, 92, 231, 0.08) !important;
+    position: relative;
+  }
+  .row-highlight-table tr.highlighted td:first-child::before {
+    content: '';
+    position: absolute;
+    left: 0; top: 0; bottom: 0;
+    width: 3px;
+    background: linear-gradient(180deg,
+      var(--accent), var(--accent-sub), var(--accent-bright));
+    animation: side-pulse 1.5s ease-in-out infinite;
+  }
+  .row-highlight-table tr.highlighted .scene-num {
+    color: var(--accent-bright);
+    text-shadow:
+      0 0 6px rgba(184, 175, 255, 1),
+      0 0 14px rgba(108, 92, 231, 0.7);
+  }
+  @keyframes row-pulse {
+    0%, 100% { box-shadow: inset 0 0 0 1.5px transparent, 0 0 8px rgba(108, 92, 231, 0.3); }
+    50% { box-shadow: inset 0 0 0 1.5px rgba(108, 92, 231, 0.5), 0 0 24px rgba(108, 92, 231, 0.6); }
+  }
+  @keyframes side-pulse {
+    0%, 100% { opacity: 0.6; }
+    50% { opacity: 1; }
+  }
+</style>
+
+<div class="final-section">
+  <h2 class="final-title">✨ 한솔 선택: 1 + 3 합본 (네온 펄스 + 회전 보더)</h2>
+  <p style="color:var(--text-secondary); font-size:13px; line-height:1.6; margin-bottom:18px;">
+    글자 자체에 네온 펄스 (자체 글로우) + 텍스트 주위에 회전 그라데이션 보더. 호버 시 글로우 강화 + 보더 회전 가속.
+  </p>
+
+  <div class="demo-bar">
+    <div class="demo-cell">
+      <div class="demo-label">평소 (펄스 + 천천히 회전)</div>
+      <span class="combo-wrap"><span class="combo-text">EP01-A-15</span></span>
+    </div>
+    <div class="demo-cell">
+      <div class="demo-label">호버 (강한 글로우 + 빠른 회전)</div>
+      <span class="combo-wrap"><span class="combo-text">EP01-A-15</span></span>
+    </div>
+  </div>
+
+  <h3 style="margin-top:32px; color:var(--accent-bright);">📍 (8번 추가) 토스트 클릭 후 시트 뷰 행 하이라이트</h3>
+  <p style="color:var(--text-secondary); font-size:13px; line-height:1.6;">
+    토스트의 '씬 보기' 클릭 → 마지막 뷰가 시트 뷰면 해당 행이 같은 톤으로 빛남. 2번 펄스 (약 4.8초) 후 자동으로 가라앉음.
+  </p>
+
+  <table class="row-highlight-table">
+    <tr><th style="width:120px;">씬번호</th><th>메모</th><th style="width:80px;">BG담당</th><th style="width:60px;">LO</th></tr>
+    <tr><td><span class="scene-num">EP01-A-14</span></td><td>도시 외경</td><td>한솔</td><td>✓</td></tr>
+    <tr class="highlighted"><td><span class="scene-num">EP01-A-15</span></td><td>골목 진입 ← 토스트로 이동된 씬</td><td>한솔</td><td>✓</td></tr>
+    <tr><td><span class="scene-num">EP01-A-16</span></td><td>벽 그림자</td><td>한솔</td><td>✓</td></tr>
+    <tr><td><span class="scene-num">EP01-A-17</span></td><td>달려오는 인물</td><td>윤스</td><td></td></tr>
+  </table>
+
+  <p style="text-align:center; color:var(--accent-sub); font-size:13px; margin-top:18px;">
+    ⬆️ 이 디자인으로 실 코드 적용해도 될까요?
+  </p>
+</div>
+
+</div>
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bflow",
-  "version": "1.14.1",
+  "version": "1.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bflow",
-      "version": "1.14.1",
+      "version": "1.15.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@liveblocks/client": "^3.14.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.14.1",
+  "version": "1.15.0",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -694,7 +694,17 @@ export default function App() {
 
         // INSERT 이벤트: 다른 사용자가 내 씬에 댓글 / @멘션 시 알림
         if (payload?.eventType === 'INSERT' && payload?.new) {
-          const newComment = payload.new as { scene_id?: string; user_name?: string; user_id?: string; text?: string; mentions?: string[] };
+          // comments 테이블 컬럼: scene_id 는 사실 scene.no(sort_order, 예: '1', '2'...).
+          // 정확한 씬 매칭은 scene_uuid 컬럼 사용 (electron/supabase.ts:872 참고).
+          const newComment = payload.new as {
+            scene_id?: string;
+            scene_uuid?: string;
+            part_id?: string;
+            user_name?: string;
+            user_id?: string;
+            text?: string;
+            mentions?: string[];
+          };
           const me = useAuthStore.getState().currentUser;
           // 한솔 테스트용 (v1.15.0): 본인이 본인 태그한 경우에도 토스트 발동되도록 user_id 자기 비교 제거.
           // 실 운영 시 본인 댓글 알림이 의미없으면 다음 PR 에서 user_id !== me.id 조건 복원.
@@ -704,11 +714,26 @@ export default function App() {
             else {
               const notiSettings = notiSettingsRef.current;
               if (notiSettings.commentNotify !== false) {
-                // scene 검색 — newComment.scene_id 가 UUID 형식일 수도, 사용자 지정 sceneId 형식일 수도 있어 둘 다 시도.
-                // (한솔 보고: 본인 멘션 시 scene 못 찾아 액션 버튼 누락 → fallback 강화)
-                const scene =
-                  useDataStore.getState().findSceneBySceneId(newComment.scene_id!) ||
-                  useDataStore.getState().findSceneByUuid(newComment.scene_id!);
+                // 한솔 보고 (2026-04-28): comments.scene_id='1' 같은 sort_order 라 기존 sceneId/UUID 매칭 모두 실패.
+                // 정확한 씬은 scene_uuid 우선. fallback 으로 part_id + sceneNo 매칭.
+                const sceneByUuid = newComment.scene_uuid
+                  ? useDataStore.getState().findSceneByUuid(newComment.scene_uuid)
+                  : null;
+                const sceneByPartAndNo = (() => {
+                  if (sceneByUuid) return null;
+                  if (!newComment.part_id || !newComment.scene_id) return null;
+                  const targetNo = Number(newComment.scene_id);
+                  if (!Number.isFinite(targetNo)) return null;
+                  for (const ep of useDataStore.getState().episodes) {
+                    for (const part of ep.parts) {
+                      if (part.id !== newComment.part_id) continue;
+                      const found = part.scenes.find((s) => Number(s.no) === targetNo);
+                      if (found) return found;
+                    }
+                  }
+                  return null;
+                })();
+                const scene = sceneByUuid ?? sceneByPartAndNo ?? null;
                 const isMentioned = Array.isArray(newComment.mentions) && newComment.mentions.includes(me.name);
                 const isAssignee = scene && scene.assignee === me.name;
 
@@ -717,11 +742,10 @@ export default function App() {
                     type: 'comment',
                     title: `${newComment.user_name || '누군가'}님이 나를 태그했습니다`,
                     body: newComment.text ? (newComment.text.length > 50 ? newComment.text.slice(0, 50) + '...' : newComment.text) : undefined,
-                    // scene 못 찾아도 newComment.scene_id 를 sceneId(UUID 매칭) + sceneName(사용자 ID 매칭) 둘 다 채워서
-                    // navigateToScene 안에서 어떤 형식이든 매칭 시도 가능.
+                    // scene 정확히 찾았으면 UUID + 사용자 sceneId. 못 찾으면 액션 버튼 비활성 (metadata 비움)
                     metadata: scene
                       ? { sceneId: scene.id, sceneName: scene.sceneId }
-                      : { sceneId: newComment.scene_id ?? '', sceneName: newComment.scene_id ?? '' },
+                      : undefined,
                   }, notiSettings);
                 } else if (isAssignee) {
                   dispatchNotification({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -704,7 +704,11 @@ export default function App() {
             else {
               const notiSettings = notiSettingsRef.current;
               if (notiSettings.commentNotify !== false) {
-                const scene = useDataStore.getState().findSceneBySceneId(newComment.scene_id!);
+                // scene 검색 — newComment.scene_id 가 UUID 형식일 수도, 사용자 지정 sceneId 형식일 수도 있어 둘 다 시도.
+                // (한솔 보고: 본인 멘션 시 scene 못 찾아 액션 버튼 누락 → fallback 강화)
+                const scene =
+                  useDataStore.getState().findSceneBySceneId(newComment.scene_id!) ||
+                  useDataStore.getState().findSceneByUuid(newComment.scene_id!);
                 const isMentioned = Array.isArray(newComment.mentions) && newComment.mentions.includes(me.name);
                 const isAssignee = scene && scene.assignee === me.name;
 
@@ -713,7 +717,10 @@ export default function App() {
                     type: 'comment',
                     title: `${newComment.user_name || '누군가'}님이 나를 태그했습니다`,
                     body: newComment.text ? (newComment.text.length > 50 ? newComment.text.slice(0, 50) + '...' : newComment.text) : undefined,
-                    metadata: scene ? { sceneId: scene.id, sceneName: scene.sceneId } : undefined,
+                    // scene 못 찾아도 newComment.scene_id 라도 sceneName 으로 — canNavigate=true 보장 + navigateToScene 가 같은 키로 재시도
+                    metadata: scene
+                      ? { sceneId: scene.id, sceneName: scene.sceneId }
+                      : { sceneName: newComment.scene_id ?? '' },
                   }, notiSettings);
                 } else if (isAssignee) {
                   dispatchNotification({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -696,7 +696,9 @@ export default function App() {
         if (payload?.eventType === 'INSERT' && payload?.new) {
           const newComment = payload.new as { scene_id?: string; user_name?: string; user_id?: string; text?: string; mentions?: string[] };
           const me = useAuthStore.getState().currentUser;
-          if (me && newComment.user_id && newComment.user_id !== me.id && newComment.scene_id) {
+          // 한솔 테스트용 (v1.15.0): 본인이 본인 태그한 경우에도 토스트 발동되도록 user_id 자기 비교 제거.
+          // 실 운영 시 본인 댓글 알림이 의미없으면 다음 PR 에서 user_id !== me.id 조건 복원.
+          if (me && newComment.user_id && newComment.scene_id) {
             const dedupeKey = `comment:${newComment.user_id}:${newComment.scene_id}`;
             if (!dedupeNotification(dedupeKey)) { /* 이미 broadcast로 처리됨 */ }
             else {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -717,10 +717,11 @@ export default function App() {
                     type: 'comment',
                     title: `${newComment.user_name || '누군가'}님이 나를 태그했습니다`,
                     body: newComment.text ? (newComment.text.length > 50 ? newComment.text.slice(0, 50) + '...' : newComment.text) : undefined,
-                    // scene 못 찾아도 newComment.scene_id 라도 sceneName 으로 — canNavigate=true 보장 + navigateToScene 가 같은 키로 재시도
+                    // scene 못 찾아도 newComment.scene_id 를 sceneId(UUID 매칭) + sceneName(사용자 ID 매칭) 둘 다 채워서
+                    // navigateToScene 안에서 어떤 형식이든 매칭 시도 가능.
                     metadata: scene
                       ? { sceneId: scene.id, sceneName: scene.sceneId }
-                      : { sceneName: newComment.scene_id ?? '' },
+                      : { sceneId: newComment.scene_id ?? '', sceneName: newComment.scene_id ?? '' },
                   }, notiSettings);
                 } else if (isAssignee) {
                   dispatchNotification({

--- a/src/components/NotificationPanel.tsx
+++ b/src/components/NotificationPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { Bell, Check, Trash2, MessageSquare, RefreshCw, Award } from 'lucide-react';
+import { Bell, Check, Trash2, MessageSquare, RefreshCw, Award, ExternalLink } from 'lucide-react';
 import { useNotificationStore, type AppNotification, type NotificationType } from '@/stores/useNotificationStore';
 import { useAppStore } from '@/stores/useAppStore';
 import { useDataStore } from '@/stores/useDataStore';
@@ -32,17 +32,24 @@ function typeConfig(type: NotificationType) {
 // ─── 알림 항목 ───────────────────────────────────────
 function NotificationItem({ n, onNavigate }: { n: AppNotification; onNavigate: (n: AppNotification) => void }) {
   const markAsRead = useNotificationStore((s) => s.markAsRead);
+  const removeNotification = useNotificationStore((s) => s.removeNotification);
   const cfg = typeConfig(n.type);
   const Icon = cfg.icon;
+  const hasNavigateTarget = !!(n.metadata?.sceneId || n.metadata?.sceneName);
+
+  const handleItemClick = () => {
+    if (!n.isRead) markAsRead(n.id);
+    onNavigate(n);
+  };
 
   return (
-    <button
-      onClick={() => {
-        if (!n.isRead) markAsRead(n.id);
-        onNavigate(n);
-      }}
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={handleItemClick}
+      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleItemClick(); } }}
       className={cn(
-        'w-full text-left px-3 py-2.5 flex gap-2.5 transition-colors cursor-pointer rounded-lg',
+        'group/noti relative w-full text-left px-3 py-2.5 flex gap-2.5 transition-colors cursor-pointer rounded-lg',
         n.isRead
           ? 'hover:bg-bg-border/15'
           : 'bg-accent/[0.08] hover:bg-accent/[0.12]',
@@ -71,7 +78,41 @@ function NotificationItem({ n, onNavigate }: { n: AppNotification; onNavigate: (
         )}
         <span className="text-[10px] text-text-secondary/50 mt-1 block">{timeAgo(n.createdAt)}</span>
       </div>
-    </button>
+
+      {/* 한솔 결정: 호버 시 우측에 [씬 보기 / 읽음 / 삭제] 액션 fade-in.
+          본문 클릭은 그대로 자동 (씬 이동 + 읽음). 액션 버튼은 stopPropagation 으로 분리. */}
+      <div className="absolute right-2 top-2 flex items-center gap-1 opacity-0 group-hover/noti:opacity-100 transition-opacity">
+        {hasNavigateTarget && (
+          <button
+            type="button"
+            title="씬 보기"
+            onClick={(e) => { e.stopPropagation(); handleItemClick(); }}
+            className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-[10.5px] font-medium bg-accent/15 text-accent-sub border border-accent/30 hover:bg-accent/25"
+          >
+            <ExternalLink size={10} />
+            <span>씬 보기</span>
+          </button>
+        )}
+        {!n.isRead && (
+          <button
+            type="button"
+            title="읽음 처리"
+            onClick={(e) => { e.stopPropagation(); markAsRead(n.id); }}
+            className="inline-flex items-center justify-center w-5 h-5 rounded text-[#00D9A0] bg-[#00D9A0]/10 border border-[#00D9A0]/30 hover:bg-[#00D9A0]/20"
+          >
+            <Check size={11} />
+          </button>
+        )}
+        <button
+          type="button"
+          title="삭제"
+          onClick={(e) => { e.stopPropagation(); removeNotification(n.id); }}
+          className="inline-flex items-center justify-center w-5 h-5 rounded text-[#FF7675] bg-[#FF7675]/10 border border-[#FF7675]/30 hover:bg-[#FF7675]/20"
+        >
+          <Trash2 size={11} />
+        </button>
+      </div>
+    </div>
   );
 }
 

--- a/src/components/NotificationPanel.tsx
+++ b/src/components/NotificationPanel.tsx
@@ -65,16 +65,19 @@ function NotificationItem({ n, onNavigate }: { n: AppNotification; onNavigate: (
         <Icon size={14} style={{ color: n.isRead ? 'rgb(var(--color-text-secondary) / 0.55)' : cfg.color }} />
       </div>
 
-      {/* 내용 */}
+      {/* 내용 — truncate 된 텍스트는 호버 시 GlobalTooltip 으로 전체 노출 */}
       <div className="flex-1 min-w-0">
-        <p className={cn(
-          'text-[12px] leading-tight truncate',
-          n.isRead ? 'text-text-secondary/80' : 'text-text-primary font-medium',
-        )}>
+        <p
+          title={n.title}
+          className={cn(
+            'text-[12px] leading-tight truncate',
+            n.isRead ? 'text-text-secondary/80' : 'text-text-primary font-medium',
+          )}
+        >
           {n.title}
         </p>
         {n.body && (
-          <p className="text-[11px] text-text-secondary/65 mt-0.5 truncate">{n.body}</p>
+          <p title={n.body} className="text-[11px] text-text-secondary/65 mt-0.5 truncate">{n.body}</p>
         )}
         <span className="text-[10px] text-text-secondary/50 mt-1 block">{timeAgo(n.createdAt)}</span>
       </div>
@@ -184,6 +187,13 @@ function NotificationDropdown() {
           }
         }
       }
+      // 매칭 실패 — 씬 뷰로만이라도 이동 + 안내 (한솔 결정: 알림 패널 씬 보기 무반응 fix)
+      console.warn('[NotificationPanel] 씬 매칭 실패', { sceneId, sceneName, episodeCount: episodes.length });
+      setView('scenes');
+      useAppStore.getState().setToast?.({
+        type: 'warning',
+        message: '씬을 자동으로 찾지 못했어요. 씬 뷰에서 직접 확인해주세요.',
+      });
     }
     setPanelOpen(false);
   };

--- a/src/components/NotificationPanel.tsx
+++ b/src/components/NotificationPanel.tsx
@@ -80,8 +80,9 @@ function NotificationItem({ n, onNavigate }: { n: AppNotification; onNavigate: (
       </div>
 
       {/* 한솔 결정: 호버 시 우측에 [씬 보기 / 읽음 / 삭제] 액션 fade-in.
-          본문 클릭은 그대로 자동 (씬 이동 + 읽음). 액션 버튼은 stopPropagation 으로 분리. */}
-      <div className="absolute right-2 top-2 flex items-center gap-1 opacity-0 group-hover/noti:opacity-100 transition-opacity">
+          본문 클릭은 그대로 자동 (씬 이동 + 읽음). 액션 버튼은 stopPropagation 으로 분리.
+          flex sibling 으로 두어 평소에도 영역만 차지 (opacity 0) → 본문 truncate 가 액션 영역까지 침범하지 않음. */}
+      <div className="flex items-center gap-1 self-start mt-0.5 flex-shrink-0 opacity-0 group-hover/noti:opacity-100 transition-opacity">
         {hasNavigateTarget && (
           <button
             type="button"

--- a/src/components/scenes/SceneSheetView.tsx
+++ b/src/components/scenes/SceneSheetView.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useMemo, useCallback, Fragment } from 'react';
 import { createPortal } from 'react-dom';
 import { motion } from 'framer-motion';
-import { MessageCircle, Trash2, ArrowUpRight } from 'lucide-react';
+import { MessageCircle, Trash2 } from 'lucide-react';
 import { STAGES, DEPARTMENT_CONFIGS } from '@/types';
 import type { Scene, Stage, Department } from '@/types';
 import type { SceneGroupMode } from '@/stores/useAppStore';
@@ -21,6 +21,8 @@ interface SceneSheetViewProps {
   searchQuery?: string;
   selectedSceneIds?: Set<string>;
   sceneGroupMode: SceneGroupMode;
+  /** 한솔 결정 (8번): 토스트 클릭 후 진입 시 강조할 sceneId */
+  highlightSceneId?: string | null;
   onToggle: (sceneId: string, stage: Stage) => void;
   onDelete: (sceneIndex: number) => void;
   onOpenDetail: (sceneIndex: number) => void;
@@ -283,6 +285,7 @@ export function SceneSheetView({
   searchQuery,
   selectedSceneIds,
   sceneGroupMode,
+  highlightSceneId,
   onToggle,
   onDelete,
   onOpenDetail,
@@ -622,6 +625,7 @@ export function SceneSheetView({
                       'hover:bg-accent/5',
                       isRowSelected && 'bg-accent/10 hover:bg-accent/15',
                       searchQuery && 'bg-accent/5 border-l-2 border-l-accent/60',
+                      highlightSceneId && scene.sceneId === highlightSceneId && 'scene-row-highlighted',
                     )}
                     onClick={(e) => {
                       if ((e.ctrlKey || e.metaKey) && onCtrlClick) {
@@ -630,14 +634,15 @@ export function SceneSheetView({
                     }}
                     onDoubleClick={() => onOpenDetail(idx)}
                   >
-                  {/* 씬번호 + 레이아웃 뱃지 + 댓글 뱃지 + 호버 시 ↗ */}
-                  <td className="px-2 py-1.5 font-mono text-xs text-accent group/scenecell">
-                    <span className="flex items-center gap-1.5">
-                      <HighlightText text={scene.sceneId || '-'} query={searchQuery} />
-                      <ArrowUpRight
-                        size={11}
-                        className="text-accent opacity-0 group-hover/scenecell:opacity-100 transition-opacity flex-shrink-0"
-                      />
+                  {/* 씬번호 + 레이아웃 뱃지 + 댓글 뱃지.
+                      한솔 결정 (5번): 1+3 합본 효과 — 텍스트 네온 펄스 + wrap 회전 보더. */}
+                  <td className="px-2 py-1.5 font-mono text-xs">
+                    <span className="flex items-center gap-2">
+                      <span className="scene-num-glow-wrap">
+                        <span className="scene-num-glow-text">
+                          <HighlightText text={scene.sceneId || '-'} query={searchQuery} />
+                        </span>
+                      </span>
                       {scene.layoutId && (
                         <span className="text-[11px] italic font-medium text-accent-sub flex-shrink-0">
                           L#{scene.layoutId}

--- a/src/components/scenes/SceneSheetView.tsx
+++ b/src/components/scenes/SceneSheetView.tsx
@@ -1,7 +1,7 @@
-import { useState, useRef, useEffect, useMemo, useCallback } from 'react';
+import { useState, useRef, useEffect, useMemo, useCallback, Fragment } from 'react';
 import { createPortal } from 'react-dom';
 import { motion } from 'framer-motion';
-import { MessageCircle, Trash2 } from 'lucide-react';
+import { MessageCircle, Trash2, ArrowUpRight } from 'lucide-react';
 import { STAGES, DEPARTMENT_CONFIGS } from '@/types';
 import type { Scene, Stage, Department } from '@/types';
 import type { SceneGroupMode } from '@/stores/useAppStore';
@@ -565,11 +565,8 @@ export function SceneSheetView({
           {/* ── 헤더 ── */}
           <thead className="sticky top-0 z-10">
             <tr className="bg-bg-card border-b border-bg-border">
-              {sceneGroupMode === 'layout' && (
-                <th className="w-20 px-2 py-2 text-left text-xs font-medium text-text-secondary border-r border-bg-border/50">
-                  레이아웃
-                </th>
-              )}
+              {/* 한솔 결정 (1-B): 레이아웃 별 보기 시 별도 컬럼 대신 행 위에 그룹 헤더 행을 삽입.
+                  컬럼 수가 일반 모드와 동일하게 유지된다. */}
               <th className="w-20 px-2 py-2 text-left text-xs font-medium text-text-secondary">씬번호</th>
               <th className="px-2 py-2 text-left text-xs font-medium text-text-secondary">메모</th>
               <th className="w-14 px-1 py-2 text-center text-xs font-medium text-text-secondary">스토리보드</th>
@@ -601,43 +598,51 @@ export function SceneSheetView({
               const layoutKey = meta?.layoutKey ?? '';
 
               return (
-                <motion.tr
-                  key={`${scene.sceneId}-${idx}`}
-                  initial={{ opacity: 0, y: 4 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.15, delay: Math.min(rowIndex * 0.01, 0.2) }}
-                  className={cn(
-                    'border-b border-bg-border/30 transition-colors group',
-                    rowIndex % 2 === 0 ? 'bg-bg-card/20' : 'bg-bg-primary/10',
-                    'hover:bg-accent/5',
-                    isRowSelected && 'bg-accent/10 hover:bg-accent/15',
-                    searchQuery && 'bg-accent/5 border-l-2 border-l-accent/60',
-                    sceneGroupMode === 'layout' && isFirstInGroup && rowIndex > 0 && 'border-t-2 border-t-bg-border',
-                  )}
-                  onClick={(e) => {
-                    if ((e.ctrlKey || e.metaKey) && onCtrlClick) {
-                      onCtrlClick(scene.sceneId);
-                    }
-                  }}
-                  onDoubleClick={() => onOpenDetail(idx)}
-                >
-                  {/* 레이아웃 병합 셀 */}
+                <Fragment key={`${scene.sceneId}-${idx}`}>
+                  {/* 한솔 결정 (1-B): 레이아웃 별 보기 시 그룹 시작 위에 헤더 행 삽입 (카드 뷰 섹션 스타일) */}
                   {sceneGroupMode === 'layout' && isFirstInGroup && (
-                    <td
-                      rowSpan={groupSize}
-                      className="px-2 py-2 text-center font-mono text-xs font-bold border-r border-bg-border/50 align-middle"
-                      style={{ color: deptConfig.color }}
-                    >
-                      {layoutKey !== '미분류' ? `#${layoutKey}` : (
-                        <span className="text-text-secondary/40 font-normal">-</span>
-                      )}
-                    </td>
+                    <tr className="bg-accent/8 border-y border-accent/30">
+                      <td colSpan={100} className="px-3 py-2">
+                        <span className="inline-flex items-center gap-2">
+                          <span className="text-sm font-bold text-accent">
+                            {layoutKey !== '미분류' ? `L#${layoutKey}` : '레이아웃 미분류'}
+                          </span>
+                          <span className="text-[11px] text-text-secondary">{groupSize}개 씬</span>
+                        </span>
+                      </td>
+                    </tr>
                   )}
-
-                  {/* 씬번호 + 댓글 뱃지 */}
-                  <td className="px-2 py-1.5 font-mono text-xs text-accent">
-                    <span className="flex items-center gap-1">
+                  <motion.tr
+                    initial={{ opacity: 0, y: 4 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.15, delay: Math.min(rowIndex * 0.01, 0.2) }}
+                    className={cn(
+                      'border-b border-bg-border/30 transition-colors group',
+                      rowIndex % 2 === 0 ? 'bg-bg-card/20' : 'bg-bg-primary/10',
+                      'hover:bg-accent/5',
+                      isRowSelected && 'bg-accent/10 hover:bg-accent/15',
+                      searchQuery && 'bg-accent/5 border-l-2 border-l-accent/60',
+                    )}
+                    onClick={(e) => {
+                      if ((e.ctrlKey || e.metaKey) && onCtrlClick) {
+                        onCtrlClick(scene.sceneId);
+                      }
+                    }}
+                    onDoubleClick={() => onOpenDetail(idx)}
+                  >
+                  {/* 씬번호 + 레이아웃 뱃지 + 댓글 뱃지 + 호버 시 ↗ */}
+                  <td className="px-2 py-1.5 font-mono text-xs text-accent group/scenecell">
+                    <span className="flex items-center gap-1.5">
                       <HighlightText text={scene.sceneId || '-'} query={searchQuery} />
+                      <ArrowUpRight
+                        size={11}
+                        className="text-accent opacity-0 group-hover/scenecell:opacity-100 transition-opacity flex-shrink-0"
+                      />
+                      {scene.layoutId && (
+                        <span className="text-[11px] italic font-medium text-accent-sub flex-shrink-0">
+                          L#{scene.layoutId}
+                        </span>
+                      )}
                       {(() => {
                         const cc = commentCounts[`${sheetName}:${scene.no}`];
                         return cc > 0 ? (
@@ -718,7 +723,8 @@ export function SceneSheetView({
                       <Trash2 size={13} />
                     </button>
                   </td>
-                </motion.tr>
+                  </motion.tr>
+                </Fragment>
               );
             })}
           </tbody>

--- a/src/components/scenes/SceneSheetView.tsx
+++ b/src/components/scenes/SceneSheetView.tsx
@@ -313,11 +313,16 @@ export function SceneSheetView({
   }, [scenes, sceneGroupMode]);
 
   const layoutMeta = useMemo(() => {
-    if (!layoutGroups) return new Map<Scene, { isFirst: boolean; groupSize: number; layoutKey: string }>();
-    const meta = new Map<Scene, { isFirst: boolean; groupSize: number; layoutKey: string }>();
+    if (!layoutGroups) return new Map<Scene, { isFirst: boolean; isLast: boolean; groupSize: number; layoutKey: string }>();
+    const meta = new Map<Scene, { isFirst: boolean; isLast: boolean; groupSize: number; layoutKey: string }>();
     for (const [layoutKey, groupScenes] of layoutGroups) {
       groupScenes.forEach((scene, i) => {
-        meta.set(scene, { isFirst: i === 0, groupSize: groupScenes.length, layoutKey });
+        meta.set(scene, {
+          isFirst: i === 0,
+          isLast: i === groupScenes.length - 1,
+          groupSize: groupScenes.length,
+          layoutKey,
+        });
       });
     }
     return meta;
@@ -597,15 +602,20 @@ export function SceneSheetView({
               const meta = layoutMeta.get(scene);
               const isRowSelected = selectedSceneIds?.has(scene.sceneId);
               const isFirstInGroup = meta?.isFirst ?? false;
+              const isLastInGroup = meta?.isLast ?? false;
               const groupSize = meta?.groupSize ?? 1;
               const layoutKey = meta?.layoutKey ?? '';
+              const isLayoutMode = sceneGroupMode === 'layout';
 
               return (
                 <Fragment key={`${scene.sceneId}-${idx}`}>
-                  {/* 한솔 결정 (1-B): 레이아웃 별 보기 시 그룹 시작 위에 헤더 행 삽입 (카드 뷰 섹션 스타일) */}
-                  {sceneGroupMode === 'layout' && isFirstInGroup && (
-                    <tr className="bg-accent/8 border-y border-accent/30">
-                      <td colSpan={100} className="px-3 py-2">
+                  {/* 한솔 결정 (1-B 시안 2 + 굵은 보더): 카드 박스 헤더 + 그룹 사이 빈 간격 */}
+                  {isLayoutMode && isFirstInGroup && rowIndex > 0 && (
+                    <tr className="scene-row-group-gap"><td colSpan={100}></td></tr>
+                  )}
+                  {isLayoutMode && isFirstInGroup && (
+                    <tr className="scene-group-header">
+                      <td colSpan={100}>
                         <span className="inline-flex items-center gap-2">
                           <span className="text-sm font-bold text-accent">
                             {layoutKey !== '미분류' ? `L#${layoutKey}` : '레이아웃 미분류'}
@@ -626,6 +636,8 @@ export function SceneSheetView({
                       isRowSelected && 'bg-accent/10 hover:bg-accent/15',
                       searchQuery && 'bg-accent/5 border-l-2 border-l-accent/60',
                       highlightSceneId && scene.sceneId === highlightSceneId && 'scene-row-highlighted',
+                      isLayoutMode && !isLastInGroup && 'scene-row-group-mid',
+                      isLayoutMode && isLastInGroup && 'scene-row-group-last',
                     )}
                     onClick={(e) => {
                       if ((e.ctrlKey || e.metaKey) && onCtrlClick) {

--- a/src/components/scenes/UnifiedSceneSheetView.tsx
+++ b/src/components/scenes/UnifiedSceneSheetView.tsx
@@ -315,11 +315,16 @@ export function UnifiedSceneSheetView({
   }, [layoutGroups, mergedScenes]);
 
   const layoutMeta = useMemo(() => {
-    if (!layoutGroups) return new Map<MergedScene, { isFirst: boolean; groupSize: number; layoutKey: string }>();
-    const meta = new Map<MergedScene, { isFirst: boolean; groupSize: number; layoutKey: string }>();
+    if (!layoutGroups) return new Map<MergedScene, { isFirst: boolean; isLast: boolean; groupSize: number; layoutKey: string }>();
+    const meta = new Map<MergedScene, { isFirst: boolean; isLast: boolean; groupSize: number; layoutKey: string }>();
     for (const [layoutKey, groupScenes] of layoutGroups) {
       groupScenes.forEach((m, i) => {
-        meta.set(m, { isFirst: i === 0, groupSize: groupScenes.length, layoutKey });
+        meta.set(m, {
+          isFirst: i === 0,
+          isLast: i === groupScenes.length - 1,
+          groupSize: groupScenes.length,
+          layoutKey,
+        });
       });
     }
     return meta;
@@ -648,8 +653,10 @@ export function UnifiedSceneSheetView({
               const meta = layoutMeta.get(m);
               const isRowSelected = selectedSceneIds.has(`bg:${mergedKey}`) || selectedSceneIds.has(`act:${mergedKey}`);
               const isFirstInGroup = meta?.isFirst ?? false;
+              const isLastInGroup = meta?.isLast ?? false;
               const groupSize = meta?.groupSize ?? 1;
               const layoutKey = meta?.layoutKey ?? '';
+              const isLayoutMode = sceneGroupMode === 'layout';
               // 한솔 결정 (8번): 토스트 클릭 후 진입 시 해당 행 빛남
               const isHighlighted = !!highlightSceneId && (
                 bgScene?.sceneId === highlightSceneId || actScene?.sceneId === highlightSceneId
@@ -665,10 +672,13 @@ export function UnifiedSceneSheetView({
 
               return (
                 <Fragment key={mergedKey}>
-                  {/* 한솔 결정 (1-B): 레이아웃 별 보기 시 그룹 시작 위에 헤더 행 삽입 (카드 뷰 섹션 스타일) */}
-                  {sceneGroupMode === 'layout' && isFirstInGroup && (
-                    <tr className="bg-accent/8 border-y border-accent/30">
-                      <td colSpan={100} className="px-3 py-2">
+                  {/* 한솔 결정 (1-B 시안 2 + 굵은 보더): 그룹 시작 위에 액센트 카드 박스 헤더 행 */}
+                  {isLayoutMode && isFirstInGroup && rowIndex > 0 && (
+                    <tr className="scene-row-group-gap"><td colSpan={100}></td></tr>
+                  )}
+                  {isLayoutMode && isFirstInGroup && (
+                    <tr className="scene-group-header">
+                      <td colSpan={100}>
                         <span className="inline-flex items-center gap-2">
                           <span className="text-sm font-bold text-accent">
                             {layoutKey !== '미분류' ? `L#${layoutKey}` : '레이아웃 미분류'}
@@ -689,6 +699,8 @@ export function UnifiedSceneSheetView({
                       isRowSelected && 'bg-accent/10 hover:bg-accent/15',
                       searchQuery && 'bg-accent/5 border-l-2 border-l-accent/60',
                       isHighlighted && 'scene-row-highlighted',
+                      isLayoutMode && !isLastInGroup && 'scene-row-group-mid',
+                      isLayoutMode && isLastInGroup && 'scene-row-group-last',
                     )}
                     onClick={(e) => {
                       if ((e.ctrlKey || e.metaKey) && onCtrlClick) {

--- a/src/components/scenes/UnifiedSceneSheetView.tsx
+++ b/src/components/scenes/UnifiedSceneSheetView.tsx
@@ -1,7 +1,7 @@
-import { useState, useRef, useEffect, useMemo, useCallback } from 'react';
+import { useState, useRef, useEffect, useMemo, useCallback, Fragment } from 'react';
 import { createPortal } from 'react-dom';
 import { motion } from 'framer-motion';
-import { MessageCircle, Trash2 } from 'lucide-react';
+import { MessageCircle, Trash2, ArrowUpRight } from 'lucide-react';
 import { STAGES, DEPARTMENT_CONFIGS } from '@/types';
 import type { MergedScene, Stage, Scene } from '@/types';
 import type { SceneGroupMode } from '@/stores/useAppStore';
@@ -591,11 +591,8 @@ export function UnifiedSceneSheetView({
               <th />
             </tr>
             <tr className="bg-bg-card border-b border-bg-border">
-              {sceneGroupMode === 'layout' && (
-                <th className="w-20 px-2 py-2 text-left text-xs font-medium text-text-secondary border-r border-bg-border/50">
-                  레이아웃
-                </th>
-              )}
+              {/* 한솔 결정 (1-B): 레이아웃 별 보기 시 별도 컬럼 대신 행 위에 그룹 헤더 행을 삽입.
+                  sceneGroupMode === 'layout' 컬럼 분기 제거 — 컬럼 수가 일반 모드와 동일하게 유지된다. */}
               <th className="w-20 px-2 py-2 text-left text-xs font-medium text-text-secondary">씬번호</th>
               <th className="px-2 py-2 text-left text-xs font-medium text-text-secondary">메모</th>
               <th className="w-14 px-1 py-2 text-center text-xs font-medium text-text-secondary">SB</th>
@@ -660,50 +657,60 @@ export function UnifiedSceneSheetView({
               );
 
               return (
-                <motion.tr
-                  key={mergedKey}
-                  initial={{ opacity: 0, y: 4 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.15, delay: Math.min(rowIndex * 0.01, 0.2) }}
-                  className={cn(
-                    'border-b border-bg-border/30 transition-colors group cursor-pointer',
-                    rowIndex % 2 === 0 ? 'bg-bg-card/20' : 'bg-bg-primary/10',
-                    'hover:bg-accent/5',
-                    isRowSelected && 'bg-accent/10 hover:bg-accent/15',
-                    searchQuery && 'bg-accent/5 border-l-2 border-l-accent/60',
-                    sceneGroupMode === 'layout' && isFirstInGroup && rowIndex > 0 && 'border-t-2 border-t-bg-border',
-                  )}
-                  onClick={(e) => {
-                    if ((e.ctrlKey || e.metaKey) && onCtrlClick) {
-                      onCtrlClick(mergedKey);
-                    }
-                  }}
-                  onDoubleClick={() => {
-                    // 통합 모달 콜백 우선 — BG+ACT 를 함께 열기
-                    if (onOpenMerged) {
-                      onOpenMerged(m);
-                      return;
-                    }
-                    if (bgScene && bgSheetName) onOpenDetail(bgSheetName, bgSceneIndex);
-                    else if (actScene && actSheetName) onOpenDetail(actSheetName, actSceneIndex);
-                  }}
-                >
-                  {/* 레이아웃 병합 셀 */}
+                <Fragment key={mergedKey}>
+                  {/* 한솔 결정 (1-B): 레이아웃 별 보기 시 그룹 시작 위에 헤더 행 삽입 (카드 뷰 섹션 스타일) */}
                   {sceneGroupMode === 'layout' && isFirstInGroup && (
-                    <td
-                      rowSpan={groupSize}
-                      className="px-2 py-2 text-center font-mono text-xs font-bold border-r border-bg-border/50 align-middle text-accent"
-                    >
-                      {layoutKey !== '미분류' ? `#${layoutKey}` : (
-                        <span className="text-text-secondary/40 font-normal">-</span>
-                      )}
-                    </td>
+                    <tr className="bg-accent/8 border-y border-accent/30">
+                      <td colSpan={100} className="px-3 py-2">
+                        <span className="inline-flex items-center gap-2">
+                          <span className="text-sm font-bold text-accent">
+                            {layoutKey !== '미분류' ? `L#${layoutKey}` : '레이아웃 미분류'}
+                          </span>
+                          <span className="text-[11px] text-text-secondary">{groupSize}개 씬</span>
+                        </span>
+                      </td>
+                    </tr>
                   )}
+                  <motion.tr
+                    initial={{ opacity: 0, y: 4 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.15, delay: Math.min(rowIndex * 0.01, 0.2) }}
+                    className={cn(
+                      'border-b border-bg-border/30 transition-colors group cursor-pointer',
+                      rowIndex % 2 === 0 ? 'bg-bg-card/20' : 'bg-bg-primary/10',
+                      'hover:bg-accent/5',
+                      isRowSelected && 'bg-accent/10 hover:bg-accent/15',
+                      searchQuery && 'bg-accent/5 border-l-2 border-l-accent/60',
+                    )}
+                    onClick={(e) => {
+                      if ((e.ctrlKey || e.metaKey) && onCtrlClick) {
+                        onCtrlClick(mergedKey);
+                      }
+                    }}
+                    onDoubleClick={() => {
+                      // 통합 모달 콜백 우선 — BG+ACT 를 함께 열기
+                      if (onOpenMerged) {
+                        onOpenMerged(m);
+                        return;
+                      }
+                      if (bgScene && bgSheetName) onOpenDetail(bgSheetName, bgSceneIndex);
+                      else if (actScene && actSheetName) onOpenDetail(actSheetName, actSceneIndex);
+                    }}
+                  >
 
-                  {/* 씬번호 + 댓글 뱃지 */}
-                  <td className="px-2 py-1.5 font-mono text-xs text-accent">
-                    <span className="flex items-center gap-1">
+                  {/* 씬번호 + 레이아웃 뱃지 + 댓글 뱃지 + 호버 시 ↗ (더블클릭 가능 어포던스) */}
+                  <td className="px-2 py-1.5 font-mono text-xs text-accent group/scenecell">
+                    <span className="flex items-center gap-1.5">
                       <HighlightText text={sceneId || primary.sceneId || '-'} query={searchQuery} />
+                      <ArrowUpRight
+                        size={11}
+                        className="text-accent opacity-0 group-hover/scenecell:opacity-100 transition-opacity flex-shrink-0"
+                      />
+                      {primary.layoutId && (
+                        <span className="text-[11px] italic font-medium text-accent-sub flex-shrink-0">
+                          L#{primary.layoutId}
+                        </span>
+                      )}
                       {commentBadgeCounts.total > 0 && (
                         <span className="inline-flex items-center gap-0.5 bg-accent/20 text-accent px-1 py-px rounded-full">
                           <MessageCircle size={9} fill="currentColor" />
@@ -848,7 +855,8 @@ export function UnifiedSceneSheetView({
                       )}
                     </div>
                   </td>
-                </motion.tr>
+                  </motion.tr>
+                </Fragment>
               );
             })}
           </tbody>

--- a/src/components/scenes/UnifiedSceneSheetView.tsx
+++ b/src/components/scenes/UnifiedSceneSheetView.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useMemo, useCallback, Fragment } from 'react';
 import { createPortal } from 'react-dom';
 import { motion } from 'framer-motion';
-import { MessageCircle, Trash2, ArrowUpRight } from 'lucide-react';
+import { MessageCircle, Trash2 } from 'lucide-react';
 import { STAGES, DEPARTMENT_CONFIGS } from '@/types';
 import type { MergedScene, Stage, Scene } from '@/types';
 import type { SceneGroupMode } from '@/stores/useAppStore';
@@ -23,6 +23,8 @@ interface UnifiedSceneSheetViewProps {
   searchQuery?: string;
   selectedSceneIds: Set<string>;
   sceneGroupMode: SceneGroupMode;
+  /** 한솔 결정 (8번): 토스트 클릭 후 시트 뷰 진입 시 강조할 sceneId */
+  highlightSceneId?: string | null;
   onToggle: (sheetName: string, sceneId: string, stage: Stage) => void;
   onDelete: (sheetName: string, sceneIndex: number) => void;
   onOpenDetail: (sheetName: string, sceneIndex: number) => void;
@@ -277,6 +279,7 @@ export function UnifiedSceneSheetView({
   searchQuery,
   selectedSceneIds,
   sceneGroupMode,
+  highlightSceneId,
   onToggle,
   onDelete,
   onOpenDetail,
@@ -647,6 +650,10 @@ export function UnifiedSceneSheetView({
               const isFirstInGroup = meta?.isFirst ?? false;
               const groupSize = meta?.groupSize ?? 1;
               const layoutKey = meta?.layoutKey ?? '';
+              // 한솔 결정 (8번): 토스트 클릭 후 진입 시 해당 행 빛남
+              const isHighlighted = !!highlightSceneId && (
+                bgScene?.sceneId === highlightSceneId || actScene?.sceneId === highlightSceneId
+              );
 
               const commentBadgeCounts = getMergedCommentBadgeCounts(
                 m,
@@ -681,6 +688,7 @@ export function UnifiedSceneSheetView({
                       'hover:bg-accent/5',
                       isRowSelected && 'bg-accent/10 hover:bg-accent/15',
                       searchQuery && 'bg-accent/5 border-l-2 border-l-accent/60',
+                      isHighlighted && 'scene-row-highlighted',
                     )}
                     onClick={(e) => {
                       if ((e.ctrlKey || e.metaKey) && onCtrlClick) {
@@ -698,14 +706,15 @@ export function UnifiedSceneSheetView({
                     }}
                   >
 
-                  {/* 씬번호 + 레이아웃 뱃지 + 댓글 뱃지 + 호버 시 ↗ (더블클릭 가능 어포던스) */}
-                  <td className="px-2 py-1.5 font-mono text-xs text-accent group/scenecell">
-                    <span className="flex items-center gap-1.5">
-                      <HighlightText text={sceneId || primary.sceneId || '-'} query={searchQuery} />
-                      <ArrowUpRight
-                        size={11}
-                        className="text-accent opacity-0 group-hover/scenecell:opacity-100 transition-opacity flex-shrink-0"
-                      />
+                  {/* 씬번호 + 레이아웃 뱃지 + 댓글 뱃지.
+                      한솔 결정 (5번): 1+3 합본 효과 — 텍스트 네온 펄스 + wrap 회전 보더. */}
+                  <td className="px-2 py-1.5 font-mono text-xs">
+                    <span className="flex items-center gap-2">
+                      <span className="scene-num-glow-wrap">
+                        <span className="scene-num-glow-text">
+                          <HighlightText text={sceneId || primary.sceneId || '-'} query={searchQuery} />
+                        </span>
+                      </span>
                       {primary.layoutId && (
                         <span className="text-[11px] italic font-medium text-accent-sub flex-shrink-0">
                           L#{primary.layoutId}

--- a/src/components/ui/GlobalTooltip.tsx
+++ b/src/components/ui/GlobalTooltip.tsx
@@ -64,17 +64,15 @@ export function GlobalTooltipProvider() {
       originalTitle.current = title;
       target.removeAttribute('title');
 
+      // 한솔 결정: 마우스 위치 따라가는 툴팁 (작업 진행 위젯과 동일 패턴)
+      const initialX = e.clientX;
+      const initialY = e.clientY;
       showTimer.current = setTimeout(() => {
-        const rect = target.getBoundingClientRect();
-        const centerX = rect.left + rect.width / 2;
-        // 위/아래 자동: 화면 상단 120px 이내면 아래, 그 외 위
-        const showBelow = rect.top < 120;
-        const y = showBelow ? rect.bottom + 8 : rect.top - 8;
-
+        const showBelow = initialY < 120;
         setTooltip({
           text: title,
-          x: centerX,
-          y,
+          x: initialX,
+          y: showBelow ? initialY + 16 : initialY - 12,
           position: showBelow ? 'bottom' : 'top',
         });
       }, SHOW_DELAY);
@@ -92,6 +90,26 @@ export function GlobalTooltipProvider() {
       }
     };
 
+    // 한솔 결정: 마우스 따라가는 툴팁 — currentEl 위에서 마우스 움직이면 위치 즉시 업데이트
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!currentEl.current) return;
+      const target = (e.target as HTMLElement)?.closest?.('[title]') as HTMLElement | null;
+      // 같은 currentEl 안이거나 자식 요소만 처리
+      if (target !== currentEl.current && !currentEl.current.contains(e.target as Node)) return;
+      const x = e.clientX;
+      const y = e.clientY;
+      setTooltip((prev) => {
+        if (!prev) return prev;
+        const showBelow = y < 120;
+        return {
+          text: prev.text,
+          x,
+          y: showBelow ? y + 16 : y - 12,
+          position: showBelow ? 'bottom' : 'top',
+        };
+      });
+    };
+
     const handleScroll = () => {
       clearTimeout(showTimer.current);
       setTooltip(null);
@@ -100,6 +118,7 @@ export function GlobalTooltipProvider() {
 
     document.addEventListener('mouseover', handleMouseOver, true);
     document.addEventListener('mouseout', handleMouseOut, true);
+    document.addEventListener('mousemove', handleMouseMove, true);
     document.addEventListener('scroll', handleScroll, true);
     document.addEventListener('mousedown', handleScroll, true);
 
@@ -109,6 +128,7 @@ export function GlobalTooltipProvider() {
       restoreTitle();
       document.removeEventListener('mouseover', handleMouseOver, true);
       document.removeEventListener('mouseout', handleMouseOut, true);
+      document.removeEventListener('mousemove', handleMouseMove, true);
       document.removeEventListener('scroll', handleScroll, true);
       document.removeEventListener('mousedown', handleScroll, true);
     };
@@ -118,9 +138,10 @@ export function GlobalTooltipProvider() {
     <AnimatePresence>
       {tooltip && (
         <motion.div
-          key={tooltip.text + tooltip.x}
-          initial={{ opacity: 0, scale: 0.92, y: tooltip.position === 'top' ? 4 : -4 }}
-          animate={{ opacity: 1, scale: 1, y: 0 }}
+          // 한솔 결정: text 만 key 로 — 마우스 따라 x/y 변경 시 re-mount 안 되고 style 만 갱신 (깜빡임 X)
+          key={tooltip.text}
+          initial={{ opacity: 0, scale: 0.92 }}
+          animate={{ opacity: 1, scale: 1 }}
           exit={{ opacity: 0, scale: 0.92 }}
           transition={{ duration: 0.12, ease: [0.2, 0, 0, 1] }}
           className="fixed z-[99999] pointer-events-none"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { WidgetPopup } from './views/WidgetPopup';
 import './index.css';
 import './styles/path-link.css';
 import './styles/activity-widget.css';
+import './styles/scene-effects.css';
 
 // 브라우저 개발 환경: electronAPI가 없으면 mock 설치
 if (!window.electronAPI && import.meta.env.DEV) {

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -21,13 +21,16 @@ export function setUsersSheetsMode(enabled: boolean): void {
 }
 
 // ─── 최초 사용자 (파일이 없을 때 자동 시드) ────
+// 비밀번호는 코드에 하드코딩하지 않는다 (production 번들에 평문 노출 방지).
+// 빈 사용자 목록에서 시드되더라도 빈 password 로는 로그인 매칭 불가 → Supabase Studio 에서 별도 설정.
+// 실 운영은 Supabase 사용자 row 가 살아있어 이 시드 fallback 자체가 거의 호출되지 않으므로 영향 없음.
 
 const SEED_USER: AppUser = {
   id: '00000000-0000-0000-0000-000000000001',
   name: '배한솔',
   slackId: 'U05DFV9UAN5',
-  password: '1q2w3e4r!A',
-  isInitialPassword: false,
+  password: '',
+  isInitialPassword: true,
   createdAt: '2025-01-01T00:00:00.000Z',
   role: 'admin',
 };

--- a/src/stores/useNotificationStore.ts
+++ b/src/stores/useNotificationStore.ts
@@ -49,6 +49,7 @@ interface NotificationState {
   addNotification: (n: Omit<AppNotification, 'id' | 'createdAt' | 'isRead'>) => void;
   markAsRead: (id: string) => void;
   markAllAsRead: () => void;
+  removeNotification: (id: string) => void;
   clearAll: () => void;
   setPanelOpen: (open: boolean) => void;
   togglePanel: () => void;
@@ -94,6 +95,12 @@ export const useNotificationStore = create<NotificationState>((set, get) => ({
 
   markAllAsRead: () => {
     const next = get().notifications.map((n) => ({ ...n, isRead: true }));
+    setNotifications(set, next);
+    persistToDisk(next);
+  },
+
+  removeNotification: (id) => {
+    const next = get().notifications.filter((n) => n.id !== id);
     setNotifications(set, next);
     persistToDisk(next);
   },

--- a/src/styles/scene-effects.css
+++ b/src/styles/scene-effects.css
@@ -1,0 +1,137 @@
+/**
+ * 시트 뷰 씬 번호 빛나는 효과 + 행 하이라이트
+ *
+ * (5) 한솔 결정: 시안 1 (네온 펄스) + 시안 3 (회전 보더) 합본
+ * (8) 토스트 '씬 보기' 클릭 후 시트 뷰 행 하이라이트 — 동일 톤
+ */
+
+/* CSS @property 등록 — conic-gradient 회전 애니메이션용 */
+@property --scene-effect-angle {
+  syntax: '<angle>';
+  initial-value: 0deg;
+  inherits: false;
+}
+
+/* ── 5번: 씬 번호 wrap (보더 회전) ── */
+.scene-num-glow-wrap {
+  position: relative;
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 7px;
+  isolation: isolate;
+  cursor: pointer;
+}
+
+.scene-num-glow-wrap::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  padding: 1.5px;
+  border-radius: 7px;
+  background: conic-gradient(
+    from var(--scene-effect-angle),
+    rgb(var(--color-accent)),
+    rgb(var(--color-accent-sub)),
+    rgb(var(--color-accent) / 1.0),
+    rgb(var(--color-accent-sub)),
+    rgb(var(--color-accent))
+  );
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+          mask-composite: exclude;
+  animation: scene-effect-rotate 3s linear infinite;
+  opacity: 0.55;
+  transition: opacity 0.3s, filter 0.3s;
+  pointer-events: none;
+}
+
+.scene-num-glow-wrap:hover::before {
+  opacity: 1;
+  animation-duration: 1.2s;
+  filter: blur(0.5px);
+}
+
+/* ── 5번: 씬 번호 텍스트 (네온 펄스) ── */
+.scene-num-glow-text {
+  color: rgb(var(--color-accent));
+  text-shadow:
+    0 0 4px rgb(var(--color-accent) / 0.6),
+    0 0 12px rgb(var(--color-accent) / 0.3);
+  animation: scene-effect-pulse 2.4s ease-in-out infinite;
+  transition: color 0.3s, text-shadow 0.3s;
+}
+
+.scene-num-glow-wrap:hover .scene-num-glow-text {
+  color: rgb(var(--color-accent-sub));
+  text-shadow:
+    0 0 6px rgb(var(--color-accent-sub) / 1.0),
+    0 0 18px rgb(var(--color-accent) / 0.8),
+    0 0 32px rgb(var(--color-accent) / 0.4);
+}
+
+@keyframes scene-effect-rotate {
+  to { --scene-effect-angle: 360deg; }
+}
+
+@keyframes scene-effect-pulse {
+  0%, 100% {
+    text-shadow:
+      0 0 4px rgb(var(--color-accent) / 0.5),
+      0 0 10px rgb(var(--color-accent) / 0.25);
+  }
+  50% {
+    text-shadow:
+      0 0 8px rgb(var(--color-accent) / 0.8),
+      0 0 18px rgb(var(--color-accent) / 0.45);
+  }
+}
+
+/* ── 8번: 시트 뷰 행 하이라이트 (토스트 → 모달 이동 시 강조) ──
+ * 적용 클래스: <tr> 에 .scene-row-highlighted 추가.
+ * 약 4.8초간 펄스 (2회) 후 자체 가라앉음. JS 측에서 setTimeout 으로 클래스 제거.
+ */
+.scene-row-highlighted {
+  position: relative;
+  isolation: isolate;
+  animation: scene-row-pulse 2.4s ease-in-out 2;
+  background: rgb(var(--color-accent) / 0.08) !important;
+}
+
+.scene-row-highlighted > td {
+  background: rgb(var(--color-accent) / 0.08) !important;
+  position: relative;
+}
+
+.scene-row-highlighted > td:first-child::before {
+  content: '';
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  width: 3px;
+  background: linear-gradient(
+    180deg,
+    rgb(var(--color-accent)),
+    rgb(var(--color-accent-sub)),
+    rgb(var(--color-accent))
+  );
+  animation: scene-row-side-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes scene-row-pulse {
+  0%, 100% {
+    box-shadow:
+      inset 0 0 0 1.5px transparent,
+      0 0 8px rgb(var(--color-accent) / 0.3);
+  }
+  50% {
+    box-shadow:
+      inset 0 0 0 1.5px rgb(var(--color-accent) / 0.5),
+      0 0 24px rgb(var(--color-accent) / 0.6);
+  }
+}
+
+@keyframes scene-row-side-pulse {
+  0%, 100% { opacity: 0.6; }
+  50% { opacity: 1; }
+}

--- a/src/styles/scene-effects.css
+++ b/src/styles/scene-effects.css
@@ -135,3 +135,49 @@
   0%, 100% { opacity: 0.6; }
   50% { opacity: 1; }
 }
+
+/* ── 1-B: 레이아웃별 보기 카드 박스 + 굵은 보더 (한솔 시안 2 + 굵은 보더) ──
+ * table 분리 없이 한 table 안에서 카드 느낌을 표현:
+ * - 그룹 헤더 행: 진한 액센트 배경 + 위쪽 3px 굵은 액센트 보더
+ * - 그룹 마지막 행: 아래쪽 3px 굵은 액센트 보더 + 추가 padding
+ * - 행 양쪽: 얇은 액센트 보더로 카드 가장자리 흉내
+ */
+.scene-group-header > td {
+  background: rgb(var(--color-accent) / 0.18) !important;
+  border-top: 3px solid rgb(var(--color-accent) / 0.85) !important;
+  padding: 10px 12px !important;
+}
+.scene-group-header > td:first-child {
+  border-left: 2px solid rgb(var(--color-accent) / 0.6) !important;
+}
+.scene-group-header > td:last-child {
+  border-right: 2px solid rgb(var(--color-accent) / 0.6) !important;
+}
+
+.scene-row-group-mid > td:first-child {
+  border-left: 2px solid rgb(var(--color-accent) / 0.6) !important;
+}
+.scene-row-group-mid > td:last-child {
+  border-right: 2px solid rgb(var(--color-accent) / 0.6) !important;
+}
+
+.scene-row-group-last > td {
+  border-bottom: 3px solid rgb(var(--color-accent) / 0.85) !important;
+  padding-bottom: 10px !important;
+}
+.scene-row-group-last > td:first-child {
+  border-left: 2px solid rgb(var(--color-accent) / 0.6) !important;
+  border-bottom-left-radius: 6px;
+}
+.scene-row-group-last > td:last-child {
+  border-right: 2px solid rgb(var(--color-accent) / 0.6) !important;
+  border-bottom-right-radius: 6px;
+}
+
+/* 그룹 사이 간격 — 빈 행으로 카드 분리감 */
+.scene-row-group-gap > td {
+  height: 14px !important;
+  padding: 0 !important;
+  border: none !important;
+  background: transparent !important;
+}

--- a/src/utils/notificationHelper.ts
+++ b/src/utils/notificationHelper.ts
@@ -36,7 +36,13 @@ function navigateToScene(sceneUuid?: string, sceneName?: string) {
       }
     }
   }
-  // 매칭 실패 — 씬 뷰로만이라도 이동 (silent return 대신)
+  // 매칭 실패 — 씬 뷰로만이라도 이동 + 디버그 로그 (한솔이 콘솔에서 원인 파악 가능)
+  console.warn('[navigateToScene] 매칭 실패', {
+    sceneUuid,
+    sceneName,
+    episodeCount: episodes.length,
+    sampleSceneIds: episodes[0]?.parts[0]?.scenes.slice(0, 3).map((s) => ({ id: s.id, sceneId: s.sceneId })),
+  });
   useAppStore.getState().setView('scenes');
   useAppStore.getState().setToast?.({
     type: 'warning',

--- a/src/utils/notificationHelper.ts
+++ b/src/utils/notificationHelper.ts
@@ -49,14 +49,13 @@ export function dispatchNotification(payload: NotifyPayload, settings?: Notifica
   const canNavigate = !!(sceneId || sceneName);
 
   // 1. Sonner 토스트 (기본 스타일)
-  // 한솔 결정 (8번): 라벨 '씬 보기' → '확인' (간결). 동작은 동일하게 씬 모달로 포커스 이동.
-  // 토스트 노출 시간을 8초로 늘려 한솔이 충분히 인지할 시간 확보.
+  // 라벨 '씬 보기' 그대로 유지. 노출 시간 8초로 늘려 한솔이 인지할 시간 확보.
   sonnerToast(payload.title, {
     description: payload.body,
     duration: 8000,
     ...(canNavigate && {
       action: {
-        label: '확인',
+        label: '씬 보기',
         onClick: () => navigateToScene(sceneId, sceneName),
       },
     }),

--- a/src/utils/notificationHelper.ts
+++ b/src/utils/notificationHelper.ts
@@ -18,7 +18,8 @@ export interface NotificationSettings {
   sound?: boolean;
 }
 
-/** 씬 UUID로 해당 에피소드 번호를 찾아 씬 뷰로 이동 */
+/** 씬 UUID/이름으로 해당 에피소드 번호를 찾아 씬 뷰로 이동.
+ *  매칭 실패 시 fallback: 씬 뷰로만이라도 이동 + 안내 토스트 (한솔이 직접 찾을 수 있게). */
 function navigateToScene(sceneUuid?: string, sceneName?: string) {
   if (!sceneUuid && !sceneName) return;
   const episodes = useDataStore.getState().episodes;
@@ -35,6 +36,12 @@ function navigateToScene(sceneUuid?: string, sceneName?: string) {
       }
     }
   }
+  // 매칭 실패 — 씬 뷰로만이라도 이동 (silent return 대신)
+  useAppStore.getState().setView('scenes');
+  useAppStore.getState().setToast?.({
+    type: 'warning',
+    message: '씬을 자동으로 찾지 못했어요. 씬 뷰에서 직접 확인해주세요.',
+  });
 }
 
 /**

--- a/src/utils/notificationHelper.ts
+++ b/src/utils/notificationHelper.ts
@@ -49,11 +49,14 @@ export function dispatchNotification(payload: NotifyPayload, settings?: Notifica
   const canNavigate = !!(sceneId || sceneName);
 
   // 1. Sonner 토스트 (기본 스타일)
+  // 한솔 결정 (8번): 라벨 '씬 보기' → '확인' (간결). 동작은 동일하게 씬 모달로 포커스 이동.
+  // 토스트 노출 시간을 8초로 늘려 한솔이 충분히 인지할 시간 확보.
   sonnerToast(payload.title, {
     description: payload.body,
+    duration: 8000,
     ...(canNavigate && {
       action: {
-        label: '씬 보기',
+        label: '확인',
         onClick: () => navigateToScene(sceneId, sceneName),
       },
     }),

--- a/src/utils/scenesViewPersist.ts
+++ b/src/utils/scenesViewPersist.ts
@@ -1,0 +1,64 @@
+/**
+ * 씬 뷰 마지막 상태 영속화 — 사용자가 떠났다가 돌아와도 직전에 보던 상태로 복원.
+ *
+ * 저장 항목 (모두 localStorage 단일 키):
+ * - 뷰 모드 ('card' | 'sheet')
+ * - 마지막 본 에피소드 번호
+ * - 트리 펼침 여부
+ *
+ * 단일 사용자 PC 환경이라 사용자별 분리 불필요. try/catch 로 localStorage 비활성 환경(개인정보보호 모드 등) 무시.
+ */
+
+const KEYS = {
+  viewMode: 'bflow_scenes_view_mode',
+  lastEpisode: 'bflow_scenes_last_episode',
+  treeOpen: 'bflow_scenes_tree_open',
+} as const;
+
+export type SceneViewMode = 'card' | 'sheet';
+
+export function loadPersistedSceneViewMode(): SceneViewMode | null {
+  try {
+    const v = localStorage.getItem(KEYS.viewMode);
+    return v === 'card' || v === 'sheet' ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+export function savePersistedSceneViewMode(mode: SceneViewMode): void {
+  try { localStorage.setItem(KEYS.viewMode, mode); } catch { /* ignore */ }
+}
+
+export function loadPersistedLastEpisode(): number | null {
+  try {
+    const raw = localStorage.getItem(KEYS.lastEpisode);
+    if (raw === null || raw === '') return null;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+export function savePersistedLastEpisode(ep: number | null): void {
+  try {
+    if (ep === null) localStorage.removeItem(KEYS.lastEpisode);
+    else localStorage.setItem(KEYS.lastEpisode, String(ep));
+  } catch { /* ignore */ }
+}
+
+export function loadPersistedTreeOpen(): boolean | null {
+  try {
+    const v = localStorage.getItem(KEYS.treeOpen);
+    if (v === '1') return true;
+    if (v === '0') return false;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function savePersistedTreeOpen(open: boolean): void {
+  try { localStorage.setItem(KEYS.treeOpen, open ? '1' : '0'); } catch { /* ignore */ }
+}

--- a/src/views/ScenesView.tsx
+++ b/src/views/ScenesView.tsx
@@ -3547,6 +3547,7 @@ export function ScenesView() {
                 searchQuery={searchQuery}
                 selectedSceneIds={selectedSceneIds}
                 sceneGroupMode={sceneGroupMode}
+                highlightSceneId={highlightSceneId}
                 onToggle={(sheet, id, stage) => handleToggleForSheet(sheet, id, stage)}
                 onDelete={(sheet, idx) => handleDeleteSceneForSheet(sheet, idx)}
                 onOpenDetail={(sheet, idx) => { setDetailContext({ sheetName: sheet, sceneIndex: idx }); setDetailSceneIndex(idx); }}
@@ -3700,6 +3701,7 @@ export function ScenesView() {
                   searchQuery={searchQuery}
                   selectedSceneIds={selectedSceneIds}
                   sceneGroupMode="layout"
+                  highlightSceneId={highlightSceneId}
                   onToggle={handleToggle}
                   onDelete={handleDeleteScene}
                   onOpenDetail={(idx) => setDetailSceneIndex(idx)}
@@ -3800,6 +3802,7 @@ export function ScenesView() {
                 searchQuery={searchQuery}
                 selectedSceneIds={selectedSceneIds}
                 sceneGroupMode="flat"
+                highlightSceneId={highlightSceneId}
                 onToggle={handleToggle}
                 onDelete={handleDeleteScene}
                 onOpenDetail={(idx) => setDetailSceneIndex(idx)}

--- a/src/views/ScenesView.tsx
+++ b/src/views/ScenesView.tsx
@@ -665,6 +665,11 @@ import { Confetti } from '@/components/ui/Confetti';
 import { SceneDetailModal } from '@/components/scenes/SceneDetailModal';
 import { GlassDropdown } from '@/components/common/GlassDropdown';
 import { PanelLeftOpen } from 'lucide-react';
+import {
+  loadPersistedSceneViewMode, savePersistedSceneViewMode,
+  loadPersistedLastEpisode, savePersistedLastEpisode,
+  loadPersistedTreeOpen, savePersistedTreeOpen,
+} from '@/utils/scenesViewPersist';
 
 // ─── 씬 카드 (요약 카드 — 클릭으로 상세 모달 열기) ──────────────
 
@@ -755,7 +760,7 @@ function SceneCard({ scene, sceneIndex, celebrating, department, isHighlighted, 
             <HighlightText text={scene.sceneId || '(씬번호 없음)'} query={searchQuery} />
           </span>
           {scene.layoutId && (
-            <span className="text-[11px] italic text-text-secondary/50 shrink-0">
+            <span className="text-[12px] italic font-medium text-accent-sub shrink-0">
               L#{scene.layoutId}
             </span>
           )}
@@ -1502,7 +1507,35 @@ export function ScenesView() {
   const [celebratingId, setCelebratingId] = useState<string | null>(null);
   const [batchEditOpen, setBatchEditOpen] = useState(false);
   const [batchAssigneeValue, setBatchAssigneeValue] = useState('');
-  const [treeOpen, setTreeOpen] = useState(true);
+  // treeOpen 초기값 — 영속화된 값이 있으면 그걸로, 없으면 true (디폴트 펼침)
+  const [treeOpen, setTreeOpen] = useState(() => loadPersistedTreeOpen() ?? true);
+
+  // 마운트 시 / episodes 가 처음 채워지는 시점에 영속화된 상태(viewMode + lastEpisode) 1회 복원.
+  // ref guard 로 한솔이 직접 변경한 값이 첫 마운트 때 saved 로 되돌아가지 않게 보장.
+  const persistRestoredRef = useRef(false);
+  useEffect(() => {
+    if (persistRestoredRef.current) return;
+    if (episodes.length === 0) return; // episodes 가 늦게 로드될 때까지 대기
+
+    const savedMode = loadPersistedSceneViewMode();
+    if (savedMode) setSceneViewMode(savedMode);
+
+    const savedEp = loadPersistedLastEpisode();
+    if (savedEp !== null && episodes.some((ep) => ep.episodeNumber === savedEp)) {
+      setSelectedEpisode(savedEp);
+    }
+
+    persistRestoredRef.current = true;
+  }, [episodes, setSceneViewMode, setSelectedEpisode]);
+
+  // 변화 감지 → 즉시 영속화. 디폴트 값일 때 호출되어도 무해.
+  useEffect(() => { savePersistedSceneViewMode(sceneViewMode); }, [sceneViewMode]);
+  useEffect(() => {
+    if (selectedEpisode !== null && selectedEpisode !== undefined) {
+      savePersistedLastEpisode(selectedEpisode);
+    }
+  }, [selectedEpisode]);
+  useEffect(() => { savePersistedTreeOpen(treeOpen); }, [treeOpen]);
 
   // 파트 컨텍스트 메뉴
   const { menuPosition: partMenuPos, openMenu: openPartMenu, closeMenu: closePartMenu } = useContextMenu();
@@ -3242,25 +3275,10 @@ export function ScenesView() {
           </div>
         </div>
 
-        {/* 2줄: 보기 설정 (담당자 + 상태 필터 + 정렬 + 뷰모드 + 검색) */}
+        {/* 2줄: 보기 설정 (담당자 + 상태 필터 + 정렬 + 뷰모드 + 검색)
+            한솔 결정: 옵션 접기 = 완전 숨김 (요약 칩 라인 제거). 펼치기 시 다시 표시. */}
         <AnimatePresence initial={false} mode="wait">
-          {sceneControlsCollapsed ? (
-            <motion.div
-              key="scene-controls-collapsed"
-              initial={{ opacity: 0, height: 0, y: -6 }}
-              animate={{ opacity: 1, height: 'auto', y: 0 }}
-              exit={{ opacity: 0, height: 0, y: -6 }}
-              transition={{ duration: 0.2, ease: 'easeOut' }}
-              className="overflow-hidden"
-            >
-              <div className="flex flex-wrap items-center gap-2 rounded-lg border border-bg-border/50 bg-bg-primary/20 px-3 py-2">
-                <span className="text-[11px] font-medium tracking-[0.18em] text-text-secondary/60">현재 옵션</span>
-                {sceneControlsSummary.map((item) => (
-                  <SceneOptionSummaryChip key={item.label} label={item.label} value={item.value} />
-                ))}
-              </div>
-            </motion.div>
-          ) : (
+          {sceneControlsCollapsed ? null : (
             <motion.div
               key="scene-controls-expanded"
               initial={{ opacity: 0, height: 0, y: -6 }}


### PR DESCRIPTION
## 📋 업데이트 요약

> 이번 업데이트에서 달라진 점을 간략하게 정리했습니다.

- 🛡️ **[보안]** 빌드된 \`.exe\` 안에 한솔 admin 의 옛 password 가 평문으로 들어가 있던 문제 수정 (다음 빌드부터 깨끗)
- 📐 **시트 뷰에 레이아웃 번호가 셀마다 보이고**, 레이아웃별 보기는 *카드 박스* 처럼 섹션이 명확히 분리됨
- 💾 **씬 뷰 진입 시 마지막 상태 그대로** — 뷰 모드(카드/시트) + 마지막 에피소드 + 트리 펼침/접힘 자동 복원
- ✨ **시트 뷰 씬 번호에 마우스 올리면 글자가 빛나며 보더가 회전** — "더블클릭으로 상세 모달" 단서
- ⬇️ **상단바 옵션 접기 = 완전 숨김** — 요약 칩 라인까지 사라짐
- 💬 **댓글 알림 토스트** — 멘션/담당 씬 댓글 도착 시 8초 노출 + '씬 보기' 클릭 → 시트 뷰 진입 시 *해당 행이 빛남*
- 🔔 **알림 패널에 호버 액션 3종** — [씬 보기 / 읽음 / 삭제] 버튼이 마우스 올릴 때 부드럽게 등장
- 🎯 **알림/툴팁 시스템 정밀화** — 댓글 씬 매칭 정확화, GlobalTooltip 이 마우스 따라 자연스럽게 이동, 잘린 텍스트 호버 시 전체 노출

## 🔧 상세 기술 설명

### 🅐 시트 뷰 레이아웃 표시 정상화 (3가지)

#### 1-A. 셀에 \`L#레이아웃\` 항상 표시
- 기존: \`sceneGroupMode === 'layout'\` 일 때만 별도 컬럼/rowspan
- 변경: 시트 행의 *씬번호 셀 안* 에 작은 italic 뱃지로 항상 표시 (sceneGroupMode 무관)
- \`UnifiedSceneSheetView.tsx\` + \`SceneSheetView.tsx\` 둘 다 적용

#### 1-B. 레이아웃별 보기 = 카드 박스 + 굵은 보더 (한솔 시안 2 + 굵은 보더)
- 그룹 헤더에 위쪽 3px 굵은 액센트 보더 + 진한 액센트 배경
- 그룹 마지막 행에 아래쪽 3px 굵은 보더 + 둥근 모서리 + 양쪽 보더
- 그룹 사이 14px 빈 행 → 카드 분리감
- \`scene-effects.css\` 의 \`.scene-group-header / .scene-row-group-mid / .scene-row-group-last / .scene-row-group-gap\` 클래스
- layoutMeta 에 \`isLast\` 추가, motion.tr className 분기

#### 1-C. layoutId 라벨 가시성 강화
- \`text-text-secondary/50 italic 11px\` → \`text-accent-sub italic 12px font-medium\`
- 카드/시트 뷰 일관 적용

### 🅑 마지막 상태 기억 (\`src/utils/scenesViewPersist.ts\`)
- 신규 유틸 + ScenesView 통합
- \`bflow_scenes_view_mode\` / \`bflow_scenes_last_episode\` / \`bflow_scenes_tree_open\` 3개 키
- 마운트 시 \`useRef\` guard 로 episodes 채워진 시점 1회 복원
- 변경 감지 useEffect 3개로 즉시 저장. localStorage 비활성 환경 try/catch

### 🅒 시트 뷰 씬 번호 효과 — 시안 1+3 합본 (네온 펄스 + 회전 보더)
- \`@property --scene-effect-angle\` 등록으로 conic-gradient 회전 애니메이션
- 평소: 보더 3s 회전 + 글자 2.4s 펄스
- 호버: 보더 1.2s 가속 + 3겹 text-shadow 글로우
- ↗ ArrowUpRight 아이콘 제거, 씬 번호 wrap 자체가 효과

### 🅓 상단바 옵션 접기 = 완전 숨김
- \`ScenesView.tsx:3247-3262\` collapsed 분기를 \`null\` 로 변경. 요약 칩 라인 제거
- AnimatePresence 그대로 유지, 펼치기 애니메이션 보존

### 🅔 댓글 토스트 + 행 하이라이트 + 알림 패널 강화

**1) 토스트**: 라벨 \`씬 보기\` + duration 8초

**2) 시트 뷰 행 하이라이트**: 토스트 클릭 → 마지막 뷰가 시트 뷰면 해당 행이 좌측 보라 그라데이션 막대 + 행 글로우 펄스 (2회, 약 4.8초)

**3) 알림 패널 호버 액션 (시안 1)**:
- 평소엔 깔끔, 호버 시 우측에 \`[씬 보기 / Check / Trash2]\` lucide 아이콘 fade-in
- \`flex sibling + opacity\` 패턴 — 본문 truncate 가 액션 영역 침범 안 함 (이전 absolute 시 텍스트 간섭 문제 해결)
- \`useNotificationStore.removeNotification(id)\` 신규 추가

**4) 본인 멘션 테스트 분기**: \`user_id !== me.id\` 임시 제거 (한솔 테스트용)

### 🅕 SEED_USER 보안 hotfix (작업 중 발견)
- \`userService.ts\` 의 \`SEED_USER.password='1q2w3e4r!A'\` → \`''\` (빈값)
- \`isInitialPassword=true\` 변경
- production 빌드 검증: main entry chunk 에 실 password 0 매치 ✅

### 🎯 알림/툴팁 정밀화 (작업 중 추가)

#### 1. 댓글 알림 씬 매칭 정상화
한솔 디버그 로그로 발견: \`comments.scene_id\` 컬럼이 *씬 UUID 가 아닌 sort_order(no)*. 코드 주석에 명시되어 있음 (\`electron/supabase.ts:857-859\`). 별도 \`scene_uuid\` 컬럼이 있어 정확 매칭 가능.
- App.tsx 댓글 Realtime 분기에서 scene 검색을 2단계로:
  1) \`scene_uuid\` → \`findSceneByUuid\`
  2) fallback: \`part_id + scene_id(no)\` 조합으로 episodes 트리 직접 검색
- scene 못 찾으면 metadata=undefined → \`씬 보기\` 버튼 비활성 (헛수고 클릭 방지)
- 매칭 실패 시 console.warn 로 sceneUuid/sceneName + episodes 샘플 출력 (디버그)

#### 2. GlobalTooltip 마우스 따라가기 (작업 진행 위젯 패턴)
- \`handleMouseMove\` 신규: currentEl 위 마우스 이동 시 위치 즉시 업데이트
- 시작 위치 \`getBoundingClientRect\` → \`e.clientX/clientY\` 마우스 좌표
- motion.div key 를 \`text\` 만으로 (x/y 변경 시 re-mount 안 됨, 깜빡임 X)
- 캘린더 등 모든 \`[title]\` 요소 자동 적용

#### 3. 알림 텍스트 \`...\` 호버 툴팁
- NotificationItem 의 title/body \`<p>\` 에 \`title\` 속성 추가 → GlobalTooltip 자동 인터셉트
- truncate 된 본문도 호버 시 전체 노출

#### 4. NotificationDropdown 씬 보기 무반응 fix
- 매칭 실패 시 silent return 대신 *씬 뷰로 이동 + 안내 토스트 + console.warn*

## 🚧 개발 난항

### 9번(미리보기 모드) 폐기 결정
9번 작업 중 SEED_USER 평문 노출 발견. 9번 자체는 한솔 결정으로 폐기 (PR #42), SEED_USER hotfix 만 본 PR 에 포함.

### 1+6번 의도 명확화 3회
- 1차: 단순 스타일 강화로 이해
- 2차: 한솔 명확화로 *3가지 변경* 임을 파악 (셀 표시 + 카드 스타일 그룹핑 + 라벨 강화)
- 3차: 카드 스타일이 *충분히 분리되지 않아* 시안 5개 추가 제시 → 시안 2 (카드 박스) + 굵은 보더로 결정

### 5번 시안 6개 → 1+3 합본 결정
시안 6개 비교 후 한솔이 1(네온 펄스) + 3(회전 보더) 합본 선택. 그것으로 행 하이라이트도 매칭 톤 통일.

### 토스트 씬 매칭 디버그 — 정답이 댓글 코드 주석에
처음에 metadata sceneId/sceneName 양쪽에 \`newComment.scene_id\` fallback 채웠으나 매칭 실패. 한솔 콘솔 로그 \`{sceneId:'1', sceneName:'1'}\` 보고 \`comments.scene_id\` 가 *sort_order* 임을 \`electron/supabase.ts\` 주석에서 발견. 정확한 매칭은 \`scene_uuid\` + \`part_id + scene.no\` 조합.

### 알림 텍스트 vs 액션 버튼 간섭
액션 그룹을 \`absolute right-2 top-2\` 로 띄웠더니 본문 truncate 가 우측 끝까지 차지해 글자가 가려짐. \`flex sibling + opacity\` 패턴으로 변경 → 영역만 차지 + 호버 시 자연스러운 fade-in.

## ✅ 테스트 가이드

### 사용자 테스트

> 한솔님이 직접 다음 시나리오를 확인해주세요.

1. **🛡️ 즉시 (PR 머지 전)**: Supabase Studio 또는 앱 안에서 *실 admin 비밀번호* 를 새 강한 값으로 변경

2. **시트 뷰 레이아웃 표시**:
   - 씬 뷰 → 시트 뷰 모드
   - ✅ 각 씬 행의 씬번호 옆에 \`L#XXXX\` 라벨 (액센트색 italic) 표시
   - 그룹핑 \`레이아웃별\` 변경 → ✅ \`L#XX (n개 씬)\` 헤더 + 카드 박스 분리

3. **마지막 상태 기억**:
   - 시트 모드 + 특정 에피소드 + 트리 접기 → 다른 뷰 → 다시 씬 뷰
   - ✅ 직전 상태 그대로 복원

4. **씬 번호 빛나는 효과**:
   - 시트 뷰에서 씬 번호 셀에 마우스 올림
   - ✅ 글자 강한 글로우 + 외곽 보더 빠르게 회전. 더블클릭 시 씬 모달.

5. **상단바 접기**:
   - 씬 뷰 *옵션 접기* 버튼 → ✅ 옵션 줄 *완전 사라짐*

6. **댓글 토스트 + 행 하이라이트**:
   - 다른 직원이 한솔 멘션 또는 한솔 담당 씬에 댓글
   - ✅ 우상단 토스트 8초 + '씬 보기' 클릭 → 정확한 씬 모달 / 시트 뷰 행 빛남

7. **알림 패널 호버 액션**:
   - 종모양 클릭 → 알림 항목에 마우스 올림
   - ✅ 우측에 [씬 보기 + ExternalLink][Check][Trash2] 부드럽게 등장
   - ✅ 본문이 길면 \`...\` + 호버 시 글래스 툴팁으로 전체 노출

8. **마우스 따라가는 툴팁**:
   - 캘린더, 위젯 어디든 \`title\` 속성 있는 곳에 호버
   - ✅ 툴팁이 마우스 위치 따라 자연스럽게 이동

### 개발자 테스트

\`\`\`bash
npm run build:vite                          # tsc + vite PASS

# SEED_USER 평문 노출 검증
main_chunk=\$(cat dist/index.html | grep -oE 'index-[A-Za-z0-9_-]+\.js' | head -1)
grep -c "1q2w3e4r!A" "dist/assets/\$main_chunk"   # → 0 ✅
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)