### PR TITLE
[v1.15.2] 시트 뷰 L# 레이아웃 라벨 라이트 모드 가시성

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/components/scenes/SceneSheetView.tsx
+++ b/src/components/scenes/SceneSheetView.tsx
@@ -656,7 +656,7 @@ export function SceneSheetView({
                         </span>
                       </span>
                       {scene.layoutId && (
-                        <span className="text-[11px] italic font-medium text-accent-sub flex-shrink-0">
+                        <span className="text-[11px] italic font-medium text-accent flex-shrink-0">
                           L#{scene.layoutId}
                         </span>
                       )}

--- a/src/components/scenes/UnifiedSceneSheetView.tsx
+++ b/src/components/scenes/UnifiedSceneSheetView.tsx
@@ -728,7 +728,7 @@ export function UnifiedSceneSheetView({
                         </span>
                       </span>
                       {primary.layoutId && (
-                        <span className="text-[11px] italic font-medium text-accent-sub flex-shrink-0">
+                        <span className="text-[11px] italic font-medium text-accent flex-shrink-0">
                           L#{primary.layoutId}
                         </span>
                       )}

--- a/src/views/ScenesView.tsx
+++ b/src/views/ScenesView.tsx
@@ -760,7 +760,7 @@ function SceneCard({ scene, sceneIndex, celebrating, department, isHighlighted, 
             <HighlightText text={scene.sceneId || '(씬번호 없음)'} query={searchQuery} />
           </span>
           {scene.layoutId && (
-            <span className="text-[12px] italic font-medium text-accent-sub shrink-0">
+            <span className="text-[12px] italic font-medium text-accent shrink-0">
               L#{scene.layoutId}
             </span>
           )}


### PR DESCRIPTION
## 📋 업데이트 요약

> 이번 업데이트에서 달라진 점을 간략하게 정리했습니다.

- 🎨 **라이트 모드에서 씬 뷰 시트뷰의 L# 레이아웃 글자가 너무 옅어 안 보이던 문제 수정**

## 🔧 상세 기술 설명

원인: layoutId 라벨이 `text-accent-sub` (연보라, RGB 162 155 254) 사용. 라이트 모드의 흰 배경 위에서 너무 옅어 사실상 안 보였습니다. 다크 모드에서는 어두운 배경이라 OK였음.

수정 (3건 — `text-accent-sub` → `text-accent`):
- `src/views/ScenesView.tsx:763` 카드 뷰 셀 layoutId
- `src/components/scenes/UnifiedSceneSheetView.tsx:731` 통합 시트 셀 layoutId
- `src/components/scenes/SceneSheetView.tsx:659` 단일 부서 시트 셀 layoutId

`text-accent` (진한 보라, RGB 108 92 231) 은 라이트/다크 모두 충분한 대비를 가지므로 두 모드 모두 가독성 보장됩니다.

## 🚧 개발 난항

특이사항 없음.

## ✅ 테스트 가이드

### 사용자 테스트
1. 앱 → 설정 → 라이트 모드 전환
2. 씬 뷰 → 시트 뷰 모드 진입
3. ✅ 기대: 씬 번호 옆 `L#XX` 라벨이 *진한 보라색 italic* 으로 명확히 보임
4. 다크 모드 전환 → ✅ 기대: 동일하게 진한 보라색으로 잘 보임 (회귀 X)

🤖 Generated with [Claude Code](https://claude.com/claude-code)