### PR TITLE
[v1.15.3] 멘션 알림 '씬 보기' 버튼 누락 수정 (다른 PC 사용자)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -742,10 +742,12 @@ export default function App() {
                     type: 'comment',
                     title: `${newComment.user_name || '누군가'}님이 나를 태그했습니다`,
                     body: newComment.text ? (newComment.text.length > 50 ? newComment.text.slice(0, 50) + '...' : newComment.text) : undefined,
-                    // scene 정확히 찾았으면 UUID + 사용자 sceneId. 못 찾으면 액션 버튼 비활성 (metadata 비움)
+                    // scene 정확히 찾았으면 UUID + 사용자 sceneId. 못 찾아도 scene_uuid 라도 넣어 '씬 보기' 버튼은 항상 노출
+                    // (한솔 보고 v1.15.3: 다른 PC 사용자가 멘션 받았을 때 useDataStore 에 그 씬이 없어 metadata=undefined → 버튼 누락)
+                    // navigateToScene 이 매칭 실패하면 자체 fallback 으로 씬 뷰 이동 + 안내
                     metadata: scene
                       ? { sceneId: scene.id, sceneName: scene.sceneId }
-                      : undefined,
+                      : (newComment.scene_uuid ? { sceneId: newComment.scene_uuid } : undefined),
                   }, notiSettings);
                 } else if (isAssignee) {
                   dispatchNotification({


### PR DESCRIPTION
## 📋 업데이트 요약

> 이번 업데이트에서 달라진 점을 간략하게 정리했습니다.

- 🐛 **다른 PC 사용자가 멘션 알림 받을 때 '씬 보기' 버튼이 안 뜨던 문제 수정** (장삐쭈 → 강선영 케이스)

## 🔧 상세 기술 설명

원인:
- 다른 PC 사용자(예: 강선영)의 `useDataStore.episodes` 가 *모든 씬* 을 다 로드하지는 않은 상태
- 멘션 알림 도착 시 App.tsx 의 scene 검색 (findSceneByUuid + part_id+no fallback) 둘 다 실패 → `metadata = undefined`
- NotificationItem 의 `hasNavigateTarget = !!(metadata?.sceneId || metadata?.sceneName)` → false → '씬 보기' 버튼 미표시
- '읽음' 버튼은 사용자가 본문 클릭/액션 클릭 시 `markAsRead` 호출되어 정상적으로 사라짐 (이건 의도된 동작)

수정 (`App.tsx:740-749` isMentioned 분기):
```tsx
metadata: scene
  ? { sceneId: scene.id, sceneName: scene.sceneId }
  : (newComment.scene_uuid ? { sceneId: newComment.scene_uuid } : undefined),
```

scene 객체를 못 찾아도 `newComment.scene_uuid` 가 있으면 그걸 metadata.sceneId 에 넣어 '씬 보기' 버튼이 *항상* 표시되게 함.

클릭 시 `navigateToScene` 이:
1. 다시 episodes 전체 검색 (그 사이 더 로드됐을 수 있음) → 매칭되면 정확한 씬 모달
2. 매칭 실패 시 fallback (씬 뷰로 이동 + warning 토스트 + console.warn)

## 🚧 개발 난항

특이사항 없음. App.tsx 한 줄 수정.

## ✅ 테스트 가이드

### 사용자 테스트
1. PC A: 사용자 A 로그인 + 댓글 작성하면서 사용자 B 멘션
2. PC B: 사용자 B 로그인 상태 (PC A 와 별도)
3. ✅ 기대: PC B 의 알림 패널 카드에 호버 시 [씬 보기 / Check / Trash2] 3 버튼 표시
4. '씬 보기' 클릭 → 정확한 씬 모달 또는 (씬 못 찾으면) 씬 뷰로 이동 + 안내 토스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)