### PR TITLE
[v1.15.11] cross-episode 알림 씬 이동 race 근본 fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.15.10",
+  "version": "1.15.11",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -637,6 +637,32 @@ export default function App() {
     })();
   }, [currentUser, authReady]);
 
+  // v1.15.11 (한솔 보고): persistRestore 책임을 ScenesView 외부로 이동.
+  // 이전엔 ScenesView 마운트 시 saved last episode 를 복원했는데, 외부에서 navigateToScene 으로
+  // setSelectedEpisode 를 set한 직후 ScenesView 가 첫 마운트 되는 케이스에서 race condition 발생 →
+  // 다른 에피소드 알림 클릭 시 마지막 본 에피소드로 되돌아가는 버그.
+  // 해결: 앱 root 에서 episodes 첫 로드 시 한 번만 saved 복원. selectedEpisode 가 이미 set 되어 있으면 skip.
+  // → ScenesView 마운트 / unmount 와 무관하게 race 자체가 사라짐.
+  const episodesForInit = useDataStore((s) => s.episodes);
+  const selectedEpisodeForInit = useAppStore((s) => s.selectedEpisode);
+  const lastEpisodeRestoredRef = useRef(false);
+  useEffect(() => {
+    if (lastEpisodeRestoredRef.current) return;
+    if (episodesForInit.length === 0) return;
+    if (selectedEpisodeForInit !== null && selectedEpisodeForInit !== undefined) {
+      // 외부 (예: 알림 navigate) 가 이미 set 했으면 건드리지 않음
+      lastEpisodeRestoredRef.current = true;
+      return;
+    }
+    void import('@/utils/scenesViewPersist').then(({ loadPersistedLastEpisode }) => {
+      const saved = loadPersistedLastEpisode();
+      if (saved !== null && episodesForInit.some((ep) => ep.episodeNumber === saved)) {
+        useAppStore.getState().setSelectedEpisode(saved);
+      }
+      lastEpisodeRestoredRef.current = true;
+    });
+  }, [episodesForInit, selectedEpisodeForInit]);
+
   // 테마 변경 시: CSS 적용 + appdata 저장 (초기화 완료 후에만 저장)
   useEffect(() => {
     if (!themeInitRef.current) return; // init()에서 테마 로드 전까지 저장 방지

--- a/src/views/ScenesView.tsx
+++ b/src/views/ScenesView.tsx
@@ -667,7 +667,7 @@ import { GlassDropdown } from '@/components/common/GlassDropdown';
 import { PanelLeftOpen } from 'lucide-react';
 import {
   loadPersistedSceneViewMode, savePersistedSceneViewMode,
-  loadPersistedLastEpisode, savePersistedLastEpisode,
+  savePersistedLastEpisode,
   loadPersistedTreeOpen, savePersistedTreeOpen,
 } from '@/utils/scenesViewPersist';
 
@@ -1510,34 +1510,18 @@ export function ScenesView() {
   // treeOpen 초기값 — 영속화된 값이 있으면 그걸로, 없으면 true (디폴트 펼침)
   const [treeOpen, setTreeOpen] = useState(() => loadPersistedTreeOpen() ?? true);
 
-  // 마운트 시 / episodes 가 처음 채워지는 시점에 영속화된 상태(viewMode + lastEpisode) 1회 복원.
-  // ref guard 로 한솔이 직접 변경한 값이 첫 마운트 때 saved 로 되돌아가지 않게 보장.
+  // v1.15.11 (한솔 보고): selectedEpisode 복원은 App.tsx 의 root-level init useEffect 로 이전.
+  // 이전엔 ScenesView 마운트 시 saved last episode 를 복원했는데 외부 navigate 와 race 발생 →
+  // 다른 에피소드 알림 클릭 시 마지막 본 에피소드로 되돌아가는 버그.
+  // 여기선 sceneViewMode (cards/sheet/grouped) 만 1회 복원 — selectedEpisode 와 무관하므로 race 없음.
   const persistRestoredRef = useRef(false);
   useEffect(() => {
     if (persistRestoredRef.current) return;
-    if (episodes.length === 0) return; // episodes 가 늦게 로드될 때까지 대기
-
+    if (episodes.length === 0) return;
     const savedMode = loadPersistedSceneViewMode();
     if (savedMode) setSceneViewMode(savedMode);
-
-    const savedEp = loadPersistedLastEpisode();
-    // v1.15.10: 외부에서 selectedEpisode 가 이미 set 된 경우(예: 다른 에피소드 댓글 알림 클릭으로
-    // navigateToScene 이 호출된 직후) saved 로 덮어쓰지 않음 — 외부 navigation 우선.
-    const currentSelected = useAppStore.getState().selectedEpisode;
-    const currentIsValid =
-      currentSelected !== null &&
-      currentSelected !== undefined &&
-      episodes.some((ep) => ep.episodeNumber === currentSelected);
-    if (
-      savedEp !== null &&
-      episodes.some((ep) => ep.episodeNumber === savedEp) &&
-      !currentIsValid
-    ) {
-      setSelectedEpisode(savedEp);
-    }
-
     persistRestoredRef.current = true;
-  }, [episodes, setSceneViewMode, setSelectedEpisode]);
+  }, [episodes, setSceneViewMode]);
 
   // 변화 감지 → 즉시 영속화. 디폴트 값일 때 호출되어도 무해.
   useEffect(() => { savePersistedSceneViewMode(sceneViewMode); }, [sceneViewMode]);


### PR DESCRIPTION
## 📋 업데이트 요약

> 이번 업데이트에서 달라진 점을 간략하게 정리했습니다.

- 🐛 **알림 → 씬 이동 정확도 완전 수정**: 대시보드나 다른 화면에서 *다른 에피소드*의 댓글 알림을 클릭했을 때 마지막 본 에피소드 화면으로 잘못 돌아가던 문제를 근본부터 수정했습니다. 이제 어떤 화면에서든 어떤 에피소드 알림을 클릭해도 정확히 그 에피소드로 이동합니다.

## 🔧 상세 기술 설명

### v1.15.10 의 부분 fix 한계
- v1.15.10 은 ScenesView 마운트 시 useEffect 안에서 `useAppStore.getState().selectedEpisode` 가 valid 면 saved 복원을 스킵하는 가드 추가.
- 한솔 보고: 씬 뷰 안에서 알림 클릭 시 OK (이미 마운트된 상태 → ref guard active), 그러나 대시보드 / 메인 다른 화면에서 클릭 시 여전히 race → 마지막 본 에피소드 화면에서 같은 sceneNo 의 씬만 빛남.
- 원인 추정: ScenesView 가 view 전환으로 unmount/remount 되면서 매번 ref 가 false 로 초기화 + episodes lazy load + zustand state 의 미묘한 fire 타이밍 — currentIsValid 가드가 일관되게 작동하지 않음.

### 근본 fix
- **persistRestore 책임을 ScenesView 외부로 이전.**
  - `src/App.tsx` root-level useEffect: episodes 첫 로드 시 1회만 `selectedEpisode === null` 일 때 saved 복원.
  - selectedEpisode 가 이미 set 되어 있으면 (외부 navigate) → skip + `lastEpisodeRestoredRef = true` → 재진입 봉인.
  - lazy import 로 scenesViewPersist 모듈 분리 (App.tsx 번들 가벼움 유지).
- **`src/views/ScenesView.tsx` 의 persistRestore 는 sceneViewMode 만 책임.**
  - selectedEpisode 처리 코드 + currentIsValid 가드 제거.
  - `loadPersistedLastEpisode` import 제거 (사용처 없어짐).
  - `savePersistedLastEpisode` 는 그대로 — selectedEpisode 변경 시 저장 책임 유지.
- **selectedPart 도 한솔이 우려한 동일 문제 없음 확인.**
  - notificationHelper.ts / NotificationPanel.tsx 의 navigate 시 `setSelectedPart(part.partId)` 가 명시적으로 호출됨.
  - ScenesView 내 자동 reset 로직 부재 (사용자 액션에서만 set).
  - selectedEpisode race 사라지면 selectedPart 도 자동 정상화.

### 결과
- ScenesView 가 unmount → mount 되어도 selectedEpisode 가 saved 로 덮어써지지 않음.
- 대시보드 / 메인 / 어떤 화면에서든 알림 클릭 시 정확한 에피소드 + 파트 + 씬 하이라이트.
- 첫 앱 시작 시 saved last episode 복원은 그대로 유지 (App.tsx init).

## 🚧 개발 난항

### v1.15.10 race 진단의 한계
- **문제**: useEffect ref guard + currentIsValid 분기로도 race 가 일관되지 않게 발생.
- **시도**: store 상태, useEffect deps, mount 타이밍, episodes 로드 순서 모두 분석 — 모든 시나리오에서 정상 동작해야 한다는 결론.
- **해결**: 동작 방식 바꾸기. *언제* 가드해야 할지 따지지 말고 *어디서* 복원할지 옮기는 게 더 깔끔. ScenesView 가 매번 마운트될 때 처리하는 것 자체가 race 의 원천 → root-level 1회 처리로 단순화.
- **교훈**: race condition 은 가드 추가보다 책임 이동이 근본 fix. ScenesView 처럼 자주 unmount/remount 되는 컴포넌트의 마운트 시점에서 store 상태를 복원하는 패턴은 외부 navigate 와 충돌 위험이 항상 존재.

## ✅ 테스트 가이드

### 사용자 테스트
> 아래 시나리오를 직접 실행해서 정상 동작을 확인해주세요.

1. **대시보드에서 다른 에피소드 알림 클릭 (핵심)**
   - 마지막으로 ep2 의 씬 뷰를 봤다가 대시보드로 이동
   - ep1 의 어떤 씬에 멘션된 catch-up 알림이 있다고 가정
   - 알림 패널 열어 그 알림 클릭 → "씬 보기"
   - ✅ 기대: ep1 의 해당 씬으로 정확히 이동 + 펄스 효과 + 정확한 파트 시트
   - ❌ 비정상: ep2 화면이 그대로면서 같은 sceneNo 만 빛남

2. **씬 뷰 내에서 다른 에피소드 알림 클릭 (회귀)**
   - 씬 뷰 안에서 알림 패널 열어 다른 에피소드 알림 클릭
   - ✅ 기대: 정상 이동 (v1.15.10 동작 유지)

3. **앱 재시작 시 마지막 에피소드 복원 (회귀)**
   - 알림 없이 그냥 앱 종료 후 재실행
   - 씬 뷰 진입 시 ✅ 기대: 마지막에 봤던 에피소드 자동 선택

### 개발자 테스트
```bash
npm run build:vite  # tsc + vite 빌드 통과 확인
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)