### PR TITLE
[v1.15.8] Codex P1 fix — 사용자 삭제 시 comp_revisions 테이블 정확히

### DIFF
--- a/electron/supabase.ts
+++ b/electron/supabase.ts
@@ -834,12 +834,12 @@ export async function deleteUser(userId: string): Promise<void> {
       .eq('assignee', userName);
     if (scenesErr) console.warn('[deleteUser] scenes.assignee 비우기 실패:', scenesErr);
 
-    // 3) revisions.assignee 비우기 (revisions 테이블에도 assignee 컬럼 있음)
+    // 3) comp_revisions.assignee 비우기 (Codex P1: 실 테이블명 — 'revisions' 아님)
     const { error: revsErr } = await supabase
-      .from('revisions')
+      .from('comp_revisions')
       .update({ assignee: null })
       .eq('assignee', userName);
-    if (revsErr) console.warn('[deleteUser] revisions.assignee 비우기 실패:', revsErr);
+    if (revsErr) console.warn('[deleteUser] comp_revisions.assignee 비우기 실패:', revsErr);
   }
 
   // 4) user 삭제

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.15.7",
+  "version": "1.15.8",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
PR #50 코덱스 리뷰 P1 반영.

`deleteUser` 가 `revisions` 테이블에 update 시도 → 실제 테이블명은 `comp_revisions`. 런타임 에러 + warn 만 출력 후 user 삭제 진행 → revisions assignee 가 비워지지 않음 (의도한 fix 가 반쪽만 작동).

수정: `.from('revisions')` → `.from('comp_revisions')` (electron/supabase.ts:839).

🤖 Generated with [Claude Code](https://claude.com/claude-code)