### PR TITLE
[v1.15.7] catch-up JSON 에러 + 메모 플로팅 줄바꿈 초기화 fix

### DIFF
--- a/electron/supabase.ts
+++ b/electron/supabase.ts
@@ -836,26 +836,32 @@ export async function fetchMissedMentions(
   since: string,
   limit = 50,
 ): Promise<SupabaseComment[]> {
+  // 한솔 보고 (v1.15.7): .contains('mentions', [userName]) 가 mentions 컬럼 타입(jsonb vs text[])과
+  // 충돌해 "invalid input syntax for type json" 에러. server filter 에서 mentions 빼고 client 에서 처리.
+  // server: since + 본인 댓글 제외만. client: mentions 배열에 userName 포함 검사.
+  // 200 한계는 last_seen 짧은 기간이라 보통 충분 (멘션 매칭은 전체 중 소수).
   const { data, error } = await supabase
     .from('comments')
     .select('*')
     .gt('created_at', since)
     .neq('user_id', userId)
-    .contains('mentions', [userName])
     .order('created_at', { ascending: false })
-    .limit(limit);
+    .limit(200);
   if (error) throw new Error(`fetchMissedMentions failed: ${error.message}`);
-  return (data || []).map((c) => ({
-    id: c.id,
-    partId: c.part_id,
-    sceneId: c.scene_id,
-    userId: c.user_id,
-    userName: c.user_name,
-    text: c.text,
-    mentions: c.mentions || [],
-    createdAt: c.created_at,
-    editedAt: c.edited_at,
-  }));
+  return (data || [])
+    .filter((c) => Array.isArray(c.mentions) && c.mentions.includes(userName))
+    .slice(0, limit)
+    .map((c) => ({
+      id: c.id,
+      partId: c.part_id,
+      sceneId: c.scene_id,
+      userId: c.user_id,
+      userName: c.user_name,
+      text: c.text,
+      mentions: c.mentions || [],
+      createdAt: c.created_at,
+      editedAt: c.edited_at,
+    }));
 }
 
 /** 파트별 댓글 읽기 */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.15.6",
+  "version": "1.15.7",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/components/widgets/MemoWidget.tsx
+++ b/src/components/widgets/MemoWidget.tsx
@@ -284,25 +284,25 @@ export function MemoWidget() {
     return () => window.removeEventListener('storage', handler);
   }, [memoKey]);
 
-  // 언마운트 시 즉시 저장 (debounce flush)
+  // 언마운트 시 즉시 저장 — 한솔 보고 (v1.15.7): 플로팅 위젯 닫고 다시 열면 줄바꿈이 초기화됨.
+  // 기존엔 saveTimerRef.current 가 있을 때만 즉시 저장 → debounce 만료 + 새 변경 race 케이스에서 마지막
+  // 값이 누락될 수 있음. 조건 제거 + 항상 마지막 memoDataRef 를 Supabase 에 push.
   useEffect(() => {
     return () => {
-      if (saveTimerRef.current) {
-        clearTimeout(saveTimerRef.current);
-        const data = memoDataRef.current;
-        (async () => {
-          try {
-            const userId = useAuthStore.getState().currentUser?.id;
-            if (!userId) return;
-            await supabaseService.upsertMemo(userId, memoKey, {
-              tabs: data.tabs,
-              activeTabId: data.activeTabId,
-              fontSize: data.fontSize,
-            });
-            localStorage.setItem('memo-sync', `${memoKey}:${Date.now()}`);
-          } catch { /* ignore */ }
-        })();
-      }
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+      const data = memoDataRef.current;
+      (async () => {
+        try {
+          const userId = useAuthStore.getState().currentUser?.id;
+          if (!userId) return;
+          await supabaseService.upsertMemo(userId, memoKey, {
+            tabs: data.tabs,
+            activeTabId: data.activeTabId,
+            fontSize: data.fontSize,
+          });
+          localStorage.setItem('memo-sync', `${memoKey}:${Date.now()}`);
+        } catch { /* ignore */ }
+      })();
     };
   }, [memoKey]);
 


### PR DESCRIPTION
두 fix 한 묶음:

🐛 **catch-up Supabase 에러**: `.contains('mentions', [userName])` 가 컬럼 타입과 충돌해 JSON syntax 에러. server filter 에서 mentions 빼고 client 에서 처리.

🐛 **메모 위젯 플로팅 줄바꿈 초기화**: 언마운트 cleanup 이 `saveTimerRef.current` 있을 때만 저장 → race 케이스에서 마지막 값 누락. 조건 제거 + 항상 즉시 저장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)