### PR TITLE
[v1.15.1] 최근 작업 위젯 라이트 모드 색상 토큰 정리

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bflow",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bflow",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@liveblocks/client": "^3.14.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/components/widgets/RecentActivityWidget.tsx
+++ b/src/components/widgets/RecentActivityWidget.tsx
@@ -187,7 +187,7 @@ export function RecentActivityWidget() {
 
 function ModeToggle({ mode, onChange }: { mode: GoldenMode; onChange: (m: GoldenMode) => void }) {
   return (
-    <div className="flex gap-[2px] bg-black/25 p-[2px] rounded-[7px]">
+    <div className="flex gap-[2px] bg-bg-border/40 p-[2px] rounded-[7px]">
       <ModeButton active={mode === 'heatmap'} onClick={() => onChange('heatmap')} title="히트맵 모드">
         <Grid3x3 size={11} />
         <span className="text-[10.5px]">히트맵</span>

--- a/src/components/widgets/activity/ActivityFeed.tsx
+++ b/src/components/widgets/activity/ActivityFeed.tsx
@@ -81,7 +81,7 @@ function FeedItemRow({ activity, isSelf, isInsideGroup }: FeedItemRowProps) {
   const verb = getActivityVerb(activity);
   return (
     <div
-      className={`flex gap-2.5 py-2 px-3.5 border-b border-bg-border/15 transition-colors hover:bg-white/[0.025] cursor-pointer relative ${
+      className={`flex gap-2.5 py-2 px-3.5 border-b border-bg-border/15 transition-colors hover:bg-bg-border/20 cursor-pointer relative ${
         isSelf ? 'bg-accent/[0.04]' : ''
       } ${isInsideGroup ? 'pl-12' : ''}`}
     >
@@ -137,7 +137,7 @@ function FeedGroup({ items, isSelf }: FeedGroupProps) {
     <div className={`border-b border-bg-border/15 ${isSelf ? 'bg-accent/[0.04]' : ''} relative`}>
       {isSelf && <span className="absolute left-0 top-0 bottom-0 w-[2px] bg-accent-sub" />}
       <div
-        className="flex gap-2.5 py-2 px-3.5 cursor-pointer transition-colors hover:bg-white/[0.025]"
+        className="flex gap-2.5 py-2 px-3.5 cursor-pointer transition-colors hover:bg-bg-border/20"
         onClick={() => setOpen((o) => !o)}
       >
         <Avatar name={head.userName} color={getUserColorFromId(head.userId)} />
@@ -179,7 +179,7 @@ function FeedGroup({ items, isSelf }: FeedGroupProps) {
             animate={{ height: 'auto', opacity: 1 }}
             exit={{ height: 0, opacity: 0 }}
             transition={{ duration: 0.2 }}
-            className="overflow-hidden bg-black/15"
+            className="overflow-hidden bg-bg-border/30"
           >
             {items.map((it) => (
               <FeedItemRow key={it.id} activity={it} isSelf={isSelf} isInsideGroup />


### PR DESCRIPTION
## 📋 업데이트 요약

> 이번 업데이트에서 달라진 점을 간략하게 정리했습니다.

- 🎨 **라이트 모드에서 최근 작업 위젯의 모드 토글 (히트맵/시간대/요일) 버튼 배경이 검정**으로 보이던 문제 수정
- 🎨 활동 피드 행 호버, 그룹 펼치기 영역도 라이트 모드 자연스럽게 적응

## 🔧 상세 기술 설명

`RecentActivityWidget.tsx` 와 `ActivityFeed.tsx` 에 남아있던 `bg-black/*` / `bg-white/*` 하드코딩 4건을 테마 토큰(`bg-bg-border/*`) 으로 일괄 정리.

| 위치 | 기존 | 변경 |
|---|---|---|
| `RecentActivityWidget.tsx:190` ModeToggle 컨테이너 | `bg-black/25` | `bg-bg-border/40` |
| `ActivityFeed.tsx:84` 피드 행 호버 | `hover:bg-white/[0.025]` | `hover:bg-bg-border/20` |
| `ActivityFeed.tsx:140` 그룹 헤더 호버 | `hover:bg-white/[0.025]` | `hover:bg-bg-border/20` |
| `ActivityFeed.tsx:182` 그룹 펼치기 영역 | `bg-black/15` | `bg-bg-border/30` |

`bg-bg-border` 토큰은 라이트 모드에서 옅은 회색 / 다크 모드에서 진한 회색이 되어 양쪽 모드에서 자연스럽게 적응됩니다.

## 🚧 개발 난항

특이사항 없음. 단순 토큰 치환.

## ✅ 테스트 가이드

### 사용자 테스트
1. 앱 → 설정 → 테마 → **라이트 모드** 전환
2. 대시보드 → 최근 작업 위젯 확인
3. ✅ 기대: 모드 토글(히트맵/시간대/요일) 버튼 배경이 *옅은 회색* (검정 X)
4. ✅ 기대: 활동 피드 항목에 마우스 올리면 *옅은 회색 호버* (흰색이라 안 보이던 문제 X)

### 개발자 테스트
```bash
npm run build:vite   # tsc + vite PASS

# bg-black/white 하드코딩 잔재 검색 — 0이어야 함
grep -nE "bg-(black|white)" src/components/widgets/activity/*.tsx src/components/widgets/RecentActivityWidget.tsx
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)