### PR TITLE
[v1.15.12] 댓글 패널 cowork 스타일 + 이미지 첨부

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -12,6 +12,12 @@
       "runtimeExecutable": "python",
       "runtimeArgs": ["-m", "http.server", "5555"],
       "port": 5555
+    },
+    {
+      "name": "comment-mockup",
+      "runtimeExecutable": "python",
+      "runtimeArgs": ["-m", "http.server", "5557"],
+      "port": 5557
     }
   ]
 }

--- a/demo/comment-mockup.html
+++ b/demo/comment-mockup.html
@@ -1,0 +1,540 @@
+<!DOCTYPE html>
+<html lang="ko" data-color-mode="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>B flow 댓글 패널 디자인 목업</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <style>
+    :root {
+      --bg-primary: #0F1117;
+      --bg-card: #1A1D27;
+      --bg-card-elev: #232634;
+      --bg-input: #14161F;
+      --border: #2D3041;
+      --border-strong: #3D4154;
+      --text-primary: #E8E8EE;
+      --text-secondary: #8B8DA3;
+      --text-tertiary: #6A6E84;
+      --accent: #6C5CE7;
+      --accent-light: #A29BFE;
+      --green: #10B981;
+      --red: #EF4444;
+      --shadow-base: 0 4px 16px rgba(0,0,0,0.25);
+      --shadow-card: 0 4px 16px rgba(0,0,0,0.25), 0 0 0 1px rgba(108,92,231,0.06);
+      --pulse-rgb: 108, 92, 231;
+    }
+    [data-color-mode="light"] {
+      --bg-primary: #F4F5FB;
+      --bg-card: #FFFFFF;
+      --bg-card-elev: #F8F9FE;
+      --bg-input: #FFFFFF;
+      --border: #E0E2EC;
+      --border-strong: #C7CAD8;
+      --text-primary: #1A1D27;
+      --text-secondary: #6A6E84;
+      --text-tertiary: #9396A8;
+      --shadow-base: 0 4px 16px rgba(20,22,30,0.08);
+      --shadow-card: 0 4px 16px rgba(20,22,30,0.08), 0 0 0 1px rgba(108,92,231,0.04);
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--bg-primary);
+      color: var(--text-primary);
+      font-family: 'Pretendard', -apple-system, BlinkMacSystemFont, 'Apple SD Gothic Neo', 'Malgun Gothic', sans-serif;
+      min-height: 100vh;
+      transition: background 250ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+    ::-webkit-scrollbar { width: 8px; height: 8px; }
+    ::-webkit-scrollbar-track { background: transparent; }
+    ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 4px; }
+    ::-webkit-scrollbar-thumb:hover { background: var(--border-strong); }
+    .smooth { transition: all 250ms cubic-bezier(0.16, 1, 0.3, 1); }
+    .smooth-fast { transition: all 150ms cubic-bezier(0.16, 1, 0.3, 1); }
+    textarea { font-family: inherit; }
+    input[type=range] { accent-color: var(--accent); }
+
+    /* 입력창 부드러운 자라기 */
+    .smooth-h {
+      transition: height 220ms cubic-bezier(0.16, 1, 0.3, 1);
+    }
+
+    /* 입력 카드 (떠있는 모습) — focus 펄스 효과 */
+    .input-card {
+      box-shadow: var(--shadow-card);
+      transition: border-color 200ms ease, box-shadow 250ms cubic-bezier(0.16, 1, 0.3, 1);
+    }
+    .input-card-focused {
+      animation: input-pulse 2.4s ease-in-out infinite;
+    }
+    @keyframes input-pulse {
+      0%, 100% {
+        box-shadow:
+          var(--shadow-base),
+          0 0 0 1px rgba(var(--pulse-rgb), 0.28);
+      }
+      50% {
+        box-shadow:
+          var(--shadow-base),
+          0 0 0 6px rgba(var(--pulse-rgb), 0.16);
+      }
+    }
+    /* 드래그 중 입력 카드 — 펄스 멈추고 진한 강조 */
+    .input-card-dragover {
+      animation: none !important;
+      box-shadow:
+        var(--shadow-base),
+        0 0 0 2px rgba(var(--pulse-rgb), 0.55) !important;
+    }
+
+    /* 드래그 오버레이 — 댓글 패널 전체 덮음 */
+    .drop-overlay {
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      background: rgba(var(--pulse-rgb), 0.16);
+      backdrop-filter: blur(2px);
+      -webkit-backdrop-filter: blur(2px);
+      border: 2px dashed rgba(var(--pulse-rgb), 0.7);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      pointer-events: none;
+      z-index: 20;
+      animation: drop-overlay-in 180ms cubic-bezier(0.16, 1, 0.3, 1);
+    }
+    @keyframes drop-overlay-in {
+      from { opacity: 0; transform: scale(0.98); }
+      to { opacity: 1; transform: scale(1); }
+    }
+    .drop-icon {
+      animation: drop-icon-bounce 1.2s ease-in-out infinite;
+    }
+    @keyframes drop-icon-bounce {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-6px); }
+    }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" data-presets="env,react">
+    const { useState, useRef, useEffect, useLayoutEffect, useCallback } = React;
+
+    const DEMO_COMMENTS = [
+      { id: 1, author: '한솔', text: '안녕하세요! 이 씬 작업 시작합니다.', isOwn: true, time: '14:23' },
+      { id: 2, author: '민지', text: '네 안녕하세요. 레퍼런스 확인했어요.', isOwn: false, time: '14:25' },
+      { id: 3, author: '동수', text: '@한솔 회의는 언제 잡으면 될까요?', isOwn: false, time: '14:30' },
+      { id: 4, author: '한솔', text: '오늘 4시 어떠세요?', isOwn: true, time: '14:32' },
+      { id: 5, author: '수빈', text: '4시 좋아요!', isOwn: false, time: '14:33' },
+      { id: 6, author: '민지', text: '저도 가능합니다 🙂', isOwn: false, time: '14:35' },
+      { id: 7, author: '기훈', text: '이 부분 컨셉 다시 한번 확인 부탁드립니다.', isOwn: false, time: '14:40' },
+    ];
+
+    function CommentBubble({ c }) {
+      return (
+        <div className={`flex ${c.isOwn ? 'justify-end' : 'justify-start'}`}>
+          <div className="max-w-[78%]">
+            <div className="flex items-center gap-2 mb-1" style={{ flexDirection: c.isOwn ? 'row-reverse' : 'row' }}>
+              <span className="text-xs font-medium" style={{ color: 'var(--text-secondary)' }}>{c.author}</span>
+              <span className="text-[10px]" style={{ color: 'var(--text-tertiary)' }}>{c.time}</span>
+            </div>
+            <div
+              className="px-3 py-2 rounded-lg text-sm leading-relaxed whitespace-pre-wrap break-words"
+              style={{
+                background: c.isOwn ? 'var(--accent)' : 'var(--bg-card-elev)',
+                color: c.isOwn ? '#fff' : 'var(--text-primary)',
+                border: c.isOwn ? 'none' : '1px solid var(--border)',
+              }}
+            >
+              {c.text}
+              {c.images && c.images.length > 0 && (
+                <div className={`grid gap-1 mt-2 ${c.images.length === 1 ? 'grid-cols-1' : 'grid-cols-2'}`}>
+                  {c.images.map((img, i) => (
+                    <img key={i} src={img} className="rounded-md w-full object-cover" style={{ maxHeight: 140 }} alt="" />
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    // ── 현재 디자인 ──
+    function CurrentCommentPanel({ width, panelHeight, comments, inputText, setInputText }) {
+      const taRef = useRef(null);
+      useEffect(() => {
+        const ta = taRef.current;
+        if (!ta) return;
+        ta.style.height = 'auto';
+        ta.style.height = Math.min(ta.scrollHeight, 200) + 'px';
+      }, [inputText]);
+
+      return (
+        <div
+          className="flex flex-col rounded-xl border smooth"
+          style={{
+            width,
+            height: panelHeight,
+            background: 'var(--bg-card)',
+            borderColor: 'var(--border)',
+          }}
+        >
+          <div
+            className="flex items-center justify-between px-4 py-3 border-b"
+            style={{ borderColor: 'var(--border)' }}
+          >
+            <span className="font-semibold text-sm">댓글 및 활동</span>
+            <span className="text-xs" style={{ color: 'var(--text-secondary)' }}>{comments.length}개</span>
+          </div>
+
+          <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3 min-h-0">
+            {comments.map(c => <CommentBubble key={c.id} c={c} />)}
+          </div>
+
+          <div className="px-4 py-3 border-t" style={{ borderColor: 'var(--border)' }}>
+            <div className="flex gap-2 items-end">
+              <textarea
+                ref={taRef}
+                value={inputText}
+                onChange={e => setInputText(e.target.value)}
+                placeholder="댓글 입력..."
+                rows={1}
+                className="flex-1 px-3 py-2 rounded-xl border text-sm resize-none outline-none smooth-fast"
+                style={{
+                  background: 'var(--bg-input)',
+                  borderColor: 'var(--border)',
+                  color: 'var(--text-primary)',
+                  maxHeight: 200,
+                  minHeight: 40,
+                }}
+              />
+              <button
+                className="px-4 py-2 rounded-xl text-sm font-medium text-white smooth-fast"
+                style={{ background: 'var(--green)' }}
+              >전송</button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    // ── 새 디자인 ──
+    function NewCommentPanel({ width, panelHeight, comments, inputText, setInputText, attachedImages, addImage, removeImage, inputMaxPct }) {
+      const taRef = useRef(null);
+      const [draggingOver, setDraggingOver] = useState(false);
+      const [focused, setFocused] = useState(false);
+      const [taHeight, setTaHeight] = useState(40);
+
+      const inputBoxMaxPx = Math.floor(panelHeight * inputMaxPct);
+      const imageRowHeight = attachedImages.length > 0 ? 80 : 0;
+      const taMaxPx = Math.max(40, inputBoxMaxPx - imageRowHeight - 24);
+
+      // 측정만 'auto'로 잠깐, 곧바로 이전 height 복원 → setState 가 transition 발동 (px → px)
+      useLayoutEffect(() => {
+        const ta = taRef.current;
+        if (!ta) return;
+        const prev = ta.style.height;
+        ta.style.height = 'auto';
+        const sh = ta.scrollHeight;
+        ta.style.height = prev;
+        const next = Math.max(40, Math.min(sh, taMaxPx));
+        setTaHeight(next);
+      }, [inputText, taMaxPx]);
+
+      const handlePaste = (e) => {
+        const items = Array.from(e.clipboardData?.items || []);
+        const imageItems = items.filter(it => it.type.startsWith('image/'));
+        if (imageItems.length > 0) {
+          e.preventDefault();
+          imageItems.forEach(it => {
+            const file = it.getAsFile();
+            if (file) {
+              const url = URL.createObjectURL(file);
+              addImage({ id: Date.now() + Math.random(), url });
+            }
+          });
+        }
+      };
+      // 드래그 카운터 — 자식 위로 이동 시 깜빡임 방지
+      const dragCounter = useRef(0);
+      const handleDragEnter = (e) => {
+        e.preventDefault();
+        if (e.dataTransfer?.types?.includes('Files')) {
+          dragCounter.current += 1;
+          if (dragCounter.current === 1) setDraggingOver(true);
+        }
+      };
+      const handleDragOver = (e) => { e.preventDefault(); };
+      const handleDragLeave = (e) => {
+        e.preventDefault();
+        dragCounter.current = Math.max(0, dragCounter.current - 1);
+        if (dragCounter.current === 0) setDraggingOver(false);
+      };
+      const handleDrop = (e) => {
+        e.preventDefault();
+        dragCounter.current = 0;
+        setDraggingOver(false);
+        const files = Array.from(e.dataTransfer.files).filter(f => f.type.startsWith('image/'));
+        files.forEach(f => {
+          const url = URL.createObjectURL(f);
+          addImage({ id: Date.now() + Math.random(), url });
+        });
+      };
+
+      return (
+        <div
+          onDragEnter={handleDragEnter}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+          className="flex flex-col rounded-xl border smooth relative"
+          style={{
+            width,
+            height: panelHeight,
+            background: 'var(--bg-card)',
+            borderColor: 'var(--border)',
+          }}
+        >
+          {draggingOver && (
+            <div className="drop-overlay">
+              <div className="flex flex-col items-center gap-2 px-4 text-center">
+                <div className="drop-icon text-5xl">🖼️</div>
+                <div className="text-base font-semibold" style={{ color: 'var(--accent-light)' }}>
+                  이미지를 여기에 놓으세요
+                </div>
+                <div className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+                  여러 장을 한 번에 첨부할 수 있어요
+                </div>
+              </div>
+            </div>
+          )}
+          <div
+            className="flex items-center justify-between px-4 py-3 border-b"
+            style={{ borderColor: 'var(--border)' }}
+          >
+            <span className="font-semibold text-sm">댓글 및 활동</span>
+            <span className="text-xs" style={{ color: 'var(--text-secondary)' }}>{comments.length}개</span>
+          </div>
+
+          <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3 min-h-0 smooth">
+            {comments.map(c => <CommentBubble key={c.id} c={c} />)}
+          </div>
+
+          <div className="px-3 pb-3 pt-2">
+            <div
+              onPaste={handlePaste}
+              className={`rounded-xl border p-2 input-card ${focused && !draggingOver ? 'input-card-focused' : ''} ${draggingOver ? 'input-card-dragover' : ''}`}
+              style={{
+                background: 'var(--bg-card-elev)',
+                borderColor: draggingOver ? 'var(--accent)' : (focused ? 'var(--accent-light)' : 'var(--border-strong)'),
+              }}
+            >
+              {attachedImages.length > 0 && (
+                <div className="flex gap-2 mb-2 overflow-x-auto pb-1 smooth" style={{ height: 76 }}>
+                  {attachedImages.map(img => (
+                    <div key={img.id} className="relative flex-shrink-0 group">
+                      <img
+                        src={img.url}
+                        className="w-16 h-16 object-cover rounded-lg border smooth-fast"
+                        style={{ borderColor: 'var(--border)' }}
+                        alt=""
+                      />
+                      <button
+                        onClick={() => removeImage(img.id)}
+                        className="absolute -top-1.5 -right-1.5 w-5 h-5 rounded-full text-white text-[11px] flex items-center justify-center smooth-fast hover:scale-110"
+                        style={{ background: 'var(--red)', border: '2px solid var(--bg-card-elev)' }}
+                        title="제거"
+                      >×</button>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              <div className="flex items-end gap-1.5">
+                <textarea
+                  ref={taRef}
+                  value={inputText}
+                  onChange={e => setInputText(e.target.value)}
+                  onFocus={() => setFocused(true)}
+                  onBlur={() => setFocused(false)}
+                  placeholder="댓글 입력... (Ctrl+V / 드래그로 이미지 첨부)"
+                  rows={1}
+                  className="flex-1 px-2 py-2 text-sm resize-none outline-none bg-transparent leading-relaxed smooth-h"
+                  style={{ color: 'var(--text-primary)', height: taHeight, minHeight: 40 }}
+                />
+                <button
+                  onClick={() => addImage({
+                    id: Date.now() + Math.random(),
+                    url: `https://picsum.photos/seed/${Math.floor(Math.random()*1000)}/200/200`
+                  })}
+                  className="w-9 h-9 rounded-lg flex items-center justify-center text-base smooth-fast"
+                  style={{ background: 'transparent', color: 'var(--text-secondary)' }}
+                  title="이미지 첨부"
+                  onMouseEnter={e => { e.currentTarget.style.background = 'var(--bg-card)'; e.currentTarget.style.color = 'var(--text-primary)'; }}
+                  onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'var(--text-secondary)'; }}
+                >📎</button>
+                <button
+                  className="w-9 h-9 rounded-lg flex items-center justify-center text-white smooth-fast"
+                  style={{ background: 'var(--accent)' }}
+                  title="전송"
+                  onMouseEnter={e => e.currentTarget.style.background = 'var(--accent-light)'}
+                  onMouseLeave={e => e.currentTarget.style.background = 'var(--accent)'}
+                >↑</button>
+              </div>
+            </div>
+            <div className="text-[10px] text-center mt-1.5" style={{ color: 'var(--text-tertiary)' }}>
+              입력 카드 최대 높이 {inputBoxMaxPx}px (패널의 35%) · 그 이상은 입력창 안에서 스크롤
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    function App() {
+      const [inputText, setInputText] = useState('');
+      const [attachedImages, setAttachedImages] = useState([]);
+      const [panelWidth, setPanelWidth] = useState(320);
+      const inputMaxPct = 0.35; // 한솔 결정: 35% 고정
+      const [colorMode, setColorMode] = useState('dark');
+      const panelHeight = 620;
+
+      const addImage = (img) => setAttachedImages(prev => [...prev, img]);
+      const removeImage = (id) => setAttachedImages(prev => prev.filter(i => i.id !== id));
+
+      useEffect(() => {
+        document.documentElement.dataset.colorMode = colorMode;
+      }, [colorMode]);
+
+      const fillText = (lines) => {
+        const samples = [
+          '이 씬 수정 필요해요.',
+          '컨셉 톤을 좀 더 어둡게 가는 게 좋을 것 같아요.',
+          '레퍼런스 다시 확인해 주세요.',
+          '@민지 색감 한번 봐주실래요?',
+          '내일 회의 때 같이 얘기하면 좋을 것 같습니다.',
+          '디테일이 살짝 부족한 것 같은데...',
+          '구도는 좋아요.',
+          '캐릭터 위치 조금만 옮기면 완벽할 듯.',
+          '그림자 방향 한번 더 체크 부탁드려요.',
+          '마지막으로 한 번 더 검토 후 넘어가겠습니다.',
+        ].slice(0, lines);
+        setInputText(samples.join('\n'));
+      };
+
+      return (
+        <div className="min-h-screen p-6">
+          <div className="max-w-7xl mx-auto">
+            <div className="mb-6 flex items-center justify-between flex-wrap gap-4">
+              <div>
+                <h1 className="text-xl font-bold mb-1">B flow 댓글 패널 디자인 목업</h1>
+                <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
+                  좌측: 현재 디자인 / 우측: 새 디자인 (cowork 스타일, 입력창이 카드처럼 떠있음)
+                </p>
+              </div>
+              <button
+                onClick={() => setColorMode(m => m === 'dark' ? 'light' : 'dark')}
+                className="px-3 py-2 rounded-lg text-sm border smooth-fast"
+                style={{ borderColor: 'var(--border)', background: 'var(--bg-card)' }}
+              >
+                {colorMode === 'dark' ? '☀️ 라이트 모드' : '🌙 다크 모드'}
+              </button>
+            </div>
+
+            <div
+              className="rounded-xl border p-4 mb-6 grid grid-cols-1 md:grid-cols-2 gap-6"
+              style={{ background: 'var(--bg-card)', borderColor: 'var(--border)' }}
+            >
+              <div>
+                <label className="text-xs block mb-2 font-medium" style={{ color: 'var(--text-secondary)' }}>패널 너비</label>
+                <div className="flex gap-2">
+                  {[320, 380, 420].map(w => (
+                    <button
+                      key={w}
+                      onClick={() => setPanelWidth(w)}
+                      className="px-3 py-1.5 rounded text-xs border smooth-fast"
+                      style={{
+                        background: panelWidth === w ? 'var(--accent)' : 'transparent',
+                        borderColor: panelWidth === w ? 'var(--accent)' : 'var(--border)',
+                        color: panelWidth === w ? '#fff' : 'var(--text-primary)',
+                      }}
+                    >{w}px</button>
+                  ))}
+                </div>
+                <p className="text-[10px] mt-1" style={{ color: 'var(--text-tertiary)' }}>
+                  현재 앱은 320px (w-80) · 입력 카드 최대 높이 <span style={{ color: 'var(--accent-light)' }}>35% 고정</span> ({Math.floor(panelHeight * inputMaxPct)}px)
+                </p>
+              </div>
+
+              <div>
+                <label className="text-xs block mb-2 font-medium" style={{ color: 'var(--text-secondary)' }}>테스트 컨트롤</label>
+                <div className="flex gap-1.5 flex-wrap">
+                  <button onClick={() => setInputText('')} className="px-2.5 py-1 rounded text-xs border smooth-fast" style={{ borderColor: 'var(--border)' }}>비우기</button>
+                  {[1, 3, 6, 10].map(n => (
+                    <button key={n} onClick={() => fillText(n)} className="px-2.5 py-1 rounded text-xs border smooth-fast" style={{ borderColor: 'var(--border)' }}>{n}줄</button>
+                  ))}
+                  <button
+                    onClick={() => addImage({ id: Date.now() + Math.random(), url: `https://picsum.photos/seed/${Math.floor(Math.random()*1000)}/200/200` })}
+                    className="px-2.5 py-1 rounded text-xs border smooth-fast"
+                    style={{ borderColor: 'var(--border)' }}
+                  >🖼️ 이미지 추가</button>
+                  <button onClick={() => setAttachedImages([])} className="px-2.5 py-1 rounded text-xs border smooth-fast" style={{ borderColor: 'var(--border)' }}>이미지 비우기</button>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex gap-8 items-start justify-center flex-wrap">
+              <div>
+                <div className="text-xs font-semibold mb-3 text-center" style={{ color: 'var(--text-tertiary)' }}>◀ 현재 디자인 (변경 전)</div>
+                <CurrentCommentPanel
+                  width={panelWidth}
+                  panelHeight={panelHeight}
+                  comments={DEMO_COMMENTS}
+                  inputText={inputText}
+                  setInputText={setInputText}
+                />
+              </div>
+              <div>
+                <div className="text-xs font-semibold mb-3 text-center" style={{ color: 'var(--accent-light)' }}>새 디자인 (cowork 스타일) ▶</div>
+                <NewCommentPanel
+                  width={panelWidth}
+                  panelHeight={panelHeight}
+                  comments={DEMO_COMMENTS}
+                  inputText={inputText}
+                  setInputText={setInputText}
+                  attachedImages={attachedImages}
+                  addImage={addImage}
+                  removeImage={removeImage}
+                  inputMaxPct={inputMaxPct}
+                />
+              </div>
+            </div>
+
+            <div
+              className="mt-8 max-w-2xl mx-auto rounded-xl border p-4 text-sm"
+              style={{ background: 'var(--bg-card)', borderColor: 'var(--border)' }}
+            >
+              <p className="font-semibold mb-2">💡 직접 시도해 보세요</p>
+              <ul className="text-xs space-y-1" style={{ color: 'var(--text-secondary)' }}>
+                <li>• <strong>입력창에 텍스트 길게 입력</strong> → 위 댓글 영역이 동적으로 줄어듦</li>
+                <li>• <strong>📎 아이콘 클릭</strong> → 데모 이미지 추가 (한 댓글에 여러 장)</li>
+                <li>• <strong>이미지 파일 드래그</strong> → 입력 카드 위로 던지면 보라 점선 테두리</li>
+                <li>• <strong>Ctrl+V</strong> → 클립보드의 스크린샷 바로 붙여넣기</li>
+                <li>• <strong>상단 컨트롤</strong> → 패널 너비 (320/380/420px), 입력창 최대 높이 슬라이더로 비교</li>
+                <li>• <strong>다크/라이트 모드</strong> 우상단 버튼으로 전환</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+  </script>
+</body>
+</html>

--- a/docs/superpowers/specs/2026-04-28-comment-panel-cowork-style-design.md
+++ b/docs/superpowers/specs/2026-04-28-comment-panel-cowork-style-design.md
@@ -1,0 +1,292 @@
+# 댓글 패널 cowork 스타일 + 이미지 첨부 — 디자인 문서
+
+**작성일**: 2026-04-28
+**대상 브랜치**: `claude/naughty-antonelli-ff9d16`
+**대상 버전**: v1.15.12 (예정)
+**작성자**: 한솔 × Claude
+
+---
+
+## 배경
+
+씬 디테일 모달의 댓글 입력창이 작고 단순해서 긴 피드백 작성/이미지 첨부가 불편했다. 클로드 데스크탑 cowork 입력창처럼 **카드로 떠있는 입력창** + **부드러운 자라기** + **이미지 첨부 (클립보드/드래그/버튼)** 를 한 묶음으로 도입한다. 같은 `CommentPanel.tsx` 가 [SceneDetailModal](../../../src/components/scenes/SceneDetailModal.tsx) 과 [UnifiedSceneDetailModal](../../../src/components/scenes/UnifiedSceneDetailModal.tsx) 두 곳에서 쓰이므로 **컴포넌트 한 곳만 고치면 양쪽 다 자동 적용**.
+
+---
+
+## 결정사항 요약 (브레인스토밍 결과)
+
+| # | 항목 | 한솔 결정 |
+|---|---|---|
+| 🅐 | 입력창 자라는 동작 | **A** — 패널 전체 높이는 고정, 입력창이 자라면 위 댓글 목록만 줄어듦 |
+| 🅑 | 시각적 분리 스타일 | **떠있는 카드** (cowork 스타일) — 입력창에 그림자 + 미세 보더로 떠있는 느낌, 위 목록과 12~16px 간격 |
+| 🅒 | 이미지 체판 동작 | **표준 채팅앱 스타일** — Ctrl+V / 드래그 / 📎 버튼 모두 지원, 한 댓글에 텍스트+이미지 여러 장 |
+| 🅓 | 입력 카드 최대 높이 | **35% 고정** (예: 패널 620px → 217px). 그 이상 텍스트는 입력창 안에서 스크롤 |
+| 🅔 | Focus 시 시각 신호 | **펄스 빛** — 액센트 보라 ring, 1px ↔ 6px, 2.4초 주기, 강도 0.16~0.28 |
+| 🅕 | 자라는 애니메이션 | **부드러운 transition** — `height 220ms cubic-bezier(0.16, 1, 0.3, 1)` (앱 표준 이징) |
+| 🅖 | 드래그 인식 영역 | **댓글 패널 전체** (입력 카드만 X) — 사용자가 어디로 떨어뜨려도 OK |
+| 🅗 | 드래그 오버레이 | 패널 전체에 보라 16% 반투명 + 2px 점선 + 🖼️ 큰 아이콘(통통 애니메이션) + "이미지를 여기에 놓으세요" 안내 |
+
+---
+
+## 시각적 변화 (요약)
+
+```
+┌─ 변경 전 ────────────────┐    ┌─ 변경 후 ────────────────┐
+│ 댓글 및 활동              │    │ 댓글 및 활동              │
+│                          │    │                          │
+│ 한솔  안녕하세요           │    │ 한솔  안녕하세요           │
+│ 민지  네 안녕하세요         │    │ 민지  네 안녕하세요         │
+│ 동수  회의 언제죠?         │    │ 동수  회의 언제죠?         │
+│ ...                      │    │ ...                      │
+│                          │    │                          │
+│ ─────────── 분리선 ──     │    │ ┌─ 떠있는 카드 ────┐     │
+│ [한 줄 입력...]   [전송]  │    │ │ [🖼️][🖼️] (썸네일) │     │
+└──────────────────────────┘    │ │ 입력...    📎 ↑  │     │
+                                │ └──────────────────┘     │
+                                └──────────────────────────┘
+```
+
+- 입력 카드: 약간 진한 배경(`--bg-card-elev`) + 그림자 + 보더, focus 시 보라 펄스 ring
+- 이미지 썸네일: 64x64, 가로 스크롤 줄, 호버 시 빨간 X 제거 버튼
+- 드래그 시: 패널 전체에 보라 반투명 오버레이, 큰 🖼️ 아이콘 통통 애니메이션
+- 좌측 변경 전: 단순 분리선 + textarea + 초록 전송 버튼
+- 우측 변경 후: 떠있는 카드 + 보라 ↑ 화살표 전송 버튼 + 📎 첨부 버튼
+
+---
+
+## 데이터 모델 변경
+
+### comments 테이블 — `images JSONB` 컬럼 추가
+
+**현재 스키마** ([DEVLOG/supabase-init.sql:62-73](../../../DEVLOG/supabase-init.sql)):
+```sql
+CREATE TABLE comments (
+  id TEXT PRIMARY KEY,
+  part_id UUID NOT NULL REFERENCES parts(id) ON DELETE CASCADE,
+  scene_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  user_name TEXT NOT NULL,
+  text TEXT NOT NULL,
+  mentions JSONB DEFAULT '[]'::jsonb,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  edited_at TIMESTAMPTZ
+);
+```
+
+**변경**: `mentions` 패턴과 동일한 `JSONB` 컬럼 추가
+```sql
+ALTER TABLE comments ADD COLUMN images JSONB DEFAULT '[]'::jsonb;
+```
+
+**저장 형식**: 이미지 URL 배열 (Supabase Storage 의 CDN URL)
+```jsonb
+["https://...storage.../scene-images/EP01_A_BG/3/comment-abc.jpg", "..."]
+```
+
+**호환성**: default `'[]'::jsonb` 라 기존 댓글에 영향 없음. 신규 버전 클라이언트만 images 필드 사용.
+
+### TypeScript 타입 변경
+
+`SceneComment` 인터페이스 ([commentService.ts:16](../../../src/services/commentService.ts)):
+```ts
+export interface SceneComment {
+  id: string;
+  userId: string;
+  userName: string;
+  text: string;
+  images?: string[];        // ← 추가 (선택, 기본 빈 배열)
+  mentions: string[];
+  createdAt: string;
+  editedAt?: string;
+}
+```
+
+`text` 는 빈 문자열 허용 (이미지만 보내는 댓글 가능). UI 검증: `text.trim() === '' && images.length === 0` 일 때만 전송 버튼 disabled.
+
+---
+
+## 영향 범위 (구현 위치)
+
+| Layer | 파일 | 변경 |
+|---|---|---|
+| DB | Supabase `comments` 테이블 | `images JSONB` 컬럼 추가 (마이그레이션) |
+| Electron preload | [electron/preload.ts:110-113](../../../electron/preload.ts) | `supabaseAddComment`, `supabaseEditComment` 시그니처에 `images: string[]` 파라미터 추가 |
+| Electron main | [electron/main.ts](../../../electron/main.ts) (해당 IPC 핸들러) | images 파라미터 받아 supabase insert/update |
+| Service | [src/services/supabaseService.ts:137,141](../../../src/services/supabaseService.ts) | wrapper 시그니처 업데이트 |
+| Service | [src/services/commentService.ts](../../../src/services/commentService.ts) | `addComment`/`updateComment` 시그니처에 images 추가, SceneComment 인터페이스 갱신 |
+| Types | [src/types/index.ts:499-500](../../../src/types/index.ts) | electronAPI 타입 시그니처 업데이트 |
+| Mock | [src/mocks/devElectronAPI.ts:118-119](../../../src/mocks/devElectronAPI.ts) | dev mock 시그니처 맞춤 |
+| Component | [src/components/scenes/CommentPanel.tsx](../../../src/components/scenes/CommentPanel.tsx) | **메인 작업** — 입력 카드 분리, 부드러운 자라기, 펄스, 드래그 오버레이, 이미지 업로드 |
+| 이미지 업로드 | [src/services/storageService.ts](../../../src/services/storageService.ts) | **재사용** — 기존 `uploadImage()` 그대로. 이미지 ID/scene/comment 포맷만 추가 정의 |
+
+---
+
+## 애니메이션/디자인 토큰 디테일
+
+### CSS 토큰
+```css
+--shadow-base: 0 4px 16px rgba(0,0,0,0.25);  /* light 모드 별도 */
+--pulse-rgb: 108, 92, 231;                    /* 액센트 보라 RGB */
+```
+
+### 핵심 클래스
+```css
+/* 부드러운 자라기 */
+.comment-input-textarea {
+  transition: height 220ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* 떠있는 입력 카드 */
+.comment-input-card {
+  background: var(--bg-card-elev);
+  border: 1px solid var(--border-strong);
+  box-shadow: var(--shadow-card);
+  transition: border-color 200ms ease, box-shadow 250ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+.comment-input-card.focused {
+  animation: comment-input-pulse 2.4s ease-in-out infinite;
+  border-color: var(--accent-light);
+}
+@keyframes comment-input-pulse {
+  0%, 100% { box-shadow: var(--shadow-base), 0 0 0 1px rgba(var(--pulse-rgb), 0.28); }
+  50%      { box-shadow: var(--shadow-base), 0 0 0 6px rgba(var(--pulse-rgb), 0.16); }
+}
+.comment-input-card.dragover {
+  animation: none !important;
+  box-shadow: var(--shadow-base), 0 0 0 2px rgba(var(--pulse-rgb), 0.55) !important;
+}
+
+/* 드래그 오버레이 (패널 전체) */
+.comment-drop-overlay {
+  position: absolute; inset: 0; border-radius: inherit;
+  background: rgba(var(--pulse-rgb), 0.16);
+  backdrop-filter: blur(2px);
+  border: 2px dashed rgba(var(--pulse-rgb), 0.7);
+  z-index: 20; pointer-events: none;
+  animation: drop-overlay-in 180ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+.comment-drop-icon {
+  animation: drop-icon-bounce 1.2s ease-in-out infinite;
+}
+```
+
+### 자라는 동작 구현 패턴
+```ts
+// useLayoutEffect — paint 전 동기 측정/복원으로 시각적 점프 방지
+useLayoutEffect(() => {
+  const ta = taRef.current;
+  if (!ta) return;
+  const prev = ta.style.height;
+  ta.style.height = 'auto';        // 측정만 잠깐
+  const sh = ta.scrollHeight;
+  ta.style.height = prev;          // 즉시 복원 → React가 다음 렌더에서 px → px transition
+  setTaHeight(Math.min(sh, taMaxPx));
+}, [text, taMaxPx]);
+```
+**원리**: `auto → px` 사이는 transition 안 됨, `px → px` 사이는 부드러움. 측정 시 잠깐 'auto' 갔다가 곧바로 이전 px 복원해서 시각 점프 방지.
+
+### 드래그 카운터 패턴
+```ts
+const dragCounter = useRef(0);
+// dragenter: counter++, counter===1 일 때만 setDraggingOver(true)
+// dragleave: counter--, counter===0 일 때만 setDraggingOver(false)
+// drop: counter=0, setDraggingOver(false)
+```
+자식 요소 위로 드래그가 옮겨갈 때 발생하는 깜빡임 방지.
+
+---
+
+## 이미지 업로드 흐름
+
+1. **사용자 트리거**: Ctrl+V (paste) / 드래그 드롭 / 📎 버튼 (file picker)
+2. **즉시 미리보기**: `URL.createObjectURL(file)` 로 로컬 blob URL → 썸네일 줄에 즉시 표시 (낙관적)
+3. **백그라운드 업로드**: `imageUtils.resizeBlob(file, 800, 0.8)` → `storageService.uploadImage(sheetName, sceneId, 'comment', base64)` → CDN URL 반환
+4. **업로드 상태 표시**: 썸네일에 회색 오버레이 + 진행 스피너 (업로드 중) → 완료 시 사라짐
+5. **댓글 전송**: 모든 이미지 업로드 완료 후 `addComment(sceneKey, { text, images: [url1, url2, ...] })` 호출. 업로드 중이면 전송 버튼 비활성.
+6. **렌더링**: 댓글 말풍선 안에 텍스트 위/아래로 이미지 그리드(1장=full width / 2~4장=2x2 / 5장+=가로 스크롤). 클릭 시 라이트박스 (다음 단계)
+
+이미지 사이즈/포맷:
+- 업로드 직전 800px 최장변, JPEG 80% 품질로 리사이즈 (`imageUtils.resizeBlob` 기존 패턴)
+- Storage 경로: `scene-images/{sheetName}/{sceneId}/comment-{commentId}-{idx}.jpg`
+
+엣지 케이스:
+- 업로드 실패 → 썸네일에 빨간 X 아이콘 + 재시도 버튼
+- 빈 텍스트 + 빈 이미지 → 전송 비활성
+- 업로드 중인 이미지가 있으면 → 전송 버튼 회색 ("업로드 중..." 툴팁)
+
+---
+
+## 라이트박스 (이미지 클릭 확대) — 후속 검토
+
+이번 PR 스코프엔 **포함**. 표준 패턴:
+- 댓글 이미지 클릭 → 화면 전체 어두운 배경 + 이미지 원본 크기로 표시
+- ESC / 배경 클릭 / 우상단 X / 좌우 화살표 키 (여러 장 시) 로 닫기/이동
+- framer-motion 모달 진입 애니메이션 (앱 표준 0.2s easeOut)
+
+기존 앱에 이미 이미지 표시 컴포넌트가 있으면 (예: `SceneImageBox`) 라이트박스 패턴 재사용 — 구현 단계에서 확인.
+
+---
+
+## 구현 단계 (체크리스트)
+
+### Phase 1: DB & 백엔드
+- [ ] Supabase `comments` 테이블에 `images JSONB DEFAULT '[]'::jsonb` 컬럼 추가 (마이그레이션)
+- [ ] `electron/preload.ts` `supabaseAddComment` / `supabaseEditComment` 시그니처에 `images: string[]` 추가
+- [ ] `electron/main.ts` IPC 핸들러에서 images 파라미터를 supabase insert/update 에 전달
+- [ ] `src/types/index.ts` electronAPI 타입 업데이트
+- [ ] `src/mocks/devElectronAPI.ts` mock 시그니처 맞춤
+
+### Phase 2: Service Layer
+- [ ] `SceneComment` 인터페이스에 `images?: string[]` 추가
+- [ ] `commentService.addComment` / `updateComment` 에 images 파라미터 (default `[]`)
+- [ ] `commentService.loadPartComments` 의 raw → SceneComment 매핑에서 images 포함
+
+### Phase 3: CommentPanel 메인 구현
+- [ ] 입력 카드 분리 (떠있는 박스, CSS 클래스 `comment-input-card`)
+- [ ] textarea 부드러운 자라기 (useLayoutEffect + state + transition 220ms)
+- [ ] focus 펄스 애니메이션 (CSS `comment-input-pulse` 2.4s)
+- [ ] 입력 카드 최대 높이 35% 고정
+- [ ] 댓글 패널 전체에 onDragEnter/Over/Leave/Drop (드래그 카운터 패턴)
+- [ ] 드래그 오버레이 (보라 반투명 + 🖼️ 아이콘 + 안내문구, `comment-drop-overlay`)
+- [ ] 이미지 썸네일 줄 (가로 스크롤, 호버 X 버튼)
+- [ ] 📎 버튼 + 파일 picker
+- [ ] Ctrl+V paste 핸들러 (textarea 또는 카드 영역)
+- [ ] 이미지 업로드 (storageService 재사용) + 진행 상태 표시
+- [ ] 빈 텍스트 + 빈 이미지면 전송 비활성
+- [ ] 보낸 후 댓글 말풍선 안에 이미지 그리드 표시
+- [ ] 라이트박스 (클릭 시 확대 보기) — 가능하면 기존 패턴 재사용
+
+### Phase 4: 검증
+- [ ] `tsc --noEmit` 통과
+- [ ] `vite build` 통과
+- [ ] dev 서버에서 시각 확인 (preview 모드 mock 로그인 — `?preview=1`)
+- [ ] 시나리오: 짧은 댓글 / 긴 댓글 (스크롤) / 이미지만 / 텍스트+이미지 여러장 / 드래그 / 클립보드 / 업로드 실패
+
+---
+
+## 위험/엣지 케이스
+
+1. **DB 마이그레이션 후 구버전 클라이언트** — 구버전은 images 컬럼 모름 → 무시해도 OK (`text` 만 표시). 새 기능이라 신규 사용자만 영향. 한솔이 v1.15.12 빌드 배포하면 자동 동기화.
+
+2. **이미지 업로드 실패 시 댓글 처리** — 업로드 실패한 이미지는 댓글에 포함 안 함. 사용자가 재시도 또는 이미지 제거 후 전송.
+
+3. **clipboard.items 다중 이미지 동시 paste** — 한 번에 여러 이미지 paste 가능. 모두 썸네일 줄에 추가.
+
+4. **모바일/터치** — 현재 앱은 데스크탑 전용 (Electron). 모바일 터치 첨부는 스코프 외.
+
+5. **이미지 사이즈 한계** — Supabase Storage 무료 플랜은 50MB/파일. 800px 리사이즈 후 1MB 이하 보장. 한솔의 워크플로우에서 사실상 무관.
+
+6. **이미지 삭제** — 댓글 삭제 시 storage 이미지도 같이 정리할지? 이번 PR 스코프엔 **미포함** (cleanup 작업은 별도). 데이터는 남지만 새 댓글 전송에는 영향 없음.
+
+---
+
+## 참고 자료
+
+- 디자인 목업: `demo/comment-mockup.html` (이번 작업 중 띄움, 한솔 시각 확인 완료)
+- 디자인 토큰 출처: 앱 글로벌 CSS — 보라 액센트 `#6C5CE7`, sharp easing `cubic-bezier(0.16, 1, 0.3, 1)` 250ms 표준
+- 이미지 업로드 인프라: `storageService.uploadImage` (Supabase Storage `scene-images` 버킷)
+- 동기 패턴 참고: 기존 `SceneDetailModal` 의 이미지 업로드 (`UnifiedSceneDetailModal.tsx:158-205`) — 같은 흐름 재사용
+
+---
+
+*문서 버전: 2026-04-28 작성*

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1199,7 +1199,7 @@ ipcMain.handle('supabase:add-comment', wrapIpc(async (_e: unknown, commentId: st
     } catch { /* 무시 */ }
   }
 }));
-ipcMain.handle('supabase:edit-comment', wrapIpc(async (_e: unknown, commentId: string, text: string, mentions: string[], images: string[] = []) => {
+ipcMain.handle('supabase:edit-comment', wrapIpc(async (_e: unknown, commentId: string, text: string, mentions: string[], images?: string[]) => {
   await sbEditComment(commentId, text, mentions, images);
 }));
 ipcMain.handle('supabase:delete-comment', wrapIpc(async (_e: unknown, commentId: string) => {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1161,8 +1161,8 @@ ipcMain.handle('supabase:fetch-missed-mentions', wrapIpc(async (
   return sbFetchMissedMentions(userId, userName, since, limit ?? 50);
 }));
 ipcMain.handle('supabase:add-comment', wrapIpc(async (_e: unknown, commentId: string, partUuid: string, sceneId: string,
-  userId: string, userName: string, text: string, mentions: string[], createdAt: string) => {
-  await sbAddComment(commentId, partUuid, sceneId, userId, userName, text, mentions, createdAt);
+  userId: string, userName: string, text: string, mentions: string[], createdAt: string, images: string[] = []) => {
+  await sbAddComment(commentId, partUuid, sceneId, userId, userName, text, mentions, createdAt, images);
   // 활동 기록 — partUuid 로 부서/에피소드 + scene UUID 자동 조회
   // (sceneId 가 TEXT 형식이라 scenes 테이블 조회로 UUID 변환 — 그룹화 정확성 + 부서 필터 통과)
   if (currentActivityUser) {
@@ -1199,8 +1199,8 @@ ipcMain.handle('supabase:add-comment', wrapIpc(async (_e: unknown, commentId: st
     } catch { /* 무시 */ }
   }
 }));
-ipcMain.handle('supabase:edit-comment', wrapIpc(async (_e: unknown, commentId: string, text: string, mentions: string[]) => {
-  await sbEditComment(commentId, text, mentions);
+ipcMain.handle('supabase:edit-comment', wrapIpc(async (_e: unknown, commentId: string, text: string, mentions: string[], images: string[] = []) => {
+  await sbEditComment(commentId, text, mentions, images);
 }));
 ipcMain.handle('supabase:delete-comment', wrapIpc(async (_e: unknown, commentId: string) => {
   await sbDeleteComment(commentId);

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -111,10 +111,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   supabaseFetchMissedMentions: (userId: string, userName: string, since: string, limit?: number) =>
     ipcRenderer.invoke('supabase:fetch-missed-mentions', userId, userName, since, limit),
   supabaseAddComment: (commentId: string, partUuid: string, sceneId: string,
-    userId: string, userName: string, text: string, mentions: string[], createdAt: string) =>
-    ipcRenderer.invoke('supabase:add-comment', commentId, partUuid, sceneId, userId, userName, text, mentions, createdAt),
-  supabaseEditComment: (commentId: string, text: string, mentions: string[]) =>
-    ipcRenderer.invoke('supabase:edit-comment', commentId, text, mentions),
+    userId: string, userName: string, text: string, mentions: string[], createdAt: string, images: string[] = []) =>
+    ipcRenderer.invoke('supabase:add-comment', commentId, partUuid, sceneId, userId, userName, text, mentions, createdAt, images),
+  supabaseEditComment: (commentId: string, text: string, mentions: string[], images: string[] = []) =>
+    ipcRenderer.invoke('supabase:edit-comment', commentId, text, mentions, images),
   supabaseDeleteComment: (commentId: string) =>
     ipcRenderer.invoke('supabase:delete-comment', commentId),
   // 비공개 캘린더 이벤트 (Supabase 전용, Google Calendar 비연동)

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -113,7 +113,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   supabaseAddComment: (commentId: string, partUuid: string, sceneId: string,
     userId: string, userName: string, text: string, mentions: string[], createdAt: string, images: string[] = []) =>
     ipcRenderer.invoke('supabase:add-comment', commentId, partUuid, sceneId, userId, userName, text, mentions, createdAt, images),
-  supabaseEditComment: (commentId: string, text: string, mentions: string[], images: string[] = []) =>
+  supabaseEditComment: (commentId: string, text: string, mentions: string[], images?: string[]) =>
     ipcRenderer.invoke('supabase:edit-comment', commentId, text, mentions, images),
   supabaseDeleteComment: (commentId: string) =>
     ipcRenderer.invoke('supabase:delete-comment', commentId),

--- a/electron/storage.ts
+++ b/electron/storage.ts
@@ -63,7 +63,7 @@ function toBuffer(base64Data: string): Buffer {
 export async function uploadImage(
   sheetName: string,
   sceneId: string,
-  imageType: 'storyboard' | 'guide',
+  imageType: 'storyboard' | 'guide' | 'comment',
   base64Data: string,
 ): Promise<{ ok: boolean; url?: string; error?: string }> {
   try {

--- a/electron/supabase.ts
+++ b/electron/supabase.ts
@@ -1005,12 +1005,17 @@ export async function editComment(
  *  댓글 삭제 후 storage 에 영구 orphan 파일이 쌓이는 문제 방지.
  */
 export async function deleteComment(commentId: string): Promise<void> {
-  // 1) 행 삭제 전에 attached image URL 조회
-  const { data: row } = await supabase
+  // 1) 행 삭제 전에 attached image URL 조회.
+  // Codex P2 12차(2026-04-30): maybeSingle 의 error 도 명시 체크 — 일시적 네트워크/PostgREST 에러로
+  // images 가 [] 로 silent fallback 되면 storage 객체가 정리되지 않은 채 row 만 삭제되어 orphan.
+  const { data: row, error: fetchErr } = await supabase
     .from('comments')
     .select('images')
     .eq('id', commentId)
     .maybeSingle();
+  if (fetchErr) {
+    console.warn('[deleteComment] images 조회 실패 — storage 정리 누락 가능:', fetchErr);
+  }
   const images = (row?.images ?? []) as unknown[];
 
   // 2) 댓글 row 삭제

--- a/electron/supabase.ts
+++ b/electron/supabase.ts
@@ -978,16 +978,23 @@ export async function addComment(
   broadcastCommentAdded(sceneId, userName, userId, text, mentions);
 }
 
-/** 댓글 수정 */
+/** 댓글 수정.
+ *  Codex P1(2026-04-29): images 가 undefined 면 update payload 에서 빼서 기존 값 보존.
+ *  Sheets fallback 으로 attachment 정보를 모르는 댓글을 수정할 때 실 이미지 URL 들을 silently 덮어쓰지 않도록.
+ */
 export async function editComment(
   commentId: string,
   text: string,
   mentions: string[],
-  images: string[] = [],
+  images?: string[],
 ): Promise<void> {
+  const updates: Record<string, unknown> = {
+    text, mentions, edited_at: new Date().toISOString(),
+  };
+  if (images !== undefined) updates.images = images;
   const { error } = await supabase
     .from('comments')
-    .update({ text, mentions, images, edited_at: new Date().toISOString() })
+    .update(updates)
     .eq('id', commentId);
   throwIfError(error);
   broadcastDataChange('comments', 'UPDATE');

--- a/electron/supabase.ts
+++ b/electron/supabase.ts
@@ -1027,10 +1027,15 @@ export async function deleteComment(commentId: string): Promise<void> {
     })
     .filter((p): p is string => !!p);
   if (paths.length > 0) {
+    // Codex P2 11차(2026-04-30): supabase.storage.remove() 는 API 실패 시 throw 대신 { data, error } 를 반환.
+    // try/catch 만으로는 잡지 못하므로 error 객체를 명시적으로 확인.
     try {
-      await supabase.storage.from(STORAGE_BUCKET).remove(paths);
+      const { error: storageErr } = await supabase.storage.from(STORAGE_BUCKET).remove(paths);
+      if (storageErr) {
+        console.warn('[deleteComment] storage 이미지 정리 실패 (orphan 가능):', storageErr);
+      }
     } catch (err) {
-      console.warn('[deleteComment] storage 이미지 정리 실패 (orphan 가능):', err);
+      console.warn('[deleteComment] storage 이미지 정리 예외:', err);
     }
   }
 

--- a/electron/supabase.ts
+++ b/electron/supabase.ts
@@ -1000,10 +1000,40 @@ export async function editComment(
   broadcastDataChange('comments', 'UPDATE');
 }
 
-/** 댓글 삭제 */
+/** 댓글 삭제.
+ *  Codex P2 10차(2026-04-30): comment row 삭제 시 images JSONB 에 저장된 storage 객체들도 함께 정리 →
+ *  댓글 삭제 후 storage 에 영구 orphan 파일이 쌓이는 문제 방지.
+ */
 export async function deleteComment(commentId: string): Promise<void> {
+  // 1) 행 삭제 전에 attached image URL 조회
+  const { data: row } = await supabase
+    .from('comments')
+    .select('images')
+    .eq('id', commentId)
+    .maybeSingle();
+  const images = (row?.images ?? []) as unknown[];
+
+  // 2) 댓글 row 삭제
   const { error } = await supabase.from('comments').delete().eq('id', commentId);
   throwIfError(error);
+
+  // 3) storage 객체 정리 (fire-and-forget — 실패해도 row 삭제 자체는 이미 성공)
+  const STORAGE_BUCKET = 'scene-images';
+  const paths = images
+    .filter((u): u is string => typeof u === 'string')
+    .map((url) => {
+      const m = url.match(/\/storage\/v1\/object\/public\/scene-images\/(.+)$/);
+      return m ? m[1] : null;
+    })
+    .filter((p): p is string => !!p);
+  if (paths.length > 0) {
+    try {
+      await supabase.storage.from(STORAGE_BUCKET).remove(paths);
+    } catch (err) {
+      console.warn('[deleteComment] storage 이미지 정리 실패 (orphan 가능):', err);
+    }
+  }
+
   broadcastDataChange('comments', 'DELETE');
 }
 

--- a/electron/supabase.ts
+++ b/electron/supabase.ts
@@ -134,6 +134,7 @@ export interface SupabaseComment {
   userName: string;
   text: string;
   mentions: string[];
+  images: string[];
   createdAt: string;
   editedAt: string | null;
 }
@@ -902,6 +903,7 @@ export async function fetchMissedMentions(
         userName: c.user_name,
         text: c.text,
         mentions: c.mentions || [],
+        images: c.images || [],            // v1.15.12: 이미지 첨부
         createdAt: c.created_at,
         editedAt: c.edited_at,
       });
@@ -931,6 +933,7 @@ export async function readCommentsForPart(partUuid: string): Promise<SupabaseCom
     userName: c.user_name,
     text: c.text,
     mentions: c.mentions || [],
+    images: c.images || [],
     createdAt: c.created_at,
     editedAt: c.edited_at,
   }));
@@ -946,6 +949,7 @@ export async function addComment(
   text: string,
   mentions: string[],
   createdAt: string,
+  images: string[] = [],
 ): Promise<void> {
   // 이슈 F(2026-04-23) + Codex P1(2차): 댓글 경로의 sceneId는 scene.no (=sort_order).
   // sort_order 정확 매칭으로 scene_number 표기 규칙과 무관하게 정확히 식별.
@@ -967,6 +971,7 @@ export async function addComment(
     user_name: userName,
     text,
     mentions,
+    images,
     created_at: createdAt,
   });
   throwIfError(error);
@@ -978,10 +983,11 @@ export async function editComment(
   commentId: string,
   text: string,
   mentions: string[],
+  images: string[] = [],
 ): Promise<void> {
   const { error } = await supabase
     .from('comments')
-    .update({ text, mentions, edited_at: new Date().toISOString() })
+    .update({ text, mentions, images, edited_at: new Date().toISOString() })
     .eq('id', commentId);
   throwIfError(error);
   broadcastDataChange('comments', 'UPDATE');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.15.11",
+  "version": "1.15.12",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/components/scenes/CommentPanel.tsx
+++ b/src/components/scenes/CommentPanel.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
-import { Pencil, Trash2 } from 'lucide-react';
+import { useState, useEffect, useRef, useLayoutEffect, useCallback, useMemo } from 'react';
+import { Pencil, Trash2, Paperclip, X, ImagePlus, ArrowUp } from 'lucide-react';
 import { useAuthStore } from '@/stores/useAuthStore';
 import { useAppStore } from '@/stores/useAppStore';
 import {
@@ -11,10 +11,13 @@ import {
 } from '@/services/commentService';
 import type { SceneComment } from '@/services/commentService';
 import { sendMentionWebhook } from '@/services/slackWebhookService';
-import { formatTime, formatTimeShort } from '@/utils/formatTime';
+import { formatTimeShort } from '@/utils/formatTime';
 import { PathLinkifiedText } from '@/components/common/PathLinkifiedText';
+import * as storageService from '@/services/storageService';
+import { resizeBlob } from '@/utils/imageUtils';
+import '@/styles/comment-panel.css';
 
-// ─── 메인 컴포넌트 ───────────────────────────
+// ─── 타입 ───────────────────────────────────
 
 interface CommentPanelProps {
   /** 기본 sceneKey. 새 댓글은 항상 이 키에 저장된다 */
@@ -27,27 +30,91 @@ interface CommentPanelProps {
 /** 내부 렌더링용 — 원본이 어느 sceneKey 에서 왔는지 추적 */
 type SceneCommentWithSource = SceneComment & { _sourceKey?: string };
 
+/** 첨부 진행 중인 이미지 — 업로드 완료 시 uploadedUrl 채워짐 */
+interface AttachedImage {
+  id: string;
+  previewUrl: string;       // blob URL — 즉시 미리보기
+  uploadedUrl?: string;     // CDN URL — 업로드 완료 후
+  uploading: boolean;
+  error?: string;
+}
+
+// ─── sceneKey 분해 ─────────────────────────
+function parseSceneKey(sceneKey: string): { sheetName: string; sceneId: string } {
+  const idx = sceneKey.lastIndexOf(':');
+  return { sheetName: sceneKey.substring(0, idx), sceneId: sceneKey.substring(idx + 1) };
+}
+
+// ─── 메인 컴포넌트 ──────────────────────────
+
 export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: CommentPanelProps) {
   const { currentUser, users } = useAuthStore();
+  const { setView, setHighlightUserName } = useAppStore();
+
+  const { sheetName, sceneId } = useMemo(() => parseSceneKey(sceneKey), [sceneKey]);
+
+  // 댓글 상태
   const [comments, setComments] = useState<SceneCommentWithSource[]>([]);
-  const [input, setInput] = useState('');
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editText, setEditText] = useState('');
+
+  // 입력 상태
+  const [input, setInput] = useState('');
+  const [taHeight, setTaHeight] = useState(40);
+  const [focused, setFocused] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [attachedImages, setAttachedImages] = useState<AttachedImage[]>([]);
+
+  // 멘션 자동완성
   const [showMentions, setShowMentions] = useState(false);
   const [mentionFilter, setMentionFilter] = useState('');
-  const [submitting, setSubmitting] = useState(false);
   const [mentionIndex, setMentionIndex] = useState(0);
+
+  // 드래그 + 라이트박스
+  const [draggingOver, setDraggingOver] = useState(false);
+  const [lightboxUrl, setLightboxUrl] = useState<string | null>(null);
+
+  // 패널 높이 측정 — 입력 카드 35% 한계 계산
+  const [panelHeight, setPanelHeight] = useState(0);
+
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const mentionDropdownRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const dragCounter = useRef(0);
 
-  // 댓글 로드 — primary + optional secondary 조회 후 시간순 병합.
-  //
-  // 모드별 동작:
-  // - sheets 모드: loadPartComments 가 BG·ACT 양쪽 파트를 통합 조회하므로 primary 결과에 이미
-  //   양쪽 댓글이 모두 포함된다. secondary 결과는 primary 와 겹치지만 commentId dedupe 로 안전.
-  // - 로컬(파일) 모드 (Codex P2 2차, 2026-04-23): getComments 가 단일 sceneKey 만 읽으므로
-  //   통합 뷰 상세 모달에서 counterpart 부서 댓글을 보려면 secondary 도 반드시 조회해야 한다.
+  // ── 입력 카드 + textarea 한계 계산 ──
+  // 패널 전체 높이의 35% 까지 입력 카드가 자란다. 그 이상은 textarea 안에서 스크롤.
+  // textarea 가 hard cap (taMaxPx) 을 넘지 않게 막아 toolbar 영역이 카드 maxHeight 안에 항상 보이게 보장.
+  const inputCardMaxPx = Math.max(140, Math.floor(panelHeight * 0.35));
+  const imageRowHeight = attachedImages.length > 0 ? 88 : 0;       // 썸네일 64 + 위아래 여백 + pb-1
+  const FOOTER_H = 56;                                              // toolbar(h-7) + mt-1.5 + border + pt-1.5 + 카드 padding(pt-2 + pb-1.5)
+  const taMaxPx = Math.max(40, inputCardMaxPx - imageRowHeight - FOOTER_H);
+
+  // 패널 ResizeObserver — 부모 높이 변화 추적
+  useLayoutEffect(() => {
+    const panel = panelRef.current;
+    if (!panel) return;
+    const update = () => setPanelHeight(panel.clientHeight);
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(panel);
+    return () => ro.disconnect();
+  }, []);
+
+  // textarea 부드러운 자라기 — 측정 시 'auto' 잠깐 → 이전 px 복원 → setState (px → px transition)
+  useLayoutEffect(() => {
+    const ta = inputRef.current;
+    if (!ta) return;
+    const prev = ta.style.height;
+    ta.style.height = 'auto';
+    const sh = ta.scrollHeight;
+    ta.style.height = prev;
+    setTaHeight(Math.max(40, Math.min(sh, taMaxPx)));
+  }, [input, taMaxPx]);
+
+  // 댓글 로드 — primary + optional secondary 시간순 병합 (기존 로직)
   const loadComments = useCallback(() => {
     const primaryPromise = getComments(sceneKey).then((list) =>
       list.map<SceneCommentWithSource>((c) => ({ ...c, _sourceKey: sceneKey })),
@@ -62,7 +129,6 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
       const merged = [...a, ...b].sort(
         (x, y) => new Date(x.createdAt).getTime() - new Date(y.createdAt).getTime(),
       );
-      // commentId 기준 중복 제거 — sheets 모드 통합 조회로 primary·secondary가 겹쳐도 안전.
       const seen = new Set<string>();
       const deduped = merged.filter((c) => {
         if (seen.has(c.id)) return false;
@@ -76,7 +142,7 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
 
   useEffect(() => { loadComments(); }, [loadComments]);
 
-  // 다른 PC에서 댓글 변경 시 자동 리로드 (300ms 디바운스로 중복 방지)
+  // 다른 PC 변경 시 자동 리로드 (300ms 디바운스)
   useEffect(() => {
     let timer: ReturnType<typeof setTimeout> | null = null;
     const handler = () => {
@@ -104,9 +170,114 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
     items[mentionIndex]?.scrollIntoView({ block: 'nearest' });
   }, [mentionIndex, showMentions]);
 
-  // 댓글 작성 (낙관적 업데이트 + 중복 방지) — 저장은 항상 primary(sceneKey)에만
+  // 라이트박스 ESC 닫기
+  useEffect(() => {
+    if (!lightboxUrl) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setLightboxUrl(null);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [lightboxUrl]);
+
+  // 컴포넌트 언마운트 시 blob URL 정리
+  useEffect(() => {
+    return () => {
+      attachedImages.forEach(a => {
+        try { URL.revokeObjectURL(a.previewUrl); } catch { /* ignore */ }
+      });
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ── 이미지 업로드 ──
+  const uploadAttachedImage = useCallback(async (id: string, file: File | Blob) => {
+    try {
+      const base64 = await resizeBlob(file, 800, 0.8);
+      const result = await storageService.uploadImage(sheetName, sceneId, 'comment', base64);
+      if (result.ok && result.url) {
+        const url = result.url;
+        setAttachedImages(prev => prev.map(a =>
+          a.id === id ? { ...a, uploadedUrl: url, uploading: false } : a
+        ));
+      } else {
+        throw new Error(result.error || '업로드 실패');
+      }
+    } catch (err) {
+      console.error('[댓글 이미지 업로드 실패]', err);
+      const msg = err instanceof Error ? err.message : String(err);
+      setAttachedImages(prev => prev.map(a =>
+        a.id === id ? { ...a, uploading: false, error: msg } : a
+      ));
+    }
+  }, [sheetName, sceneId]);
+
+  const addAttachedImageFromBlob = useCallback((file: File | Blob) => {
+    const id = crypto.randomUUID();
+    const previewUrl = URL.createObjectURL(file);
+    setAttachedImages(prev => [...prev, { id, previewUrl, uploading: true }]);
+    void uploadAttachedImage(id, file);
+  }, [uploadAttachedImage]);
+
+  const removeAttachedImage = (id: string) => {
+    setAttachedImages(prev => {
+      const target = prev.find(a => a.id === id);
+      if (target?.previewUrl) {
+        try { URL.revokeObjectURL(target.previewUrl); } catch { /* ignore */ }
+      }
+      return prev.filter(a => a.id !== id);
+    });
+  };
+
+  // 클립보드 paste
+  const handlePaste = (e: React.ClipboardEvent) => {
+    const items = Array.from(e.clipboardData?.items || []);
+    const imageItems = items.filter(it => it.type.startsWith('image/'));
+    if (imageItems.length === 0) return;
+    e.preventDefault();
+    imageItems.forEach(it => {
+      const f = it.getAsFile();
+      if (f) addAttachedImageFromBlob(f);
+    });
+  };
+
+  // 드래그 카운터 패턴 — 자식 위 이동 시 깜빡임 방지
+  const handleDragEnter = (e: React.DragEvent) => {
+    e.preventDefault();
+    if (Array.from(e.dataTransfer?.types || []).includes('Files')) {
+      dragCounter.current += 1;
+      if (dragCounter.current === 1) setDraggingOver(true);
+    }
+  };
+  const handleDragOver = (e: React.DragEvent) => { e.preventDefault(); };
+  const handleDragLeave = (e: React.DragEvent) => {
+    e.preventDefault();
+    dragCounter.current = Math.max(0, dragCounter.current - 1);
+    if (dragCounter.current === 0) setDraggingOver(false);
+  };
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    dragCounter.current = 0;
+    setDraggingOver(false);
+    const files = Array.from(e.dataTransfer.files || []).filter(f => f.type.startsWith('image/'));
+    files.forEach(addAttachedImageFromBlob);
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files || []).filter(f => f.type.startsWith('image/'));
+    files.forEach(addAttachedImageFromBlob);
+    e.target.value = '';
+  };
+
+  // ── 전송 ──
+  const hasUploadingImage = attachedImages.some(a => a.uploading);
+  const uploadedImageUrls = attachedImages.map(a => a.uploadedUrl).filter((u): u is string => !!u);
+  const canSubmit = !submitting
+    && !hasUploadingImage
+    && (input.trim().length > 0 || uploadedImageUrls.length > 0);
+
   const handleSubmit = async () => {
-    if (!input.trim() || !currentUser || submitting) return;
+    if (!canSubmit || !currentUser) return;
     setSubmitting(true);
 
     const mentions = extractMentions(input, users.map(u => u.name));
@@ -116,39 +287,41 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
       userName: currentUser.name,
       text: input.trim(),
       mentions,
+      images: uploadedImageUrls,
       createdAt: new Date().toISOString(),
       _sourceKey: sceneKey,
     };
 
-    // 낙관적: 즉시 UI 반영
+    // 낙관적 UI
     const next = [...comments, comment];
     setComments(next);
     onCountChange?.(next.length);
+
+    // 입력 영역 초기화 + blob URL 정리
     setInput('');
-    // 전송 후 입력란 높이 초기화
-    if (inputRef.current) {
-      inputRef.current.style.height = 'auto';
-    }
+    setAttachedImages(prev => {
+      prev.forEach(a => {
+        try { URL.revokeObjectURL(a.previewUrl); } catch { /* ignore */ }
+      });
+      return [];
+    });
     setShowMentions(false);
 
     try {
       await addComment(sceneKey, comment);
 
-      // 슬랙 웹훅: 멘션된 사용자에게 알림 전송 (fire-and-forget)
-      console.log('[댓글 웹훅] mentions:', mentions, 'currentUser.slackId:', currentUser.slackId);
+      // 슬랙 멘션 웹훅 (기존 로직 보존)
       if (mentions.length > 0 && currentUser.slackId) {
-        const [sheetName, sceneId] = sceneKey.split(':');
         const parts = sheetName.match(/^EP(\d+)_([A-Z])_/);
         const epLabel = parts ? `EP.${parts[1].padStart(2, '0')}` : sheetName;
         const partLabel = parts ? `${parts[2]}파트` : '';
-
         for (const mentionedName of mentions) {
           const target = users.find(u => u.name === mentionedName);
           if (target?.slackId && target.slackId !== currentUser.slackId) {
             sendMentionWebhook({
               commentText: comment.text,
               episodeLabel: epLabel,
-              sceneId: sceneId || '',
+              sceneId,
               partLabel,
               sheetName,
               authorSlackId: currentUser.slackId,
@@ -158,7 +331,6 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
         }
       }
     } catch (err) {
-      // 롤백
       console.error('[댓글 추가 실패]', err);
       setComments(comments);
       onCountChange?.(comments.length);
@@ -167,15 +339,15 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
     }
   };
 
-  // 댓글 수정 (낙관적) — 대상 댓글의 _sourceKey 로 작업 (통합 뷰에서도 안전)
+  // 댓글 수정 (낙관적) — 이미지는 기존 그대로 유지 (수정은 텍스트만)
   const handleEdit = async (commentId: string) => {
     if (!editText.trim()) return;
     const target = comments.find((c) => c.id === commentId);
     const targetKey = target?._sourceKey ?? sceneKey;
     const mentions = extractMentions(editText, users.map(u => u.name));
+    const existingImages = target?.images ?? [];
     const prevComments = [...comments];
 
-    // 낙관적 UI 업데이트
     setComments(prev =>
       prev.map(c =>
         c.id === commentId
@@ -186,7 +358,7 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
     setEditingId(null);
 
     try {
-      await updateComment(targetKey, commentId, editText.trim(), mentions);
+      await updateComment(targetKey, commentId, editText.trim(), mentions, existingImages);
     } catch (err) {
       console.error('[댓글 수정 실패]', err);
       setComments(prevComments);
@@ -200,7 +372,6 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
     const prevComments = [...comments];
     const next = comments.filter(c => c.id !== commentId);
 
-    // 낙관적 UI 업데이트
     setComments(next);
     onCountChange?.(next.length);
 
@@ -213,16 +384,9 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
     }
   };
 
-  // @멘션 감지
+  // @멘션 입력 추적 (자라기 동작은 useLayoutEffect 가 담당)
   const handleInputChange = (text: string) => {
     setInput(text);
-    // 입력란 auto-grow (애니메이션 없이 즉시 리사이즈).
-    // Cowork 식 부드러운 전환은 v1.13.0 백로그 이슈 A2 에서 리팩토링 예정.
-    const ta = inputRef.current;
-    if (ta) {
-      ta.style.height = 'auto';
-      ta.style.height = `${Math.min(ta.scrollHeight, 200)}px`;
-    }
     const lastAt = text.lastIndexOf('@');
     if (lastAt >= 0) {
       const afterAt = text.slice(lastAt + 1);
@@ -236,7 +400,6 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
     setShowMentions(false);
   };
 
-  // @멘션 삽입
   const insertMention = (userName: string) => {
     const lastAt = input.lastIndexOf('@');
     const before = input.slice(0, lastAt);
@@ -249,15 +412,11 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
     u.name.toLowerCase().includes(mentionFilter)
   );
 
-  // @멘션 클릭 → 팀원 뷰로 이동 + 글로우 하이라이트
-  const { setView, setHighlightUserName } = useAppStore();
   const handleMentionClick = (userName: string) => {
     setHighlightUserName(userName);
     setView('team');
   };
 
-  // 텍스트 내 @멘션 렌더 (굵은 글씨 + 배경 하이라이트 + 클릭 가능)
-  // PathLinkifiedText 가 G:\ 경로를 PathBadge 로 분리하고, 그 사이 텍스트만 이 함수가 받아 멘션 처리.
   const renderMentionInSegment = (segment: string, baseIdx: number) => {
     const parts = segment.split(/(@\S+)/g);
     return parts.map((part, i) => {
@@ -286,9 +445,18 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
     <PathLinkifiedText text={text} renderTextSegment={renderMentionInSegment} />
   );
 
+  // ─── 렌더링 ────────────────────────────────
+
   return (
-    <div className="flex flex-col h-full">
-      {/* 댓글 목록 — 채팅 스타일. select-text: 말풍선·이름·시간 모두 드래그 선택 가능 (복사용) */}
+    <div
+      ref={panelRef}
+      onDragEnter={handleDragEnter}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+      className="flex flex-col h-full relative"
+    >
+      {/* 댓글 목록 */}
       <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-3 space-y-4 min-h-0 select-text">
         {comments.length === 0 ? (
           <div className="text-center py-10">
@@ -299,9 +467,10 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
           comments.map((comment) => {
             const isOwn = currentUser?.id === comment.userId;
             const isEditing = editingId === comment.id;
+            const hasImages = (comment.images?.length ?? 0) > 0;
             return (
               <div key={comment.id} className="group">
-                {/* 메타: 이름 + 시간 */}
+                {/* 메타 */}
                 <div className={`flex items-center gap-2 mb-1 ${isOwn ? 'justify-end' : 'justify-start'}`}>
                   {isOwn ? (
                     <>
@@ -367,13 +536,32 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
                           isOwn ? 'bg-emerald-500/20' : 'bg-bg-border/70'
                         }`}
                       >
-                        {renderText(comment.text)}
+                        {comment.text && <div>{renderText(comment.text)}</div>}
+                        {hasImages && (
+                          <div
+                            className={`grid gap-1 ${comment.text ? 'mt-2' : ''} ${
+                              comment.images!.length === 1 ? 'grid-cols-1' : 'grid-cols-2'
+                            }`}
+                          >
+                            {comment.images!.map((url, i) => (
+                              <img
+                                key={i}
+                                src={url}
+                                alt=""
+                                className="rounded-md w-full object-cover cursor-zoom-in hover:opacity-90 transition-opacity"
+                                style={{ maxHeight: 160 }}
+                                onClick={() => setLightboxUrl(url)}
+                                loading="lazy"
+                              />
+                            ))}
+                          </div>
+                        )}
                       </div>
                     )}
 
-                    {/* 수정/삭제 (자기 댓글만) — 호버 시 표시 */}
+                    {/* 수정/삭제 (자기 댓글만) */}
                     {isOwn && !isEditing && (
-                      <div className={`absolute top-0 ${isOwn ? '-left-14' : '-right-14'} flex gap-0.5 opacity-0 group-hover/bubble:opacity-100 transition-opacity`}>
+                      <div className="absolute top-0 -left-14 flex gap-0.5 opacity-0 group-hover/bubble:opacity-100 transition-opacity">
                         <button
                           onClick={() => { setEditingId(comment.id); setEditText(comment.text); }}
                           className="p-1 rounded hover:bg-bg-border/50 text-text-secondary hover:text-text-primary transition-colors cursor-pointer"
@@ -398,11 +586,11 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
         )}
       </div>
 
-      {/* 입력 영역 */}
-      <div className="px-4 py-3 border-t border-bg-border relative">
+      {/* 입력 영역 — 떠있는 카드 (위 댓글 영역과 시각적 분리) */}
+      <div className="px-3 pb-3 pt-3 relative">
         {/* @멘션 자동완성 */}
         {showMentions && filteredUsers.length > 0 && (
-          <div ref={mentionDropdownRef} className="absolute bottom-full left-4 right-4 mb-1 bg-bg-card border border-bg-border rounded-lg shadow-lg max-h-32 overflow-y-auto z-10">
+          <div ref={mentionDropdownRef} className="absolute bottom-full left-3 right-3 mb-1 bg-bg-card border border-bg-border rounded-lg shadow-lg max-h-32 overflow-y-auto z-30">
             {filteredUsers.map((user, i) => (
               <button
                 key={user.id}
@@ -417,15 +605,62 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
             ))}
           </div>
         )}
-        <div className="flex gap-2 items-end">
+
+        <div
+          onPaste={handlePaste}
+          className={`comment-input-card rounded-xl border px-2.5 pt-2 pb-1.5 ${focused && !draggingOver ? 'focused' : ''} ${draggingOver ? 'dragover' : ''}`}
+          style={{
+            background: 'rgb(var(--comment-card-elev-rgb))',
+            borderColor: draggingOver
+              ? 'rgb(var(--color-accent))'
+              : (focused ? 'rgb(var(--color-accent-sub))' : 'rgb(var(--color-bg-border))'),
+            maxHeight: inputCardMaxPx,
+          }}
+        >
+          {/* 이미지 썸네일 줄 */}
+          {attachedImages.length > 0 && (
+            <div className="flex gap-2 mb-2 overflow-x-auto pb-1" style={{ height: 76 }}>
+              {attachedImages.map(img => (
+                <div key={img.id} className="relative flex-shrink-0">
+                  <img
+                    src={img.previewUrl}
+                    className="w-16 h-16 object-cover rounded-lg border border-bg-border"
+                    alt=""
+                  />
+                  {img.uploading && (
+                    <div className="absolute inset-0 bg-black/40 rounded-lg flex items-center justify-center">
+                      <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                    </div>
+                  )}
+                  {img.error && (
+                    <div className="absolute inset-0 bg-red-500/40 rounded-lg flex items-center justify-center" title={`업로드 실패: ${img.error}`}>
+                      <X size={20} className="text-white" />
+                    </div>
+                  )}
+                  <button
+                    onClick={() => removeAttachedImage(img.id)}
+                    className="absolute -top-1.5 -right-1.5 w-5 h-5 rounded-full bg-red-500 text-white text-[11px] flex items-center justify-center hover:scale-110 transition-transform cursor-pointer"
+                    style={{ border: '2px solid rgb(var(--comment-card-elev-rgb))' }}
+                    title="제거"
+                  >×</button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* textarea — 풀 너비 */}
           <textarea
             ref={inputRef}
             value={input}
             onChange={(e) => handleInputChange(e.target.value)}
-            placeholder="댓글 입력..."
-            className="flex-1 bg-bg-primary border border-bg-border rounded-xl px-3 py-2 text-xs text-text-primary placeholder:text-text-secondary/40 resize-none focus:outline-none focus:border-accent min-h-[32px] max-h-[200px] overflow-y-auto"
+            onFocus={() => setFocused(true)}
+            onBlur={() => setFocused(false)}
+            placeholder="댓글 입력... (Ctrl+V / 드래그로 이미지)"
+            rows={1}
+            className="comment-input-textarea block w-full px-2 py-1.5 text-xs resize-none outline-none bg-transparent leading-relaxed text-text-primary placeholder:text-text-secondary/40 overflow-y-auto"
+            style={{ height: taHeight, maxHeight: taMaxPx, boxSizing: 'border-box' }}
             onKeyDown={(e) => {
-              // @멘션 드롭다운 키보드 탐색
+              // @멘션 키보드 탐색
               if (showMentions && filteredUsers.length > 0) {
                 if (e.key === 'ArrowDown') {
                   e.preventDefault();
@@ -454,19 +689,79 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
               }
             }}
           />
-          <button
-            onClick={handleSubmit}
-            disabled={!input.trim() || submitting}
-            className="px-3.5 py-2 rounded-xl bg-[#10B981] hover:bg-[#10B981]/80 disabled:opacity-30 disabled:cursor-not-allowed text-white text-xs font-medium transition-colors cursor-pointer"
-          >
-            {submitting ? (
-              <div className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-            ) : (
-              '전송'
-            )}
-          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            multiple
+            hidden
+            onChange={handleFileChange}
+          />
+          {/* 하단 toolbar — 좌측 첨부, 우측 전송 (cowork 스타일) */}
+          <div className="flex items-center justify-between mt-1.5 pt-1.5 border-t border-bg-border/40">
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              className="w-7 h-7 rounded-md flex items-center justify-center text-text-secondary hover:bg-bg-card hover:text-text-primary transition-colors cursor-pointer"
+              title="이미지 첨부"
+            >
+              <Paperclip size={14} />
+            </button>
+            <button
+              onClick={handleSubmit}
+              disabled={!canSubmit}
+              className="w-7 h-7 rounded-md flex items-center justify-center bg-accent hover:bg-accent-sub text-white disabled:opacity-30 disabled:cursor-not-allowed transition-colors cursor-pointer"
+              title={hasUploadingImage ? '이미지 업로드 중...' : '전송 (Enter)'}
+            >
+              {submitting ? (
+                <div className="w-3 h-3 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+              ) : (
+                <ArrowUp size={14} strokeWidth={2.5} />
+              )}
+            </button>
+          </div>
         </div>
       </div>
+
+      {/* 드래그 오버레이 */}
+      {draggingOver && (
+        <div className="comment-drop-overlay">
+          <div className="flex flex-col items-center gap-2 px-4 text-center">
+            <div className="comment-drop-icon text-accent">
+              <ImagePlus size={48} strokeWidth={1.6} />
+            </div>
+            <div className="text-sm font-semibold text-accent-sub">
+              이미지를 여기에 놓으세요
+            </div>
+            <div className="text-[11px] text-text-secondary">
+              여러 장을 한 번에 첨부할 수 있어요
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* 라이트박스 (이미지 클릭 시 확대) */}
+      {lightboxUrl && (
+        <div
+          className="comment-lightbox-backdrop cursor-zoom-out"
+          onClick={() => setLightboxUrl(null)}
+          role="dialog"
+          aria-modal="true"
+        >
+          <img
+            src={lightboxUrl}
+            alt=""
+            className="comment-lightbox-image cursor-default"
+            onClick={(e) => e.stopPropagation()}
+          />
+          <button
+            onClick={() => setLightboxUrl(null)}
+            className="absolute top-4 right-4 w-10 h-10 rounded-full bg-black/50 hover:bg-black/70 text-white flex items-center justify-center transition-colors cursor-pointer"
+            title="닫기 (ESC)"
+          >
+            <X size={20} />
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/scenes/CommentPanel.tsx
+++ b/src/components/scenes/CommentPanel.tsx
@@ -383,6 +383,22 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
       }
     } catch (err) {
       console.error('[댓글 추가 실패]', err);
+
+      // Codex P2 9차(2026-04-29): addComment 실패 + panel 이 그 동안 unmount 된 케이스 (slow request 중 close).
+      // setState 가 unmounted component 에서 drop 되어 prevAttached 의 uploadedUrl 정리 안 됨 → orphan.
+      // mountedRef 체크 후 state 복원 대신 storage 직접 정리.
+      if (!mountedRef.current) {
+        prevAttached.forEach(a => {
+          try { URL.revokeObjectURL(a.previewUrl); } catch { /* ignore */ }
+          if (a.uploadedUrl) {
+            storageService.deleteImage(a.uploadedUrl).catch(err2 => {
+              console.warn('[댓글 전송 실패 + unmount] storage 정리 실패:', err2);
+            });
+          }
+        });
+        return;
+      }
+
       // 롤백 — 댓글 리스트는 항상 복원.
       setComments(comments);
       onCountChange?.(comments.length);

--- a/src/components/scenes/CommentPanel.tsx
+++ b/src/components/scenes/CommentPanel.tsx
@@ -216,25 +216,30 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
       const result = await storageService.uploadImage(sheetName, sceneId, 'comment', base64);
       if (result.ok && result.url) {
         const url = result.url;
-        // Codex P2 8차(2026-04-29): unmount 후 upload 완료 시 React 가 setState drop → orphan 발생.
-        // mountedRef 로 직접 체크해 unmount 됐으면 즉시 storage 정리. setAttachedImages updater 안 side-effect 의존 X.
+        // Codex P2 8차(2026-04-29): unmount 후 upload 완료 시 React 가 setState drop → orphan.
         if (!mountedRef.current) {
           storageService.deleteImage(url).catch(err => {
             console.warn('[댓글 이미지 unmount race] 정리 실패:', err);
           });
           return;
         }
-        // mounted 상태 — ref 로 사용자가 진행 중 X 로 제거했는지 확인.
-        const stillExists = attachedImagesRef.current.some(a => a.id === id);
-        if (!stillExists) {
-          storageService.deleteImage(url).catch(err => {
-            console.warn('[댓글 이미지 race] 사용자 제거 후 도착한 업로드 객체 정리 실패:', err);
-          });
-          return;
-        }
-        setAttachedImages(prev => prev.map(a =>
-          a.id === id ? { ...a, uploadedUrl: url, uploading: false } : a
-        ));
+        // Codex P2 13차(2026-04-30): attachedImagesRef 가 useEffect 로 동기화되어 한 렌더 늦을 수 있어 race —
+        // 사용자 X 클릭 직후 ref 가 stale 한 상태에서 도착한 upload 가 stillExists=true 로 인식되면
+        // 이후 setAttachedImages.map 이 no-op 이 되어 uploadedUrl 이 어디에도 안 남고 orphan 발생.
+        // 해결: setAttachedImages functional updater 안에서 latest prev 로 직접 검사 (React 가 latest state 보장).
+        setAttachedImages(prev => {
+          const exists = prev.some(a => a.id === id);
+          if (!exists) {
+            // 사용자 X 클릭으로 이미 제거 → 도착한 upload 객체 정리
+            storageService.deleteImage(url).catch(err => {
+              console.warn('[댓글 이미지 race] 사용자 제거 후 도착한 업로드 객체 정리 실패:', err);
+            });
+            return prev;
+          }
+          return prev.map(a =>
+            a.id === id ? { ...a, uploadedUrl: url, uploading: false } : a
+          );
+        });
       } else {
         throw new Error(result.error || '업로드 실패');
       }

--- a/src/components/scenes/CommentPanel.tsx
+++ b/src/components/scenes/CommentPanel.tsx
@@ -329,11 +329,16 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
 
     // Codex P2(2026-04-29): blob URL revoke 와 attachedImages 초기화는 전송 성공 *후* 에 수행.
     // 실패 시 사용자가 같은 페이로드(텍스트 + 첨부)로 재시도할 수 있어야 새 이미지 첨부 흐름의 신뢰성이 보장된다.
+    // Codex P1 6차(2026-04-29): ref sync useEffect 가 한 렌더 늦을 수 있어, setState 직후 unmount 가 일어나면
+    // unmount cleanup 이 pre-submit 첨부물을 보고 in-flight 댓글의 이미지를 삭제하는 race 발생 가능.
+    // setState 와 동시에 ref 도 즉시 동기화하여 cleanup 이 항상 최신 상태(빈 배열) 를 본다.
     const prevInput = input;
     const prevAttached = attachedImages;
     setInput('');
+    inputValueRef.current = '';
     setShowMentions(false);
-    setAttachedImages([]);  // UI 에서는 즉시 비움 (낙관적), 실패 시 복원
+    setAttachedImages([]);
+    attachedImagesRef.current = [];
 
     try {
       await addComment(sceneKey, comment);

--- a/src/components/scenes/CommentPanel.tsx
+++ b/src/components/scenes/CommentPanel.tsx
@@ -180,11 +180,14 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
     return () => window.removeEventListener('keydown', onKey);
   }, [lightboxUrl]);
 
-  // 컴포넌트 언마운트 시 blob URL 정리.
-  // Codex P2(2026-04-29): 빈 deps 의 cleanup 은 초기 렌더 시 attachedImages([])만 capture →
-  // 이후 추가된 미리보기 URL 들은 revoke 되지 않아 메모리 누수. ref 로 latest 값 추적해서 unmount 시 정확히 정리.
+  // Codex P2(2026-04-29): cleanup + in-flight 롤백 정확도를 위한 latest 값 ref 추적.
+  // 빈 deps 의 cleanup 은 초기 렌더 값만 capture 하므로 ref 가 필수.
   const attachedImagesRef = useRef<AttachedImage[]>([]);
   useEffect(() => { attachedImagesRef.current = attachedImages; }, [attachedImages]);
+  const inputValueRef = useRef('');
+  useEffect(() => { inputValueRef.current = input; }, [input]);
+
+  // 컴포넌트 언마운트 시 blob URL 정리
   useEffect(() => {
     return () => {
       attachedImagesRef.current.forEach(a => {
@@ -227,6 +230,13 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
       const target = prev.find(a => a.id === id);
       if (target?.previewUrl) {
         try { URL.revokeObjectURL(target.previewUrl); } catch { /* ignore */ }
+      }
+      // Codex P2 4차(2026-04-29): 백그라운드 업로드가 이미 완료된 항목을 사용자가 X 로 제거하면
+      // Storage 의 객체도 함께 삭제 (orphan 파일 방지). fire-and-forget — 실패해도 UI 흐름 안 막음.
+      if (target?.uploadedUrl) {
+        storageService.deleteImage(target.uploadedUrl).catch(err => {
+          console.warn('[댓글 첨부 제거] Storage 삭제 실패:', err);
+        });
       }
       return prev.filter(a => a.id !== id);
     });
@@ -342,20 +352,19 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
       setComments(comments);
       onCountChange?.(comments.length);
 
-      // Codex P2 3차(2026-04-29): 전송 중 사용자가 새 드래프트를 입력했을 수 있다 (composer 는 in-flight 에도 편집 가능).
-      // 사용자 작업을 덮어쓰지 않게 functional updater 로 latest 값 확인 후, 비어있을 때만 prev 복원.
-      // 사용자가 새 작업을 시작했으면 prev 의 blob URL 만 revoke 해 leak 방지.
-      setInput(curr => (curr.length > 0 ? curr : prevInput));
-      setAttachedImages(curr => {
-        if (curr.length > 0) {
-          // 사용자가 새로 첨부 → prev URL 들 revoke 후 현재 유지
-          prevAttached.forEach(a => {
-            try { URL.revokeObjectURL(a.previewUrl); } catch { /* ignore */ }
-          });
-          return curr;
-        }
-        return prevAttached;
-      });
+      // Codex P2 4차(2026-04-29): in-flight 동안 사용자가 새 텍스트 *또는* 새 이미지 첨부를 시작했는지
+      // 두 ref 로 함께 확인. 둘 중 하나라도 새 작업이 있으면 prev 복원하면 stale draft 와 섞임 → 덮어쓰지 않고
+      // prev blob URL 만 revoke 해 leak 방지. 새 작업이 전혀 없을 때만 prev 복원해 단순 재시도.
+      const userStartedNew =
+        inputValueRef.current.length > 0 || attachedImagesRef.current.length > 0;
+      if (userStartedNew) {
+        prevAttached.forEach(a => {
+          try { URL.revokeObjectURL(a.previewUrl); } catch { /* ignore */ }
+        });
+      } else {
+        setInput(prevInput);
+        setAttachedImages(prevAttached);
+      }
     } finally {
       setSubmitting(false);
     }

--- a/src/components/scenes/CommentPanel.tsx
+++ b/src/components/scenes/CommentPanel.tsx
@@ -180,14 +180,17 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
     return () => window.removeEventListener('keydown', onKey);
   }, [lightboxUrl]);
 
-  // 컴포넌트 언마운트 시 blob URL 정리
+  // 컴포넌트 언마운트 시 blob URL 정리.
+  // Codex P2(2026-04-29): 빈 deps 의 cleanup 은 초기 렌더 시 attachedImages([])만 capture →
+  // 이후 추가된 미리보기 URL 들은 revoke 되지 않아 메모리 누수. ref 로 latest 값 추적해서 unmount 시 정확히 정리.
+  const attachedImagesRef = useRef<AttachedImage[]>([]);
+  useEffect(() => { attachedImagesRef.current = attachedImages; }, [attachedImages]);
   useEffect(() => {
     return () => {
-      attachedImages.forEach(a => {
+      attachedImagesRef.current.forEach(a => {
         try { URL.revokeObjectURL(a.previewUrl); } catch { /* ignore */ }
       });
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // ── 이미지 업로드 ──
@@ -339,13 +342,15 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
     }
   };
 
-  // 댓글 수정 (낙관적) — 이미지는 기존 그대로 유지 (수정은 텍스트만)
+  // 댓글 수정 (낙관적) — 이미지는 기존 그대로 유지 (수정은 텍스트만).
+  // Codex P1(2026-04-29): target.images 가 undefined (Sheets fallback) 면 그대로 undefined 전달 →
+  // updateComment 가 supabase update payload 에서 images 컬럼을 제외해 실 이미지 URL 들이 보존된다.
   const handleEdit = async (commentId: string) => {
     if (!editText.trim()) return;
     const target = comments.find((c) => c.id === commentId);
     const targetKey = target?._sourceKey ?? sceneKey;
     const mentions = extractMentions(editText, users.map(u => u.name));
-    const existingImages = target?.images ?? [];
+    const existingImages = target?.images;
     const prevComments = [...comments];
 
     setComments(prev =>

--- a/src/components/scenes/CommentPanel.tsx
+++ b/src/components/scenes/CommentPanel.tsx
@@ -338,11 +338,24 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
       }
     } catch (err) {
       console.error('[댓글 추가 실패]', err);
-      // 롤백 — 댓글 리스트 + 입력 텍스트 + 첨부 이미지 모두 복원해 재시도 가능하게
+      // 롤백 — 댓글 리스트는 항상 복원.
       setComments(comments);
       onCountChange?.(comments.length);
-      setInput(prevInput);
-      setAttachedImages(prevAttached);
+
+      // Codex P2 3차(2026-04-29): 전송 중 사용자가 새 드래프트를 입력했을 수 있다 (composer 는 in-flight 에도 편집 가능).
+      // 사용자 작업을 덮어쓰지 않게 functional updater 로 latest 값 확인 후, 비어있을 때만 prev 복원.
+      // 사용자가 새 작업을 시작했으면 prev 의 blob URL 만 revoke 해 leak 방지.
+      setInput(curr => (curr.length > 0 ? curr : prevInput));
+      setAttachedImages(curr => {
+        if (curr.length > 0) {
+          // 사용자가 새로 첨부 → prev URL 들 revoke 후 현재 유지
+          prevAttached.forEach(a => {
+            try { URL.revokeObjectURL(a.previewUrl); } catch { /* ignore */ }
+          });
+          return curr;
+        }
+        return prevAttached;
+      });
     } finally {
       setSubmitting(false);
     }

--- a/src/components/scenes/CommentPanel.tsx
+++ b/src/components/scenes/CommentPanel.tsx
@@ -380,8 +380,15 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
       const userStartedNew =
         inputValueRef.current.length > 0 || attachedImagesRef.current.length > 0;
       if (userStartedNew) {
+        // Codex P2 7차(2026-04-29): 사용자가 새 드래프트 시작했고 prev 를 버리는 분기 →
+        // previewUrl 뿐 아니라 *이미 업로드 완료된* uploadedUrl 도 storage 에서 삭제 (orphan 방지).
         prevAttached.forEach(a => {
           try { URL.revokeObjectURL(a.previewUrl); } catch { /* ignore */ }
+          if (a.uploadedUrl) {
+            storageService.deleteImage(a.uploadedUrl).catch(err => {
+              console.warn('[댓글 전송 실패 롤백] 버려진 업로드 객체 정리 실패:', err);
+            });
+          }
         });
       } else {
         setInput(prevInput);

--- a/src/components/scenes/CommentPanel.tsx
+++ b/src/components/scenes/CommentPanel.tsx
@@ -187,11 +187,19 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
   const inputValueRef = useRef('');
   useEffect(() => { inputValueRef.current = input; }, [input]);
 
-  // 컴포넌트 언마운트 시 blob URL 정리
+  // 컴포넌트 언마운트 시 blob URL 정리.
+  // Codex P2 5차(2026-04-29): unmount 시점에 attachedImages 에 남아있는 항목은 모두 *전송 안 된 draft* 다
+  // (성공 시 setAttachedImages([]) 으로 비워지므로). 업로드 완료된 draft 의 uploadedUrl 도 storage 에서 삭제 →
+  // "이미지 첨부 → 업로드 완료 → 패널 닫고 떠남" 같은 정상 사용자 행동에서 발생하던 storage leak 방지.
   useEffect(() => {
     return () => {
       attachedImagesRef.current.forEach(a => {
         try { URL.revokeObjectURL(a.previewUrl); } catch { /* ignore */ }
+        if (a.uploadedUrl) {
+          storageService.deleteImage(a.uploadedUrl).catch(err => {
+            console.warn('[댓글 패널 unmount] draft Storage 정리 실패:', err);
+          });
+        }
       });
     };
   }, []);
@@ -203,9 +211,18 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
       const result = await storageService.uploadImage(sheetName, sceneId, 'comment', base64);
       if (result.ok && result.url) {
         const url = result.url;
-        setAttachedImages(prev => prev.map(a =>
-          a.id === id ? { ...a, uploadedUrl: url, uploading: false } : a
-        ));
+        // Codex P2 5차(2026-04-29): 업로드 race — 사용자가 진행 중에 X 로 이미 제거했을 수 있다.
+        // functional updater 안에서 항목 존재 여부 확인 후, 없으면 방금 업로드된 객체를 즉시 storage 에서 삭제.
+        setAttachedImages(prev => {
+          const exists = prev.some(a => a.id === id);
+          if (!exists) {
+            storageService.deleteImage(url).catch(err => {
+              console.warn('[댓글 이미지 race] 사용자 제거 후 도착한 업로드 객체 정리 실패:', err);
+            });
+            return prev;
+          }
+          return prev.map(a => a.id === id ? { ...a, uploadedUrl: url, uploading: false } : a);
+        });
       } else {
         throw new Error(result.error || '업로드 실패');
       }

--- a/src/components/scenes/CommentPanel.tsx
+++ b/src/components/scenes/CommentPanel.tsx
@@ -186,6 +186,11 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
   useEffect(() => { attachedImagesRef.current = attachedImages; }, [attachedImages]);
   const inputValueRef = useRef('');
   useEffect(() => { inputValueRef.current = input; }, [input]);
+  // Codex P2 8차(2026-04-29): unmount 후 upload 완료 race 처리 — React 가 unmounted component 의 setState 를
+  // drop 하므로 setAttachedImages updater 안의 side-effect (deleteImage) 도 실행 안 됨 → orphan.
+  // mountedRef 로 unmount 여부를 직접 확인해 그 케이스에서 storage 즉시 정리.
+  const mountedRef = useRef(true);
+  useEffect(() => () => { mountedRef.current = false; }, []);
 
   // 컴포넌트 언마운트 시 blob URL 정리.
   // Codex P2 5차(2026-04-29): unmount 시점에 attachedImages 에 남아있는 항목은 모두 *전송 안 된 draft* 다
@@ -211,23 +216,31 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
       const result = await storageService.uploadImage(sheetName, sceneId, 'comment', base64);
       if (result.ok && result.url) {
         const url = result.url;
-        // Codex P2 5차(2026-04-29): 업로드 race — 사용자가 진행 중에 X 로 이미 제거했을 수 있다.
-        // functional updater 안에서 항목 존재 여부 확인 후, 없으면 방금 업로드된 객체를 즉시 storage 에서 삭제.
-        setAttachedImages(prev => {
-          const exists = prev.some(a => a.id === id);
-          if (!exists) {
-            storageService.deleteImage(url).catch(err => {
-              console.warn('[댓글 이미지 race] 사용자 제거 후 도착한 업로드 객체 정리 실패:', err);
-            });
-            return prev;
-          }
-          return prev.map(a => a.id === id ? { ...a, uploadedUrl: url, uploading: false } : a);
-        });
+        // Codex P2 8차(2026-04-29): unmount 후 upload 완료 시 React 가 setState drop → orphan 발생.
+        // mountedRef 로 직접 체크해 unmount 됐으면 즉시 storage 정리. setAttachedImages updater 안 side-effect 의존 X.
+        if (!mountedRef.current) {
+          storageService.deleteImage(url).catch(err => {
+            console.warn('[댓글 이미지 unmount race] 정리 실패:', err);
+          });
+          return;
+        }
+        // mounted 상태 — ref 로 사용자가 진행 중 X 로 제거했는지 확인.
+        const stillExists = attachedImagesRef.current.some(a => a.id === id);
+        if (!stillExists) {
+          storageService.deleteImage(url).catch(err => {
+            console.warn('[댓글 이미지 race] 사용자 제거 후 도착한 업로드 객체 정리 실패:', err);
+          });
+          return;
+        }
+        setAttachedImages(prev => prev.map(a =>
+          a.id === id ? { ...a, uploadedUrl: url, uploading: false } : a
+        ));
       } else {
         throw new Error(result.error || '업로드 실패');
       }
     } catch (err) {
       console.error('[댓글 이미지 업로드 실패]', err);
+      if (!mountedRef.current) return;       // unmount 후 setState drop 방지
       const msg = err instanceof Error ? err.message : String(err);
       setAttachedImages(prev => prev.map(a =>
         a.id === id ? { ...a, uploading: false, error: msg } : a

--- a/src/components/scenes/CommentPanel.tsx
+++ b/src/components/scenes/CommentPanel.tsx
@@ -300,18 +300,21 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
     setComments(next);
     onCountChange?.(next.length);
 
-    // 입력 영역 초기화 + blob URL 정리
+    // Codex P2(2026-04-29): blob URL revoke 와 attachedImages 초기화는 전송 성공 *후* 에 수행.
+    // 실패 시 사용자가 같은 페이로드(텍스트 + 첨부)로 재시도할 수 있어야 새 이미지 첨부 흐름의 신뢰성이 보장된다.
+    const prevInput = input;
+    const prevAttached = attachedImages;
     setInput('');
-    setAttachedImages(prev => {
-      prev.forEach(a => {
-        try { URL.revokeObjectURL(a.previewUrl); } catch { /* ignore */ }
-      });
-      return [];
-    });
     setShowMentions(false);
+    setAttachedImages([]);  // UI 에서는 즉시 비움 (낙관적), 실패 시 복원
 
     try {
       await addComment(sceneKey, comment);
+
+      // 성공 — 이전 미리보기 blob URL revoke (메모리 정리)
+      prevAttached.forEach(a => {
+        try { URL.revokeObjectURL(a.previewUrl); } catch { /* ignore */ }
+      });
 
       // 슬랙 멘션 웹훅 (기존 로직 보존)
       if (mentions.length > 0 && currentUser.slackId) {
@@ -335,8 +338,11 @@ export function CommentPanel({ sceneKey, secondarySceneKey, onCountChange }: Com
       }
     } catch (err) {
       console.error('[댓글 추가 실패]', err);
+      // 롤백 — 댓글 리스트 + 입력 텍스트 + 첨부 이미지 모두 복원해 재시도 가능하게
       setComments(comments);
       onCountChange?.(comments.length);
+      setInput(prevInput);
+      setAttachedImages(prevAttached);
     } finally {
       setSubmitting(false);
     }

--- a/src/services/commentService.ts
+++ b/src/services/commentService.ts
@@ -19,6 +19,7 @@ export interface SceneComment {
   userName: string;
   text: string;
   mentions: string[];   // 태그된 사용자 이름 목록
+  images?: string[];    // Supabase Storage CDN URL — v1.15.12+ (이미지 첨부)
   createdAt: string;    // ISO 8601
   editedAt?: string;
 }
@@ -108,7 +109,7 @@ export async function loadPartComments(sheetName: string): Promise<CommentsStore
     }
   } catch { /* 무시 */ }
 
-  let rawComments: { id: string; partId: string; sceneId: string; userId: string; userName: string; text: string; mentions: string[]; createdAt: string; editedAt: string | null }[] = [];
+  let rawComments: { id: string; partId: string; sceneId: string; userId: string; userName: string; text: string; mentions: string[]; images?: string[]; createdAt: string; editedAt: string | null }[] = [];
 
   let supabaseFailed = false;
   if (partUuids.length > 0) {
@@ -132,7 +133,8 @@ export async function loadPartComments(sheetName: string): Promise<CommentsStore
         rawComments = (result.data ?? []).map((c) => ({
           id: c.commentId, partId: '', sceneId: c.sceneId,
           userId: c.userId, userName: c.userName, text: c.text,
-          mentions: c.mentions ?? [], createdAt: c.createdAt, editedAt: c.editedAt || null,
+          mentions: c.mentions ?? [], images: [],
+          createdAt: c.createdAt, editedAt: c.editedAt || null,
         }));
       }
     } catch { /* fallback도 실패 */ }
@@ -194,6 +196,7 @@ export async function loadPartComments(sheetName: string): Promise<CommentsStore
       userName: c.userName,
       text: c.text,
       mentions: c.mentions ?? [],
+      images: c.images ?? [],
       createdAt: c.createdAt,
       editedAt: c.editedAt || undefined,
     });
@@ -246,7 +249,7 @@ export async function addComment(sceneKey: string, comment: SceneComment): Promi
     await window.electronAPI.supabaseAddComment(
       comment.id, partUuid, sceneId,
       comment.userId, comment.userName, comment.text,
-      comment.mentions, comment.createdAt,
+      comment.mentions, comment.createdAt, comment.images ?? [],
     );
     // 캐시 업데이트 — 원본 sheet 캐시에만 낙관적 반영.
     // 반대 부서 sheet 캐시는 invalidate해서 다음 조회 시 통합 재조회로 반영 (중복 삽입 방지).
@@ -273,18 +276,18 @@ export async function addComment(sceneKey: string, comment: SceneComment): Promi
 }
 
 export async function updateComment(
-  sceneKey: string, commentId: string, text: string, mentions: string[],
+  sceneKey: string, commentId: string, text: string, mentions: string[], images: string[] = [],
 ): Promise<void> {
   const editedAt = new Date().toISOString();
 
   if (sheetsMode) {
     const { sheetName, sceneId } = parseSceneKey(sceneKey);
-    await window.electronAPI.supabaseEditComment(commentId, text, mentions);
+    await window.electronAPI.supabaseEditComment(commentId, text, mentions, images);
     // 캐시 업데이트 — commentId 기준으로 모든 캐시/리스트를 순회 (BG·ACT 양쪽 매핑 반영)
     sheetPartCache.forEach((store) => {
       for (const list of Object.values(store)) {
         const idx = list.findIndex(c => c.id === commentId);
-        if (idx >= 0) list[idx] = { ...list[idx], text, mentions, editedAt };
+        if (idx >= 0) list[idx] = { ...list[idx], text, mentions, images, editedAt };
       }
     });
     // 자기 창 뱃지/패널 즉시 갱신
@@ -300,7 +303,7 @@ export async function updateComment(
   const list = all[sceneKey];
   if (!list) return;
   const idx = list.findIndex(c => c.id === commentId);
-  if (idx >= 0) list[idx] = { ...list[idx], text, mentions, editedAt };
+  if (idx >= 0) list[idx] = { ...list[idx], text, mentions, images, editedAt };
   await saveLocal(all);
 }
 

--- a/src/services/commentService.ts
+++ b/src/services/commentService.ts
@@ -133,7 +133,9 @@ export async function loadPartComments(sheetName: string): Promise<CommentsStore
         rawComments = (result.data ?? []).map((c) => ({
           id: c.commentId, partId: '', sceneId: c.sceneId,
           userId: c.userId, userName: c.userName, text: c.text,
-          mentions: c.mentions ?? [], images: [],
+          mentions: c.mentions ?? [],
+          // Codex P1(2026-04-29): images 를 undefined 로 둔다. Sheets fallback 은 attachment 정보를 모름 →
+          // 빈 배열로 채우면 그 댓글을 수정할 때 supabaseEditComment 가 실 이미지 URL 들을 빈 배열로 덮어쓰는 사고 발생.
           createdAt: c.createdAt, editedAt: c.editedAt || null,
         }));
       }
@@ -196,7 +198,8 @@ export async function loadPartComments(sheetName: string): Promise<CommentsStore
       userName: c.userName,
       text: c.text,
       mentions: c.mentions ?? [],
-      images: c.images ?? [],
+      // images: c.images 가 undefined 면 그대로 undefined (Sheets fallback) — 수정 시 덮어쓰지 않게.
+      images: c.images,
       createdAt: c.createdAt,
       editedAt: c.editedAt || undefined,
     });
@@ -276,23 +279,24 @@ export async function addComment(sceneKey: string, comment: SceneComment): Promi
 }
 
 export async function updateComment(
-  sceneKey: string, commentId: string, text: string, mentions: string[], images: string[] = [],
+  sceneKey: string, commentId: string, text: string, mentions: string[], images?: string[],
 ): Promise<void> {
   const editedAt = new Date().toISOString();
+  // Codex P1(2026-04-29): images 를 옵셔널로 둔다. undefined 면 supabase update 에서 images 컬럼 자체를 빼고
+  // 캐시도 덮어쓰지 않는다 — Sheets fallback 댓글의 실 이미지 URL 들이 silently 삭제되는 사고 방지.
+  const imagesPatch: Pick<SceneComment, 'images'> | Record<string, never> =
+    images !== undefined ? { images } : {};
 
   if (sheetsMode) {
     const { sheetName, sceneId } = parseSceneKey(sceneKey);
     await window.electronAPI.supabaseEditComment(commentId, text, mentions, images);
-    // 캐시 업데이트 — commentId 기준으로 모든 캐시/리스트를 순회 (BG·ACT 양쪽 매핑 반영)
     sheetPartCache.forEach((store) => {
       for (const list of Object.values(store)) {
         const idx = list.findIndex(c => c.id === commentId);
-        if (idx >= 0) list[idx] = { ...list[idx], text, mentions, images, editedAt };
+        if (idx >= 0) list[idx] = { ...list[idx], text, mentions, ...imagesPatch, editedAt };
       }
     });
-    // 자기 창 뱃지/패널 즉시 갱신
     window.dispatchEvent(new CustomEvent('bflow:comments-invalidated', { detail: { sheetName } }));
-    // 다른 창에 댓글 변경 알림
     window.electronAPI?.dataNotifyChange?.({
       type: 'comment', sheetName, sceneId, commentAction: 'edit',
     });
@@ -303,7 +307,7 @@ export async function updateComment(
   const list = all[sceneKey];
   if (!list) return;
   const idx = list.findIndex(c => c.id === commentId);
-  if (idx >= 0) list[idx] = { ...list[idx], text, mentions, images, editedAt };
+  if (idx >= 0) list[idx] = { ...list[idx], text, mentions, ...imagesPatch, editedAt };
   await saveLocal(all);
 }
 

--- a/src/services/storageService.ts
+++ b/src/services/storageService.ts
@@ -7,7 +7,7 @@
 export async function uploadImage(
   sheetName: string,
   sceneId: string,
-  imageType: 'storyboard' | 'guide',
+  imageType: 'storyboard' | 'guide' | 'comment',
   base64Data: string,
 ): Promise<{ ok: boolean; url?: string; error?: string }> {
   return window.electronAPI.storageUploadImage(sheetName, sceneId, imageType, base64Data);

--- a/src/services/supabaseService.ts
+++ b/src/services/supabaseService.ts
@@ -133,12 +133,13 @@ export async function readCommentsFromSupabase(partUuid: string): Promise<unknow
 export async function addCommentToSupabase(
   commentId: string, partUuid: string, sceneId: string,
   userId: string, userName: string, text: string, mentions: string[], createdAt: string,
+  images: string[] = [],
 ): Promise<void> {
-  await window.electronAPI.supabaseAddComment(commentId, partUuid, sceneId, userId, userName, text, mentions, createdAt);
+  await window.electronAPI.supabaseAddComment(commentId, partUuid, sceneId, userId, userName, text, mentions, createdAt, images);
 }
 
-export async function editCommentInSupabase(commentId: string, text: string, mentions: string[]): Promise<void> {
-  await window.electronAPI.supabaseEditComment(commentId, text, mentions);
+export async function editCommentInSupabase(commentId: string, text: string, mentions: string[], images: string[] = []): Promise<void> {
+  await window.electronAPI.supabaseEditComment(commentId, text, mentions, images);
 }
 
 export async function deleteCommentFromSupabase(commentId: string): Promise<void> {

--- a/src/services/supabaseService.ts
+++ b/src/services/supabaseService.ts
@@ -138,7 +138,7 @@ export async function addCommentToSupabase(
   await window.electronAPI.supabaseAddComment(commentId, partUuid, sceneId, userId, userName, text, mentions, createdAt, images);
 }
 
-export async function editCommentInSupabase(commentId: string, text: string, mentions: string[], images: string[] = []): Promise<void> {
+export async function editCommentInSupabase(commentId: string, text: string, mentions: string[], images?: string[]): Promise<void> {
   await window.electronAPI.supabaseEditComment(commentId, text, mentions, images);
 }
 

--- a/src/styles/comment-panel.css
+++ b/src/styles/comment-panel.css
@@ -1,0 +1,100 @@
+/* ─── 댓글 패널 cowork 스타일 (v1.15.12) ─── */
+/* 떠있는 입력 카드 + 부드러운 자라기 + focus 펄스 + 드래그 오버레이 */
+
+:root {
+  --comment-shadow-base: 0 6px 18px rgba(0, 0, 0, 0.32);
+  --comment-card-elev-rgb: 41, 44, 60;       /* 다크 — bg-card 보다 한 단계 elevated */
+}
+[data-color-mode="light"] {
+  --comment-shadow-base: 0 6px 18px rgba(20, 22, 30, 0.12);
+  --comment-card-elev-rgb: 247, 248, 253;
+}
+
+/* textarea 부드러운 자라기 */
+.comment-input-textarea {
+  transition: height 220ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* 떠있는 입력 카드 */
+.comment-input-card {
+  box-shadow: var(--comment-shadow-base), 0 0 0 1px rgb(var(--color-accent) / 0.08);
+  transition: border-color 200ms ease, box-shadow 250ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+.comment-input-card.focused {
+  animation: comment-input-pulse 2.4s ease-in-out infinite;
+}
+@keyframes comment-input-pulse {
+  0%, 100% {
+    box-shadow:
+      var(--comment-shadow-base),
+      0 0 0 1px rgb(var(--color-accent) / 0.32);
+  }
+  50% {
+    box-shadow:
+      var(--comment-shadow-base),
+      0 0 0 6px rgb(var(--color-accent) / 0.18);
+  }
+}
+/* 드래그 중 입력 카드: 펄스 멈추고 진한 강조 */
+.comment-input-card.dragover {
+  animation: none !important;
+  box-shadow:
+    var(--comment-shadow-base),
+    0 0 0 2px rgb(var(--color-accent) / 0.6) !important;
+}
+
+/* 드래그 오버레이 — 댓글 패널 전체 덮음 */
+.comment-drop-overlay {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: rgb(var(--color-accent) / 0.18);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  border: 2px dashed rgb(var(--color-accent) / 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 20;
+  animation: comment-drop-overlay-in 180ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+@keyframes comment-drop-overlay-in {
+  from { opacity: 0; transform: scale(0.98); }
+  to { opacity: 1; transform: scale(1); }
+}
+.comment-drop-icon {
+  animation: comment-drop-icon-bounce 1.2s ease-in-out infinite;
+}
+@keyframes comment-drop-icon-bounce {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-6px); }
+}
+
+/* 라이트박스 (이미지 클릭 시 확대 보기) */
+.comment-lightbox-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.85);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: comment-lightbox-in 180ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+@keyframes comment-lightbox-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+.comment-lightbox-image {
+  max-width: 92vw;
+  max-height: 92vh;
+  object-fit: contain;
+  animation: comment-lightbox-image-in 220ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+@keyframes comment-lightbox-image-in {
+  from { opacity: 0; transform: scale(0.96); }
+  to { opacity: 1; transform: scale(1); }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -510,8 +510,8 @@ export interface ElectronAPI {
     createdAt: string;
     editedAt?: string | null;
   }>>;
-  supabaseAddComment: (commentId: string, partUuid: string, sceneId: string, userId: string, userName: string, text: string, mentions: string[], createdAt: string) => Promise<void>;
-  supabaseEditComment: (commentId: string, text: string, mentions: string[]) => Promise<void>;
+  supabaseAddComment: (commentId: string, partUuid: string, sceneId: string, userId: string, userName: string, text: string, mentions: string[], createdAt: string, images?: string[]) => Promise<void>;
+  supabaseEditComment: (commentId: string, text: string, mentions: string[], images?: string[]) => Promise<void>;
   supabaseDeleteComment: (commentId: string) => Promise<void>;
   /** 비공개 캘린더 이벤트 — Google Calendar 비연동, Supabase 전용 */
   supabaseReadPrivateEvents: (userId: string) => Promise<Array<{


### PR DESCRIPTION
## 📋 업데이트 요약

> 이번 업데이트에서 달라진 점을 간략하게 정리했습니다.

- ✨ **댓글에 이미지 첨부**: 스크린샷을 그대로 댓글 입력칸에 붙여넣기(Ctrl+V), 이미지 파일을 댓글 패널 위로 드래그, 또는 클립(📎) 아이콘 버튼으로 추가. 한 댓글에 텍스트 + 이미지 여러 장이 함께 들어갑니다.
- ✨ **이미지 클릭 시 화면 전체 확대**: 댓글 안 이미지를 클릭하면 어두운 배경 위에 큼직하게 보이고, ESC 또는 배경 클릭으로 닫힙니다.
- ⚡ **입력창 디자인 개편 (클로드 데스크탑 cowork 스타일)**: 입력창이 위 댓글 목록과 떨어진 카드 형태로 떠있고, 클릭(포커스) 시 보라색 빛이 은은하게 깜빡입니다. 글이 길어지면 입력창이 부드럽게 자라고, 위 댓글 목록은 그만큼 줄어듭니다 (패널 전체 높이의 최대 35%까지).
- ⚡ **이미지 드래그 시 안내**: 이미지 파일을 댓글 패널 위로 끌면, 패널 전체에 보라 점선 + 큼직한 아이콘 + "이미지를 여기에 놓으세요" 안내가 나타납니다.
- 🛡️ **기존 기능 100% 그대로**: @멘션 + 슬랙 알림, 댓글 수정/삭제, BG↔ACT 통합 조회, 다른 PC 즉시 반영, 로그인 시 catch-up 멘션 알림 모두 보존. 기존에 작성된 댓글들도 그대로 보입니다.

## 🔧 상세 기술 설명

### 데이터 모델 — `comments.images` JSONB 컬럼 추가
- Supabase 마이그레이션: `ALTER TABLE comments ADD COLUMN images JSONB DEFAULT '[]'::jsonb;`
- 기본값 빈 배열이라 기존 댓글 무손실. 구버전 클라이언트도 컬럼 무시 가능 → 버전 호환 안전
- 저장 형식: Supabase Storage CDN URL 배열

### Backend 시그니처 확장
- `electron/preload.ts`, `electron/main.ts` IPC 핸들러: `supabaseAddComment` / `supabaseEditComment`에 `images: string[]` 파라미터 추가 (default `[]`)
- `electron/supabase.ts`: `SupabaseComment.images: string[]` 추가, `addComment`/`editComment` insert/update에 매핑
- `electron/storage.ts`: `imageType` 유니언에 `'comment'` 추가 → Storage 경로 `scene-images/{sheet}/{scene}/comment_*.jpg`

### main 리베이스 시 의미적 충돌 해결
- main에 새로 들어온 v1.15.5+ catch-up 알림 함수 `fetchMissedMentions`의 객체 매핑이 우리가 추가한 `images` 필드를 누락 → 자동 머지 후 `images: c.images || []` 한 줄 추가로 해결
- 라인 단위 충돌은 `package.json` 버전 + `src/types/index.ts`의 `supabaseAddComment`/`supabaseEditComment` 시그니처에서 발생 (둘 다 단순 병합)

### CommentPanel.tsx 재구성
- 입력 영역 분리 — 떠있는 카드 (`comment-input-card`, `bg-card-elev` + 그림자 + 미세 보더)
- 부드러운 자라기 — `useLayoutEffect` 측정 후 이전 px 복원 → state로 setHeight → CSS `transition: height 220ms`. `auto → px` 점프 회피
- focus 펄스 — `comment-input-pulse` keyframe (2.4s, `0 0 0 1px → 6px → 1px` ring, 액센트 컬러)
- 드래그 인식 — 패널 전체 div에 `onDragEnter/Over/Leave/Drop`. 드래그 카운터 패턴(`dragCounter.current`)으로 자식 위 이동 시 깜빡임 방지
- 드래그 오버레이 — `comment-drop-overlay` (보라 16% 반투명 + 2px dashed + `ImagePlus` 아이콘 + 통통 애니메이션)
- 이미지 업로드 흐름 — `URL.createObjectURL` 즉시 미리보기 → 백그라운드 `resizeBlob(800px, JPEG 80%)` → `storageService.uploadImage` → CDN URL → 댓글 전송 시 `images` 배열로
- 라이트박스 — `comment-lightbox-backdrop` + `cursor-zoom-out` 배경 + ESC 키로 닫기
- 하단 toolbar 레이아웃 — textarea가 풀 너비, 아래쪽 미세 분리선 + 좌측 📎 / 우측 ↑ (입력칸 시각적으로 넓게)
- 35% 한계 정확 차감 — `inputCardMaxPx - imageRowHeight(88) - FOOTER_H(56)` → toolbar가 카드 maxHeight 안에 항상 보임

### 디자인 토큰 일관성
- `src/styles/comment-panel.css` 분리 (전역 import는 `CommentPanel.tsx`에서)
- 액센트 컬러 하드코딩(`rgba(108,92,231, ...)`) 제거 → `rgb(var(--color-accent) / x)` 토큰 사용 → 다크/라이트 모드 자동 따라감
- 그림자 라이트 모드 강화 (0.08 → 0.12) — 떠있는 카드 분리감 확보

### 디자인 협업 산출물
- `docs/superpowers/specs/2026-04-28-comment-panel-cowork-style-design.md` — 결정사항/구현 영향 범위 정리
- `demo/comment-mockup.html` — 브레인스토밍 단계 인터랙티브 디자인 목업 (Tailwind/React CDN)

## 🚧 개발 난항

### 1. textarea 자라는 동작이 툭툭 끊겼던 문제
- **문제**: 한솔 1차 시각 검토에서 "조금 어색하고 툭툭 끊김" 피드백
- **시도**: 처음엔 `ta.style.height = 'auto'` → 즉시 `scrollHeight` 적용. 그런데 `auto → px` 사이는 CSS transition이 안 걸림 → 끊김
- **해결**: `useLayoutEffect`로 측정 시 잠깐 'auto'로 갔다가 **즉시 이전 px 복원** → React state로 새 height 적용. 이러면 inline style 변경이 `px → px` 라 transition 정상 발동
- **교훈**: textarea auto-grow + 부드러운 transition은 측정/적용 분리가 필수. inline에 'auto'가 paint되면 깡총 점프 발생

### 2. toolbar가 카드 밖으로 삐져나간 문제
- **문제**: 한솔 2차 시각 검토에서 "댓글란이 최대로 밀리면 화살표 버튼이 카드 밖으로 내려가버림" 스크린샷 공유
- **시도**: 처음엔 `taMaxPx = inputCardMaxPx - 28`로 차감했는데 toolbar(border + padding + h-7)와 카드 padding을 합치면 ~56px 필요. 28px만 차감해서 textarea가 카드를 다 채우고 toolbar가 밖으로 밀려남
- **해결**: `FOOTER_H = 56` 상수로 정확히 차감. textarea에 `maxHeight: taMaxPx + overflow-y-auto` 명시 → textarea 한계 도달 시 자체 스크롤
- **교훈**: 카드의 `maxHeight`는 자식 합계의 hard cap. 자식 height를 직접 제어할 때는 형제 영역(toolbar) 차감 정확해야

### 3. 드래그 시 자식 위 이동 깜빡임
- **문제**: 단순 `onDragOver` / `onDragLeave`로 처리하면 드래그가 자식 요소 위로 옮겨갈 때 leave가 잠깐 발동 → 오버레이 깜빡임
- **해결**: `dragCounter.current` ref로 enter +1 / leave -1 / drop 0. counter === 1일 때만 진입, === 0일 때만 종료
- **교훈**: HTML5 drag API는 자식 진입 시마다 leave/enter pair가 발생하므로 ref counter가 표준 패턴

### 4. main 리베이스 — line 충돌은 없지만 의미 충돌 1건
- **문제**: `git merge-tree`는 exit 0 (라인 충돌 없음) 이지만 실제 rebase에서 `package.json` + `types/index.ts` 충돌 발생. 또 main에 새로 추가된 `fetchMissedMentions` 함수가 우리 `SupabaseComment.images` 필드를 매핑 안 함 → TypeScript 빌드 에러
- **해결**: 리베이스 충돌 해결(우리 v1.15.12 + main의 catch-up 정의 둘 다 유지) + `fetchMissedMentions`에 `images: c.images || []` 한 줄 추가
- **교훈**: 인터페이스에 필드 추가 시, 그 인터페이스를 사용하는 모든 매핑 함수를 grep해서 함께 손봐야

## ✅ 테스트 가이드

### 사용자 테스트 (한솔님)

> 평소처럼 dev 서버 띄우고(`npm run dev`) 미리보기 모드(`?preview=1`)에서 확인해 주세요.

1. **떠있는 카드 + 펄스**
   - 씬 카드 클릭 → 우측 댓글 패널
   - ✅ 입력창이 위 댓글 영역과 떨어진 카드로 보임 + 클릭 시 보라 빛이 은은하게 깜빡임
   - ❌ 단순 분리선처럼 붙어있거나, 펄스가 너무 강함

2. **부드러운 자라기 + 35% 한계**
   - 입력창에 긴 글 입력 (또는 줄바꿈 여러 번)
   - ✅ 입력창이 부드럽게 자라고, 위 댓글 영역이 그만큼 줄어듦. 패널 35% 한계 도달 시 입력창 안에서 스크롤
   - ✅ ↑ 화살표 버튼이 카드 안에 **항상 보임** (이전엔 카드 밖으로 삐져나감)

3. **이미지 첨부 — 3가지 방법**
   - 📎 아이콘 클릭 → 파일 선택
   - 입력창에서 Ctrl+V → 클립보드 스크린샷 붙여넣기
   - 이미지 파일을 댓글 패널 위로 드래그 → 보라 점선 오버레이 + 안내 → 놓기
   - ✅ 입력창 안에 썸네일 줄로 추가됨, 호버 시 빨간 X로 제거 가능
   - ✅ 한 댓글에 여러 장 가능

4. **댓글 전송 후 표시**
   - 텍스트만 / 이미지만 / 둘 다 시도
   - ✅ 댓글 말풍선 안에 텍스트와 이미지 그리드(1장=풀, 2장+=2x2)로 표시
   - ✅ 빈 텍스트 + 빈 이미지면 전송 비활성

5. **이미지 클릭 → 라이트박스**
   - 댓글 안 이미지 클릭
   - ✅ 화면 전체 어두워지고 이미지 크게 표시. ESC / 배경 / 우상단 X로 닫힘

6. **기존 기능 보존 확인**
   - @멘션 자동완성 → 슬랙 알림 발송
   - 자기 댓글 호버 → 수정/삭제 아이콘
   - 다른 PC에서 단 댓글이 즉시 반영되는지

### 개발자 테스트

\`\`\`bash
# 빌드 검증
npx tsc --noEmit
npm run build:vite
\`\`\`

수동 확인 사항:
- 이미지 업로드 실패 시 (네트워크 끊김 등) 썸네일에 빨간 X + 에러 토스트
- 다른 PC가 구버전 클라이언트(v1.15.x)일 때 새 댓글의 텍스트는 보이고 이미지만 안 보이는지
- catch-up 멘션 알림(v1.15.5+)이 이번 변경 후에도 정상 동작하는지

## 📊 변경 통계

- 14 files changed, 1335 insertions(+), 92 deletions(-)
- 새 파일: `src/styles/comment-panel.css`, `docs/superpowers/specs/2026-04-28-...md`, `demo/comment-mockup.html`
- DB 마이그레이션: 1건 (Supabase에 이미 적용됨)

🤖 Generated with [Claude Code](https://claude.com/claude-code)