### PR TITLE
[v1.15.5] 로그인 catch-up — 놓친 멘션 알림 일괄 수신

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -835,6 +835,7 @@ import {
   updateUser as sbUpdateUser,
   deleteUser as sbDeleteUser,
   readCommentsForPart as sbReadComments,
+  fetchMissedMentions as sbFetchMissedMentions,
   addComment as sbAddComment,
   editComment as sbEditComment,
   deleteComment as sbDeleteComment,
@@ -1148,6 +1149,16 @@ ipcMain.handle('supabase:delete-user', wrapIpc(async (_e: unknown, userId: strin
 // ─── Comments ───
 ipcMain.handle('supabase:read-comments', wrapIpc(async (_e: unknown, partUuid: string) => {
   return sbReadComments(partUuid);
+}));
+// 한솔 결정 (v1.15.5): 로그인 catch-up — last seen 이후 받은 멘션 댓글 일괄 조회
+ipcMain.handle('supabase:fetch-missed-mentions', wrapIpc(async (
+  _e: unknown,
+  userId: string,
+  userName: string,
+  since: string,
+  limit?: number,
+) => {
+  return sbFetchMissedMentions(userId, userName, since, limit ?? 50);
 }));
 ipcMain.handle('supabase:add-comment', wrapIpc(async (_e: unknown, commentId: string, partUuid: string, sceneId: string,
   userId: string, userName: string, text: string, mentions: string[], createdAt: string) => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -107,6 +107,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('supabase:delete-user', userId),
   supabaseReadComments: (partUuid: string) =>
     ipcRenderer.invoke('supabase:read-comments', partUuid),
+  // 한솔 결정 (v1.15.5): 로그인 catch-up
+  supabaseFetchMissedMentions: (userId: string, userName: string, since: string, limit?: number) =>
+    ipcRenderer.invoke('supabase:fetch-missed-mentions', userId, userName, since, limit),
   supabaseAddComment: (commentId: string, partUuid: string, sceneId: string,
     userId: string, userName: string, text: string, mentions: string[], createdAt: string) =>
     ipcRenderer.invoke('supabase:add-comment', commentId, partUuid, sceneId, userId, userName, text, mentions, createdAt),

--- a/electron/supabase.ts
+++ b/electron/supabase.ts
@@ -822,6 +822,42 @@ export async function deleteUser(userId: string): Promise<void> {
 // COMMENTS
 // ═══════════════════════════════════════════════
 
+/**
+ * 한솔 결정 (v1.15.5): 로그인 catch-up — 사용자가 last seen 이후 받은 멘션 댓글을 일괄 조회.
+ *
+ * - mentions 배열에 userName 이 포함된 댓글
+ * - created_at > since
+ * - 본인이 작성한 댓글 제외
+ * - 최대 limit 개 (기본 50). 새로운 것부터.
+ */
+export async function fetchMissedMentions(
+  userId: string,
+  userName: string,
+  since: string,
+  limit = 50,
+): Promise<SupabaseComment[]> {
+  const { data, error } = await supabase
+    .from('comments')
+    .select('*')
+    .gt('created_at', since)
+    .neq('user_id', userId)
+    .contains('mentions', [userName])
+    .order('created_at', { ascending: false })
+    .limit(limit);
+  if (error) throw new Error(`fetchMissedMentions failed: ${error.message}`);
+  return (data || []).map((c) => ({
+    id: c.id,
+    partId: c.part_id,
+    sceneId: c.scene_id,
+    userId: c.user_id,
+    userName: c.user_name,
+    text: c.text,
+    mentions: c.mentions || [],
+    createdAt: c.created_at,
+    editedAt: c.edited_at,
+  }));
+}
+
 /** 파트별 댓글 읽기 */
 export async function readCommentsForPart(partUuid: string): Promise<SupabaseComment[]> {
   const { data, error } = await supabase

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.15.4",
+  "version": "1.15.5",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -554,6 +554,54 @@ export default function App() {
     }
   }, [currentUser, setUsers]);
 
+  // 한솔 결정 (v1.15.5): 로그인 catch-up — last_seen_at 이후 받은 멘션 댓글을 알림 패널에 누적
+  // (토스트 X, 알림 패널 + 요약 토스트 1번). 사용자별 ref 로 한 번만 발동.
+  const catchupDoneUserIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!currentUser) return;
+    if (!authReady) return;
+    if (catchupDoneUserIdRef.current === currentUser.id) return;
+
+    catchupDoneUserIdRef.current = currentUser.id;
+    const me = currentUser;
+
+    (async () => {
+      const { getLastSeenAt, setLastSeenAt, ensureLastSeenInitialized } = await import('@/utils/lastSeenTracker');
+      const lastSeen = getLastSeenAt(me.id);
+      if (!lastSeen) {
+        // 첫 로그인 — 이전 알림 catch-up 안 함, 시각만 기록
+        ensureLastSeenInitialized(me.id);
+        return;
+      }
+      try {
+        const missed = await window.electronAPI?.supabaseFetchMissedMentions?.(me.id, me.name, lastSeen, 50);
+        if (!missed || missed.length === 0) {
+          setLastSeenAt(me.id, new Date().toISOString());
+          return;
+        }
+        // 알림 패널에만 누적 (토스트 X — 한꺼번에 N 개 띄우면 시끄러움)
+        const store = useNotificationStore.getState();
+        for (const c of missed) {
+          store.addNotification({
+            type: 'comment',
+            title: `${c.userName || '누군가'}님이 나를 태그했습니다`,
+            body: c.text ? (c.text.length > 50 ? c.text.slice(0, 50) + '...' : c.text) : undefined,
+            // scene_uuid 가 SupabaseComment 변환에서 빠져있어 partId+sceneId(no) 로만 표기 — 클릭 시 navigateToScene 자체 fallback 동작
+            metadata: { sceneName: c.sceneId },
+          });
+        }
+        // 요약 토스트 1번 (한솔이 인지)
+        sonnerToast(`놓친 알림 ${missed.length}개를 가져왔어요`, {
+          description: '종 모양을 클릭해 확인해주세요.',
+          duration: 6000,
+        });
+        setLastSeenAt(me.id, new Date().toISOString());
+      } catch (err) {
+        console.warn('[catchup] 멘션 catch-up 실패:', err);
+      }
+    })();
+  }, [currentUser, authReady]);
+
   // 테마 변경 시: CSS 적용 + appdata 저장 (초기화 완료 후에만 저장)
   useEffect(() => {
     if (!themeInitRef.current) return; // init()에서 테마 로드 전까지 저장 방지

--- a/src/mocks/devElectronAPI.ts
+++ b/src/mocks/devElectronAPI.ts
@@ -115,6 +115,7 @@ export function installDevElectronAPI(): void {
     supabaseUpdateUser: async () => {},
     supabaseDeleteUser: async () => {},
     supabaseReadComments: async () => [],
+    supabaseFetchMissedMentions: async () => [],
     supabaseAddComment: async () => {},
     supabaseEditComment: async () => {},
     supabaseDeleteComment: async () => {},

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -496,6 +496,18 @@ export interface ElectronAPI {
   supabaseUpdateUser: (userId: string, updates: Record<string, string>) => Promise<void>;
   supabaseDeleteUser: (userId: string) => Promise<void>;
   supabaseReadComments: (partUuid: string) => Promise<unknown[]>;
+  /** 한솔 결정 (v1.15.5): 로그인 catch-up — last seen 이후 받은 멘션 댓글 일괄 조회 */
+  supabaseFetchMissedMentions: (userId: string, userName: string, since: string, limit?: number) => Promise<Array<{
+    id: string;
+    partId: string;
+    sceneId: string;
+    userId: string;
+    userName: string;
+    text: string;
+    mentions: string[];
+    createdAt: string;
+    editedAt?: string | null;
+  }>>;
   supabaseAddComment: (commentId: string, partUuid: string, sceneId: string, userId: string, userName: string, text: string, mentions: string[], createdAt: string) => Promise<void>;
   supabaseEditComment: (commentId: string, text: string, mentions: string[]) => Promise<void>;
   supabaseDeleteComment: (commentId: string) => Promise<void>;

--- a/src/utils/lastSeenTracker.ts
+++ b/src/utils/lastSeenTracker.ts
@@ -1,0 +1,33 @@
+/**
+ * 한솔 결정 (v1.15.5): 알림 catch-up 을 위한 last_seen_at 추적.
+ *
+ * 사용자가 마지막으로 알림을 처리한 시각을 localStorage 에 사용자별 저장.
+ * 로그인 시 그 시각 이후의 멘션 댓글을 Supabase 에서 조회해 알림 패널에 누적.
+ *
+ * - PC 단위 저장 (PC 간 동기화는 후속 v1.16+ 에서 검토)
+ * - 첫 로그인 시 마지막 시각이 없으면 *현재* 시각으로 초기화 (이전 알림 catch-up X)
+ */
+
+const KEY_PREFIX = 'bflow_notification_last_seen_';
+
+export function getLastSeenAt(userId: string): string | null {
+  try {
+    const v = localStorage.getItem(KEY_PREFIX + userId);
+    return v || null;
+  } catch {
+    return null;
+  }
+}
+
+export function setLastSeenAt(userId: string, isoString: string): void {
+  try {
+    localStorage.setItem(KEY_PREFIX + userId, isoString);
+  } catch { /* 개인정보보호 모드 등 — 무시 */ }
+}
+
+/** 한 번도 기록 없으면 현재 시각으로 초기화. 다음 catch-up 부터 의미 가짐. */
+export function ensureLastSeenInitialized(userId: string): void {
+  if (!getLastSeenAt(userId)) {
+    setLastSeenAt(userId, new Date().toISOString());
+  }
+}


### PR DESCRIPTION
## 📋 업데이트 요약

> 이번 업데이트에서 달라진 점을 간략하게 정리했습니다.

- 🔔 **로그아웃 상태에서 받은 멘션 알림을 로그인 시 일괄 수신** — 이제 다른 PC 에서 작성된 멘션도 놓치지 않음
- 🧊 **시끄러움 방지** — 토스트는 안 띄우고 *알림 패널에만 누적* + 요약 토스트 1번 ("놓친 알림 N개 가져왔어요")

## 🔧 상세 기술 설명

### 흐름
1. 사용자 로그인 시 `localStorage` 의 `bflow_notification_last_seen_<userId>` 조회
2. 그 시각 이후 받은 *멘션* 댓글을 Supabase 에서 일괄 조회 (최대 50건)
3. `useNotificationStore.addNotification` 으로 알림 패널 누적
4. 요약 토스트 1번 (sonner) 으로 인지
5. `last_seen_at = new Date().toISOString()` 업데이트

### 설계 포인트
- `catchupDoneUserIdRef` 로 사용자당 1회만 발동 (재마운트/StrictMode 안전)
- 첫 로그인은 이전 알림 X (`last_seen` 없으면 현재 시각으로 초기화만)
- 본인 작성 댓글 제외 (`.neq('user_id', userId)`)
- mentions 배열 server-side 필터 (`.contains('mentions', [userName])`) — Supabase 부하 최소화

### Supabase 사용량
사용자당 로그인 1회당 1쿼리 + `created_at` 인덱스 + limit 50. 한 사용자가 하루 5~10번 로그인해도 부하 무시할 수준.

### 신규 파일/함수
- `src/utils/lastSeenTracker.ts`: localStorage 사용자별 추적 (PC 단위, 후속에서 PC 간 동기화 검토)
- `electron/supabase.ts`: `fetchMissedMentions(userId, userName, since, limit)`
- `electron/main.ts`: `supabase:fetch-missed-mentions` IPC handler
- `electron/preload.ts`: `supabaseFetchMissedMentions` API
- `src/types/index.ts`: ElectronAPI 타입
- `src/mocks/devElectronAPI.ts`: dev mock 빈 배열 반환
- `src/App.tsx`: 로그인 catch-up useEffect

## 🚧 개발 난항

특이사항 없음. 기존 mention 알림 트리거 흐름과 별도라 영향 X.

## ✅ 테스트 가이드

### 사용자 테스트
1. PC A: 사용자 A 로그아웃 (또는 BFLOW 종료)
2. PC B: 사용자 B 로그인 + 사용자 A 멘션 댓글 N개 작성
3. PC A: 사용자 A 다시 로그인
4. ✅ 기대: 우측에 *놓친 알림 N개를 가져왔어요* 토스트 6초 노출
5. ✅ 기대: 종 모양 알림 패널 열면 N개 멘션 알림 표시 (미읽음 상태)
6. ✅ 기대: 알림 항목 클릭 시 정상적으로 씬 모달/시트 뷰 행 하이라이트로 이동

### 개발자 테스트
```bash
npm run build:vite  # tsc + vite PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)