### PR TITLE
[v1.15.10] 다른 에피소드 catch-up 알림 씬 이동 race 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.15.9",
+  "version": "1.15.10",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/views/ScenesView.tsx
+++ b/src/views/ScenesView.tsx
@@ -1521,7 +1521,18 @@ export function ScenesView() {
     if (savedMode) setSceneViewMode(savedMode);
 
     const savedEp = loadPersistedLastEpisode();
-    if (savedEp !== null && episodes.some((ep) => ep.episodeNumber === savedEp)) {
+    // v1.15.10: 외부에서 selectedEpisode 가 이미 set 된 경우(예: 다른 에피소드 댓글 알림 클릭으로
+    // navigateToScene 이 호출된 직후) saved 로 덮어쓰지 않음 — 외부 navigation 우선.
+    const currentSelected = useAppStore.getState().selectedEpisode;
+    const currentIsValid =
+      currentSelected !== null &&
+      currentSelected !== undefined &&
+      episodes.some((ep) => ep.episodeNumber === currentSelected);
+    if (
+      savedEp !== null &&
+      episodes.some((ep) => ep.episodeNumber === savedEp) &&
+      !currentIsValid
+    ) {
       setSelectedEpisode(savedEp);
     }
 


### PR DESCRIPTION
## 📋 업데이트 요약

> 이번 업데이트에서 달라진 점을 간략하게 정리했습니다.

- 🐛 **알림 → 씬 이동 정확도 개선**: 마지막으로 본 에피소드가 아닌 *다른 에피소드*의 댓글 알림을 클릭했을 때, 가끔 마지막 본 에피소드 화면으로 잘못 돌아가던 문제를 수정했습니다. 이제 어떤 에피소드의 알림이든 클릭하면 바로 그 에피소드의 해당 씬이 정확히 하이라이트됩니다.

## 🔧 상세 기술 설명

### 문제: persistRestore vs navigateToScene 의 set race
- `App.tsx` catch-up 분기와 `notificationHelper.ts:navigateToScene` 은 알림 클릭 시:
  1. `setSelectedEpisode(targetEp)` — 알림이 가리키는 에피소드로 변경
  2. `setView('scenes')` — 씬 뷰로 전환
  3. `setHighlightSceneId(scene.id)` — 하이라이트 트리거
- 그런데 `ScenesView` 가 마운트되는 순간, 한 번 실행되는 `persistRestore` useEffect 가 localStorage 의 *마지막으로 본 에피소드(savedEp)* 를 다시 `setSelectedEpisode(savedEp)` 로 덮어쓰는 race 발생.
- 결과: targetEp=2 가 set 됐다가 곧바로 savedEp=1 로 덮여 → 씬 뷰는 ep1 화면을 보여주고 ep2 의 sceneId 는 매칭 실패.

### 해결
- `src/views/ScenesView.tsx:1516-1538` persistRestore useEffect 에 `currentIsValid` 분기 추가:
  ```tsx
  const currentSelected = useAppStore.getState().selectedEpisode;
  const currentIsValid =
    currentSelected !== null &&
    currentSelected !== undefined &&
    episodes.some((ep) => ep.episodeNumber === currentSelected);
  if (savedEp !== null && episodes.some(...) && !currentIsValid) {
    setSelectedEpisode(savedEp);
  }
  ```
- 외부에서 이미 valid 한 selectedEpisode 가 set 된 상태면 saved 복원 스킵 → 외부 navigation 이 우선.
- viewMode (cards/sheet/grouped) 복원은 그대로 — selectedEpisode 와 무관하므로 영향 없음.

## 🚧 개발 난항

특이사항 없음 — race 진단 후 한 곳만 가드 추가로 해결.

## ✅ 테스트 가이드

### 사용자 테스트
> 아래 시나리오를 직접 실행해서 정상 동작을 확인해주세요.

1. **다른 에피소드 댓글 알림 → 씬 이동**
   - 마지막으로 ep1 의 씬 뷰를 보고 앱을 종료
   - 다른 직원이 ep2 의 어떤 씬에 나를 멘션
   - 앱 재실행 → catch-up 알림 토스트가 뜨면 클릭
   - ✅ 기대: ep2 의 해당 씬으로 정확히 이동 + 씬 번호 네온 펄스 효과
   - ❌ 비정상: ep1 의 씬 뷰로 돌아가고 sceneId 매칭 실패

2. **같은 에피소드 댓글 알림 (회귀 확인)**
   - 마지막으로 본 에피소드와 동일한 에피소드의 댓글 알림 클릭
   - ✅ 기대: 기존처럼 정상 동작

3. **앱 재실행 시 마지막 본 에피소드 복원 (회귀 확인)**
   - 알림이 없는 상태에서 앱을 그냥 종료 후 재실행
   - 씬 뷰 진입 시 ✅ 마지막으로 봤던 에피소드가 자동 선택됨

### 개발자 테스트
```bash
npm run build:vite  # tsc + vite 빌드 통과 확인
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)