### PR TITLE
[v1.15.9] catch-up 알림 씬 매칭 — sceneUuid + fallback 추가

### DIFF
--- a/electron/supabase.ts
+++ b/electron/supabase.ts
@@ -128,6 +128,8 @@ export interface SupabaseComment {
   id: string;
   partId: string;
   sceneId: string;
+  /** 한솔 결정 (v1.15.9): 정확한 씬 매칭용 UUID (catch-up 의 navigateToScene 에서 활용) */
+  sceneUuid?: string | null;
   userId: string;
   userName: string;
   text: string;
@@ -895,6 +897,7 @@ export async function fetchMissedMentions(
         id: c.id,
         partId: c.part_id,
         sceneId: c.scene_id,
+        sceneUuid: c.scene_uuid ?? null,  // v1.15.9: 정확 씬 매칭용
         userId: c.user_id,
         userName: c.user_name,
         text: c.text,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.15.8",
+  "version": "1.15.9",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -593,13 +593,35 @@ export default function App() {
           return;
         }
         // 알림 패널에만 누적 (토스트 X — 한꺼번에 N 개 띄우면 시끄러움)
+        // 한솔 보고 (v1.15.9): catch-up 알림에서 씬 매칭이 안 됨. Realtime 분기와 동일 패턴으로
+        // scene_uuid 우선 + part_id+sceneNo fallback 으로 정확한 scene 찾아 metadata 채움.
+        const ds = useDataStore.getState();
         const store = useNotificationStore.getState();
         for (const c of missed) {
+          // 1) scene_uuid 로 정확 매칭
+          let scene = c.sceneUuid ? ds.findSceneByUuid(c.sceneUuid) : null;
+          // 2) part_id + sceneNo 조합으로 fallback
+          if (!scene && c.partId && c.sceneId) {
+            const targetNo = Number(c.sceneId);
+            if (Number.isFinite(targetNo)) {
+              for (const ep of ds.episodes) {
+                for (const part of ep.parts) {
+                  if (part.id !== c.partId) continue;
+                  const found = part.scenes.find((s) => Number(s.no) === targetNo);
+                  if (found) { scene = found; break; }
+                }
+                if (scene) break;
+              }
+            }
+          }
           store.addNotification({
             type: 'comment',
             title: `${c.userName || '누군가'}님이 나를 태그했습니다`,
             body: c.text ? (c.text.length > 50 ? c.text.slice(0, 50) + '...' : c.text) : undefined,
-            metadata: { sceneName: c.sceneId },
+            // scene 매칭 성공 시 UUID + 사용자 sceneId 둘 다. 못 찾아도 sceneUuid 라도 넣어 '씬 보기' 버튼은 노출
+            metadata: scene
+              ? { sceneId: scene.id, sceneName: scene.sceneId }
+              : (c.sceneUuid ? { sceneId: c.sceneUuid } : undefined),
           });
         }
         // 요약 토스트 1번 (한솔이 인지)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -501,6 +501,8 @@ export interface ElectronAPI {
     id: string;
     partId: string;
     sceneId: string;
+    /** v1.15.9: 정확 씬 매칭용 UUID (catch-up navigateToScene 에서 활용) */
+    sceneUuid?: string | null;
     userId: string;
     userName: string;
     text: string;


### PR DESCRIPTION
한솔 보고: catch-up 잘 오는데 알림 클릭 시 씬 매칭 실패.

**원인**: catch-up 분기에서 `metadata: { sceneName: c.sceneId }` 만 설정. `c.sceneId` 는 sort_order ('1') 라 navigateToScene 매칭 실패. Realtime 분기는 scene_uuid 활용으로 정상이었지만 catch-up 흐름은 누락.

**수정**:
1. SupabaseComment 타입에 `sceneUuid?` 추가
2. fetchMissedMentions row 매핑에 `sceneUuid: c.scene_uuid` 추가
3. ElectronAPI 타입 반환 타입에 sceneUuid 추가
4. App.tsx catch-up 분기에 Realtime 과 동일한 scene 매칭 로직 (scene_uuid 우선 + part_id+sceneNo fallback)
5. 매칭 성공: metadata = { sceneId: scene.id, sceneName: scene.sceneId }
6. 매칭 실패라도 sceneUuid 있으면 metadata.sceneId 에 넣어 '씬 보기' 버튼 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)