### PR TITLE
[v1.16.0] BG/ACT 메모 동시 노출 + 씬 길이 변경 라벨 (LD/SD)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -18,6 +18,12 @@
       "runtimeExecutable": "python",
       "runtimeArgs": ["-m", "http.server", "5557"],
       "port": 5557
+    },
+    {
+      "name": "scene-meta-mockup",
+      "runtimeExecutable": "python",
+      "runtimeArgs": ["-m", "http.server", "5558"],
+      "port": 5558
     }
   ]
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -19,7 +19,8 @@
       "Bash(gh pr:*)",
       "Read(//g/공유 드라이브/JBBJ 자료실/한솔이의 두근두근 실험실/Bflow-BGonly//**)",
       "Read(//g/공유 드라이브/JBBJ 자료실/한솔이의 두근두근 실험실/Bflow-BGonly/**)",
-      "mcp__67cc0a56-abf9-4d18-9a05-e0e9d2c4761a__list_projects"
+      "mcp__67cc0a56-abf9-4d18-9a05-e0e9d2c4761a__list_projects",
+      "Bash(xargs wc *)"
     ]
   }
 }

--- a/DEVLOG/2026-05-01-add-length-change-migration.sql
+++ b/DEVLOG/2026-05-01-add-length-change-migration.sql
@@ -1,0 +1,16 @@
+-- v1.16.0 — scenes 테이블에 length_change 컬럼 추가
+--
+-- 씬 길이 변경 시각 라벨 (수동 토글, 영구).
+--   'LD' = Long Duration (길이 늘어남)
+--   'SD' = Short Duration (길이 줄어듦)
+--   NULL = 표시 없음 (기본)
+--
+-- 카드/시트 우클릭 메뉴로 토글. 영구 라벨 — 사용자가 직접 해제할 때까지 유지.
+-- 적용: Supabase SQL Editor에서 실행 후, scenes Realtime 채널에 자동 포함됨.
+
+ALTER TABLE scenes
+  ADD COLUMN IF NOT EXISTS length_change text NULL
+    CHECK (length_change IS NULL OR length_change IN ('LD', 'SD'));
+
+COMMENT ON COLUMN scenes.length_change IS
+  '씬 길이 변경 시각 라벨: LD(늘어남) / SD(줄어듦) / NULL(표시 없음). 카드/시트 우클릭으로 토글, 영구 라벨.';

--- a/demo/scene-meta-mockup.html
+++ b/demo/scene-meta-mockup.html
@@ -1,0 +1,2270 @@
+<!DOCTYPE html>
+<html lang="ko" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>B flow — 메모 + 씬 길이 변경 시안</title>
+<style>
+  /* ── 디자인 토큰 (실제 앱과 동일) ── */
+  :root[data-theme="dark"] {
+    --bg-primary: #0F1117;
+    --bg-card: #1A1D27;
+    --bg-card-elevated: #21242F;
+    --bg-border: #2D3041;
+    --bg-border-soft: rgba(45, 48, 65, 0.5);
+    --text-primary: #E8E8EE;
+    --text-secondary: #8B8DA3;
+    --text-muted: rgba(232, 232, 238, 0.4);
+    --accent: #6C5CE7;
+    --accent-soft: rgba(108, 92, 231, 0.15);
+    --memo: #FCD34D;       /* amber-300 */
+    --memo-soft: rgba(252, 211, 77, 0.7);
+    --memo-bg-only: #93C5FD;  /* BG 전용 톤 (살짝 시안 메모) */
+    --memo-act-only: #FDA4AF; /* ACT 전용 톤 (살짝 핑크 메모) */
+    --grow-up: #34D399;        /* 늘어남 */
+    --grow-up-soft: rgba(52, 211, 153, 0.15);
+    --shrink-down: #FB7185;    /* 줄어듦 */
+    --shrink-down-soft: rgba(251, 113, 133, 0.15);
+    --bg-stage-empty: rgba(255, 255, 255, 0.04);
+    --section-label: #8B8DA3;
+  }
+  :root[data-theme="light"] {
+    --bg-primary: #F4F5F8;
+    --bg-card: #FFFFFF;
+    --bg-card-elevated: #FAFBFD;
+    --bg-border: #E2E4EB;
+    --bg-border-soft: rgba(226, 228, 235, 0.6);
+    --text-primary: #1F2230;
+    --text-secondary: #6B7080;
+    --text-muted: rgba(31, 34, 48, 0.45);
+    --accent: #5848D9;
+    --accent-soft: rgba(88, 72, 217, 0.12);
+    --memo: #B45309;       /* amber-700 */
+    --memo-soft: rgba(180, 83, 9, 0.85);
+    --memo-bg-only: #1D4ED8;
+    --memo-act-only: #BE185D;
+    --grow-up: #059669;
+    --grow-up-soft: rgba(5, 150, 105, 0.14);
+    --shrink-down: #DC2626;
+    --shrink-down-soft: rgba(220, 38, 38, 0.12);
+    --bg-stage-empty: rgba(0, 0, 0, 0.04);
+    --section-label: #6B7080;
+  }
+
+  /* BG 단계 색 */
+  :root {
+    --stage-bg-lo: #C4BCFA;
+    --stage-bg-done: #A599F5;
+    --stage-bg-review: #8677EF;
+    --stage-bg-png: #6C5CE7;
+    --stage-act-lo: #F5BEB3;
+    --stage-act-done: #EDA293;
+    --stage-act-review: #E58A76;
+    --stage-act-png: #E17055;
+  }
+
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Pretendard", "Apple SD Gothic Neo", "Malgun Gothic", sans-serif;
+    font-size: 14px;
+    transition: background 0.2s ease, color 0.2s ease;
+    line-height: 1.5;
+  }
+
+  .header {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    backdrop-filter: blur(10px);
+    background: color-mix(in srgb, var(--bg-primary) 85%, transparent);
+    border-bottom: 1px solid var(--bg-border);
+    padding: 16px 32px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .header h1 {
+    font-size: 16px;
+    margin: 0;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+  .header .subtitle {
+    font-size: 11px;
+    color: var(--text-secondary);
+    margin-top: 2px;
+  }
+  .theme-toggle {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    background: var(--bg-card);
+    border: 1px solid var(--bg-border);
+    border-radius: 999px;
+    padding: 4px;
+  }
+  .theme-toggle button {
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    padding: 6px 12px;
+    border-radius: 999px;
+    cursor: pointer;
+    font-size: 12px;
+    transition: all 0.15s;
+  }
+  .theme-toggle button.active {
+    background: var(--accent);
+    color: white;
+  }
+
+  main { padding: 32px; max-width: 1480px; margin: 0 auto; }
+
+  /* ── 섹션 ── */
+  section {
+    margin-bottom: 56px;
+  }
+  .section-title {
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--section-label);
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    margin-bottom: 6px;
+  }
+  .section-desc {
+    font-size: 13px;
+    color: var(--text-secondary);
+    margin-bottom: 20px;
+    max-width: 760px;
+  }
+
+  .options-grid {
+    display: grid;
+    gap: 20px;
+    grid-template-columns: repeat(auto-fit, minmax(310px, 1fr));
+  }
+  .options-grid.three { grid-template-columns: repeat(auto-fit, minmax(310px, 1fr)); }
+  .options-grid.two { grid-template-columns: repeat(auto-fit, minmax(380px, 1fr)); }
+
+  .option-frame {
+    background: var(--bg-card-elevated);
+    border: 1px solid var(--bg-border-soft);
+    border-radius: 14px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .option-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+  }
+  .option-label .badge {
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 10px;
+    background: var(--bg-card);
+    border: 1px solid var(--bg-border);
+  }
+  .option-label .badge.before { color: var(--text-muted); }
+  .option-label .badge.after { color: var(--accent); border-color: var(--accent); background: var(--accent-soft); }
+  .option-label .badge.recommended { color: var(--grow-up); border-color: var(--grow-up); background: var(--grow-up-soft); }
+  .option-note {
+    font-size: 11px;
+    color: var(--text-muted);
+    line-height: 1.5;
+  }
+
+  /* ── 카드 (실제 UnifiedSceneCard 재현) ── */
+  .scene-card {
+    background: var(--bg-card);
+    border: 1px solid var(--bg-border);
+    border-radius: 12px;
+    overflow: visible;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.08), 0 8px 20px rgba(0,0,0,0.12);
+    position: relative;
+    cursor: pointer;
+    transition: all 0.15s ease;
+  }
+  :root[data-theme="light"] .scene-card {
+    box-shadow: 0 1px 3px rgba(0,0,0,0.04), 0 4px 12px rgba(0,0,0,0.06);
+  }
+  .scene-card:hover {
+    transform: translateY(-2px);
+    border-color: color-mix(in srgb, var(--accent) 70%, transparent);
+  }
+
+  .card-header {
+    padding: 14px 16px 8px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .card-header-left {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+  }
+  .scene-no {
+    font-size: 13px;
+    font-family: "JetBrains Mono", "Consolas", monospace;
+    color: color-mix(in srgb, var(--text-secondary) 50%, transparent);
+  }
+  .scene-id {
+    font-size: 15px;
+    font-family: "JetBrains Mono", "Consolas", monospace;
+    font-weight: 700;
+    color: var(--text-primary);
+  }
+  .layout-id {
+    font-size: 11px;
+    font-style: italic;
+    color: color-mix(in srgb, var(--text-secondary) 50%, transparent);
+  }
+  .pct-pill {
+    background: color-mix(in srgb, var(--bg-primary) 80%, transparent);
+    border: 1px solid var(--bg-border-soft);
+    color: var(--text-primary);
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .card-thumb {
+    margin: 2px 16px 4px;
+    height: 80px;
+    background: var(--bg-border);
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-muted);
+    font-size: 11px;
+    overflow: hidden;
+    position: relative;
+    background:
+      linear-gradient(135deg, color-mix(in srgb, var(--accent) 8%, var(--bg-card-elevated)) 0%, var(--bg-card-elevated) 100%);
+  }
+  .card-thumb::after {
+    content: "📷 콘티 / 가이드";
+  }
+
+  /* 메모 영역 */
+  .memo {
+    margin: 4px 16px 0;
+    font-size: 11px;
+    color: var(--memo-soft);
+    line-height: 1.5;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  /* 변경안: 메모 두 개 (수직 스택) */
+  .memo-stack {
+    margin: 4px 16px 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .memo-stack .memo-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 11px;
+    line-height: 1.4;
+    overflow: hidden;
+  }
+  .memo-stack .memo-tag {
+    flex-shrink: 0;
+    font-size: 9px;
+    font-weight: 700;
+    padding: 1px 5px;
+    border-radius: 4px;
+    letter-spacing: 0.03em;
+  }
+  .memo-stack .memo-tag.bg {
+    color: var(--memo-bg-only);
+    background: color-mix(in srgb, var(--memo-bg-only) 14%, transparent);
+  }
+  .memo-stack .memo-tag.act {
+    color: var(--memo-act-only);
+    background: color-mix(in srgb, var(--memo-act-only) 14%, transparent);
+  }
+  .memo-stack .memo-text {
+    color: var(--memo-soft);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+
+  /* 변경안: 메모 두 개 (한 줄 통합 + 점 구분) */
+  .memo-inline {
+    margin: 4px 16px 0;
+    font-size: 11px;
+    color: var(--memo-soft);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    line-height: 1.5;
+  }
+  .memo-inline .memo-tag-inline {
+    font-size: 9px;
+    font-weight: 700;
+    margin-right: 3px;
+    letter-spacing: 0.03em;
+  }
+  .memo-inline .memo-tag-inline.bg { color: var(--memo-bg-only); }
+  .memo-inline .memo-tag-inline.act { color: var(--memo-act-only); }
+  .memo-inline .memo-sep {
+    margin: 0 8px;
+    color: var(--text-muted);
+  }
+
+  /* BG / ACT 섹션 (단계 트랙) */
+  .dept-section {
+    padding: 0 16px;
+    margin-top: 6px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .dept-section.last { padding-bottom: 14px; }
+  .dept-label {
+    font-size: 10px;
+    font-weight: 700;
+    color: var(--text-secondary);
+    width: 38px;
+    flex-shrink: 0;
+    letter-spacing: 0.04em;
+  }
+  .dept-track {
+    flex: 1;
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 3px;
+  }
+  .stage-cell {
+    height: 22px;
+    border-radius: 5px;
+    background: var(--bg-stage-empty);
+    border: 1px solid var(--bg-border-soft);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    color: var(--text-muted);
+    transition: all 0.15s;
+  }
+  .stage-cell.bg-lo.on { background: var(--stage-bg-lo); color: white; border-color: transparent; }
+  .stage-cell.bg-done.on { background: var(--stage-bg-done); color: white; border-color: transparent; }
+  .stage-cell.bg-review.on { background: var(--stage-bg-review); color: white; border-color: transparent; }
+  .stage-cell.bg-png.on { background: var(--stage-bg-png); color: white; border-color: transparent; }
+  .stage-cell.act-lo.on { background: var(--stage-act-lo); color: white; border-color: transparent; }
+  .stage-cell.act-done.on { background: var(--stage-act-done); color: white; border-color: transparent; }
+  .stage-cell.act-review.on { background: var(--stage-act-review); color: white; border-color: transparent; }
+  .stage-cell.act-png.on { background: var(--stage-act-png); color: white; border-color: transparent; }
+
+  /* ── 길이 변경 라벨 (옵션 변형) ── */
+
+  /* 옵션 1: 헤더 옆 작은 화살표 배지 */
+  .length-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    font-size: 10px;
+    font-weight: 700;
+    padding: 2px 7px;
+    border-radius: 999px;
+    letter-spacing: 0.02em;
+    user-select: none;
+  }
+  .length-badge.up {
+    color: var(--grow-up);
+    background: var(--grow-up-soft);
+    border: 1px solid color-mix(in srgb, var(--grow-up) 35%, transparent);
+  }
+  .length-badge.down {
+    color: var(--shrink-down);
+    background: var(--shrink-down-soft);
+    border: 1px solid color-mix(in srgb, var(--shrink-down) 35%, transparent);
+  }
+  .length-badge .arrow {
+    font-size: 9px;
+    line-height: 1;
+  }
+
+  /* 옵션 2: 카드 좌측 보더 (subtle) */
+  .scene-card.length-up-border {
+    border-left: 3px solid var(--grow-up);
+    padding-left: 0;
+  }
+  .scene-card.length-down-border {
+    border-left: 3px solid var(--shrink-down);
+  }
+  .length-corner-tag {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 5;
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    font-size: 9px;
+    font-weight: 700;
+    padding: 2px 6px;
+    border-radius: 4px;
+    letter-spacing: 0.02em;
+  }
+  .length-corner-tag.up {
+    color: var(--grow-up);
+    background: var(--grow-up-soft);
+  }
+  .length-corner-tag.down {
+    color: var(--shrink-down);
+    background: var(--shrink-down-soft);
+  }
+
+  /* 옵션 3: 씬번호 위 작은 인디케이터 점 */
+  .length-dot-wrap {
+    position: relative;
+    display: inline-flex;
+  }
+  .length-dot {
+    position: absolute;
+    top: -2px;
+    right: -8px;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    box-shadow: 0 0 0 2px var(--bg-card);
+  }
+  .length-dot.up { background: var(--grow-up); }
+  .length-dot.down { background: var(--shrink-down); }
+
+  /* 옵션 4: 아이콘 + 라벨 (의미 명확) */
+  .length-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 10px;
+    font-weight: 600;
+    padding: 3px 8px 3px 6px;
+    border-radius: 6px;
+    letter-spacing: -0.01em;
+  }
+  .length-chip.up {
+    color: var(--grow-up);
+    background: var(--grow-up-soft);
+    border: 1px solid color-mix(in srgb, var(--grow-up) 28%, transparent);
+  }
+  .length-chip.down {
+    color: var(--shrink-down);
+    background: var(--shrink-down-soft);
+    border: 1px solid color-mix(in srgb, var(--shrink-down) 28%, transparent);
+  }
+  .length-chip svg {
+    width: 11px;
+    height: 11px;
+    stroke-width: 2.5;
+  }
+
+  /* 한솔 결정: <->  / >-<  표기 (LD / SD 툴팁) */
+  .length-symbol {
+    display: inline-flex;
+    align-items: center;
+    font-family: "JetBrains Mono", "Consolas", monospace;
+    font-size: 11px;
+    font-weight: 800;
+    letter-spacing: 0.06em;
+    padding: 2px 7px;
+    border-radius: 5px;
+    cursor: help;
+    user-select: none;
+    line-height: 1.2;
+    position: relative;
+  }
+  .length-symbol.up {
+    color: var(--grow-up);
+    background: var(--grow-up-soft);
+    border: 1px solid color-mix(in srgb, var(--grow-up) 30%, transparent);
+  }
+  .length-symbol.down {
+    color: var(--shrink-down);
+    background: var(--shrink-down-soft);
+    border: 1px solid color-mix(in srgb, var(--shrink-down) 30%, transparent);
+  }
+  .length-symbol .lbl {
+    margin-left: 4px;
+    font-size: 9px;
+    font-weight: 700;
+    opacity: 0.85;
+    letter-spacing: 0.08em;
+  }
+
+  /* SVG 아이콘 (<->  /  >-< ) — 텍스트 줄바꿈 위험 없음 */
+  .length-icon {
+    display: inline-block;
+    vertical-align: middle;
+    flex-shrink: 0;
+    width: 20px;
+    height: 10px;
+    overflow: visible;
+  }
+  .length-icon.sm { width: 16px; height: 8px; }
+  .length-icon.lg { width: 26px; height: 13px; }
+
+  /* 컨텍스트별 자동 크기 조정 */
+  .length-symbol-sheet .length-icon { width: 16px; height: 8px; }
+  .length-symbol .length-icon { width: 20px; height: 10px; vertical-align: middle; }
+  .length-corner-tag .length-icon { width: 18px; height: 9px; vertical-align: middle; }
+  .ctx-menu .item .icon { display: inline-flex; align-items: center; justify-content: center; width: 22px; height: 16px; }
+  .ctx-menu .item .icon .length-icon { width: 20px; height: 10px; }
+  .inline-toggle .length-icon { width: 14px; height: 7px; }
+
+  /* 시트 셀 안 라벨: 작은 칩 형태 — 절대 잘리지 않게 */
+  .length-symbol-sheet {
+    display: inline-flex;
+    align-items: center;
+    font-family: "JetBrains Mono", "Consolas", monospace;
+    font-size: 10px;
+    font-weight: 800;
+    letter-spacing: 0.04em;
+    padding: 1px 5px;
+    border-radius: 4px;
+    margin-right: 6px;
+    cursor: help;
+    white-space: nowrap;       /* 잘림 방지 */
+    flex-shrink: 0;            /* 줄어들지 않게 */
+    line-height: 1.3;
+  }
+  .length-symbol-sheet.up {
+    color: var(--grow-up);
+    background: var(--grow-up-soft);
+    border: 1px solid color-mix(in srgb, var(--grow-up) 28%, transparent);
+  }
+  .length-symbol-sheet.down {
+    color: var(--shrink-down);
+    background: var(--shrink-down-soft);
+    border: 1px solid color-mix(in srgb, var(--shrink-down) 28%, transparent);
+  }
+
+  /* 시트 셀: 씬번호 셀 안 화살표 잘림 방지 */
+  .sheet-cell.no {
+    white-space: nowrap;
+    overflow: visible;
+  }
+
+  /* ── 시트 뷰 (재현) ── */
+  .sheet-frame {
+    background: var(--bg-card);
+    border: 1px solid var(--bg-border);
+    border-radius: 10px;
+    overflow: hidden;
+  }
+  .sheet-row {
+    display: grid;
+    grid-template-columns: 56px 90px 1fr 90px 90px 100px 110px;
+    border-bottom: 1px solid var(--bg-border-soft);
+    align-items: stretch;
+    transition: background 0.1s;
+  }
+  .sheet-row:hover {
+    background: color-mix(in srgb, var(--accent) 4%, transparent);
+  }
+  .sheet-row.header {
+    background: var(--bg-card-elevated);
+    color: var(--text-secondary);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+  .sheet-cell {
+    padding: 9px 10px;
+    border-right: 1px solid var(--bg-border-soft);
+    display: flex;
+    align-items: center;
+    font-size: 12px;
+    color: var(--text-primary);
+    overflow: hidden;
+    min-height: 36px;
+  }
+  .sheet-cell.no {
+    color: var(--text-muted);
+    font-family: "JetBrains Mono", monospace;
+    font-weight: 600;
+    justify-content: flex-start;
+    gap: 6px;
+  }
+  .sheet-cell.id {
+    font-family: "JetBrains Mono", monospace;
+    font-weight: 700;
+  }
+  .sheet-cell.memo {
+    color: var(--memo-soft);
+    font-size: 11.5px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .sheet-cell.memo-stacked {
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: center;
+    gap: 2px;
+    padding: 6px 10px;
+  }
+  .sheet-cell.memo-stacked .row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    overflow: hidden;
+    min-height: 16px;
+  }
+  .sheet-cell.memo-stacked .memo-tag {
+    flex-shrink: 0;
+    font-size: 9px;
+    font-weight: 700;
+    padding: 1px 5px;
+    border-radius: 4px;
+    letter-spacing: 0.03em;
+  }
+  .sheet-cell.memo-stacked .memo-tag.bg { color: var(--memo-bg-only); background: color-mix(in srgb, var(--memo-bg-only) 14%, transparent); }
+  .sheet-cell.memo-stacked .memo-tag.act { color: var(--memo-act-only); background: color-mix(in srgb, var(--memo-act-only) 14%, transparent); }
+  .sheet-cell.memo-stacked .text {
+    color: var(--memo-soft);
+    font-size: 11.5px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+  .sheet-cell.dept-progress {
+    justify-content: center;
+    gap: 3px;
+  }
+  .sheet-cell.dept-progress .stage {
+    width: 14px;
+    height: 14px;
+    border-radius: 3px;
+    background: var(--bg-stage-empty);
+    border: 1px solid var(--bg-border-soft);
+  }
+  .sheet-cell.dept-progress .stage.on.bg-lo { background: var(--stage-bg-lo); border-color: transparent; }
+  .sheet-cell.dept-progress .stage.on.bg-done { background: var(--stage-bg-done); border-color: transparent; }
+  .sheet-cell.dept-progress .stage.on.bg-review { background: var(--stage-bg-review); border-color: transparent; }
+  .sheet-cell.dept-progress .stage.on.bg-png { background: var(--stage-bg-png); border-color: transparent; }
+  .sheet-cell.dept-progress .stage.on.act-lo { background: var(--stage-act-lo); border-color: transparent; }
+  .sheet-cell.dept-progress .stage.on.act-done { background: var(--stage-act-done); border-color: transparent; }
+  .sheet-cell.dept-progress .stage.on.act-review { background: var(--stage-act-review); border-color: transparent; }
+  .sheet-cell.dept-progress .stage.on.act-png { background: var(--stage-act-png); border-color: transparent; }
+  .sheet-cell:last-child { border-right: none; }
+
+  /* 시트 행에 길이 변경 표시 (옵션) */
+  .sheet-row.length-up { background: linear-gradient(90deg, var(--grow-up-soft) 0%, transparent 5%); }
+  .sheet-row.length-down { background: linear-gradient(90deg, var(--shrink-down-soft) 0%, transparent 5%); }
+  .sheet-row.length-up:hover { background: linear-gradient(90deg, var(--grow-up-soft) 0%, color-mix(in srgb, var(--accent) 4%, transparent) 5%); }
+  .sheet-row.length-down:hover { background: linear-gradient(90deg, var(--shrink-down-soft) 0%, color-mix(in srgb, var(--accent) 4%, transparent) 5%); }
+
+  /* 우클릭 메뉴 데모 */
+  .ctx-menu {
+    background: var(--bg-card);
+    border: 1px solid var(--bg-border);
+    border-radius: 10px;
+    box-shadow: 0 8px 24px rgba(0,0,0,0.3), 0 2px 6px rgba(0,0,0,0.15);
+    padding: 6px;
+    width: 220px;
+    font-size: 12px;
+  }
+  .ctx-menu .item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 7px 10px;
+    border-radius: 6px;
+    color: var(--text-primary);
+    cursor: pointer;
+    transition: background 0.1s;
+  }
+  .ctx-menu .item:hover {
+    background: var(--accent-soft);
+    color: var(--accent);
+  }
+  .ctx-menu .item.section-title {
+    color: var(--text-secondary);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    padding: 8px 10px 4px;
+    pointer-events: none;
+  }
+  .ctx-menu .item .icon { width: 16px; height: 16px; flex-shrink: 0; opacity: 0.7; }
+  .ctx-menu .item.up:hover { color: var(--grow-up); background: var(--grow-up-soft); }
+  .ctx-menu .item.down:hover { color: var(--shrink-down); background: var(--shrink-down-soft); }
+  .ctx-menu .divider { height: 1px; background: var(--bg-border-soft); margin: 4px 6px; }
+
+  /* 작은 인라인 토글 버튼 */
+  .inline-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    background: transparent;
+    border: 1px dashed var(--bg-border);
+    color: var(--text-muted);
+    padding: 2px 7px;
+    border-radius: 999px;
+    font-size: 10px;
+    cursor: pointer;
+    transition: all 0.15s;
+  }
+  .inline-toggle:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+    background: var(--accent-soft);
+    border-style: solid;
+  }
+
+  /* 도움말 표 */
+  .legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px 18px;
+    font-size: 12px;
+    color: var(--text-secondary);
+    margin-top: 10px;
+    padding: 12px 14px;
+    background: var(--bg-card-elevated);
+    border-radius: 8px;
+    border: 1px solid var(--bg-border-soft);
+  }
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  /* ── 최종 통합 시안 (강조) ── */
+  .final-frame {
+    background: linear-gradient(135deg, color-mix(in srgb, var(--accent) 6%, var(--bg-card-elevated)) 0%, var(--bg-card-elevated) 100%);
+    border: 1px solid color-mix(in srgb, var(--accent) 30%, var(--bg-border));
+    border-radius: 14px;
+    padding: 20px;
+  }
+  .final-frame .option-label {
+    color: var(--accent);
+  }
+
+  /* 페이지 푸터 */
+  footer {
+    margin-top: 64px;
+    padding: 24px 32px;
+    border-top: 1px solid var(--bg-border-soft);
+    color: var(--text-muted);
+    font-size: 11px;
+    text-align: center;
+  }
+</style>
+</head>
+<body>
+  <!-- SVG 아이콘 정의 (한 번만 정의하고 <use>로 재사용) -->
+  <svg style="position:absolute;width:0;height:0;overflow:hidden" aria-hidden="true">
+    <defs>
+      <!-- LD: <-> 양옆 바깥쪽 화살촉 (길이 늘어남) -->
+      <symbol id="ic-ld" viewBox="0 0 20 10">
+        <line x1="3" y1="5" x2="17" y2="5" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/>
+        <polyline points="6,2 3,5 6,8" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+        <polyline points="14,2 17,5 14,8" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+      </symbol>
+      <!-- SD: >-< 양옆 안쪽 화살촉 (길이 줄어듦) -->
+      <symbol id="ic-sd" viewBox="0 0 20 10">
+        <line x1="6" y1="5" x2="14" y2="5" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/>
+        <polyline points="3,2 6,5 3,8" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+        <polyline points="17,2 14,5 17,8" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+      </symbol>
+      <!-- 해제 -->
+      <symbol id="ic-clear" viewBox="0 0 20 10">
+        <line x1="4" y1="5" x2="16" y2="5" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-dasharray="2 2"/>
+      </symbol>
+    </defs>
+  </svg>
+
+  <header class="header">
+    <div>
+      <h1>B flow — 메모 노출 + 씬 길이 변경 시각 효과</h1>
+      <div class="subtitle">현재 안 vs 변경 안 비교 · 다크/라이트 대응</div>
+    </div>
+    <div class="theme-toggle" role="group">
+      <button class="active" id="btn-dark" type="button">다크</button>
+      <button id="btn-light" type="button">라이트</button>
+    </div>
+  </header>
+
+  <main>
+    <!-- ───────── HERO : 페이지 최상단 최종 확정안 ───────── -->
+    <section style="margin-bottom: 64px;">
+      <div class="section-title" style="color: var(--accent); font-size: 12px;">★ 최종 확정안</div>
+      <p class="section-desc" style="font-size: 13px;">
+        한솔 결정 반영 — 카드/시트 메모 동시 노출 + 씬 길이 변경 SVG 아이콘 라벨 + 우클릭 토글.
+      </p>
+
+      <div class="final-frame">
+        <div class="option-label" style="margin-bottom: 8px;">
+          <span class="badge after recommended">최종</span> 카드 + 시트 통합
+        </div>
+        <p style="font-size: 12px; color: var(--text-secondary); margin: 0 0 18px; line-height: 1.7;">
+          <strong style="color: var(--text-primary)">메모</strong>: 카드는 BG/ACT 수직 스택(라벨 칩), 시트는 BG/ACT 컬럼 분리 ·
+          <strong style="color: var(--text-primary)">씬 길이 변경</strong>:
+          <span class="length-symbol up" style="font-size:10px; padding:1px 5px; vertical-align:middle;" title="LD"><svg class="length-icon" aria-hidden="true"><use href="#ic-ld"/></svg></span> LD(늘어남) /
+          <span class="length-symbol down" style="font-size:10px; padding:1px 5px; vertical-align:middle;" title="SD"><svg class="length-icon" aria-hidden="true"><use href="#ic-sd"/></svg></span> SD(줄어듦) ·
+          <strong style="color: var(--text-primary)">위치</strong>: 카드 우상단(% 옆), 시트 행 좌측 그라데이션 + 씬번호 옆 ·
+          <strong style="color: var(--text-primary)">토글</strong>: 카드/시트 우클릭 메뉴 동일 ·
+          <strong style="color: var(--text-primary)">유지</strong>: 영구 라벨(수동 해제 전까지)
+        </p>
+
+        <!-- 카드 3개 시나리오 -->
+        <div style="margin-bottom: 22px;">
+          <div style="font-size: 11px; color: var(--section-label); font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; margin-bottom: 10px;">카드 뷰 (LD / 변경없음 / SD)</div>
+          <div style="display: grid; grid-template-columns: repeat(3, minmax(280px, 1fr)); gap: 16px;">
+            <!-- LD -->
+            <div class="scene-card">
+              <div class="card-header">
+                <div class="card-header-left">
+                  <span class="scene-no">#42</span>
+                  <span class="scene-id">EP02_PT3_C42</span>
+                </div>
+                <div style="display:flex; align-items:center; gap:6px;">
+                  <span class="length-symbol up" title="LD · Long Duration (길이 늘어남)"><svg class="length-icon" aria-hidden="true"><use href="#ic-ld"/></svg></span>
+                  <span class="pct-pill">75%</span>
+                </div>
+              </div>
+              <div class="card-thumb"></div>
+              <div class="memo-stack">
+                <div class="memo-row"><span class="memo-tag bg">BG</span><span class="memo-text">캐릭터 손동작 다시 확인</span></div>
+                <div class="memo-row"><span class="memo-tag act">ACT</span><span class="memo-text">연기 톤 부드럽게</span></div>
+              </div>
+              <div class="dept-section">
+                <span class="dept-label">BG</span>
+                <div class="dept-track">
+                  <div class="stage-cell bg-lo on">LO</div><div class="stage-cell bg-done on">완료</div>
+                  <div class="stage-cell bg-review on">검수</div><div class="stage-cell bg-png">PNG</div>
+                </div>
+              </div>
+              <div class="dept-section last">
+                <span class="dept-label">ACT</span>
+                <div class="dept-track">
+                  <div class="stage-cell act-lo on">LO</div><div class="stage-cell act-done on">완료</div>
+                  <div class="stage-cell act-review">검수</div><div class="stage-cell act-png">PNG</div>
+                </div>
+              </div>
+            </div>
+
+            <!-- 변경없음 -->
+            <div class="scene-card">
+              <div class="card-header">
+                <div class="card-header-left">
+                  <span class="scene-no">#43</span>
+                  <span class="scene-id">EP02_PT3_C43</span>
+                </div>
+                <span class="pct-pill">25%</span>
+              </div>
+              <div class="card-thumb"></div>
+              <div class="memo-stack">
+                <div class="memo-row"><span class="memo-tag bg">BG</span><span class="memo-text">바닥 그림자 정리</span></div>
+                <div class="memo-row"><span class="memo-tag act" style="opacity:0.4">ACT</span><span class="memo-text" style="color:var(--text-muted)">메모 없음</span></div>
+              </div>
+              <div class="dept-section">
+                <span class="dept-label">BG</span>
+                <div class="dept-track">
+                  <div class="stage-cell bg-lo on">LO</div><div class="stage-cell bg-done">완료</div>
+                  <div class="stage-cell bg-review">검수</div><div class="stage-cell bg-png">PNG</div>
+                </div>
+              </div>
+              <div class="dept-section last">
+                <span class="dept-label">ACT</span>
+                <div class="dept-track">
+                  <div class="stage-cell act-lo on">LO</div><div class="stage-cell act-done on">완료</div>
+                  <div class="stage-cell act-review on">검수</div><div class="stage-cell act-png on">PNG</div>
+                </div>
+              </div>
+            </div>
+
+            <!-- SD -->
+            <div class="scene-card">
+              <div class="card-header">
+                <div class="card-header-left">
+                  <span class="scene-no">#44</span>
+                  <span class="scene-id">EP02_PT3_C44</span>
+                </div>
+                <div style="display:flex; align-items:center; gap:6px;">
+                  <span class="length-symbol down" title="SD · Short Duration (길이 줄어듦)"><svg class="length-icon" aria-hidden="true"><use href="#ic-sd"/></svg></span>
+                  <span class="pct-pill">50%</span>
+                </div>
+              </div>
+              <div class="card-thumb"></div>
+              <div class="memo-stack">
+                <div class="memo-row"><span class="memo-tag bg">BG</span><span class="memo-text">차량 위치 다시</span></div>
+                <div class="memo-row"><span class="memo-tag act">ACT</span><span class="memo-text">표정 더 풀어주세요</span></div>
+              </div>
+              <div class="dept-section">
+                <span class="dept-label">BG</span>
+                <div class="dept-track">
+                  <div class="stage-cell bg-lo on">LO</div><div class="stage-cell bg-done on">완료</div>
+                  <div class="stage-cell bg-review">검수</div><div class="stage-cell bg-png">PNG</div>
+                </div>
+              </div>
+              <div class="dept-section last">
+                <span class="dept-label">ACT</span>
+                <div class="dept-track">
+                  <div class="stage-cell act-lo on">LO</div><div class="stage-cell act-done">완료</div>
+                  <div class="stage-cell act-review">검수</div><div class="stage-cell act-png">PNG</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- 시트 (B2 컬럼 분리, 4행) -->
+        <div>
+          <div style="font-size: 11px; color: var(--section-label); font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; margin-bottom: 10px;">시트 뷰 (BG/ACT 메모 컬럼 분리 + 씬번호 옆 SVG 칩)</div>
+          <div class="sheet-frame">
+            <div class="sheet-row header" style="grid-template-columns: 64px 100px 1fr 1fr 80px 80px 100px 110px;">
+              <div class="sheet-cell no">#</div>
+              <div class="sheet-cell">씬 ID</div>
+              <div class="sheet-cell">BG 메모</div>
+              <div class="sheet-cell">ACT 메모</div>
+              <div class="sheet-cell">담당자</div>
+              <div class="sheet-cell">레이아웃</div>
+              <div class="sheet-cell">BG 진행</div>
+              <div class="sheet-cell">ACT 진행</div>
+            </div>
+            <div class="sheet-row length-up" style="grid-template-columns: 64px 100px 1fr 1fr 80px 80px 100px 110px;">
+              <div class="sheet-cell no">
+                <span class="length-symbol-sheet up" title="LD · Long Duration (길이 늘어남)"><svg class="length-icon" aria-hidden="true"><use href="#ic-ld"/></svg></span>
+                42
+              </div>
+              <div class="sheet-cell id">EP02_PT3_C42</div>
+              <div class="sheet-cell memo">캐릭터 손동작 다시 확인</div>
+              <div class="sheet-cell memo">연기 톤 부드럽게</div>
+              <div class="sheet-cell">한솔</div>
+              <div class="sheet-cell">L#108</div>
+              <div class="sheet-cell dept-progress"><div class="stage on bg-lo"></div><div class="stage on bg-done"></div><div class="stage on bg-review"></div><div class="stage"></div></div>
+              <div class="sheet-cell dept-progress"><div class="stage on act-lo"></div><div class="stage on act-done"></div><div class="stage"></div><div class="stage"></div></div>
+            </div>
+            <div class="sheet-row" style="grid-template-columns: 64px 100px 1fr 1fr 80px 80px 100px 110px;">
+              <div class="sheet-cell no">43</div>
+              <div class="sheet-cell id">EP02_PT3_C43</div>
+              <div class="sheet-cell memo">바닥 그림자 정리</div>
+              <div class="sheet-cell memo" style="color: var(--text-muted)">—</div>
+              <div class="sheet-cell">한솔</div>
+              <div class="sheet-cell">L#109</div>
+              <div class="sheet-cell dept-progress"><div class="stage on bg-lo"></div><div class="stage"></div><div class="stage"></div><div class="stage"></div></div>
+              <div class="sheet-cell dept-progress"><div class="stage on act-lo"></div><div class="stage on act-done"></div><div class="stage on act-review"></div><div class="stage on act-png"></div></div>
+            </div>
+            <div class="sheet-row length-down" style="grid-template-columns: 64px 100px 1fr 1fr 80px 80px 100px 110px;">
+              <div class="sheet-cell no">
+                <span class="length-symbol-sheet down" title="SD · Short Duration (길이 줄어듦)"><svg class="length-icon" aria-hidden="true"><use href="#ic-sd"/></svg></span>
+                44
+              </div>
+              <div class="sheet-cell id">EP02_PT3_C44</div>
+              <div class="sheet-cell memo">차량 위치 다시</div>
+              <div class="sheet-cell memo">표정 더 풀어주세요</div>
+              <div class="sheet-cell">한솔</div>
+              <div class="sheet-cell">L#110</div>
+              <div class="sheet-cell dept-progress"><div class="stage on bg-lo"></div><div class="stage on bg-done"></div><div class="stage"></div><div class="stage"></div></div>
+              <div class="sheet-cell dept-progress"><div class="stage on act-lo"></div><div class="stage"></div><div class="stage"></div><div class="stage"></div></div>
+            </div>
+            <div class="sheet-row length-up" style="grid-template-columns: 64px 100px 1fr 1fr 80px 80px 100px 110px;">
+              <div class="sheet-cell no">
+                <span class="length-symbol-sheet up" title="LD · Long Duration (길이 늘어남)"><svg class="length-icon" aria-hidden="true"><use href="#ic-ld"/></svg></span>
+                45
+              </div>
+              <div class="sheet-cell id">EP02_PT3_C45</div>
+              <div class="sheet-cell memo">건물 외벽 톤 다운…</div>
+              <div class="sheet-cell memo">대사 후 1프레임 늦게 시선…</div>
+              <div class="sheet-cell">민준</div>
+              <div class="sheet-cell">L#111</div>
+              <div class="sheet-cell dept-progress"><div class="stage on bg-lo"></div><div class="stage on bg-done"></div><div class="stage on bg-review"></div><div class="stage on bg-png"></div></div>
+              <div class="sheet-cell dept-progress"><div class="stage on act-lo"></div><div class="stage on act-done"></div><div class="stage on act-review"></div><div class="stage"></div></div>
+            </div>
+          </div>
+        </div>
+
+        <p style="font-size: 11px; color: var(--text-muted); margin: 18px 0 0; text-align: right;">↓ 아래로 스크롤하면 옵션 비교(A~E)와 자세한 시나리오(G, H), 우클릭 메뉴 데모(섹션 F)를 볼 수 있어요.</p>
+      </div>
+    </section>
+
+    <!-- ───────── SECTION A : 메모 두 개 표시 (카드 뷰) ───────── -->
+    <section>
+      <div class="section-title">A · 카드 뷰 — BG/ACT 메모 동시 노출</div>
+      <p class="section-desc">
+        현재는 BG 메모가 있으면 ACT 메모가 가려집니다(또는 그 반대). 양쪽 메모를 동시에 보여주는 방법 3안.
+      </p>
+
+      <div class="options-grid three">
+        <!-- 현재 안 -->
+        <div class="option-frame">
+          <div class="option-label"><span class="badge before">현재 안</span> BG 메모만 보임</div>
+          <div class="scene-card">
+            <div class="card-header">
+              <div class="card-header-left">
+                <span class="scene-no">#42</span>
+                <span class="scene-id">EP02_PT3_C42</span>
+                <span class="layout-id">L#108</span>
+              </div>
+              <span class="pct-pill">75%</span>
+            </div>
+            <div class="card-thumb"></div>
+            <div class="memo">캐릭터 손동작 다시 확인 필요 — 가이드 참고</div>
+            <div class="dept-section">
+              <span class="dept-label">BG</span>
+              <div class="dept-track">
+                <div class="stage-cell bg-lo on">LO</div>
+                <div class="stage-cell bg-done on">완료</div>
+                <div class="stage-cell bg-review on">검수</div>
+                <div class="stage-cell bg-png">PNG</div>
+              </div>
+            </div>
+            <div class="dept-section last">
+              <span class="dept-label">ACT</span>
+              <div class="dept-track">
+                <div class="stage-cell act-lo on">LO</div>
+                <div class="stage-cell act-done on">완료</div>
+                <div class="stage-cell act-review">검수</div>
+                <div class="stage-cell act-png">PNG</div>
+              </div>
+            </div>
+          </div>
+          <div class="option-note">⚠ ACT 메모("연기 톤 부드럽게")가 입력돼 있어도 화면엔 안 나옴.</div>
+        </div>
+
+        <!-- 옵션 A1: 수직 스택 + 라벨 -->
+        <div class="option-frame">
+          <div class="option-label"><span class="badge after">옵션 A1</span> 수직 스택 (라벨 칩)</div>
+          <div class="scene-card">
+            <div class="card-header">
+              <div class="card-header-left">
+                <span class="scene-no">#42</span>
+                <span class="scene-id">EP02_PT3_C42</span>
+                <span class="layout-id">L#108</span>
+              </div>
+              <span class="pct-pill">75%</span>
+            </div>
+            <div class="card-thumb"></div>
+            <div class="memo-stack">
+              <div class="memo-row">
+                <span class="memo-tag bg">BG</span>
+                <span class="memo-text">캐릭터 손동작 다시 확인 필요 — 가이드 참고</span>
+              </div>
+              <div class="memo-row">
+                <span class="memo-tag act">ACT</span>
+                <span class="memo-text">연기 톤 부드럽게, 마지막 컷 시선 처리 다시</span>
+              </div>
+            </div>
+            <div class="dept-section">
+              <span class="dept-label">BG</span>
+              <div class="dept-track">
+                <div class="stage-cell bg-lo on">LO</div>
+                <div class="stage-cell bg-done on">완료</div>
+                <div class="stage-cell bg-review on">검수</div>
+                <div class="stage-cell bg-png">PNG</div>
+              </div>
+            </div>
+            <div class="dept-section last">
+              <span class="dept-label">ACT</span>
+              <div class="dept-track">
+                <div class="stage-cell act-lo on">LO</div>
+                <div class="stage-cell act-done on">완료</div>
+                <div class="stage-cell act-review">검수</div>
+                <div class="stage-cell act-png">PNG</div>
+              </div>
+            </div>
+          </div>
+          <div class="option-note">✓ 두 메모를 명확히 구분. 카드 높이 +14px 정도 증가. 라벨 색이 부서별로 다름.</div>
+        </div>
+
+        <!-- 옵션 A2: 한 줄 통합 (점 구분) -->
+        <div class="option-frame">
+          <div class="option-label"><span class="badge after">옵션 A2</span> 한 줄 통합</div>
+          <div class="scene-card">
+            <div class="card-header">
+              <div class="card-header-left">
+                <span class="scene-no">#42</span>
+                <span class="scene-id">EP02_PT3_C42</span>
+                <span class="layout-id">L#108</span>
+              </div>
+              <span class="pct-pill">75%</span>
+            </div>
+            <div class="card-thumb"></div>
+            <div class="memo-inline">
+              <span class="memo-tag-inline bg">BG</span>
+              캐릭터 손동작 다시 확인
+              <span class="memo-sep">·</span>
+              <span class="memo-tag-inline act">ACT</span>
+              연기 톤 부드럽게
+            </div>
+            <div class="dept-section">
+              <span class="dept-label">BG</span>
+              <div class="dept-track">
+                <div class="stage-cell bg-lo on">LO</div>
+                <div class="stage-cell bg-done on">완료</div>
+                <div class="stage-cell bg-review on">검수</div>
+                <div class="stage-cell bg-png">PNG</div>
+              </div>
+            </div>
+            <div class="dept-section last">
+              <span class="dept-label">ACT</span>
+              <div class="dept-track">
+                <div class="stage-cell act-lo on">LO</div>
+                <div class="stage-cell act-done on">완료</div>
+                <div class="stage-cell act-review">검수</div>
+                <div class="stage-cell act-png">PNG</div>
+              </div>
+            </div>
+          </div>
+          <div class="option-note">✓ 카드 높이 변화 없음. 다만 메모가 길면 잘림. 한쪽이 길면 다른쪽이 거의 안 보일 수 있음.</div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ───────── SECTION B : 메모 두 개 표시 (시트 뷰) ───────── -->
+    <section>
+      <div class="section-title">B · 시트 뷰 — BG/ACT 메모 동시 노출</div>
+      <p class="section-desc">
+        시트 뷰는 한 셀(메모 컬럼)에 두 부서 내용을 어떻게 담을지가 관건. 행 높이 vs 가독성.
+      </p>
+
+      <!-- 현재 안 -->
+      <div style="margin-bottom: 24px;">
+        <div class="option-label" style="margin-bottom: 8px;"><span class="badge before">현재 안</span> 메모 셀에 BG만</div>
+        <div class="sheet-frame">
+          <div class="sheet-row header">
+            <div class="sheet-cell no">#</div>
+            <div class="sheet-cell">씬 ID</div>
+            <div class="sheet-cell">메모</div>
+            <div class="sheet-cell">담당자</div>
+            <div class="sheet-cell">레이아웃</div>
+            <div class="sheet-cell">BG 진행</div>
+            <div class="sheet-cell">ACT 진행</div>
+          </div>
+          <div class="sheet-row">
+            <div class="sheet-cell no">42</div>
+            <div class="sheet-cell id">EP02_PT3_C42</div>
+            <div class="sheet-cell memo">캐릭터 손동작 다시 확인 필요</div>
+            <div class="sheet-cell">한솔</div>
+            <div class="sheet-cell">L#108</div>
+            <div class="sheet-cell dept-progress"><div class="stage on bg-lo"></div><div class="stage on bg-done"></div><div class="stage on bg-review"></div><div class="stage"></div></div>
+            <div class="sheet-cell dept-progress"><div class="stage on act-lo"></div><div class="stage on act-done"></div><div class="stage"></div><div class="stage"></div></div>
+          </div>
+          <div class="sheet-row">
+            <div class="sheet-cell no">43</div>
+            <div class="sheet-cell id">EP02_PT3_C43</div>
+            <div class="sheet-cell memo">바닥 그림자 정리 필요</div>
+            <div class="sheet-cell">한솔</div>
+            <div class="sheet-cell">L#109</div>
+            <div class="sheet-cell dept-progress"><div class="stage on bg-lo"></div><div class="stage"></div><div class="stage"></div><div class="stage"></div></div>
+            <div class="sheet-cell dept-progress"><div class="stage on act-lo"></div><div class="stage on act-done"></div><div class="stage on act-review"></div><div class="stage on act-png"></div></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- 옵션 B1: 셀 안 두 줄 -->
+      <div style="margin-bottom: 24px;">
+        <div class="option-label" style="margin-bottom: 8px;"><span class="badge after">옵션 B1</span> 한 셀에 두 줄 (라벨 칩 포함, 행 높이 +12px)</div>
+        <div class="sheet-frame">
+          <div class="sheet-row header">
+            <div class="sheet-cell no">#</div>
+            <div class="sheet-cell">씬 ID</div>
+            <div class="sheet-cell">메모 (BG / ACT)</div>
+            <div class="sheet-cell">담당자</div>
+            <div class="sheet-cell">레이아웃</div>
+            <div class="sheet-cell">BG 진행</div>
+            <div class="sheet-cell">ACT 진행</div>
+          </div>
+          <div class="sheet-row">
+            <div class="sheet-cell no">42</div>
+            <div class="sheet-cell id">EP02_PT3_C42</div>
+            <div class="sheet-cell memo-stacked">
+              <div class="row"><span class="memo-tag bg">BG</span><span class="text">캐릭터 손동작 다시 확인 필요</span></div>
+              <div class="row"><span class="memo-tag act">ACT</span><span class="text">연기 톤 부드럽게</span></div>
+            </div>
+            <div class="sheet-cell">한솔</div>
+            <div class="sheet-cell">L#108</div>
+            <div class="sheet-cell dept-progress"><div class="stage on bg-lo"></div><div class="stage on bg-done"></div><div class="stage on bg-review"></div><div class="stage"></div></div>
+            <div class="sheet-cell dept-progress"><div class="stage on act-lo"></div><div class="stage on act-done"></div><div class="stage"></div><div class="stage"></div></div>
+          </div>
+          <div class="sheet-row">
+            <div class="sheet-cell no">43</div>
+            <div class="sheet-cell id">EP02_PT3_C43</div>
+            <div class="sheet-cell memo-stacked">
+              <div class="row"><span class="memo-tag bg">BG</span><span class="text">바닥 그림자 정리 필요</span></div>
+              <div class="row"><span class="memo-tag act">ACT</span><span class="text">—</span></div>
+            </div>
+            <div class="sheet-cell">한솔</div>
+            <div class="sheet-cell">L#109</div>
+            <div class="sheet-cell dept-progress"><div class="stage on bg-lo"></div><div class="stage"></div><div class="stage"></div><div class="stage"></div></div>
+            <div class="sheet-cell dept-progress"><div class="stage on act-lo"></div><div class="stage on act-done"></div><div class="stage on act-review"></div><div class="stage on act-png"></div></div>
+          </div>
+        </div>
+        <div class="option-note" style="margin-top: 8px;">✓ 양쪽 메모를 모두 표시. 한쪽만 있으면 "—" 또는 빈 줄. 메모 컬럼 너비 충분히 확보.</div>
+      </div>
+
+      <!-- 옵션 B2: 메모 컬럼 분리 -->
+      <div>
+        <div class="option-label" style="margin-bottom: 8px;"><span class="badge after">옵션 B2</span> BG 메모 / ACT 메모 컬럼 분리</div>
+        <div class="sheet-frame">
+          <div class="sheet-row header" style="grid-template-columns: 56px 90px 1fr 1fr 80px 80px 100px 110px;">
+            <div class="sheet-cell no">#</div>
+            <div class="sheet-cell">씬 ID</div>
+            <div class="sheet-cell">BG 메모</div>
+            <div class="sheet-cell">ACT 메모</div>
+            <div class="sheet-cell">담당자</div>
+            <div class="sheet-cell">레이아웃</div>
+            <div class="sheet-cell">BG 진행</div>
+            <div class="sheet-cell">ACT 진행</div>
+          </div>
+          <div class="sheet-row" style="grid-template-columns: 56px 90px 1fr 1fr 80px 80px 100px 110px;">
+            <div class="sheet-cell no">42</div>
+            <div class="sheet-cell id">EP02_PT3_C42</div>
+            <div class="sheet-cell memo">캐릭터 손동작 다시 확인 필요</div>
+            <div class="sheet-cell memo">연기 톤 부드럽게</div>
+            <div class="sheet-cell">한솔</div>
+            <div class="sheet-cell">L#108</div>
+            <div class="sheet-cell dept-progress"><div class="stage on bg-lo"></div><div class="stage on bg-done"></div><div class="stage on bg-review"></div><div class="stage"></div></div>
+            <div class="sheet-cell dept-progress"><div class="stage on act-lo"></div><div class="stage on act-done"></div><div class="stage"></div><div class="stage"></div></div>
+          </div>
+          <div class="sheet-row" style="grid-template-columns: 56px 90px 1fr 1fr 80px 80px 100px 110px;">
+            <div class="sheet-cell no">43</div>
+            <div class="sheet-cell id">EP02_PT3_C43</div>
+            <div class="sheet-cell memo">바닥 그림자 정리 필요</div>
+            <div class="sheet-cell memo" style="color: var(--text-muted);">—</div>
+            <div class="sheet-cell">한솔</div>
+            <div class="sheet-cell">L#109</div>
+            <div class="sheet-cell dept-progress"><div class="stage on bg-lo"></div><div class="stage"></div><div class="stage"></div><div class="stage"></div></div>
+            <div class="sheet-cell dept-progress"><div class="stage on act-lo"></div><div class="stage on act-done"></div><div class="stage on act-review"></div><div class="stage on act-png"></div></div>
+          </div>
+        </div>
+        <div class="option-note" style="margin-top: 8px;">✓ 깔끔한 컬럼 분리. 가로 공간이 많이 필요. 다른 컬럼 너비가 좁아짐. 컬럼 헤더 변경 + 너비 재조정 필요.</div>
+      </div>
+    </section>
+
+    <!-- ───────── SECTION C : 길이 변경 표시 (카드 뷰) ───────── -->
+    <section>
+      <div class="section-title">C · 카드 뷰 — 씬 길이 변경 표시</div>
+      <p class="section-desc">
+        '늘어남'/'줄어듦' 영구 라벨을 어디에 어떻게 표시할지 4안. 모두 수동 토글 후 영구 유지.
+      </p>
+
+      <div class="options-grid three">
+        <!-- 옵션 C1: 헤더 옆 화살표 칩 -->
+        <div class="option-frame">
+          <div class="option-label"><span class="badge after recommended">옵션 C1 추천</span> 헤더 옆 화살표 칩</div>
+          <div class="scene-card">
+            <div class="card-header">
+              <div class="card-header-left">
+                <span class="scene-no">#42</span>
+                <span class="scene-id">EP02_PT3_C42</span>
+                <span class="length-symbol up" title="LD · Long Duration (길이 늘어남)"><svg class="length-icon" aria-hidden="true"><use href="#ic-ld"/></svg></span>
+              </div>
+              <span class="pct-pill">75%</span>
+            </div>
+            <div class="card-thumb"></div>
+            <div class="memo-stack">
+              <div class="memo-row"><span class="memo-tag bg">BG</span><span class="memo-text">캐릭터 손동작 확인</span></div>
+              <div class="memo-row"><span class="memo-tag act">ACT</span><span class="memo-text">연기 톤 부드럽게</span></div>
+            </div>
+            <div class="dept-section">
+              <span class="dept-label">BG</span>
+              <div class="dept-track">
+                <div class="stage-cell bg-lo on">LO</div><div class="stage-cell bg-done on">완료</div>
+                <div class="stage-cell bg-review on">검수</div><div class="stage-cell bg-png">PNG</div>
+              </div>
+            </div>
+            <div class="dept-section last">
+              <span class="dept-label">ACT</span>
+              <div class="dept-track">
+                <div class="stage-cell act-lo on">LO</div><div class="stage-cell act-done on">완료</div>
+                <div class="stage-cell act-review">검수</div><div class="stage-cell act-png">PNG</div>
+              </div>
+            </div>
+          </div>
+          <div class="option-note">✓ 씬 ID 옆에 직접 표시 → 시야 안에 자연스럽게. <span style="font-family:monospace;font-weight:800;color:var(--grow-up)"><svg class="length-icon" aria-hidden="true"><use href="#ic-ld"/></svg></span> 초록(LD, 늘어남) / <span style="font-family:monospace;font-weight:800;color:var(--shrink-down)"><svg class="length-icon" aria-hidden="true"><use href="#ic-sd"/></svg></span> 빨강(SD, 줄어듦).</div>
+        </div>
+
+        <!-- 옵션 C2: 좌측 보더 + 코너 태그 -->
+        <div class="option-frame">
+          <div class="option-label"><span class="badge after">옵션 C2</span> 좌측 보더 (강조 강함)</div>
+          <div class="scene-card length-up-border">
+            <div class="length-corner-tag up" title="LD · Long Duration (길이 늘어남)" style="font-family:'JetBrains Mono',monospace; font-size:11px;"><svg class="length-icon" aria-hidden="true"><use href="#ic-ld"/></svg></div>
+            <div class="card-header">
+              <div class="card-header-left">
+                <span class="scene-no" style="margin-left: 30px;">#42</span>
+                <span class="scene-id">EP02_PT3_C42</span>
+              </div>
+              <span class="pct-pill">75%</span>
+            </div>
+            <div class="card-thumb"></div>
+            <div class="memo-stack">
+              <div class="memo-row"><span class="memo-tag bg">BG</span><span class="memo-text">캐릭터 손동작 확인</span></div>
+              <div class="memo-row"><span class="memo-tag act">ACT</span><span class="memo-text">연기 톤 부드럽게</span></div>
+            </div>
+            <div class="dept-section">
+              <span class="dept-label">BG</span>
+              <div class="dept-track">
+                <div class="stage-cell bg-lo on">LO</div><div class="stage-cell bg-done on">완료</div>
+                <div class="stage-cell bg-review on">검수</div><div class="stage-cell bg-png">PNG</div>
+              </div>
+            </div>
+            <div class="dept-section last">
+              <span class="dept-label">ACT</span>
+              <div class="dept-track">
+                <div class="stage-cell act-lo on">LO</div><div class="stage-cell act-done on">완료</div>
+                <div class="stage-cell act-review">검수</div><div class="stage-cell act-png">PNG</div>
+              </div>
+            </div>
+          </div>
+          <div class="option-note">✓ 멀리서도 한눈에. 단점: 카드가 좀 더 강하게 튄다, 그리드에서 정렬이 살짝 어긋날 수 있음.</div>
+        </div>
+
+        <!-- 옵션 C3: % 배지 옆 작은 점 -->
+        <div class="option-frame">
+          <div class="option-label"><span class="badge after">옵션 C3</span> 진행률 배지 옆 작은 점</div>
+          <div class="scene-card">
+            <div class="card-header">
+              <div class="card-header-left">
+                <span class="scene-no">#42</span>
+                <span class="scene-id">EP02_PT3_C42</span>
+              </div>
+              <div style="display:flex; align-items:center; gap:8px;">
+                <span class="length-symbol up" title="LD · Long Duration (길이 늘어남)"><svg class="length-icon" aria-hidden="true"><use href="#ic-ld"/></svg></span>
+                <span class="pct-pill">75%</span>
+              </div>
+            </div>
+            <div class="card-thumb"></div>
+            <div class="memo-stack">
+              <div class="memo-row"><span class="memo-tag bg">BG</span><span class="memo-text">캐릭터 손동작 확인</span></div>
+              <div class="memo-row"><span class="memo-tag act">ACT</span><span class="memo-text">연기 톤 부드럽게</span></div>
+            </div>
+            <div class="dept-section">
+              <span class="dept-label">BG</span>
+              <div class="dept-track">
+                <div class="stage-cell bg-lo on">LO</div><div class="stage-cell bg-done on">완료</div>
+                <div class="stage-cell bg-review on">검수</div><div class="stage-cell bg-png">PNG</div>
+              </div>
+            </div>
+            <div class="dept-section last">
+              <span class="dept-label">ACT</span>
+              <div class="dept-track">
+                <div class="stage-cell act-lo on">LO</div><div class="stage-cell act-done on">완료</div>
+                <div class="stage-cell act-review">검수</div><div class="stage-cell act-png">PNG</div>
+              </div>
+            </div>
+          </div>
+          <div class="option-note">✓ 진행률 옆에 일관되게 우상단 정보 그룹. 카드 좌측은 깨끗.</div>
+        </div>
+      </div>
+
+      <div class="legend">
+        <div class="legend-item"><span class="length-symbol up" title="LD · Long Duration (길이 늘어남)"><svg class="length-icon" aria-hidden="true"><use href="#ic-ld"/></svg></span><span style="color: var(--text-secondary)">길이 늘어남</span></div>
+        <div class="legend-item"><span class="length-symbol down" title="SD · Short Duration (길이 줄어듦)"><svg class="length-icon" aria-hidden="true"><use href="#ic-sd"/></svg></span><span style="color: var(--text-secondary)">길이 줄어듦</span></div>
+        <div class="legend-item"><span style="color: var(--text-muted)">— 표시 없음 (변경 없음)</span></div>
+      </div>
+    </section>
+
+    <!-- ───────── SECTION D : 길이 변경 표시 (시트 뷰) ───────── -->
+    <section>
+      <div class="section-title">D · 시트 뷰 — 씬 길이 변경 표시</div>
+      <p class="section-desc">
+        시트 행에 어떻게 표시할지 2안. 행 자체에 색을 입히는 방식과, 셀 옆에 칩을 다는 방식.
+      </p>
+
+      <!-- 옵션 D1: 행 좌측 그라데이션 -->
+      <div style="margin-bottom: 24px;">
+        <div class="option-label" style="margin-bottom: 8px;"><span class="badge after recommended">옵션 D1 추천</span> 행 좌측 그라데이션 + 씬번호 옆 화살표</div>
+        <div class="sheet-frame">
+          <div class="sheet-row header">
+            <div class="sheet-cell no">#</div>
+            <div class="sheet-cell">씬 ID</div>
+            <div class="sheet-cell">메모 (BG / ACT)</div>
+            <div class="sheet-cell">담당자</div>
+            <div class="sheet-cell">레이아웃</div>
+            <div class="sheet-cell">BG 진행</div>
+            <div class="sheet-cell">ACT 진행</div>
+          </div>
+          <div class="sheet-row length-up">
+            <div class="sheet-cell no">
+              <span class="length-symbol-sheet up" title="LD · Long Duration (길이 늘어남)"><svg class="length-icon" aria-hidden="true"><use href="#ic-ld"/></svg></span>
+              42
+            </div>
+            <div class="sheet-cell id">EP02_PT3_C42</div>
+            <div class="sheet-cell memo-stacked">
+              <div class="row"><span class="memo-tag bg">BG</span><span class="text">캐릭터 손동작 확인</span></div>
+              <div class="row"><span class="memo-tag act">ACT</span><span class="text">연기 톤 부드럽게</span></div>
+            </div>
+            <div class="sheet-cell">한솔</div>
+            <div class="sheet-cell">L#108</div>
+            <div class="sheet-cell dept-progress"><div class="stage on bg-lo"></div><div class="stage on bg-done"></div><div class="stage on bg-review"></div><div class="stage"></div></div>
+            <div class="sheet-cell dept-progress"><div class="stage on act-lo"></div><div class="stage on act-done"></div><div class="stage"></div><div class="stage"></div></div>
+          </div>
+          <div class="sheet-row">
+            <div class="sheet-cell no">43</div>
+            <div class="sheet-cell id">EP02_PT3_C43</div>
+            <div class="sheet-cell memo-stacked">
+              <div class="row"><span class="memo-tag bg">BG</span><span class="text">바닥 그림자 정리 필요</span></div>
+              <div class="row"><span class="memo-tag act">ACT</span><span class="text">—</span></div>
+            </div>
+            <div class="sheet-cell">한솔</div>
+            <div class="sheet-cell">L#109</div>
+            <div class="sheet-cell dept-progress"><div class="stage on bg-lo"></div><div class="stage"></div><div class="stage"></div><div class="stage"></div></div>
+            <div class="sheet-cell dept-progress"><div class="stage on act-lo"></div><div class="stage on act-done"></div><div class="stage on act-review"></div><div class="stage on act-png"></div></div>
+          </div>
+          <div class="sheet-row length-down">
+            <div class="sheet-cell no">
+              <span class="length-symbol-sheet down" title="SD · Short Duration (길이 줄어듦)"><svg class="length-icon" aria-hidden="true"><use href="#ic-sd"/></svg></span>
+              44
+            </div>
+            <div class="sheet-cell id">EP02_PT3_C44</div>
+            <div class="sheet-cell memo-stacked">
+              <div class="row"><span class="memo-tag bg">BG</span><span class="text">차량 위치 다시</span></div>
+              <div class="row"><span class="memo-tag act">ACT</span><span class="text">—</span></div>
+            </div>
+            <div class="sheet-cell">한솔</div>
+            <div class="sheet-cell">L#110</div>
+            <div class="sheet-cell dept-progress"><div class="stage on bg-lo"></div><div class="stage on bg-done"></div><div class="stage"></div><div class="stage"></div></div>
+            <div class="sheet-cell dept-progress"><div class="stage on act-lo"></div><div class="stage"></div><div class="stage"></div><div class="stage"></div></div>
+          </div>
+        </div>
+        <div class="option-note" style="margin-top: 8px;">✓ 행 좌측에 매우 옅은 그라데이션 + 씬번호 앞 화살표. 다른 행과 시각적 구분이 자연스럽고 행 전체가 산만해지지 않음.</div>
+      </div>
+
+      <!-- 옵션 D2: 씬번호 옆 칩 -->
+      <div>
+        <div class="option-label" style="margin-bottom: 8px;"><span class="badge after">옵션 D2</span> 씬번호 셀에 칩 추가만</div>
+        <div class="sheet-frame">
+          <div class="sheet-row header">
+            <div class="sheet-cell no">#</div>
+            <div class="sheet-cell">씬 ID</div>
+            <div class="sheet-cell">메모 (BG / ACT)</div>
+            <div class="sheet-cell">담당자</div>
+            <div class="sheet-cell">레이아웃</div>
+            <div class="sheet-cell">BG 진행</div>
+            <div class="sheet-cell">ACT 진행</div>
+          </div>
+          <div class="sheet-row">
+            <div class="sheet-cell id" style="font-family: 'JetBrains Mono', monospace; font-weight: 600; color: var(--text-muted);">
+              <span style="margin-right: 6px;">42</span>
+              <span class="length-symbol up" style="font-size: 10px; padding: 1px 5px;" title="LD · Long Duration (길이 늘어남)"><svg class="length-icon" aria-hidden="true"><use href="#ic-ld"/></svg></span>
+            </div>
+            <div class="sheet-cell id">EP02_PT3_C42</div>
+            <div class="sheet-cell memo-stacked">
+              <div class="row"><span class="memo-tag bg">BG</span><span class="text">캐릭터 손동작 확인</span></div>
+              <div class="row"><span class="memo-tag act">ACT</span><span class="text">연기 톤 부드럽게</span></div>
+            </div>
+            <div class="sheet-cell">한솔</div>
+            <div class="sheet-cell">L#108</div>
+            <div class="sheet-cell dept-progress"><div class="stage on bg-lo"></div><div class="stage on bg-done"></div><div class="stage on bg-review"></div><div class="stage"></div></div>
+            <div class="sheet-cell dept-progress"><div class="stage on act-lo"></div><div class="stage on act-done"></div><div class="stage"></div><div class="stage"></div></div>
+          </div>
+          <div class="sheet-row">
+            <div class="sheet-cell no">43</div>
+            <div class="sheet-cell id">EP02_PT3_C43</div>
+            <div class="sheet-cell memo-stacked">
+              <div class="row"><span class="memo-tag bg">BG</span><span class="text">바닥 그림자 정리 필요</span></div>
+              <div class="row"><span class="memo-tag act">ACT</span><span class="text">—</span></div>
+            </div>
+            <div class="sheet-cell">한솔</div>
+            <div class="sheet-cell">L#109</div>
+            <div class="sheet-cell dept-progress"><div class="stage on bg-lo"></div><div class="stage"></div><div class="stage"></div><div class="stage"></div></div>
+            <div class="sheet-cell dept-progress"><div class="stage on act-lo"></div><div class="stage on act-done"></div><div class="stage on act-review"></div><div class="stage on act-png"></div></div>
+          </div>
+          <div class="sheet-row">
+            <div class="sheet-cell id" style="font-family: 'JetBrains Mono', monospace; font-weight: 600; color: var(--text-muted);">
+              <span style="margin-right: 6px;">44</span>
+              <span class="length-symbol down" style="font-size: 10px; padding: 1px 5px;" title="SD · Short Duration (길이 줄어듦)"><svg class="length-icon" aria-hidden="true"><use href="#ic-sd"/></svg></span>
+            </div>
+            <div class="sheet-cell id">EP02_PT3_C44</div>
+            <div class="sheet-cell memo-stacked">
+              <div class="row"><span class="memo-tag bg">BG</span><span class="text">차량 위치 다시</span></div>
+              <div class="row"><span class="memo-tag act">ACT</span><span class="text">—</span></div>
+            </div>
+            <div class="sheet-cell">한솔</div>
+            <div class="sheet-cell">L#110</div>
+            <div class="sheet-cell dept-progress"><div class="stage on bg-lo"></div><div class="stage on bg-done"></div><div class="stage"></div><div class="stage"></div></div>
+            <div class="sheet-cell dept-progress"><div class="stage on act-lo"></div><div class="stage"></div><div class="stage"></div><div class="stage"></div></div>
+          </div>
+        </div>
+        <div class="option-note" style="margin-top: 8px;">✓ 행 자체는 평범. 씬번호 셀이 약간 좁아짐(아이콘 들어가야 해서 56→72px 정도 필요).</div>
+      </div>
+    </section>
+
+    <!-- ───────── SECTION E : 토글 UI (어떻게 켜고 끌 것인가) ───────── -->
+    <section>
+      <div class="section-title">E · 토글 UI — '늘어남/줄어듦' 라벨을 어떻게 누르나</div>
+      <p class="section-desc">
+        라벨을 켜고 끄는 사용자 동작 2안.
+      </p>
+
+      <div class="options-grid two">
+        <!-- 옵션 E1: 우클릭 메뉴 -->
+        <div class="option-frame">
+          <div class="option-label"><span class="badge after recommended">옵션 E1 추천</span> 우클릭 메뉴 (카드/시트 행)</div>
+          <div style="background: var(--bg-primary); border-radius: 10px; padding: 24px; display: flex; gap: 24px; align-items: flex-start;">
+            <div style="opacity: 0.4; flex: 1;">
+              <div class="scene-card" style="cursor: default; pointer-events: none;">
+                <div class="card-header">
+                  <div class="card-header-left"><span class="scene-no">#42</span><span class="scene-id">EP02_PT3_C42</span></div>
+                  <span class="pct-pill">75%</span>
+                </div>
+                <div class="card-thumb" style="height: 50px;"></div>
+              </div>
+            </div>
+            <div class="ctx-menu" style="position: relative;">
+              <div class="item section-title">씬 길이 변경</div>
+              <div class="item up">
+                <span class="icon" style="font-family:'JetBrains Mono',monospace;font-weight:800;font-size:11px;text-align:center;"><svg class="length-icon" aria-hidden="true"><use href="#ic-ld"/></svg></span>
+                길이 늘어남 (LD)
+              </div>
+              <div class="item down">
+                <span class="icon" style="font-family:'JetBrains Mono',monospace;font-weight:800;font-size:11px;text-align:center;"><svg class="length-icon" aria-hidden="true"><use href="#ic-sd"/></svg></span>
+                길이 줄어듦 (SD)
+              </div>
+              <div class="divider"></div>
+              <div class="item">
+                <span class="icon" style="font-family:'JetBrains Mono',monospace;font-weight:800;font-size:11px;text-align:center;opacity:0.6;">— —</span>
+                길이 변경 표시 해제
+              </div>
+              <div class="divider"></div>
+              <div class="item" style="color: var(--text-secondary)">씬 상세 열기</div>
+              <div class="item" style="color: var(--text-secondary)">씬 삭제</div>
+            </div>
+          </div>
+          <div class="option-note">✓ 우클릭으로 메뉴 진입 → 라벨 토글. 다른 빠른 액션과 자연스럽게 묶임. 카드/시트 모두 동일 메뉴. 평소엔 카드/시트가 깨끗.</div>
+        </div>
+
+        <!-- 옵션 E2: 카드 호버 인라인 버튼 -->
+        <div class="option-frame">
+          <div class="option-label"><span class="badge after">옵션 E2</span> 호버 시 인라인 버튼 노출</div>
+          <div class="scene-card" style="border: 1px dashed color-mix(in srgb, var(--accent) 50%, var(--bg-border));">
+            <div class="card-header">
+              <div class="card-header-left">
+                <span class="scene-no">#42</span>
+                <span class="scene-id">EP02_PT3_C42</span>
+                <button class="inline-toggle" title="LD · Long Duration">
+                  <span style="font-family:'JetBrains Mono',monospace;font-weight:800;"><svg class="length-icon" aria-hidden="true"><use href="#ic-ld"/></svg></span>
+                </button>
+                <button class="inline-toggle" title="SD · Short Duration">
+                  <span style="font-family:'JetBrains Mono',monospace;font-weight:800;"><svg class="length-icon" aria-hidden="true"><use href="#ic-sd"/></svg></span>
+                </button>
+              </div>
+              <span class="pct-pill">75%</span>
+            </div>
+            <div class="card-thumb"></div>
+            <div class="memo-stack">
+              <div class="memo-row"><span class="memo-tag bg">BG</span><span class="memo-text">캐릭터 손동작</span></div>
+              <div class="memo-row"><span class="memo-tag act">ACT</span><span class="memo-text">연기 톤 부드럽게</span></div>
+            </div>
+            <div class="dept-section last">
+              <span class="dept-label">BG</span>
+              <div class="dept-track">
+                <div class="stage-cell bg-lo on">LO</div><div class="stage-cell bg-done on">완료</div>
+                <div class="stage-cell bg-review on">검수</div><div class="stage-cell bg-png">PNG</div>
+              </div>
+            </div>
+          </div>
+          <div class="option-note">⚠ 호버 안 한 상태에선 안 보이지만 호버 순간 인라인 버튼이 나타남. 약간 어수선해질 수 있음. 시트 뷰엔 적용 어려움.</div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ───────── SECTION F : 통합 미리보기 (추천안 합본) ───────── -->
+    <section>
+      <div class="section-title">F · 통합 미리보기 — 추천안 적용 시</div>
+      <p class="section-desc">
+        A1(메모 수직 스택) + C1(헤더 옆 화살표 칩) + D1(시트 행 좌측 그라데이션) + E1(우클릭 메뉴) 결합.
+      </p>
+
+      <div class="final-frame">
+        <div class="option-label" style="margin-bottom: 8px;">
+          <span class="badge after recommended">최종 확정안</span> 한솔 결정 반영
+        </div>
+        <p style="font-size: 12px; color: var(--text-secondary); margin: 0 0 18px; line-height: 1.6;">
+          카드 뷰 메모 = <strong style="color: var(--text-primary)">A1 수직 스택</strong> ·
+          시트 뷰 메모 = <strong style="color: var(--text-primary)">B2 컬럼 분리</strong> ·
+          길이 라벨 = <strong style="color: var(--text-primary)">카드 우상단(% 옆) + 시트 행 그라데이션</strong> ·
+          표기 = <strong style="color: var(--text-primary)"><span style="font-family:monospace"><svg class="length-icon" aria-hidden="true"><use href="#ic-ld"/></svg></span> (LD) / <span style="font-family:monospace"><svg class="length-icon" aria-hidden="true"><use href="#ic-sd"/></svg></span> (SD)</strong> ·
+          토글 = <strong style="color: var(--text-primary)">우클릭 메뉴</strong>
+        </p>
+
+        <!-- 카드 (3개 시나리오) -->
+        <div style="margin-bottom: 24px;">
+          <div style="font-size: 11px; color: var(--section-label); font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; margin-bottom: 10px;">카드 뷰</div>
+          <div style="display: grid; grid-template-columns: repeat(3, minmax(280px, 1fr)); gap: 16px;">
+            <!-- 카드 1: 길이 늘어남 -->
+            <div class="scene-card">
+              <div class="card-header">
+                <div class="card-header-left">
+                  <span class="scene-no">#42</span>
+                  <span class="scene-id">EP02_PT3_C42</span>
+                </div>
+                <div style="display:flex; align-items:center; gap:6px;">
+                  <span class="length-symbol up" title="LD · Long Duration (길이 늘어남)"><svg class="length-icon" aria-hidden="true"><use href="#ic-ld"/></svg></span>
+                  <span class="pct-pill">75%</span>
+                </div>
+              </div>
+              <div class="card-thumb"></div>
+              <div class="memo-stack">
+                <div class="memo-row"><span class="memo-tag bg">BG</span><span class="memo-text">캐릭터 손동작 다시 확인</span></div>
+                <div class="memo-row"><span class="memo-tag act">ACT</span><span class="memo-text">연기 톤 부드럽게</span></div>
+              </div>
+              <div class="dept-section">
+                <span class="dept-label">BG</span>
+                <div class="dept-track">
+                  <div class="stage-cell bg-lo on">LO</div><div class="stage-cell bg-done on">완료</div>
+                  <div class="stage-cell bg-review on">검수</div><div class="stage-cell bg-png">PNG</div>
+                </div>
+              </div>
+              <div class="dept-section last">
+                <span class="dept-label">ACT</span>
+                <div class="dept-track">
+                  <div class="stage-cell act-lo on">LO</div><div class="stage-cell act-done on">완료</div>
+                  <div class="stage-cell act-review">검수</div><div class="stage-cell act-png">PNG</div>
+                </div>
+              </div>
+            </div>
+
+            <!-- 카드 2: 변경 없음 -->
+            <div class="scene-card">
+              <div class="card-header">
+                <div class="card-header-left">
+                  <span class="scene-no">#43</span>
+                  <span class="scene-id">EP02_PT3_C43</span>
+                </div>
+                <span class="pct-pill">25%</span>
+              </div>
+              <div class="card-thumb"></div>
+              <div class="memo-stack">
+                <div class="memo-row"><span class="memo-tag bg">BG</span><span class="memo-text">바닥 그림자 정리</span></div>
+                <div class="memo-row"><span class="memo-tag act" style="opacity:0.4">ACT</span><span class="memo-text" style="color:var(--text-muted)">메모 없음</span></div>
+              </div>
+              <div class="dept-section">
+                <span class="dept-label">BG</span>
+                <div class="dept-track">
+                  <div class="stage-cell bg-lo on">LO</div><div class="stage-cell bg-done">완료</div>
+                  <div class="stage-cell bg-review">검수</div><div class="stage-cell bg-png">PNG</div>
+                </div>
+              </div>
+              <div class="dept-section last">
+                <span class="dept-label">ACT</span>
+                <div class="dept-track">
+                  <div class="stage-cell act-lo on">LO</div><div class="stage-cell act-done on">완료</div>
+                  <div class="stage-cell act-review on">검수</div><div class="stage-cell act-png on">PNG</div>
+                </div>
+              </div>
+            </div>
+
+            <!-- 카드 3: 길이 줄어듦 -->
+            <div class="scene-card">
+              <div class="card-header">
+                <div class="card-header-left">
+                  <span class="scene-no">#44</span>
+                  <span class="scene-id">EP02_PT3_C44</span>
+                </div>
+                <div style="display:flex; align-items:center; gap:6px;">
+                  <span class="length-symbol down" title="SD · Short Duration (길이 줄어듦)"><svg class="length-icon" aria-hidden="true"><use href="#ic-sd"/></svg></span>
+                  <span class="pct-pill">50%</span>
+                </div>
+              </div>
+              <div class="card-thumb"></div>
+              <div class="memo-stack">
+                <div class="memo-row"><span class="memo-tag bg">BG</span><span class="memo-text">차량 위치 다시</span></div>
+                <div class="memo-row"><span class="memo-tag act">ACT</span><span class="memo-text">표정 더 풀어주세요</span></div>
+              </div>
+              <div class="dept-section">
+                <span class="dept-label">BG</span>
+                <div class="dept-track">
+                  <div class="stage-cell bg-lo on">LO</div><div class="stage-cell bg-done on">완료</div>
+                  <div class="stage-cell bg-review">검수</div><div class="stage-cell bg-png">PNG</div>
+                </div>
+              </div>
+              <div class="dept-section last">
+                <span class="dept-label">ACT</span>
+                <div class="dept-track">
+                  <div class="stage-cell act-lo on">LO</div><div class="stage-cell act-done">완료</div>
+                  <div class="stage-cell act-review">검수</div><div class="stage-cell act-png">PNG</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- 시트 (B2 컬럼 분리) -->
+        <div>
+          <div style="font-size: 11px; color: var(--section-label); font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; margin-bottom: 10px;">시트 뷰</div>
+          <div class="sheet-frame" style="align-self: start;">
+            <div class="sheet-row header" style="grid-template-columns: 56px 100px 1fr 1fr 80px 80px 100px 110px;">
+              <div class="sheet-cell no">#</div>
+              <div class="sheet-cell">씬 ID</div>
+              <div class="sheet-cell">BG 메모</div>
+              <div class="sheet-cell">ACT 메모</div>
+              <div class="sheet-cell">담당자</div>
+              <div class="sheet-cell">레이아웃</div>
+              <div class="sheet-cell">BG 진행</div>
+              <div class="sheet-cell">ACT 진행</div>
+            </div>
+            <div class="sheet-row length-up" style="grid-template-columns: 56px 100px 1fr 1fr 80px 80px 100px 110px;">
+              <div class="sheet-cell no">
+                <span class="length-symbol-sheet up" title="LD · Long Duration (길이 늘어남)"><svg class="length-icon" aria-hidden="true"><use href="#ic-ld"/></svg></span>
+                42
+              </div>
+              <div class="sheet-cell id">EP02_PT3_C42</div>
+              <div class="sheet-cell memo">캐릭터 손동작 다시 확인</div>
+              <div class="sheet-cell memo">연기 톤 부드럽게</div>
+              <div class="sheet-cell">한솔</div>
+              <div class="sheet-cell">L#108</div>
+              <div class="sheet-cell dept-progress"><div class="stage on bg-lo"></div><div class="stage on bg-done"></div><div class="stage on bg-review"></div><div class="stage"></div></div>
+              <div class="sheet-cell dept-progress"><div class="stage on act-lo"></div><div class="stage on act-done"></div><div class="stage"></div><div class="stage"></div></div>
+            </div>
+            <div class="sheet-row" style="grid-template-columns: 56px 100px 1fr 1fr 80px 80px 100px 110px;">
+              <div class="sheet-cell no">43</div>
+              <div class="sheet-cell id">EP02_PT3_C43</div>
+              <div class="sheet-cell memo">바닥 그림자 정리</div>
+              <div class="sheet-cell memo" style="color: var(--text-muted)">—</div>
+              <div class="sheet-cell">한솔</div>
+              <div class="sheet-cell">L#109</div>
+              <div class="sheet-cell dept-progress"><div class="stage on bg-lo"></div><div class="stage"></div><div class="stage"></div><div class="stage"></div></div>
+              <div class="sheet-cell dept-progress"><div class="stage on act-lo"></div><div class="stage on act-done"></div><div class="stage on act-review"></div><div class="stage on act-png"></div></div>
+            </div>
+            <div class="sheet-row length-down" style="grid-template-columns: 56px 100px 1fr 1fr 80px 80px 100px 110px;">
+              <div class="sheet-cell no">
+                <span class="length-symbol-sheet down" title="SD · Short Duration (길이 줄어듦)"><svg class="length-icon" aria-hidden="true"><use href="#ic-sd"/></svg></span>
+                44
+              </div>
+              <div class="sheet-cell id">EP02_PT3_C44</div>
+              <div class="sheet-cell memo">차량 위치 다시</div>
+              <div class="sheet-cell memo">표정 더 풀어주세요</div>
+              <div class="sheet-cell">한솔</div>
+              <div class="sheet-cell">L#110</div>
+              <div class="sheet-cell dept-progress"><div class="stage on bg-lo"></div><div class="stage on bg-done"></div><div class="stage"></div><div class="stage"></div></div>
+              <div class="sheet-cell dept-progress"><div class="stage on act-lo"></div><div class="stage"></div><div class="stage"></div><div class="stage"></div></div>
+            </div>
+            <div class="sheet-row length-up" style="grid-template-columns: 56px 100px 1fr 1fr 80px 80px 100px 110px;">
+              <div class="sheet-cell no">
+                <span class="length-symbol-sheet up" title="LD · Long Duration (길이 늘어남)"><svg class="length-icon" aria-hidden="true"><use href="#ic-ld"/></svg></span>
+                45
+              </div>
+              <div class="sheet-cell id">EP02_PT3_C45</div>
+              <div class="sheet-cell memo">건물 외벽 톤 다운…</div>
+              <div class="sheet-cell memo">대사 후 1프레임 늦게 시선…</div>
+              <div class="sheet-cell">민준</div>
+              <div class="sheet-cell">L#111</div>
+              <div class="sheet-cell dept-progress"><div class="stage on bg-lo"></div><div class="stage on bg-done"></div><div class="stage on bg-review"></div><div class="stage on bg-png"></div></div>
+              <div class="sheet-cell dept-progress"><div class="stage on act-lo"></div><div class="stage on act-done"></div><div class="stage on act-review"></div><div class="stage"></div></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- 우클릭 메뉴 미니어처 (카드 + 시트 동일) -->
+        <div style="margin-top: 22px; padding: 18px; background: var(--bg-card); border: 1px solid var(--bg-border-soft); border-radius: 10px;">
+          <strong style="color: var(--text-primary); display: block; margin-bottom: 4px; font-size: 13px;">우클릭 → 토글 (카드/시트 어디서든 동일)</strong>
+          <p style="font-size: 12px; color: var(--text-secondary); margin: 0 0 16px; line-height: 1.6;">
+            카드 영역 또는 시트 행 위에서 우클릭하면 같은 메뉴가 뜨고, 거기서 LD/SD를 켜거나 해제합니다. 영구 라벨이라 다시 끄기 전까지 표시 유지.
+          </p>
+
+          <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 18px;">
+            <!-- 좌측: 카드 우클릭 -->
+            <div style="background: var(--bg-primary); border-radius: 8px; padding: 14px;">
+              <div style="font-size: 10px; color: var(--section-label); margin-bottom: 10px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase;">① 카드 위에서 우클릭</div>
+              <div style="display: flex; align-items: flex-start; gap: 12px;">
+                <div style="opacity: 0.5; flex-shrink: 0; width: 200px;">
+                  <div class="scene-card" style="pointer-events: none;">
+                    <div class="card-header">
+                      <div class="card-header-left">
+                        <span class="scene-no">#42</span>
+                        <span class="scene-id">C42</span>
+                      </div>
+                      <span class="pct-pill">75%</span>
+                    </div>
+                    <div class="card-thumb" style="height: 40px;"></div>
+                    <div class="memo-stack" style="margin-bottom: 10px;">
+                      <div class="memo-row"><span class="memo-tag bg">BG</span><span class="memo-text">손동작</span></div>
+                      <div class="memo-row"><span class="memo-tag act">ACT</span><span class="memo-text">시선</span></div>
+                    </div>
+                  </div>
+                </div>
+                <div class="ctx-menu" style="flex-shrink: 0; width: 180px;">
+                  <div class="item section-title">씬 길이 변경</div>
+                  <div class="item up">
+                    <span class="icon" style="font-family:'JetBrains Mono',monospace;font-weight:800;font-size:11px;text-align:center;"><svg class="length-icon" aria-hidden="true"><use href="#ic-ld"/></svg></span>
+                    늘어남 (LD)
+                  </div>
+                  <div class="item down">
+                    <span class="icon" style="font-family:'JetBrains Mono',monospace;font-weight:800;font-size:11px;text-align:center;"><svg class="length-icon" aria-hidden="true"><use href="#ic-sd"/></svg></span>
+                    줄어듦 (SD)
+                  </div>
+                  <div class="divider"></div>
+                  <div class="item">
+                    <span class="icon" style="font-family:'JetBrains Mono',monospace;font-weight:800;font-size:11px;text-align:center;opacity:0.6;">— —</span>
+                    표시 해제
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- 우측: 시트 우클릭 -->
+            <div style="background: var(--bg-primary); border-radius: 8px; padding: 14px;">
+              <div style="font-size: 10px; color: var(--section-label); margin-bottom: 10px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase;">② 시트 행 위에서 우클릭</div>
+              <div style="display: flex; align-items: flex-start; gap: 12px;">
+                <div style="opacity: 0.5; flex-shrink: 0; width: 220px;">
+                  <div class="sheet-frame" style="pointer-events: none;">
+                    <div class="sheet-row" style="grid-template-columns: 60px 1fr 60px;">
+                      <div class="sheet-cell no">42</div>
+                      <div class="sheet-cell id">C42</div>
+                      <div class="sheet-cell" style="font-size: 11px;">75%</div>
+                    </div>
+                    <div class="sheet-row" style="grid-template-columns: 60px 1fr 60px; background: color-mix(in srgb, var(--accent) 6%, transparent); border-left: 2px solid var(--accent);">
+                      <div class="sheet-cell no">43</div>
+                      <div class="sheet-cell id">C43</div>
+                      <div class="sheet-cell" style="font-size: 11px;">25%</div>
+                    </div>
+                    <div class="sheet-row" style="grid-template-columns: 60px 1fr 60px;">
+                      <div class="sheet-cell no">44</div>
+                      <div class="sheet-cell id">C44</div>
+                      <div class="sheet-cell" style="font-size: 11px;">50%</div>
+                    </div>
+                  </div>
+                </div>
+                <div class="ctx-menu" style="flex-shrink: 0; width: 180px;">
+                  <div class="item section-title">씬 길이 변경</div>
+                  <div class="item up">
+                    <span class="icon" style="font-family:'JetBrains Mono',monospace;font-weight:800;font-size:11px;text-align:center;"><svg class="length-icon" aria-hidden="true"><use href="#ic-ld"/></svg></span>
+                    늘어남 (LD)
+                  </div>
+                  <div class="item down">
+                    <span class="icon" style="font-family:'JetBrains Mono',monospace;font-weight:800;font-size:11px;text-align:center;"><svg class="length-icon" aria-hidden="true"><use href="#ic-sd"/></svg></span>
+                    줄어듦 (SD)
+                  </div>
+                  <div class="divider"></div>
+                  <div class="item">
+                    <span class="icon" style="font-family:'JetBrains Mono',monospace;font-weight:800;font-size:11px;text-align:center;opacity:0.6;">— —</span>
+                    표시 해제
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ───────── SECTION G : 시트 메모 자세히 비교 (B1 vs B2 / 다양한 시나리오) ───────── -->
+    <section>
+      <div class="section-title">G · 시트 메모 자세히 — 다양한 상황에서 B1 vs B2</div>
+      <p class="section-desc">
+        실제 데이터는 양쪽 다 있는 경우, 한쪽만 있는 경우, 메모가 매우 긴 경우 등이 섞여 있어요. 각 상황에서 두 안이 어떻게 보이는지 직접 비교.
+      </p>
+
+      <!-- B1: 한 셀에 두 줄 — 다양한 시나리오 -->
+      <div style="margin-bottom: 28px;">
+        <div class="option-label" style="margin-bottom: 8px;"><span class="badge after">옵션 B1</span> 한 셀에 두 줄 (라벨 칩) — 5가지 상황</div>
+        <div class="sheet-frame">
+          <div class="sheet-row header">
+            <div class="sheet-cell no">#</div>
+            <div class="sheet-cell">씬 ID</div>
+            <div class="sheet-cell">메모 (BG / ACT)</div>
+            <div class="sheet-cell">담당자</div>
+            <div class="sheet-cell">레이아웃</div>
+            <div class="sheet-cell">BG 진행</div>
+            <div class="sheet-cell">ACT 진행</div>
+          </div>
+          <!-- 양쪽 다 짧음 -->
+          <div class="sheet-row">
+            <div class="sheet-cell no">42</div>
+            <div class="sheet-cell id">EP02_PT3_C42</div>
+            <div class="sheet-cell memo-stacked">
+              <div class="row"><span class="memo-tag bg">BG</span><span class="text">캐릭터 손동작</span></div>
+              <div class="row"><span class="memo-tag act">ACT</span><span class="text">시선 처리 다시</span></div>
+            </div>
+            <div class="sheet-cell">한솔</div>
+            <div class="sheet-cell">L#108</div>
+            <div class="sheet-cell dept-progress"><div class="stage on bg-lo"></div><div class="stage on bg-done"></div><div class="stage on bg-review"></div><div class="stage"></div></div>
+            <div class="sheet-cell dept-progress"><div class="stage on act-lo"></div><div class="stage on act-done"></div><div class="stage"></div><div class="stage"></div></div>
+          </div>
+          <!-- BG만 있음 -->
+          <div class="sheet-row">
+            <div class="sheet-cell no">43</div>
+            <div class="sheet-cell id">EP02_PT3_C43</div>
+            <div class="sheet-cell memo-stacked">
+              <div class="row"><span class="memo-tag bg">BG</span><span class="text">바닥 그림자 정리 필요</span></div>
+              <div class="row"><span class="memo-tag act" style="opacity:0.4">ACT</span><span class="text" style="color:var(--text-muted)">메모 없음</span></div>
+            </div>
+            <div class="sheet-cell">한솔</div>
+            <div class="sheet-cell">L#109</div>
+            <div class="sheet-cell dept-progress"><div class="stage on bg-lo"></div><div class="stage"></div><div class="stage"></div><div class="stage"></div></div>
+            <div class="sheet-cell dept-progress"><div class="stage on act-lo"></div><div class="stage on act-done"></div><div class="stage on act-review"></div><div class="stage on act-png"></div></div>
+          </div>
+          <!-- ACT만 있음 -->
+          <div class="sheet-row">
+            <div class="sheet-cell no">44</div>
+            <div class="sheet-cell id">EP02_PT3_C44</div>
+            <div class="sheet-cell memo-stacked">
+              <div class="row"><span class="memo-tag bg" style="opacity:0.4">BG</span><span class="text" style="color:var(--text-muted)">메모 없음</span></div>
+              <div class="row"><span class="memo-tag act">ACT</span><span class="text">표정 더 풀어주세요</span></div>
+            </div>
+            <div class="sheet-cell">민준</div>
+            <div class="sheet-cell">L#110</div>
+            <div class="sheet-cell dept-progress"><div class="stage on bg-lo"></div><div class="stage on bg-done"></div><div class="stage"></div><div class="stage"></div></div>
+            <div class="sheet-cell dept-progress"><div class="stage on act-lo"></div><div class="stage"></div><div class="stage"></div><div class="stage"></div></div>
+          </div>
+          <!-- 양쪽 다 긴 메모 -->
+          <div class="sheet-row">
+            <div class="sheet-cell no">45</div>
+            <div class="sheet-cell id">EP02_PT3_C45</div>
+            <div class="sheet-cell memo-stacked">
+              <div class="row"><span class="memo-tag bg">BG</span><span class="text">건물 외벽 톤 다운, 창문 반사 살짝만 — 1차 시안 빛 너무 강함</span></div>
+              <div class="row"><span class="memo-tag act">ACT</span><span class="text">대사 후 1프레임 늦게 시선 돌리기. 손은 전체적으로 한 박자 늦춤</span></div>
+            </div>
+            <div class="sheet-cell">한솔</div>
+            <div class="sheet-cell">L#111</div>
+            <div class="sheet-cell dept-progress"><div class="stage on bg-lo"></div><div class="stage on bg-done"></div><div class="stage on bg-review"></div><div class="stage on bg-png"></div></div>
+            <div class="sheet-cell dept-progress"><div class="stage on act-lo"></div><div class="stage on act-done"></div><div class="stage on act-review"></div><div class="stage"></div></div>
+          </div>
+          <!-- 둘 다 없음 -->
+          <div class="sheet-row">
+            <div class="sheet-cell no">46</div>
+            <div class="sheet-cell id">EP02_PT3_C46</div>
+            <div class="sheet-cell memo-stacked" style="justify-content: center; align-items: center;">
+              <div class="row" style="opacity: 0.4;"><span class="text" style="color:var(--text-muted)">메모 없음 (더블클릭으로 입력)</span></div>
+            </div>
+            <div class="sheet-cell">민준</div>
+            <div class="sheet-cell">L#112</div>
+            <div class="sheet-cell dept-progress"><div class="stage on bg-lo"></div><div class="stage"></div><div class="stage"></div><div class="stage"></div></div>
+            <div class="sheet-cell dept-progress"><div class="stage on act-lo"></div><div class="stage on act-done"></div><div class="stage"></div><div class="stage"></div></div>
+          </div>
+        </div>
+        <div class="option-note" style="margin-top: 8px;">행 높이가 살짝 늘지만(36→48px) 모든 행이 일정. 한쪽만 빈 경우 흐릿하게 처리해서 시각적 균형 유지.</div>
+      </div>
+
+      <!-- B2: 컬럼 분리 — 다양한 시나리오 -->
+      <div>
+        <div class="option-label" style="margin-bottom: 8px;"><span class="badge after">옵션 B2</span> BG/ACT 메모 컬럼 분리 — 5가지 상황</div>
+        <div class="sheet-frame">
+          <div class="sheet-row header" style="grid-template-columns: 56px 90px 1fr 1fr 80px 80px 100px 110px;">
+            <div class="sheet-cell no">#</div>
+            <div class="sheet-cell">씬 ID</div>
+            <div class="sheet-cell">BG 메모</div>
+            <div class="sheet-cell">ACT 메모</div>
+            <div class="sheet-cell">담당자</div>
+            <div class="sheet-cell">레이아웃</div>
+            <div class="sheet-cell">BG 진행</div>
+            <div class="sheet-cell">ACT 진행</div>
+          </div>
+          <div class="sheet-row" style="grid-template-columns: 56px 90px 1fr 1fr 80px 80px 100px 110px;">
+            <div class="sheet-cell no">42</div>
+            <div class="sheet-cell id">EP02_PT3_C42</div>
+            <div class="sheet-cell memo">캐릭터 손동작</div>
+            <div class="sheet-cell memo">시선 처리 다시</div>
+            <div class="sheet-cell">한솔</div>
+            <div class="sheet-cell">L#108</div>
+            <div class="sheet-cell dept-progress"><div class="stage on bg-lo"></div><div class="stage on bg-done"></div><div class="stage on bg-review"></div><div class="stage"></div></div>
+            <div class="sheet-cell dept-progress"><div class="stage on act-lo"></div><div class="stage on act-done"></div><div class="stage"></div><div class="stage"></div></div>
+          </div>
+          <div class="sheet-row" style="grid-template-columns: 56px 90px 1fr 1fr 80px 80px 100px 110px;">
+            <div class="sheet-cell no">43</div>
+            <div class="sheet-cell id">EP02_PT3_C43</div>
+            <div class="sheet-cell memo">바닥 그림자 정리 필요</div>
+            <div class="sheet-cell memo" style="color: var(--text-muted)">—</div>
+            <div class="sheet-cell">한솔</div>
+            <div class="sheet-cell">L#109</div>
+            <div class="sheet-cell dept-progress"><div class="stage on bg-lo"></div><div class="stage"></div><div class="stage"></div><div class="stage"></div></div>
+            <div class="sheet-cell dept-progress"><div class="stage on act-lo"></div><div class="stage on act-done"></div><div class="stage on act-review"></div><div class="stage on act-png"></div></div>
+          </div>
+          <div class="sheet-row" style="grid-template-columns: 56px 90px 1fr 1fr 80px 80px 100px 110px;">
+            <div class="sheet-cell no">44</div>
+            <div class="sheet-cell id">EP02_PT3_C44</div>
+            <div class="sheet-cell memo" style="color: var(--text-muted)">—</div>
+            <div class="sheet-cell memo">표정 더 풀어주세요</div>
+            <div class="sheet-cell">민준</div>
+            <div class="sheet-cell">L#110</div>
+            <div class="sheet-cell dept-progress"><div class="stage on bg-lo"></div><div class="stage on bg-done"></div><div class="stage"></div><div class="stage"></div></div>
+            <div class="sheet-cell dept-progress"><div class="stage on act-lo"></div><div class="stage"></div><div class="stage"></div><div class="stage"></div></div>
+          </div>
+          <div class="sheet-row" style="grid-template-columns: 56px 90px 1fr 1fr 80px 80px 100px 110px;">
+            <div class="sheet-cell no">45</div>
+            <div class="sheet-cell id">EP02_PT3_C45</div>
+            <div class="sheet-cell memo">건물 외벽 톤 다운, 창문 반사…</div>
+            <div class="sheet-cell memo">대사 후 1프레임 늦게 시선…</div>
+            <div class="sheet-cell">한솔</div>
+            <div class="sheet-cell">L#111</div>
+            <div class="sheet-cell dept-progress"><div class="stage on bg-lo"></div><div class="stage on bg-done"></div><div class="stage on bg-review"></div><div class="stage on bg-png"></div></div>
+            <div class="sheet-cell dept-progress"><div class="stage on act-lo"></div><div class="stage on act-done"></div><div class="stage on act-review"></div><div class="stage"></div></div>
+          </div>
+          <div class="sheet-row" style="grid-template-columns: 56px 90px 1fr 1fr 80px 80px 100px 110px;">
+            <div class="sheet-cell no">46</div>
+            <div class="sheet-cell id">EP02_PT3_C46</div>
+            <div class="sheet-cell memo" style="color: var(--text-muted)">—</div>
+            <div class="sheet-cell memo" style="color: var(--text-muted)">—</div>
+            <div class="sheet-cell">민준</div>
+            <div class="sheet-cell">L#112</div>
+            <div class="sheet-cell dept-progress"><div class="stage on bg-lo"></div><div class="stage"></div><div class="stage"></div><div class="stage"></div></div>
+            <div class="sheet-cell dept-progress"><div class="stage on act-lo"></div><div class="stage on act-done"></div><div class="stage"></div><div class="stage"></div></div>
+          </div>
+        </div>
+        <div class="option-note" style="margin-top: 8px;">행 높이 그대로(36px) 유지. 컬럼 두 개로 분리되니 메모가 길면 양쪽 다 잘림. 다른 컬럼(담당자/레이아웃)이 좁아짐.</div>
+      </div>
+
+      <div class="legend" style="margin-top: 18px;">
+        <div class="legend-item">
+          <strong style="color: var(--text-primary)">B1 장점</strong>
+          <span style="color: var(--text-secondary)">메모 컬럼이 넓어서 긴 메모도 비교적 잘 보임. 시트 가로 너비 거의 그대로.</span>
+        </div>
+        <div class="legend-item">
+          <strong style="color: var(--text-primary)">B2 장점</strong>
+          <span style="color: var(--text-secondary)">행 높이 변화 없음. 한쪽만 있을 때 빈 칸이 자연스러움. 정렬/필터링 적용 가능.</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- ───────── SECTION H : 길이 라벨 3조합 자세히 ───────── -->
+    <section>
+      <div class="section-title">H · 길이 라벨 자세히 — C+D 3조합 같은 데이터로 비교</div>
+      <p class="section-desc">
+        같은 씬 데이터(<span style="font-family:monospace;font-weight:800;color:var(--grow-up)"><svg class="length-icon" aria-hidden="true"><use href="#ic-ld"/></svg></span> 1개, <span style="font-family:monospace;font-weight:800;color:var(--shrink-down)"><svg class="length-icon" aria-hidden="true"><use href="#ic-sd"/></svg></span> 1개, 변경없음 1개)를 세 가지 조합으로 보여드려요. 카드는 위, 시트는 아래.
+      </p>
+
+      <div class="options-grid three">
+        <!-- 조합 1: C1 + D1 -->
+        <div class="option-frame">
+          <div class="option-label"><span class="badge after recommended">조합 1 추천</span> C1(헤더 칩) + D1(행 그라데이션)</div>
+
+          <!-- 카드 -->
+          <div class="scene-card" style="margin-bottom: 12px;">
+            <div class="card-header">
+              <div class="card-header-left">
+                <span class="scene-no">#42</span>
+                <span class="scene-id">C42</span>
+                <span class="length-symbol up" title="LD · Long Duration (길이 늘어남)"><svg class="length-icon" aria-hidden="true"><use href="#ic-ld"/></svg></span>
+              </div>
+              <span class="pct-pill">75%</span>
+            </div>
+            <div class="card-thumb" style="height: 50px;"></div>
+            <div class="memo-stack" style="margin-bottom: 10px;">
+              <div class="memo-row"><span class="memo-tag bg">BG</span><span class="memo-text">캐릭터 손동작</span></div>
+              <div class="memo-row"><span class="memo-tag act">ACT</span><span class="memo-text">시선 처리</span></div>
+            </div>
+          </div>
+
+          <!-- 시트 (3행) -->
+          <div class="sheet-frame">
+            <div class="sheet-row" style="grid-template-columns: 50px 80px 1fr 60px;">
+              <div class="sheet-cell no">
+                <span class="length-symbol-sheet up" title="LD · Long Duration (길이 늘어남)"><svg class="length-icon" aria-hidden="true"><use href="#ic-ld"/></svg></span>
+                42
+              </div>
+              <div class="sheet-cell id">C42</div>
+              <div class="sheet-cell memo-stacked" style="font-size: 10.5px;">
+                <div class="row"><span class="memo-tag bg">BG</span><span class="text">손동작</span></div>
+                <div class="row"><span class="memo-tag act">ACT</span><span class="text">시선</span></div>
+              </div>
+              <div class="sheet-cell" style="font-size: 11px;">75%</div>
+            </div>
+            <div class="sheet-row" style="grid-template-columns: 50px 80px 1fr 60px;">
+              <div class="sheet-cell no">43</div>
+              <div class="sheet-cell id">C43</div>
+              <div class="sheet-cell memo-stacked" style="font-size: 10.5px;">
+                <div class="row"><span class="memo-tag bg">BG</span><span class="text">그림자</span></div>
+                <div class="row"><span class="memo-tag act">ACT</span><span class="text">—</span></div>
+              </div>
+              <div class="sheet-cell" style="font-size: 11px;">25%</div>
+            </div>
+            <div class="sheet-row length-down" style="grid-template-columns: 50px 80px 1fr 60px;">
+              <div class="sheet-cell no">
+                <span class="length-symbol-sheet down" title="SD · Short Duration (길이 줄어듦)"><svg class="length-icon" aria-hidden="true"><use href="#ic-sd"/></svg></span>
+                44
+              </div>
+              <div class="sheet-cell id">C44</div>
+              <div class="sheet-cell memo-stacked" style="font-size: 10.5px;">
+                <div class="row"><span class="memo-tag bg">BG</span><span class="text">차량</span></div>
+                <div class="row"><span class="memo-tag act">ACT</span><span class="text">—</span></div>
+              </div>
+              <div class="sheet-cell" style="font-size: 11px;">50%</div>
+            </div>
+          </div>
+          <div class="option-note">
+            ✓ 카드: 씬 ID 옆 칩, 시야 안 자연스럽게.<br>
+            ✓ 시트: 행 자체에 옅은 그라데이션 + 씬번호 옆 화살표.<br>
+            <strong style="color: var(--grow-up);">=&gt; 정보가 한눈에, 다른 행과 산만함 없이 구분.</strong>
+          </div>
+        </div>
+
+        <!-- 조합 2: C2 + D2 -->
+        <div class="option-frame">
+          <div class="option-label"><span class="badge after">조합 2</span> C2(좌측 보더) + D2(씬번호 칩)</div>
+
+          <div class="scene-card length-up-border" style="margin-bottom: 12px;">
+            <div class="length-corner-tag up" title="LD · Long Duration (길이 늘어남)" style="font-family:'JetBrains Mono',monospace; font-size:11px;"><svg class="length-icon" aria-hidden="true"><use href="#ic-ld"/></svg></div>
+            <div class="card-header">
+              <div class="card-header-left">
+                <span class="scene-no" style="margin-left: 30px;">#42</span>
+                <span class="scene-id">C42</span>
+              </div>
+              <span class="pct-pill">75%</span>
+            </div>
+            <div class="card-thumb" style="height: 50px;"></div>
+            <div class="memo-stack" style="margin-bottom: 10px;">
+              <div class="memo-row"><span class="memo-tag bg">BG</span><span class="memo-text">캐릭터 손동작</span></div>
+              <div class="memo-row"><span class="memo-tag act">ACT</span><span class="memo-text">시선 처리</span></div>
+            </div>
+          </div>
+
+          <div class="sheet-frame">
+            <div class="sheet-row" style="grid-template-columns: 70px 70px 1fr 60px;">
+              <div class="sheet-cell id" style="font-family: 'JetBrains Mono', monospace; font-weight: 600; color: var(--text-muted);">
+                <span style="margin-right: 5px;">42</span>
+                <span class="length-chip up" style="font-size: 9px; padding: 1px 4px;">
+                  <svg viewBox="0 0 16 16" fill="none" stroke="currentColor"><path d="M8 13V3M3 7l5-5 5 5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                </span>
+              </div>
+              <div class="sheet-cell id">C42</div>
+              <div class="sheet-cell memo-stacked" style="font-size: 10.5px;">
+                <div class="row"><span class="memo-tag bg">BG</span><span class="text">손동작</span></div>
+                <div class="row"><span class="memo-tag act">ACT</span><span class="text">시선</span></div>
+              </div>
+              <div class="sheet-cell" style="font-size: 11px;">75%</div>
+            </div>
+            <div class="sheet-row" style="grid-template-columns: 70px 70px 1fr 60px;">
+              <div class="sheet-cell no">43</div>
+              <div class="sheet-cell id">C43</div>
+              <div class="sheet-cell memo-stacked" style="font-size: 10.5px;">
+                <div class="row"><span class="memo-tag bg">BG</span><span class="text">그림자</span></div>
+                <div class="row"><span class="memo-tag act">ACT</span><span class="text">—</span></div>
+              </div>
+              <div class="sheet-cell" style="font-size: 11px;">25%</div>
+            </div>
+            <div class="sheet-row" style="grid-template-columns: 70px 70px 1fr 60px;">
+              <div class="sheet-cell id" style="font-family: 'JetBrains Mono', monospace; font-weight: 600; color: var(--text-muted);">
+                <span style="margin-right: 5px;">44</span>
+                <span class="length-chip down" style="font-size: 9px; padding: 1px 4px;">
+                  <svg viewBox="0 0 16 16" fill="none" stroke="currentColor"><path d="M8 3V13M13 9l-5 5-5-5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                </span>
+              </div>
+              <div class="sheet-cell id">C44</div>
+              <div class="sheet-cell memo-stacked" style="font-size: 10.5px;">
+                <div class="row"><span class="memo-tag bg">BG</span><span class="text">차량</span></div>
+                <div class="row"><span class="memo-tag act">ACT</span><span class="text">—</span></div>
+              </div>
+              <div class="sheet-cell" style="font-size: 11px;">50%</div>
+            </div>
+          </div>
+          <div class="option-note">
+            ✓ 카드: 좌측 보더가 강해서 멀리서도 한눈에.<br>
+            ⚠ 카드 모양이 다른 카드보다 살짝 튀어 그리드에서 도드라짐.<br>
+            ⚠ 시트 씬번호 셀이 70px로 넓어져야 함.
+          </div>
+        </div>
+
+        <!-- 조합 3: C3 + D1 -->
+        <div class="option-frame">
+          <div class="option-label"><span class="badge after">조합 3</span> C3(우측 칩) + D1(행 그라데이션)</div>
+
+          <div class="scene-card" style="margin-bottom: 12px;">
+            <div class="card-header">
+              <div class="card-header-left">
+                <span class="scene-no">#42</span>
+                <span class="scene-id">C42</span>
+              </div>
+              <div style="display:flex; align-items:center; gap:6px;">
+                <span class="length-symbol up" title="LD · Long Duration (길이 늘어남)"><svg class="length-icon" aria-hidden="true"><use href="#ic-ld"/></svg></span>
+                <span class="pct-pill">75%</span>
+              </div>
+            </div>
+            <div class="card-thumb" style="height: 50px;"></div>
+            <div class="memo-stack" style="margin-bottom: 10px;">
+              <div class="memo-row"><span class="memo-tag bg">BG</span><span class="memo-text">캐릭터 손동작</span></div>
+              <div class="memo-row"><span class="memo-tag act">ACT</span><span class="memo-text">시선 처리</span></div>
+            </div>
+          </div>
+
+          <div class="sheet-frame">
+            <div class="sheet-row length-up" style="grid-template-columns: 50px 80px 1fr 60px;">
+              <div class="sheet-cell no">
+                <span class="length-symbol-sheet up" title="LD · Long Duration (길이 늘어남)"><svg class="length-icon" aria-hidden="true"><use href="#ic-ld"/></svg></span>
+                42
+              </div>
+              <div class="sheet-cell id">C42</div>
+              <div class="sheet-cell memo-stacked" style="font-size: 10.5px;">
+                <div class="row"><span class="memo-tag bg">BG</span><span class="text">손동작</span></div>
+                <div class="row"><span class="memo-tag act">ACT</span><span class="text">시선</span></div>
+              </div>
+              <div class="sheet-cell" style="font-size: 11px;">75%</div>
+            </div>
+            <div class="sheet-row" style="grid-template-columns: 50px 80px 1fr 60px;">
+              <div class="sheet-cell no">43</div>
+              <div class="sheet-cell id">C43</div>
+              <div class="sheet-cell memo-stacked" style="font-size: 10.5px;">
+                <div class="row"><span class="memo-tag bg">BG</span><span class="text">그림자</span></div>
+                <div class="row"><span class="memo-tag act">ACT</span><span class="text">—</span></div>
+              </div>
+              <div class="sheet-cell" style="font-size: 11px;">25%</div>
+            </div>
+            <div class="sheet-row length-down" style="grid-template-columns: 50px 80px 1fr 60px;">
+              <div class="sheet-cell no">
+                <span class="length-symbol-sheet down" title="SD · Short Duration (길이 줄어듦)"><svg class="length-icon" aria-hidden="true"><use href="#ic-sd"/></svg></span>
+                44
+              </div>
+              <div class="sheet-cell id">C44</div>
+              <div class="sheet-cell memo-stacked" style="font-size: 10.5px;">
+                <div class="row"><span class="memo-tag bg">BG</span><span class="text">차량</span></div>
+                <div class="row"><span class="memo-tag act">ACT</span><span class="text">—</span></div>
+              </div>
+              <div class="sheet-cell" style="font-size: 11px;">50%</div>
+            </div>
+          </div>
+          <div class="option-note">
+            ✓ 카드: 우상단(% 옆)에 라벨 → 정보 그룹화.<br>
+            ✓ 시트: 조합 1과 동일 (D1).<br>
+            ⚠ 카드 좌측은 깨끗하지만 시야가 우상단으로 분산.
+          </div>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <footer>
+    B flow · 메모 + 씬 길이 변경 시안 · 디자인 톤은 기존 #6C5CE7 액센트 시스템 + 라이트 모드 대응 유지 · 최종 확정안 (섹션 F)
+  </footer>
+
+  <script>
+    const root = document.documentElement;
+    const btnDark = document.getElementById('btn-dark');
+    const btnLight = document.getElementById('btn-light');
+    btnDark.addEventListener('click', () => {
+      root.dataset.theme = 'dark';
+      btnDark.classList.add('active');
+      btnLight.classList.remove('active');
+    });
+    btnLight.addEventListener('click', () => {
+      root.dataset.theme = 'light';
+      btnLight.classList.add('active');
+      btnDark.classList.remove('active');
+    });
+  </script>
+</body>
+</html>

--- a/docs/superpowers/specs/2026-04-30-memo-and-scene-length-design.md
+++ b/docs/superpowers/specs/2026-04-30-memo-and-scene-length-design.md
@@ -1,0 +1,345 @@
+# BG/ACT 메모 동시 노출 + 씬 길이 변경 시각 효과 — 디자인 문서
+
+**작성일**: 2026-04-30
+**대상 브랜치**: `claude/inspiring-blackwell-d59141`
+**대상 버전**: v1.16.0 (예정)
+**작성자**: 한솔 × Claude
+**시안 목업**: [`demo/scene-meta-mockup.html`](../../../demo/scene-meta-mockup.html) (다크/라이트 토글, 9개 섹션 비교)
+
+---
+
+## 배경
+
+전체 뷰(부서 통합 모드)에서 두 가지 현장 마찰을 해결한다:
+
+1. **메모 노출 한계**: 카드 뷰/시트 뷰 모두 `bgScene ?? actScene`로 **BG 메모만 노출**되어 ACT 메모가 가려진다. 양쪽 모두 메모를 적었어도 한쪽만 보임.
+2. **씬 길이 변경 인지 부재**: 한 씬의 길이(영상 시간)가 늘어나거나 줄어들었음을 카드/시트에서 시각적으로 인지할 수단이 없음. 작업자가 변경 여부를 놓침.
+
+---
+
+## 결정사항 요약
+
+| 항목 | 한솔 결정 |
+|---|---|
+| 카드 뷰 메모 노출 | **A1**: BG/ACT 수직 스택 (각 줄 앞 라벨 칩 `[BG]` `[ACT]`) |
+| 시트 뷰 메모 노출 | **B2**: BG 메모 / ACT 메모 컬럼 분리 |
+| 씬 길이 변경 데이터 | 새 필드 추가, **수치 무관**. 늘어남/줄어듦 **여부**만 |
+| 입력 방식 | **수동 토글** (수치 입력 X) |
+| 표시 지속 | **영구 라벨** (사용자가 수동 해제할 때까지) |
+| 길이 라벨 표기 | **SVG 아이콘**: `<->` 모양(LD, 늘어남) / `>-<` 모양(SD, 줄어듦). 텍스트 아닌 라인+화살촉 SVG로 줄바꿈 안전 |
+| 카드 라벨 위치 | **우상단 (% 진행률 배지 옆)** — 정보 그룹화 |
+| 시트 라벨 위치 | **행 좌측 그라데이션** + **씬번호 셀 옆 SVG 칩** |
+| 토글 UI | **우클릭 메뉴** (카드/시트 동일 메뉴) |
+| 색상 톤 | LD = 초록(#34D399 다크 / #059669 라이트), SD = 빨강(#FB7185 다크 / #DC2626 라이트). 라이트 모드 대응 |
+| 툴팁 | LD = "Long Duration · 길이 늘어남", SD = "Short Duration · 길이 줄어듦" |
+| 메모 텍스트 italic | **사용 금지** (placeholder 포함) — 장기 디자인 원칙 |
+
+---
+
+## 섹션 1: BG/ACT 메모 동시 노출
+
+### 1-A. 카드 뷰 (옵션 A1 수직 스택)
+
+**현재 동작**:
+- [`src/components/scenes/UnifiedSceneCard.tsx:67`](../../../src/components/scenes/UnifiedSceneCard.tsx) 에서 `const primaryScene = bgScene ?? actScene;`
+- [라인 207-213](../../../src/components/scenes/UnifiedSceneCard.tsx) 에서 `primaryScene.memo` 한 줄만 렌더 (`text-[11px] text-amber-400/70 line-clamp-1`)
+- 결과: BG가 있으면 BG 메모만, BG가 없을 때만 ACT 메모.
+
+**변경 후 동작**:
+- 메모 영역에 **두 줄** 렌더 (BG 있으면 BG 줄, ACT 있으면 ACT 줄). 각 줄은 라벨 칩 + 메모 텍스트.
+- 한쪽만 있으면 한 줄만 표시 (양쪽 다 비어있으면 메모 영역 자체 비표시).
+- 두 부서 모두 메모가 있을 때 카드 높이 약 +14px 증가.
+
+**라벨 칩 디자인**:
+- BG 라벨: 시안 컬러 (`--memo-bg-only`: 다크 #93C5FD / 라이트 #1D4ED8) + 14% 배경
+- ACT 라벨: 핑크 컬러 (`--memo-act-only`: 다크 #FDA4AF / 라이트 #BE185D) + 14% 배경
+- 9px / 폰트 700 / `padding: 1px 5px` / 라운드 4px
+
+**메모 텍스트**:
+- 11px / `text-amber-400/70` 톤 유지 (`--memo-soft`)
+- `line-clamp: 1` (한 줄로 자름, 넘치면 ellipsis)
+- **`font-style: italic` 절대 금지** (장기 원칙)
+
+**구현 위치**: [`UnifiedSceneCard.tsx:207-213`](../../../src/components/scenes/UnifiedSceneCard.tsx)
+
+### 1-B. 시트 뷰 (옵션 B2 컬럼 분리)
+
+**현재 동작**:
+- [`UnifiedSceneSheetView.tsx:465`](../../../src/components/scenes/UnifiedSceneSheetView.tsx) 의 `getCellValue`에서 `(m.bgScene ?? m.actScene)?.memo`
+- [라인 746](../../../src/components/scenes/UnifiedSceneSheetView.tsx) 의 `SheetEditableCell` value도 동일 로직
+- [라인 449-452](../../../src/components/scenes/UnifiedSceneSheetView.tsx) `saveField`도 BG 우선 저장
+
+**변경 후 동작**:
+- 시트 컬럼 정의에서 기존 단일 "메모" 컬럼을 **"BG 메모"**, **"ACT 메모"** 두 컬럼으로 분리.
+- 각 컬럼의 셀 편집은 해당 부서의 Scene에만 저장 (BG 메모 셀 수정 → bgScene.memo, ACT 메모 셀 수정 → actScene.memo).
+- 한쪽이 비어있는 셀은 dim 처리 (`color: var(--text-muted)`, italic 금지) + `—` 표시.
+- 행 높이 변화 없음.
+
+**컬럼 너비**:
+- 기존 메모 컬럼 너비를 둘로 분할 (각 `1fr`)
+- 다른 컬럼(담당자/레이아웃 등)이 좁아지므로, 컬럼 정의 재조정 필요
+
+**구현 위치**:
+- 컬럼 정의: [`UnifiedSceneSheetView.tsx`](../../../src/components/scenes/UnifiedSceneSheetView.tsx) 의 column 정의부 (구체 라인은 구현 단계 확인)
+- `getCellValue`/`saveField`: 위 라인들을 `bgMemo`/`actMemo` 분기로 변경
+
+### 1-C. 데이터 모델
+
+**변경 없음**. 기존에도 bgScene/actScene이 별도 객체로 분리돼 있고 각각 `memo` 필드 보유 ([`src/types/index.ts:60-75`](../../../src/types/index.ts)). UI 분기만 변경.
+
+---
+
+## 섹션 2: 씬 길이 변경 시각 효과
+
+### 2-A. 데이터 모델 (신규 필드)
+
+Scene 타입에 새 필드 추가 (둘 중 하나의 nullable 값):
+
+```typescript
+// src/types/index.ts Scene 인터페이스에 추가
+export interface Scene {
+  // 기존 필드 …
+  lengthChange?: 'LD' | 'SD' | null;  // null = 변경 없음
+}
+```
+
+- **LD** = Long Duration (길이 늘어남)
+- **SD** = Short Duration (길이 줄어듦)
+- `null`/`undefined` = 변경 표시 없음
+- 수치 입력 없음. 사용자가 우클릭 메뉴로 LD/SD/해제 토글.
+
+**Supabase**:
+- `comp_scenes` 테이블에 `length_change` 컬럼 추가 (`text` nullable, check constraint: `IN ('LD', 'SD')`).
+- 마이그레이션 SQL은 구현 단계에서 작성.
+- 기존 행은 NULL (변경 없음).
+
+### 2-B. SVG 아이콘 정의
+
+텍스트 `<->`/`>-<`는 좁은 컨테이너에서 줄바꿈으로 모양이 분해될 위험. **반드시 SVG**로 그려서 단일 atomic 단위로 처리.
+
+```svg
+<!-- LD: <-> 양옆 바깥쪽 화살촉 (길이 늘어남) -->
+<symbol id="ic-ld" viewBox="0 0 20 10">
+  <line x1="3" y1="5" x2="17" y2="5" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/>
+  <polyline points="6,2 3,5 6,8" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="14,2 17,5 14,8" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+</symbol>
+
+<!-- SD: >-< 양옆 안쪽 화살촉 (길이 줄어듦) -->
+<symbol id="ic-sd" viewBox="0 0 20 10">
+  <line x1="6" y1="5" x2="14" y2="5" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/>
+  <polyline points="3,2 6,5 3,8" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="17,2 14,5 17,8" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/>
+</symbol>
+```
+
+**구현 방식**:
+- 컴포넌트로 추출: `<LengthIcon kind="LD" />` / `<LengthIcon kind="SD" />` (React 컴포넌트로 SVG 인라인 반환)
+- 또는 `<symbol>`+`<use>` 방식으로 한 번 정의 후 재사용 (성능 최적화)
+- 위치: `src/components/scenes/icons/LengthIcon.tsx` (신규)
+
+**기본 크기**: 20×10 (카드용), 16×8 (시트용 sm 변형)
+
+### 2-C. 카드 뷰 표시 (헤더 우상단)
+
+**위치**: 카드 헤더 우측, % 진행률 배지 *바로 왼쪽*. 즉 `[<->] [75%]` 같은 그룹.
+
+```jsx
+<div className="card-header-right" style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+  {scene.lengthChange === 'LD' && <LengthBadge kind="LD" />}
+  {scene.lengthChange === 'SD' && <LengthBadge kind="SD" />}
+  <span className="pct-pill">{combinedPct}%</span>
+</div>
+```
+
+**LengthBadge 스타일** (`.length-symbol` 클래스):
+```css
+.length-symbol {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 7px;
+  border-radius: 5px;
+  cursor: help;          /* 툴팁 가능 */
+  white-space: nowrap;   /* 줄바꿈 방지 */
+  flex-shrink: 0;        /* 좁은 부모에서 줄어들지 않음 */
+}
+.length-symbol.up {       /* LD */
+  color: #34D399;         /* --grow-up 다크 */
+  background: rgba(52, 211, 153, 0.15);
+  border: 1px solid color-mix(in srgb, #34D399 30%, transparent);
+}
+.length-symbol.down {     /* SD */
+  color: #FB7185;         /* --shrink-down 다크 */
+  background: rgba(251, 113, 133, 0.15);
+  border: 1px solid color-mix(in srgb, #FB7185 30%, transparent);
+}
+/* 라이트 모드: --grow-up = #059669, --shrink-down = #DC2626 */
+```
+
+**툴팁**: `<span title="LD · Long Duration (길이 늘어남)">` (HTML title 속성).
+
+**구현 위치**: [`UnifiedSceneCard.tsx:175-191`](../../../src/components/scenes/UnifiedSceneCard.tsx) 의 헤더 우측 그룹
+
+### 2-D. 시트 뷰 표시 (행 좌측 그라데이션 + 씬번호 셀 SVG 칩)
+
+**1) 씬번호 셀 안 SVG 칩** (`.length-symbol-sheet`):
+```css
+.length-symbol-sheet {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 5px;
+  border-radius: 4px;
+  margin-right: 6px;
+  cursor: help;
+  white-space: nowrap;       /* 잘림 방지 */
+  flex-shrink: 0;            /* 줄어들지 않음 */
+}
+.length-symbol-sheet.up { color: #34D399; background: rgba(52,211,153,0.15); border: 1px solid color-mix(in srgb, #34D399 28%, transparent); }
+.length-symbol-sheet.down { color: #FB7185; background: rgba(251,113,133,0.15); border: 1px solid color-mix(in srgb, #FB7185 28%, transparent); }
+
+.sheet-cell.no { white-space: nowrap; overflow: visible; }  /* 칩이 잘리지 않게 */
+```
+
+```jsx
+<div className="sheet-cell no">
+  {scene.lengthChange && <LengthBadge kind={scene.lengthChange} variant="sheet" />}
+  {sceneNo}
+</div>
+```
+
+**2) 행 좌측 그라데이션** (멀리서 봐도 행 인지):
+```css
+.sheet-row.length-up { background: linear-gradient(90deg, rgba(52,211,153,0.15) 0%, transparent 5%); }
+.sheet-row.length-down { background: linear-gradient(90deg, rgba(251,113,133,0.15) 0%, transparent 5%); }
+.sheet-row.length-up:hover { background: linear-gradient(90deg, rgba(52,211,153,0.15) 0%, var(--accent-hover) 5%); }
+/* 라이트 모드 대응: 색상 변수 자동 전환 */
+```
+
+**구현 위치**: [`UnifiedSceneSheetView.tsx`](../../../src/components/scenes/UnifiedSceneSheetView.tsx) 의 시트 행 렌더, 씬번호 셀.
+
+### 2-E. 우클릭 토글 메뉴 (카드/시트 동일)
+
+**현재 패턴 참고**:
+- 우클릭 메뉴 패턴은 [`src/components/scenes/EpisodeTreeNav.tsx`](../../../src/components/scenes/EpisodeTreeNav.tsx) 에 이미 구현되어 있음. 동일 패턴 활용.
+- 새 컴포넌트: `src/components/scenes/SceneContextMenu.tsx` 만들어서 카드/시트 양쪽에서 재사용.
+
+**메뉴 항목**:
+```
+─ 씬 길이 변경 ──────
+  <-> 길이 늘어남 (LD)    ← scene.lengthChange='LD'
+  >-< 길이 줄어듦 (SD)    ← scene.lengthChange='SD'
+  ──
+  -- -- 표시 해제          ← scene.lengthChange=null
+─────────────────
+  씬 상세 열기            (기존 액션, 추가 시)
+  씬 삭제                 (기존 액션, 추가 시)
+```
+
+**Click 동작**:
+- LD/SD 클릭 시 즉시 `scene.lengthChange = 'LD'/'SD'` 낙관적 업데이트 (`useDataStore` 액션) → Supabase 동기화 → 실패 시 롤백.
+- 다른 클라이언트는 Realtime으로 ~100ms 내 수신.
+
+**위치**: 카드 [`UnifiedSceneCard.tsx`](../../../src/components/scenes/UnifiedSceneCard.tsx) 의 root motion.div + 시트 [`UnifiedSceneSheetView.tsx`](../../../src/components/scenes/UnifiedSceneSheetView.tsx) 의 행 root에 `onContextMenu` 핸들러 부착.
+
+### 2-F. Supabase 동기화
+
+**테이블 변경**:
+```sql
+-- migration: add length_change to comp_scenes
+ALTER TABLE comp_scenes ADD COLUMN length_change text NULL
+  CHECK (length_change IS NULL OR length_change IN ('LD', 'SD'));
+```
+
+**RPC/직접 update**: 기존 `supabaseService.updateSceneField` 패턴에 `length_change` 추가.
+
+**Realtime**: 기존 `comp_scenes` 채널에 `length_change` 컬럼 변경도 자동 포함됨.
+
+---
+
+## 섹션 3: 디자인 토큰 & 시스템
+
+### 3-A. 색상 토큰 추가
+
+[`src/index.css`](../../../src/index.css) 의 `:root` / `[data-color-mode="light"]`에 추가:
+
+```css
+:root {
+  --grow-up: #34D399;             /* LD 다크 */
+  --grow-up-soft: rgba(52, 211, 153, 0.15);
+  --shrink-down: #FB7185;          /* SD 다크 */
+  --shrink-down-soft: rgba(251, 113, 133, 0.15);
+}
+[data-color-mode="light"] {
+  --grow-up: #059669;
+  --grow-up-soft: rgba(5, 150, 105, 0.14);
+  --shrink-down: #DC2626;
+  --shrink-down-soft: rgba(220, 38, 38, 0.12);
+}
+```
+
+[`tailwind.config.js`](../../../tailwind.config.js) 의 colors 확장에 추가:
+```js
+colors: {
+  // 기존 …
+  'length-up': 'var(--grow-up)',
+  'length-up-soft': 'var(--grow-up-soft)',
+  'length-down': 'var(--shrink-down)',
+  'length-down-soft': 'var(--shrink-down-soft)',
+}
+```
+
+### 3-B. SVG `<defs>` 마운트 위치
+
+`src/App.tsx` 또는 별도 `<SvgIconDefs>` 컴포넌트 → 앱 root에 한 번만 마운트:
+```tsx
+<svg style={{ position: 'absolute', width: 0, height: 0, overflow: 'hidden' }} aria-hidden="true">
+  <defs>
+    <symbol id="ic-ld">{/* … */}</symbol>
+    <symbol id="ic-sd">{/* … */}</symbol>
+  </defs>
+</svg>
+```
+
+이후 어디서든 `<svg className="length-icon"><use href="#ic-ld" /></svg>` 로 참조.
+
+### 3-C. 메모 텍스트 italic 금지 (장기 원칙)
+
+- 메모 관련 모든 텍스트(`.memo-text`, `.sheet-cell.memo`, 댓글 등)에 **`font-style: italic` 사용 금지**.
+- 빈/placeholder는 색상(`--text-muted`)이나 opacity로만 약화.
+- 한솔 명시 결정 (2026-04-30, "향후에도 빼줘"). [`feedback_memo_italic.md`](../../../../../Users/user/.claude/projects/C--Bflow-BGonly/memory/feedback_memo_italic.md) 메모리에 보존.
+
+---
+
+## 섹션 4: 영향 받는 파일
+
+| 파일 | 변경 내용 |
+|---|---|
+| [`src/types/index.ts`](../../../src/types/index.ts) | `Scene` 인터페이스에 `lengthChange?: 'LD' \| 'SD' \| null` 추가 |
+| [`src/components/scenes/UnifiedSceneCard.tsx`](../../../src/components/scenes/UnifiedSceneCard.tsx) | 메모 영역 두 줄 렌더(A1) + 헤더 우상단 LD/SD 칩 + onContextMenu |
+| [`src/components/scenes/UnifiedSceneSheetView.tsx`](../../../src/components/scenes/UnifiedSceneSheetView.tsx) | 메모 컬럼 분리(B2) + 행 좌측 그라데이션 + 씬번호 옆 SVG 칩 + onContextMenu + getCellValue/saveField 분기 |
+| `src/components/scenes/SceneContextMenu.tsx` | 신규 — 카드/시트 공용 우클릭 메뉴 |
+| `src/components/scenes/icons/LengthIcon.tsx` | 신규 — `<LengthIcon kind="LD\|SD" />` 컴포넌트 |
+| `src/components/SvgIconDefs.tsx` (또는 App에 인라인) | 신규 — 페이지 root SVG defs |
+| [`src/index.css`](../../../src/index.css) | `--grow-up*`, `--shrink-down*` 토큰 + `.length-symbol*` / `.sheet-row.length-up/down` 클래스 |
+| [`tailwind.config.js`](../../../tailwind.config.js) | colors 확장 |
+| [`src/stores/useDataStore.ts`](../../../src/stores/useDataStore.ts) | `setSceneLengthChange(sceneUuid, value)` 액션 추가 (낙관적) |
+| [`electron/supabase.ts`](../../../electron/supabase.ts) | `length_change` 컬럼 read/write 처리 |
+| `DEVLOG/migrations/<날짜>-add-length-change.sql` | DB 마이그레이션 SQL |
+
+---
+
+## 섹션 5: 미해결 사항 / 추후 결정
+
+- **부서별 길이 변경 분리 여부**: 현재는 씬 단위 한 값(LD/SD/null). 만약 BG만 길이 늘어나고 ACT는 그대로인 케이스를 구분하고 싶다면 데이터 모델 확장 필요(`bgLengthChange`, `actLengthChange`). v1.16.0에서는 단일 값으로 시작, 필요 시 후속 버전에서 확장.
+- **길이 변경 이력 로깅**: Activity 로그(`comp_activities`)에 LD/SD 토글을 기록할지. 토글 빈도가 잦을 수 있으므로 v1.16.0에서는 일단 로깅 X, 향후 검토.
+- **자동 해제 트리거**: PNG 단계 완료 시 자동으로 lengthChange 해제 등은 도입하지 않음 (한솔 결정: "영구 라벨, 수동 해제까지").
+
+---
+
+## 참고 자료
+
+- 시안 목업 (다크/라이트 토글, 9개 섹션, 카드/시트 비교): [`demo/scene-meta-mockup.html`](../../../demo/scene-meta-mockup.html)
+- 미리보기 서버: `python -m http.server 5558` → http://localhost:5558/demo/scene-meta-mockup.html
+- 기존 컨텍스트 메뉴 패턴 참고: [`src/components/scenes/EpisodeTreeNav.tsx`](../../../src/components/scenes/EpisodeTreeNav.tsx)
+- 기존 카드/시트 구조: [`src/components/scenes/UnifiedSceneCard.tsx`](../../../src/components/scenes/UnifiedSceneCard.tsx) / [`src/components/scenes/UnifiedSceneSheetView.tsx`](../../../src/components/scenes/UnifiedSceneSheetView.tsx)
+- 디자인 토큰 정의 위치: [`src/index.css:59-99`](../../../src/index.css), [`tailwind.config.js`](../../../tailwind.config.js)

--- a/electron/broadcast.ts
+++ b/electron/broadcast.ts
@@ -109,11 +109,14 @@ export function broadcastSceneUpdate(
   safeSend('scene-update', { sceneUuid, stage, value, senderId, ts: Date.now() });
 }
 
-/** 씬 필드 업데이트 broadcast 전송 */
+/** 씬 필드 업데이트 broadcast 전송.
+ *  v1.16.0: value 가 null 도 허용 (lengthChange 해제 시 NULL 의미를 피어에 정확히 전달).
+ *  string 만 받던 시절엔 빈 문자열로 보내고 수신부에서 정규화했지만,
+ *  단일 수신부에 의존하면 다른 컨슈머에서 store 가 오염될 수 있어 송신부에서 normalize 해서 전달. */
 export function broadcastSceneFieldUpdate(
   sceneUuid: string,
   field: string,
-  value: string,
+  value: string | null,
   senderId?: string,
 ): void {
   safeSend('scene-field-update', { sceneUuid, field, value, senderId, ts: Date.now() });

--- a/electron/supabase.ts
+++ b/electron/supabase.ts
@@ -241,7 +241,7 @@ export async function readAllEpisodes(): Promise<SupabaseEpisodeData[]> {
     // Supabase IN 쿼리는 최대 수백 개까지 괜찮음
     const { data: sceneRows, error: sceneErr } = await supabase
       .from('scenes')
-      .select('id, part_id, scene_number, sort_order, memo, storyboard_url, guide_url, assignee, layout, lo, done, review, png')
+      .select('id, part_id, scene_number, sort_order, memo, storyboard_url, guide_url, assignee, layout, lo, done, review, png, length_change')
       .in('part_id', partIds)
       .order('sort_order');
     throwIfError(sceneErr);
@@ -317,6 +317,7 @@ export async function readAllEpisodes(): Promise<SupabaseEpisodeData[]> {
             done: s.done,
             review: s.review,
             png: s.png,
+            lengthChange: (s as { length_change?: 'LD' | 'SD' | null }).length_change ?? null,
           })),
         };
       }),
@@ -742,9 +743,12 @@ export async function updateSceneField(
     storyboardUrl: 'storyboard_url',
     guideUrl: 'guide_url',
     layoutId: 'layout',
+    lengthChange: 'length_change',
   };
   const dbField = fieldMap[field] || field;
-  const update: Record<string, unknown> = { [dbField]: value, updated_at: new Date().toISOString() };
+  // length_change: 빈 문자열은 NULL 로 저장 (CHECK constraint: NULL | 'LD' | 'SD' 만 허용)
+  const persistedValue = dbField === 'length_change' && value === '' ? null : value;
+  const update: Record<string, unknown> = { [dbField]: persistedValue, updated_at: new Date().toISOString() };
   if (senderId) update.updated_by = senderId;
   const { error } = await supabase
     .from('scenes')

--- a/electron/supabase.ts
+++ b/electron/supabase.ts
@@ -755,7 +755,8 @@ export async function updateSceneField(
     .update(update)
     .eq('id', sceneUuid);
   throwIfError(error);
-  broadcastSceneFieldUpdate(sceneUuid, field, value, senderId);
+  // v1.16.0 (Codex review fix): broadcast 시 normalized value 전송 — 수신부 의존 없이 모든 컨슈머가 일관 처리.
+  broadcastSceneFieldUpdate(sceneUuid, field, persistedValue, senderId);
 }
 
 // ═══════════════════════════════════════════════

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bflow",
-  "version": "1.15.1",
+  "version": "1.15.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bflow",
-      "version": "1.15.1",
+      "version": "1.15.12",
       "license": "UNLICENSED",
       "dependencies": {
         "@liveblocks/client": "^3.14.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.15.12",
+  "version": "1.16.0",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1013,10 +1013,9 @@ export default function App() {
 
       if (data.event === 'scene-field-update') {
         // 필드 변경 → UUID로 즉시 반영
-        const { sceneUuid, field, value, senderId } = data.payload as { sceneUuid: string; field: string; value: string; senderId?: string };
+        const { sceneUuid, field, value, senderId } = data.payload as { sceneUuid: string; field: string; value: string | null; senderId?: string };
         if (sceneUuid && field) {
-          // v1.16.0: lengthChange 필드는 '' (빈 문자열) 을 null 로 정규화
-          // (자기 앱은 낙관적 업데이트로 null 인데 broadcast 는 '' 라 피어 store 가 오염됨)
+          // v1.16.0: lengthChange 필드는 '' (빈 문자열) 을 null 로 정규화 (송신부에서도 normalize 하지만 안전망)
           const normalized = (field === 'lengthChange' && value === '') ? null : value;
           useDataStore.getState().updateSceneByUuid(sceneUuid, { [field]: normalized });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,7 @@ import { useGlobalShortcuts } from '@/hooks/useGlobalShortcuts';
 import { DEFAULT_GAS_IMAGE_URL, DEFAULT_VACATION_URL } from '@/config';
 import { Toaster, toast as sonnerToast } from 'sonner';
 import { ConfirmDialogHost } from '@/components/common/ConfirmDialog';
+import { SvgIconDefs } from '@/components/SvgIconDefs';
 import { useNotificationStore } from '@/stores/useNotificationStore';
 import { useVacationPendingStore } from '@/stores/useVacationPendingStore';
 import { dispatchNotification, type NotificationSettings } from '@/utils/notificationHelper';
@@ -1014,7 +1015,10 @@ export default function App() {
         // 필드 변경 → UUID로 즉시 반영
         const { sceneUuid, field, value, senderId } = data.payload as { sceneUuid: string; field: string; value: string; senderId?: string };
         if (sceneUuid && field) {
-          useDataStore.getState().updateSceneByUuid(sceneUuid, { [field]: value });
+          // v1.16.0: lengthChange 필드는 '' (빈 문자열) 을 null 로 정규화
+          // (자기 앱은 낙관적 업데이트로 null 인데 broadcast 는 '' 라 피어 store 가 오염됨)
+          const normalized = (field === 'lengthChange' && value === '') ? null : value;
+          useDataStore.getState().updateSceneByUuid(sceneUuid, { [field]: normalized });
 
           // 알림: 타인이 내 씬의 필드를 변경한 경우 (담당자 변경 등)
           const me = useAuthStore.getState().currentUser;
@@ -1379,6 +1383,7 @@ export default function App() {
 
   return (
     <>
+      <SvgIconDefs />
       <GradientBackdrop intensity="normal" enabled={globalGradientEnabled} />
       <MainLayout onRefresh={loadData}>{renderView()}</MainLayout>
       <SpotlightSearch />

--- a/src/components/SvgIconDefs.tsx
+++ b/src/components/SvgIconDefs.tsx
@@ -1,0 +1,74 @@
+/**
+ * 앱 전역 SVG 아이콘 정의. App root 에 한 번만 마운트한다.
+ *
+ * 화면에 보이지 않게 (position:absolute / width:0 / height:0) 두고,
+ * 어디서든 <svg className="length-icon"><use href="#ic-ld" /></svg> 로 참조.
+ *
+ * 정의:
+ *   - #ic-ld: <-> 양옆 바깥쪽 화살촉 (LD = Long Duration, 길이 늘어남)
+ *   - #ic-sd: >-< 양옆 안쪽 화살촉 (SD = Short Duration, 길이 줄어듦)
+ */
+export function SvgIconDefs() {
+  return (
+    <svg
+      style={{ position: 'absolute', width: 0, height: 0, overflow: 'hidden' }}
+      aria-hidden="true"
+    >
+      <defs>
+        {/* LD: <-> 양옆 바깥쪽 화살촉 */}
+        <symbol id="ic-ld" viewBox="0 0 20 10">
+          <line
+            x1="3" y1="5" x2="17" y2="5"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.7"
+            strokeLinecap="round"
+          />
+          <polyline
+            points="6,2 3,5 6,8"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.7"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          <polyline
+            points="14,2 17,5 14,8"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.7"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </symbol>
+
+        {/* SD: >-< 양옆 안쪽 화살촉 */}
+        <symbol id="ic-sd" viewBox="0 0 20 10">
+          <line
+            x1="6" y1="5" x2="14" y2="5"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.7"
+            strokeLinecap="round"
+          />
+          <polyline
+            points="3,2 6,5 3,8"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.7"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          <polyline
+            points="17,2 14,5 17,8"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.7"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </symbol>
+      </defs>
+    </svg>
+  );
+}

--- a/src/components/scenes/LengthIcon.tsx
+++ b/src/components/scenes/LengthIcon.tsx
@@ -1,0 +1,29 @@
+/**
+ * 씬 길이 변경 SVG 아이콘 (LD = <-> 늘어남, SD = >-< 줄어듦).
+ *
+ * 텍스트 "<->"를 그대로 쓰면 좁은 컨테이너에서 줄바꿈으로 모양이 분해될 위험이 있어,
+ * 라인+화살촉 SVG 단일 단위로 그려 atomic 하게 처리한다.
+ *
+ * 사용처: 카드 헤더 우상단 칩, 시트 씬번호 셀 옆 칩, 우클릭 메뉴 항목 아이콘.
+ *
+ * `<SvgIconDefs>` (App root) 의 <symbol id="ic-ld"|"ic-sd"> 를 <use> 로 참조한다.
+ */
+
+interface LengthIconProps {
+  kind: 'LD' | 'SD';
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+}
+
+export function LengthIcon({ kind, size = 'md', className }: LengthIconProps) {
+  const sizeClass = size === 'sm' ? 'sm' : size === 'lg' ? 'lg' : '';
+  return (
+    <svg
+      className={['length-icon', sizeClass, className].filter(Boolean).join(' ')}
+      aria-hidden="true"
+      role="img"
+    >
+      <use href={kind === 'LD' ? '#ic-ld' : '#ic-sd'} />
+    </svg>
+  );
+}

--- a/src/components/scenes/SceneContextMenu.tsx
+++ b/src/components/scenes/SceneContextMenu.tsx
@@ -1,0 +1,145 @@
+/**
+ * 카드/시트 공용 우클릭 메뉴.
+ *
+ * 현재 v1.16.0 항목:
+ *   - 길이 늘어남 (LD) — scene.lengthChange='LD'
+ *   - 길이 줄어듦 (SD) — scene.lengthChange='SD'
+ *   - 표시 해제      — scene.lengthChange=null
+ *
+ * 카드/시트 어디서 우클릭하든 동일한 메뉴.
+ * 클릭 시 즉시 낙관적 업데이트 → Supabase 저장.
+ */
+
+import { useEffect, useRef } from 'react';
+import { LengthIcon } from './LengthIcon';
+
+export interface SceneContextMenuProps {
+  x: number;
+  y: number;
+  current: 'LD' | 'SD' | null | undefined;
+  onSelect: (value: 'LD' | 'SD' | null) => void;
+  onClose: () => void;
+}
+
+export function SceneContextMenu({ x, y, current, onSelect, onClose }: SceneContextMenuProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  // 외부 클릭/Esc 닫기
+  useEffect(() => {
+    const handleDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    };
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('mousedown', handleDown);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleDown);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [onClose]);
+
+  // 화면 경계 자동 보정 — 메뉴가 잘리지 않게
+  const menuWidth = 220;
+  const menuHeight = 168;
+  const adjustedX = Math.min(x, window.innerWidth - menuWidth - 8);
+  const adjustedY = Math.min(y, window.innerHeight - menuHeight - 8);
+
+  return (
+    <div
+      ref={ref}
+      role="menu"
+      style={{
+        position: 'fixed',
+        left: adjustedX,
+        top: adjustedY,
+        zIndex: 9999,
+        width: menuWidth,
+      }}
+      className="bg-bg-card border border-bg-border rounded-lg shadow-2xl p-1.5 select-none"
+      onContextMenu={(e) => e.preventDefault()}
+    >
+      <div className="px-2.5 py-1.5 text-[10px] font-bold text-text-secondary uppercase tracking-wider">
+        씬 길이 변경
+      </div>
+
+      <MenuItem
+        active={current === 'LD'}
+        onClick={() => { onSelect('LD'); onClose(); }}
+        accent="up"
+      >
+        <span className="inline-flex items-center justify-center w-[22px] h-4 text-length-up flex-shrink-0">
+          <LengthIcon kind="LD" />
+        </span>
+        길이 늘어남 (LD)
+      </MenuItem>
+
+      <MenuItem
+        active={current === 'SD'}
+        onClick={() => { onSelect('SD'); onClose(); }}
+        accent="down"
+      >
+        <span className="inline-flex items-center justify-center w-[22px] h-4 text-length-down flex-shrink-0">
+          <LengthIcon kind="SD" />
+        </span>
+        길이 줄어듦 (SD)
+      </MenuItem>
+
+      <div className="h-px bg-bg-border/60 mx-1.5 my-1" />
+
+      <MenuItem
+        disabled={!current}
+        onClick={() => { onSelect(null); onClose(); }}
+      >
+        <span className="inline-flex items-center justify-center w-[22px] h-4 text-text-secondary/60 flex-shrink-0 font-mono text-[11px] font-bold">
+          — —
+        </span>
+        길이 변경 표시 해제
+      </MenuItem>
+    </div>
+  );
+}
+
+interface MenuItemProps {
+  children: React.ReactNode;
+  onClick: () => void;
+  active?: boolean;
+  disabled?: boolean;
+  accent?: 'up' | 'down';
+}
+
+function MenuItem({ children, onClick, active, disabled, accent }: MenuItemProps) {
+  const accentClass =
+    accent === 'up'
+      ? 'hover:bg-length-up/10 hover:text-length-up'
+      : accent === 'down'
+        ? 'hover:bg-length-down/10 hover:text-length-down'
+        : 'hover:bg-accent/10 hover:text-accent';
+
+  const activeClass = active
+    ? accent === 'up'
+      ? 'bg-length-up/10 text-length-up'
+      : accent === 'down'
+        ? 'bg-length-down/10 text-length-down'
+        : 'bg-accent/10 text-accent'
+    : 'text-text-primary';
+
+  const disabledClass = disabled ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer';
+
+  return (
+    <button
+      role="menuitem"
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled}
+      className={[
+        'w-full flex items-center gap-2.5 px-2.5 py-1.5 rounded-md text-[12px] text-left transition-colors',
+        disabled ? '' : accentClass,
+        activeClass,
+        disabledClass,
+      ].join(' ')}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/scenes/SceneContextMenu.tsx
+++ b/src/components/scenes/SceneContextMenu.tsx
@@ -59,6 +59,9 @@ export function SceneContextMenu({ x, y, current, onSelect, onClose }: SceneCont
       }}
       className="bg-bg-card border border-bg-border rounded-lg shadow-2xl p-1.5 select-none"
       onContextMenu={(e) => e.preventDefault()}
+      // v1.16.0 fix (Codex 라운드 5): 메뉴 컨테이너 click 도 부모 (카드/시트 행) 로 bubble 막음 — 안전망
+      onClick={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
     >
       <div className="px-2.5 py-1.5 text-[10px] font-bold text-text-secondary uppercase tracking-wider">
         씬 길이 변경
@@ -130,7 +133,13 @@ function MenuItem({ children, onClick, active, disabled, accent }: MenuItemProps
   return (
     <button
       role="menuitem"
-      onClick={disabled ? undefined : onClick}
+      // v1.16.0 fix (Codex 라운드 5): createPortal 이라도 React event 는 부모로 bubble.
+      //                              ancestor 의 onClick (카드 선택) 트리거 방지.
+      onClick={(e) => {
+        if (disabled) return;
+        e.stopPropagation();
+        onClick();
+      }}
       disabled={disabled}
       className={[
         'w-full flex items-center gap-2.5 px-2.5 py-1.5 rounded-md text-[12px] text-left transition-colors',

--- a/src/components/scenes/UnifiedSceneCard.tsx
+++ b/src/components/scenes/UnifiedSceneCard.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { motion } from 'framer-motion';
 import { MessageCircle, Trash2 } from 'lucide-react';
 import { cn } from '@/utils/cn';
@@ -6,8 +7,12 @@ import { sceneProgress } from '@/utils/calcStats';
 import { STAGES, DEPARTMENT_CONFIGS } from '@/types';
 import type { MergedScene, Stage, Department } from '@/types';
 import { HighlightText } from '@/components/common/HighlightText';
+import { PathLinkifiedText } from '@/components/common/PathLinkifiedText';
 import { Confetti } from '@/components/ui/Confetti';
 import { useBulkOperationsStore, type PendingOp } from '@/stores/useBulkOperationsStore';
+import { useDataStore } from '@/stores/useDataStore';
+import { LengthIcon } from './LengthIcon';
+import { SceneContextMenu } from './SceneContextMenu';
 
 // 씬 UUID에 대한 현재 일괄 작업 상태(pending / failed)를 조회
 function getPendingState(
@@ -69,6 +74,28 @@ export function UnifiedSceneCard({
   const cardRootRef = useRef<HTMLDivElement>(null);
   const prevHighlightedRef = useRef(false);
 
+  // 우클릭 컨텍스트 메뉴 상태
+  const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number } | null>(null);
+
+  // 길이 변경 토글 (BG/ACT 양쪽 동기화)
+  // v1.16.0 fix: 직렬 await 시 BG 성공 후 ACT 실패하면 DB↔UI 영구 불일치. Promise.all 병렬로 부분 실패 창 최소화.
+  const handleSetLengthChange = async (value: 'LD' | 'SD' | null) => {
+    const prevEpisodes = useDataStore.getState().episodes;
+    const valueStr = value ?? '';
+    // 낙관적: BG/ACT 모두 적용
+    if (bgScene?.id) useDataStore.getState().updateSceneByUuid(bgScene.id, { lengthChange: value });
+    if (actScene?.id) useDataStore.getState().updateSceneByUuid(actScene.id, { lengthChange: value });
+    try {
+      const tasks: Array<Promise<unknown>> = [];
+      if (bgScene?.id) tasks.push(window.electronAPI?.supabaseUpdateSceneField?.(bgScene.id, 'lengthChange', valueStr) ?? Promise.resolve());
+      if (actScene?.id) tasks.push(window.electronAPI?.supabaseUpdateSceneField?.(actScene.id, 'lengthChange', valueStr) ?? Promise.resolve());
+      await Promise.all(tasks);
+    } catch (err) {
+      useDataStore.getState().setEpisodes(prevEpisodes);
+      console.error('[lengthChange] 저장 실패', err);
+    }
+  };
+
   // 일괄 작업 상태 구독: delete/field-edit일 때 카드 전체, stage-toggle일 때 단계 셀에만 적용
   const activeOp = useBulkOperationsStore((s) => s.activeOp);
 
@@ -124,6 +151,14 @@ export function UnifiedSceneCard({
     }
   };
 
+  const handleContextMenu = (e: React.MouseEvent) => {
+    e.preventDefault();
+    setCtxMenu({ x: e.clientX, y: e.clientY });
+  };
+
+  // BG/ACT 둘 중 하나라도 lengthChange 가 있으면 그 값 (BG 우선, 양쪽 동기화 정책)
+  const lengthChange = bgScene?.lengthChange ?? actScene?.lengthChange ?? null;
+
   return (
     <motion.div
       data-scene-id={mergedKey}
@@ -142,6 +177,7 @@ export function UnifiedSceneCard({
       }}
       onClick={handleClick}
       onDoubleClick={handleDoubleClick}
+      onContextMenu={handleContextMenu}
       ref={cardRootRef}
       {...(isHighlighted ? {
         initial: { scale: 1.06 },
@@ -185,6 +221,14 @@ export function UnifiedSceneCard({
                 </span>
               );
             })()}
+            {lengthChange && (
+              <span
+                className={`length-symbol ${lengthChange === 'LD' ? 'up' : 'down'}`}
+                title={lengthChange === 'LD' ? 'LD · Long Duration (길이 늘어남)' : 'SD · Short Duration (길이 줄어듦)'}
+              >
+                <LengthIcon kind={lengthChange} />
+              </span>
+            )}
             <span className="bg-bg-primary/80 border border-bg-border/45 text-text-primary px-2.5 py-1 rounded-full text-[12px] font-semibold tabular-nums">
               {combinedPct}%
             </span>
@@ -203,12 +247,31 @@ export function UnifiedSceneCard({
           </div>
         )}
 
-        {/* ── 메모 ── */}
-        {primaryScene.memo && (
-          <div className="mx-4 mt-1" data-no-lasso>
-            <p className="text-[11px] text-amber-400/70 leading-relaxed line-clamp-1">
-              <HighlightText text={primaryScene.memo} query={searchQuery} />
-            </p>
+        {/* ── 메모 (BG/ACT 양쪽 동시 노출 — 한쪽만 있으면 한 줄) ── */}
+        {(bgScene?.memo || actScene?.memo) && (
+          <div className="mx-4 mt-1 flex flex-col gap-0.5" data-no-lasso>
+            {bgScene?.memo && (
+              <div className="flex items-center gap-1.5 overflow-hidden">
+                <span className="text-[9px] font-bold tracking-wide px-1 py-px rounded text-blue-300 bg-blue-300/15 flex-shrink-0">BG</span>
+                <p className="text-[11px] text-amber-400/70 leading-relaxed truncate min-w-0">
+                  <PathLinkifiedText
+                    text={bgScene.memo}
+                    renderTextSegment={(seg, idx) => <HighlightText key={idx} text={seg} query={searchQuery} />}
+                  />
+                </p>
+              </div>
+            )}
+            {actScene?.memo && (
+              <div className="flex items-center gap-1.5 overflow-hidden">
+                <span className="text-[9px] font-bold tracking-wide px-1 py-px rounded text-pink-300 bg-pink-300/15 flex-shrink-0">ACT</span>
+                <p className="text-[11px] text-amber-400/70 leading-relaxed truncate min-w-0">
+                  <PathLinkifiedText
+                    text={actScene.memo}
+                    renderTextSegment={(seg, idx) => <HighlightText key={idx} text={seg} query={searchQuery} />}
+                  />
+                </p>
+              </div>
+            )}
           </div>
         )}
 
@@ -243,6 +306,18 @@ export function UnifiedSceneCard({
         <div className="px-4 pb-3 pt-1 relative overflow-visible">
           <Confetti active={celebrating} onComplete={onCelebrationEnd} />
         </div>
+
+        {/* ── 우클릭 컨텍스트 메뉴 (Portal — motion.div transform 영향 회피) ── */}
+        {ctxMenu && createPortal(
+          <SceneContextMenu
+            x={ctxMenu.x}
+            y={ctxMenu.y}
+            current={lengthChange}
+            onSelect={handleSetLengthChange}
+            onClose={() => setCtxMenu(null)}
+          />,
+          document.body,
+        )}
     </motion.div>
   );
 }

--- a/src/components/scenes/UnifiedSceneCard.tsx
+++ b/src/components/scenes/UnifiedSceneCard.tsx
@@ -80,9 +80,11 @@ export function UnifiedSceneCard({
   // 길이 변경 토글 (BG/ACT 양쪽 동기화)
   // v1.16.0 fix #1: 직렬 await → Promise.all 병렬로 부분 실패 창 최소화.
   // v1.16.0 fix #2 (Codex 라운드 2): per-card in-flight ref 로 LD↔SD 연타 race 방지.
-  // v1.16.0 fix #3 (Codex 라운드 4): Promise.all reject 시 setEpisodes(prevEpisodes) 전체 롤백 →
-  //                                  BG 성공/ACT 실패 같은 부분 실패에서 성공한 DB 변경이 UI 에서 사라져 불일치.
-  //                                  Promise.allSettled + per-UUID 부분 롤백 (성공한 씬 유지).
+  // v1.16.0 fix #3 (Codex 라운드 4): Promise.allSettled + per-UUID 부분 롤백.
+  // v1.16.0 fix #4 (Codex 라운드 6): per-UUID 부분 롤백이 BG/ACT sync invariant 깸 →
+  //                                  표시 로직 (bgScene?.lengthChange ?? actScene?.lengthChange) 가 잘못된 라벨 표시 가능.
+  //                                  → 부분 실패 시 BG/ACT 둘 다 prev 로 롤백 (UI sync 보존).
+  //                                    성공한 DB 호출은 best-effort reverse 로 정합성 회복 시도.
   const lengthChangeInFlightRef = useRef(false);
   const handleSetLengthChange = async (value: 'LD' | 'SD' | null) => {
     if (lengthChangeInFlightRef.current) return;
@@ -103,12 +105,22 @@ export function UnifiedSceneCard({
           window.electronAPI?.supabaseUpdateSceneField?.(t.uuid, 'lengthChange', valueStr) ?? Promise.resolve(),
         ),
       );
-      // 실패한 uuid 만 부분 롤백
+      const anyFailed = results.some((r) => r.status === 'rejected');
+      if (!anyFailed) return;
+
+      // BG/ACT sync 보존: 둘 다 prev 로 롤백 (UI 차원에서 mergedKey invariant 유지)
+      for (const t of targets) {
+        useDataStore.getState().updateSceneByUuid(t.uuid, { lengthChange: t.prev });
+      }
+      // 성공한 DB 호출은 best-effort reverse — DB 도 최대한 sync 되게
       results.forEach((result, i) => {
-        if (result.status === 'rejected') {
+        if (result.status === 'fulfilled') {
           const t = targets[i];
-          useDataStore.getState().updateSceneByUuid(t.uuid, { lengthChange: t.prev });
-          console.error(`[lengthChange] ${t.uuid} 저장 실패`, result.reason);
+          const prevStr = t.prev ?? '';
+          window.electronAPI?.supabaseUpdateSceneField?.(t.uuid, 'lengthChange', prevStr)
+            .catch((err) => console.error(`[lengthChange] reverse 실패 ${t.uuid}`, err));
+        } else {
+          console.error(`[lengthChange] ${targets[i].uuid} 저장 실패`, result.reason);
         }
       });
     } finally {

--- a/src/components/scenes/UnifiedSceneCard.tsx
+++ b/src/components/scenes/UnifiedSceneCard.tsx
@@ -78,8 +78,13 @@ export function UnifiedSceneCard({
   const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number } | null>(null);
 
   // 길이 변경 토글 (BG/ACT 양쪽 동기화)
-  // v1.16.0 fix: 직렬 await 시 BG 성공 후 ACT 실패하면 DB↔UI 영구 불일치. Promise.all 병렬로 부분 실패 창 최소화.
+  // v1.16.0 fix #1: 직렬 await 시 BG 성공 후 ACT 실패하면 DB↔UI 영구 불일치. Promise.all 병렬로 부분 실패 창 최소화.
+  // v1.16.0 fix #2 (Codex 라운드 2): LD → SD 빠른 연타로 두 IPC 호출이 race → out-of-order commit 가능.
+  //                                  per-card in-flight ref 로 직렬화 (카드 인스턴스마다 별도 ref).
+  const lengthChangeInFlightRef = useRef(false);
   const handleSetLengthChange = async (value: 'LD' | 'SD' | null) => {
+    if (lengthChangeInFlightRef.current) return;
+    lengthChangeInFlightRef.current = true;
     const prevEpisodes = useDataStore.getState().episodes;
     const valueStr = value ?? '';
     // 낙관적: BG/ACT 모두 적용
@@ -93,6 +98,8 @@ export function UnifiedSceneCard({
     } catch (err) {
       useDataStore.getState().setEpisodes(prevEpisodes);
       console.error('[lengthChange] 저장 실패', err);
+    } finally {
+      lengthChangeInFlightRef.current = false;
     }
   };
 

--- a/src/components/scenes/UnifiedSceneCard.tsx
+++ b/src/components/scenes/UnifiedSceneCard.tsx
@@ -78,26 +78,39 @@ export function UnifiedSceneCard({
   const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number } | null>(null);
 
   // 길이 변경 토글 (BG/ACT 양쪽 동기화)
-  // v1.16.0 fix #1: 직렬 await 시 BG 성공 후 ACT 실패하면 DB↔UI 영구 불일치. Promise.all 병렬로 부분 실패 창 최소화.
-  // v1.16.0 fix #2 (Codex 라운드 2): LD → SD 빠른 연타로 두 IPC 호출이 race → out-of-order commit 가능.
-  //                                  per-card in-flight ref 로 직렬화 (카드 인스턴스마다 별도 ref).
+  // v1.16.0 fix #1: 직렬 await → Promise.all 병렬로 부분 실패 창 최소화.
+  // v1.16.0 fix #2 (Codex 라운드 2): per-card in-flight ref 로 LD↔SD 연타 race 방지.
+  // v1.16.0 fix #3 (Codex 라운드 4): Promise.all reject 시 setEpisodes(prevEpisodes) 전체 롤백 →
+  //                                  BG 성공/ACT 실패 같은 부분 실패에서 성공한 DB 변경이 UI 에서 사라져 불일치.
+  //                                  Promise.allSettled + per-UUID 부분 롤백 (성공한 씬 유지).
   const lengthChangeInFlightRef = useRef(false);
   const handleSetLengthChange = async (value: 'LD' | 'SD' | null) => {
     if (lengthChangeInFlightRef.current) return;
     lengthChangeInFlightRef.current = true;
-    const prevEpisodes = useDataStore.getState().episodes;
     const valueStr = value ?? '';
-    // 낙관적: BG/ACT 모두 적용
+    // 변경 전 값 캐싱 (BG/ACT 별도)
+    const prevBg = bgScene?.lengthChange ?? null;
+    const prevAct = actScene?.lengthChange ?? null;
+    // 낙관적
     if (bgScene?.id) useDataStore.getState().updateSceneByUuid(bgScene.id, { lengthChange: value });
     if (actScene?.id) useDataStore.getState().updateSceneByUuid(actScene.id, { lengthChange: value });
     try {
-      const tasks: Array<Promise<unknown>> = [];
-      if (bgScene?.id) tasks.push(window.electronAPI?.supabaseUpdateSceneField?.(bgScene.id, 'lengthChange', valueStr) ?? Promise.resolve());
-      if (actScene?.id) tasks.push(window.electronAPI?.supabaseUpdateSceneField?.(actScene.id, 'lengthChange', valueStr) ?? Promise.resolve());
-      await Promise.all(tasks);
-    } catch (err) {
-      useDataStore.getState().setEpisodes(prevEpisodes);
-      console.error('[lengthChange] 저장 실패', err);
+      const targets: Array<{ uuid: string; prev: 'LD' | 'SD' | null }> = [];
+      if (bgScene?.id) targets.push({ uuid: bgScene.id, prev: prevBg });
+      if (actScene?.id) targets.push({ uuid: actScene.id, prev: prevAct });
+      const results = await Promise.allSettled(
+        targets.map((t) =>
+          window.electronAPI?.supabaseUpdateSceneField?.(t.uuid, 'lengthChange', valueStr) ?? Promise.resolve(),
+        ),
+      );
+      // 실패한 uuid 만 부분 롤백
+      results.forEach((result, i) => {
+        if (result.status === 'rejected') {
+          const t = targets[i];
+          useDataStore.getState().updateSceneByUuid(t.uuid, { lengthChange: t.prev });
+          console.error(`[lengthChange] ${t.uuid} 저장 실패`, result.reason);
+        }
+      });
     } finally {
       lengthChangeInFlightRef.current = false;
     }

--- a/src/components/scenes/UnifiedSceneSheetView.tsx
+++ b/src/components/scenes/UnifiedSceneSheetView.tsx
@@ -377,17 +377,18 @@ export function UnifiedSceneSheetView({
   }, []);
 
   // 길이 변경 토글 (BG/ACT 양쪽 동기화)
-  // v1.16.0 fix #1: 직렬 await → Promise.all 병렬로 부분 실패 창 최소화.
+  // v1.16.0 fix #1: 직렬 await → Promise.all 병렬.
   // v1.16.0 fix #2 (Codex 라운드 2): per-mergedKey Set 으로 same-row 동시 호출 직렬화.
-  // v1.16.0 fix #3 (Codex 라운드 4): Promise.all reject 시 전체 롤백 → 부분 실패에서 성공한 DB 변경이 UI 에서 사라져 불일치.
-  //                                  Promise.allSettled + per-UUID 부분 롤백 (성공한 씬 유지).
+  // v1.16.0 fix #3 (Codex 라운드 4): Promise.allSettled + per-UUID 부분 롤백.
+  // v1.16.0 fix #4 (Codex 라운드 6): per-UUID 부분 롤백이 BG/ACT sync invariant 깸 →
+  //                                  부분 실패 시 BG/ACT 둘 다 prev 로 롤백 (UI sync 보존).
+  //                                  성공한 DB 호출은 best-effort reverse 로 정합성 회복 시도.
   const lengthChangeInFlightRef = useRef<Set<string>>(new Set());
   const handleSetLengthChange = useCallback(async (merged: MergedScene, value: 'LD' | 'SD' | null) => {
     const key = merged.mergedKey;
     if (lengthChangeInFlightRef.current.has(key)) return;
     lengthChangeInFlightRef.current.add(key);
     const valueStr = value ?? '';
-    // 변경 전 값 캐싱 (BG/ACT 별도)
     const prevBg = merged.bgScene?.lengthChange ?? null;
     const prevAct = merged.actScene?.lengthChange ?? null;
     if (merged.bgScene?.id) useDataStore.getState().updateSceneByUuid(merged.bgScene.id, { lengthChange: value });
@@ -401,11 +402,22 @@ export function UnifiedSceneSheetView({
           window.electronAPI?.supabaseUpdateSceneField?.(t.uuid, 'lengthChange', valueStr) ?? Promise.resolve(),
         ),
       );
+      const anyFailed = results.some((r) => r.status === 'rejected');
+      if (!anyFailed) return;
+
+      // BG/ACT sync 보존: 둘 다 prev 로 UI 롤백
+      for (const t of targets) {
+        useDataStore.getState().updateSceneByUuid(t.uuid, { lengthChange: t.prev });
+      }
+      // 성공한 DB 호출은 best-effort reverse
       results.forEach((result, i) => {
-        if (result.status === 'rejected') {
+        if (result.status === 'fulfilled') {
           const t = targets[i];
-          useDataStore.getState().updateSceneByUuid(t.uuid, { lengthChange: t.prev });
-          console.error(`[lengthChange] 시트 ${t.uuid} 저장 실패`, result.reason);
+          const prevStr = t.prev ?? '';
+          window.electronAPI?.supabaseUpdateSceneField?.(t.uuid, 'lengthChange', prevStr)
+            .catch((err) => console.error(`[lengthChange] 시트 reverse 실패 ${t.uuid}`, err));
+        } else {
+          console.error(`[lengthChange] 시트 ${targets[i].uuid} 저장 실패`, result.reason);
         }
       });
     } finally {

--- a/src/components/scenes/UnifiedSceneSheetView.tsx
+++ b/src/components/scenes/UnifiedSceneSheetView.tsx
@@ -9,7 +9,11 @@ import { sceneProgress, progressGradient } from '@/utils/calcStats';
 import { cn } from '@/utils/cn';
 import { getMergedCommentBadgeCounts } from '@/utils/mergedSceneHelpers';
 import { HighlightText } from '@/components/common/HighlightText';
+import { PathLinkifiedText } from '@/components/common/PathLinkifiedText';
 import { AssigneeSelect } from '@/components/common/AssigneeSelect';
+import { useDataStore } from '@/stores/useDataStore';
+import { LengthIcon } from './LengthIcon';
+import { SceneContextMenu } from './SceneContextMenu';
 
 // ─── Props ───────────────────────────────────────────────────
 
@@ -37,8 +41,9 @@ interface UnifiedSceneSheetViewProps {
 // ─── 셀 선택 타입 ───────────────────────────────────────────
 
 interface CellId { row: number; col: number }
-// 편집 가능 필드: 메모(0), BG담당(1), ACT담당(2)
-const EDITABLE_FIELDS = ['memo', 'bgAssignee', 'actAssignee'] as const;
+// 편집 가능 필드: BG메모(0), ACT메모(1), BG담당(2), ACT담당(3)
+// v1.16.0 — BG/ACT 메모를 별도 컬럼으로 분리 (한솔 결정 B2)
+const EDITABLE_FIELDS = ['bgMemo', 'actMemo', 'bgAssignee', 'actAssignee'] as const;
 
 function cellKey(row: number, col: number) { return `${row}:${col}`; }
 
@@ -157,12 +162,15 @@ function SheetEditableCell({
     );
   }
 
-  const isMemo = field === 'memo';
+  // v1.16.0: 메모 컬럼 분리 (bgMemo/actMemo) — 한 컬럼당 max-width 한계 + 컨텐츠 기반 동적
+  const isMemo = field === 'bgMemo' || field === 'actMemo';
   return (
     <td
+      ref={cellRef}
+      title={isMemo && value ? value : undefined}
       className={cn(
         'px-2 py-1.5 text-xs text-text-secondary cursor-cell truncate transition-colors',
-        isMemo && 'max-w-0',
+        isMemo && 'max-w-[20rem] min-w-[3.5rem]',
         isSelected
           ? 'ring-2 ring-accent ring-inset bg-accent/5'
           : 'hover:bg-accent/5',
@@ -178,7 +186,15 @@ function SheetEditableCell({
         onStartEditing();
       }}
     >
-      <HighlightText text={value || '-'} query={searchQuery} />
+      {/* v1.16.0: 메모 컬럼은 G드라이브 경로 클릭 가능 (PathBadge) */}
+      {isMemo ? (
+        <PathLinkifiedText
+          text={value || '-'}
+          renderTextSegment={(seg, idx) => <HighlightText key={idx} text={seg} query={searchQuery} />}
+        />
+      ) : (
+        <HighlightText text={value || '-'} query={searchQuery} />
+      )}
     </td>
   );
 }
@@ -337,6 +353,46 @@ export function UnifiedSceneSheetView({
   const [initialEditChar, setInitialEditChar] = useState<string | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   const tableRef = useRef<HTMLDivElement>(null);
+
+  // ── v1.16.0: 우클릭 컨텍스트 메뉴 상태 ──
+  const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number; merged: MergedScene } | null>(null);
+
+  // ── v1.16.0: 리사이즈 시 transition 일시 비활성화 (렉 방지)
+  // 행 200~400개에서 background/border/box-shadow transition 누적 부하 회피
+  useEffect(() => {
+    let resizeTimer: ReturnType<typeof setTimeout> | null = null;
+    const handleResize = () => {
+      document.documentElement.classList.add('is-resizing');
+      if (resizeTimer) clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(() => {
+        document.documentElement.classList.remove('is-resizing');
+      }, 200);
+    };
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      if (resizeTimer) clearTimeout(resizeTimer);
+      document.documentElement.classList.remove('is-resizing');
+    };
+  }, []);
+
+  // 길이 변경 토글 (BG/ACT 양쪽 동기화)
+  // v1.16.0 fix: 직렬 await → Promise.all 병렬로 부분 실패 창 최소화
+  const handleSetLengthChange = useCallback(async (merged: MergedScene, value: 'LD' | 'SD' | null) => {
+    const prevEpisodes = useDataStore.getState().episodes;
+    const valueStr = value ?? '';
+    if (merged.bgScene?.id) useDataStore.getState().updateSceneByUuid(merged.bgScene.id, { lengthChange: value });
+    if (merged.actScene?.id) useDataStore.getState().updateSceneByUuid(merged.actScene.id, { lengthChange: value });
+    try {
+      const tasks: Array<Promise<unknown>> = [];
+      if (merged.bgScene?.id) tasks.push(window.electronAPI?.supabaseUpdateSceneField?.(merged.bgScene.id, 'lengthChange', valueStr) ?? Promise.resolve());
+      if (merged.actScene?.id) tasks.push(window.electronAPI?.supabaseUpdateSceneField?.(merged.actScene.id, 'lengthChange', valueStr) ?? Promise.resolve());
+      await Promise.all(tasks);
+    } catch (err) {
+      useDataStore.getState().setEpisodes(prevEpisodes);
+      console.error('[lengthChange] 시트 저장 실패', err);
+    }
+  }, []);
   // 드래그 판정 — 단순 클릭이 범위 선택(중복 선택)으로 오해되지 않도록 임계값 설정
   const dragStartRef = useRef<{ x: number; y: number } | null>(null);
   const dragActiveRef = useRef(false);
@@ -442,14 +498,15 @@ export function UnifiedSceneSheetView({
   }, []);
 
   // 필드 저장 헬퍼: col에 따라 올바른 sheetName/sceneIndex 결정
+  // v1.16.0: BG메모(0) / ACT메모(1) / BG담당(2) / ACT담당(3) — 메모 컬럼 분리
   const saveField = useCallback((row: number, col: number, value: string) => {
     const m = displayScenes[row];
     if (!m) return;
     const fieldDef = EDITABLE_FIELDS[col];
-    if (fieldDef === 'memo') {
-      // 메모는 BG 우선, 없으면 ACT
+    if (fieldDef === 'bgMemo') {
       if (m.bgScene && bgSheetName) onFieldUpdate(bgSheetName, m.bgSceneIndex, 'memo', value);
-      else if (m.actScene && actSheetName) onFieldUpdate(actSheetName, m.actSceneIndex, 'memo', value);
+    } else if (fieldDef === 'actMemo') {
+      if (m.actScene && actSheetName) onFieldUpdate(actSheetName, m.actSceneIndex, 'memo', value);
     } else if (fieldDef === 'bgAssignee') {
       if (m.bgScene && bgSheetName) onFieldUpdate(bgSheetName, m.bgSceneIndex, 'assignee', value);
     } else if (fieldDef === 'actAssignee') {
@@ -462,7 +519,8 @@ export function UnifiedSceneSheetView({
     const m = displayScenes[row];
     if (!m) return '';
     const fieldDef = EDITABLE_FIELDS[col];
-    if (fieldDef === 'memo') return (m.bgScene ?? m.actScene)?.memo || '';
+    if (fieldDef === 'bgMemo') return m.bgScene?.memo || '';
+    if (fieldDef === 'actMemo') return m.actScene?.memo || '';
     if (fieldDef === 'bgAssignee') return m.bgScene?.assignee || '';
     if (fieldDef === 'actAssignee') return m.actScene?.assignee || '';
     return '';
@@ -562,6 +620,7 @@ export function UnifiedSceneSheetView({
 
   return (
     <motion.div
+      className="unified-scene-sheet"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.2, ease: 'easeInOut' }}
@@ -577,10 +636,10 @@ export function UnifiedSceneSheetView({
         <table className="w-full text-sm border-collapse">
           {/* ── 헤더 ── */}
           <thead className="sticky top-0 z-10">
-            {/* 부서 구분 서브헤더 (상단) */}
+            {/* 부서 구분 서브헤더 (상단) — v1.16.0: 메모 컬럼 분리에 맞춰 colSpan 조정 (2→3) */}
             <tr className="bg-bg-card border-b border-bg-border/50">
               {sceneGroupMode === 'layout' && <th />}
-              <th colSpan={2} />
+              <th colSpan={3} />
               <th className="px-2 py-1" />
               <th colSpan={2} />
               <th colSpan={4} className="py-1 text-center">
@@ -600,9 +659,11 @@ export function UnifiedSceneSheetView({
             </tr>
             <tr className="bg-bg-card border-b border-bg-border">
               {/* 한솔 결정 (1-B): 레이아웃 별 보기 시 별도 컬럼 대신 행 위에 그룹 헤더 행을 삽입.
-                  sceneGroupMode === 'layout' 컬럼 분기 제거 — 컬럼 수가 일반 모드와 동일하게 유지된다. */}
-              <th className="w-20 px-2 py-2 text-left text-xs font-medium text-text-secondary">씬번호</th>
-              <th className="px-2 py-2 text-left text-xs font-medium text-text-secondary">메모</th>
+                  sceneGroupMode === 'layout' 컬럼 분기 제거 — 컬럼 수가 일반 모드와 동일하게 유지된다.
+                  v1.16.0: 메모 컬럼을 BG/ACT 두 개로 분리 (한솔 결정 B2). */}
+              <th className="w-24 px-2 py-2 text-left text-xs font-medium text-text-secondary">씬번호</th>
+              <th className="px-2 py-2 text-left text-xs font-medium max-w-[20rem] min-w-[3.5rem]" style={{ color: bgCfg.color }}>BG 메모</th>
+              <th className="px-2 py-2 text-left text-xs font-medium max-w-[20rem] min-w-[3.5rem]" style={{ color: actCfg.color }}>ACT 메모</th>
               <th className="w-14 px-1 py-2 text-center text-xs font-medium text-text-secondary">SB</th>
               <th className="w-14 px-1 py-2 text-center text-xs font-medium text-text-secondary">가이드</th>
               {/* BG 담당 + 스테이지 */}
@@ -670,6 +731,9 @@ export function UnifiedSceneSheetView({
                 commentIdsByKey,
               );
 
+              // v1.16.0: 길이 변경 라벨 (BG/ACT 양쪽 동기화 정책 — BG 우선)
+              const lengthChange = bgScene?.lengthChange ?? actScene?.lengthChange ?? null;
+
               return (
                 <Fragment key={mergedKey}>
                   {/* 한솔 결정 (1-B 시안 2 + 굵은 보더): 그룹 시작 위에 액센트 카드 박스 헤더 행 */}
@@ -688,10 +752,7 @@ export function UnifiedSceneSheetView({
                       </td>
                     </tr>
                   )}
-                  <motion.tr
-                    initial={{ opacity: 0, y: 4 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ duration: 0.15, delay: Math.min(rowIndex * 0.01, 0.2) }}
+                  <tr
                     className={cn(
                       'border-b border-bg-border/30 transition-colors group cursor-pointer',
                       rowIndex % 2 === 0 ? 'bg-bg-card/20' : 'bg-bg-primary/10',
@@ -701,6 +762,8 @@ export function UnifiedSceneSheetView({
                       isHighlighted && 'scene-row-highlighted',
                       isLayoutMode && !isLastInGroup && 'scene-row-group-mid',
                       isLayoutMode && isLastInGroup && 'scene-row-group-last',
+                      lengthChange === 'LD' && 'sheet-row-length-up',
+                      lengthChange === 'SD' && 'sheet-row-length-down',
                     )}
                     onClick={(e) => {
                       if ((e.ctrlKey || e.metaKey) && onCtrlClick) {
@@ -716,12 +779,25 @@ export function UnifiedSceneSheetView({
                       if (bgScene && bgSheetName) onOpenDetail(bgSheetName, bgSceneIndex);
                       else if (actScene && actSheetName) onOpenDetail(actSheetName, actSceneIndex);
                     }}
+                    onContextMenu={(e) => {
+                      e.preventDefault();
+                      setCtxMenu({ x: e.clientX, y: e.clientY, merged: m });
+                    }}
                   >
 
                   {/* 씬번호 + 레이아웃 뱃지 + 댓글 뱃지.
-                      한솔 결정 (5번): 1+3 합본 효과 — 텍스트 네온 펄스 + wrap 회전 보더. */}
-                  <td className="px-2 py-1.5 font-mono text-xs">
+                      한솔 결정 (5번): 1+3 합본 효과 — 텍스트 네온 펄스 + wrap 회전 보더.
+                      v1.16.0: 길이 변경 라벨 LD/SD 칩 (씬번호 앞). */}
+                  <td className="px-2 py-1.5 font-mono text-xs" style={{ overflow: 'visible', whiteSpace: 'nowrap' }}>
                     <span className="flex items-center gap-2">
+                      {lengthChange && (
+                        <span
+                          className={`length-symbol-sheet ${lengthChange === 'LD' ? 'up' : 'down'}`}
+                          title={lengthChange === 'LD' ? 'LD · Long Duration (길이 늘어남)' : 'SD · Short Duration (길이 줄어듦)'}
+                        >
+                          <LengthIcon kind={lengthChange} size="sm" />
+                        </span>
+                      )}
                       <span className="scene-num-glow-wrap">
                         <span className="scene-num-glow-text">
                           <HighlightText text={sceneId || primary.sceneId || '-'} query={searchQuery} />
@@ -741,34 +817,31 @@ export function UnifiedSceneSheetView({
                     </span>
                   </td>
 
-                  {/* 메모 (인라인 편집) */}
-                  <SheetEditableCell
-                    value={(bgScene ?? actScene)?.memo || ''}
-                    field="memo"
-                    onSave={(v) => saveField(rowIndex, 0, v)}
-                    searchQuery={searchQuery}
-                    isSelected={selectedCells.has(cellKey(rowIndex, 0))}
-                    isEditing={editingCell?.row === rowIndex && editingCell?.col === 0}
-                    initialChar={editingCell?.row === rowIndex && editingCell?.col === 0 ? initialEditChar : undefined}
-                    onMouseDown={(e) => handleCellMouseDown(rowIndex, 0, e)}
-                    onMouseEnter={() => handleCellMouseEnter(rowIndex, 0)}
-                    onStartEditing={() => handleStartEditing(rowIndex, 0)}
-                    onStopEditing={handleStopEditing}
-                  />
-
-                  {/* 스토리보드 — BG 전용 (정책 통일) */}
-                  <SheetThumbnailCell url={bgScene?.storyboardUrl} label="스토리보드" />
-
-                  {/* 가이드 — BG 전용 */}
-                  <SheetThumbnailCell url={bgScene?.guideUrl} label="가이드" />
-
-                  {/* BG 담당자 (인라인 편집) */}
+                  {/* BG 메모 (인라인 편집, 한솔 결정 B2) */}
                   {bgScene ? (
                     <SheetEditableCell
-                      value={bgScene.assignee || ''}
-                      field="bgAssignee"
+                      value={bgScene.memo || ''}
+                      field="bgMemo"
+                      onSave={(v) => saveField(rowIndex, 0, v)}
+                      searchQuery={searchQuery}
+                      isSelected={selectedCells.has(cellKey(rowIndex, 0))}
+                      isEditing={editingCell?.row === rowIndex && editingCell?.col === 0}
+                      initialChar={editingCell?.row === rowIndex && editingCell?.col === 0 ? initialEditChar : undefined}
+                      onMouseDown={(e) => handleCellMouseDown(rowIndex, 0, e)}
+                      onMouseEnter={() => handleCellMouseEnter(rowIndex, 0)}
+                      onStartEditing={() => handleStartEditing(rowIndex, 0)}
+                      onStopEditing={handleStopEditing}
+                    />
+                  ) : (
+                    <td className="px-2 py-1.5 text-xs text-text-secondary/20">—</td>
+                  )}
+
+                  {/* ACT 메모 (인라인 편집) */}
+                  {actScene ? (
+                    <SheetEditableCell
+                      value={actScene.memo || ''}
+                      field="actMemo"
                       onSave={(v) => saveField(rowIndex, 1, v)}
-                      type="assignee"
                       searchQuery={searchQuery}
                       isSelected={selectedCells.has(cellKey(rowIndex, 1))}
                       isEditing={editingCell?.row === rowIndex && editingCell?.col === 1}
@@ -776,6 +849,32 @@ export function UnifiedSceneSheetView({
                       onMouseDown={(e) => handleCellMouseDown(rowIndex, 1, e)}
                       onMouseEnter={() => handleCellMouseEnter(rowIndex, 1)}
                       onStartEditing={() => handleStartEditing(rowIndex, 1)}
+                      onStopEditing={handleStopEditing}
+                    />
+                  ) : (
+                    <td className="px-2 py-1.5 text-xs text-text-secondary/20">—</td>
+                  )}
+
+                  {/* 스토리보드 — BG 전용 (정책 통일) */}
+                  <SheetThumbnailCell url={bgScene?.storyboardUrl} label="스토리보드" />
+
+                  {/* 가이드 — BG 전용 */}
+                  <SheetThumbnailCell url={bgScene?.guideUrl} label="가이드" />
+
+                  {/* BG 담당자 (인라인 편집) — v1.16.0 col index 1→2 (메모 분리로 시프트) */}
+                  {bgScene ? (
+                    <SheetEditableCell
+                      value={bgScene.assignee || ''}
+                      field="bgAssignee"
+                      onSave={(v) => saveField(rowIndex, 2, v)}
+                      type="assignee"
+                      searchQuery={searchQuery}
+                      isSelected={selectedCells.has(cellKey(rowIndex, 2))}
+                      isEditing={editingCell?.row === rowIndex && editingCell?.col === 2}
+                      initialChar={editingCell?.row === rowIndex && editingCell?.col === 2 ? initialEditChar : undefined}
+                      onMouseDown={(e) => handleCellMouseDown(rowIndex, 2, e)}
+                      onMouseEnter={() => handleCellMouseEnter(rowIndex, 2)}
+                      onStartEditing={() => handleStartEditing(rowIndex, 2)}
                       onStopEditing={handleStopEditing}
                     />
                   ) : (
@@ -803,20 +902,20 @@ export function UnifiedSceneSheetView({
                     </td>
                   ))}
 
-                  {/* ACT 담당자 (인라인 편집) */}
+                  {/* ACT 담당자 (인라인 편집) — v1.16.0 col index 2→3 (메모 분리로 시프트) */}
                   {actScene ? (
                     <SheetEditableCell
                       value={actScene.assignee || ''}
                       field="actAssignee"
-                      onSave={(v) => saveField(rowIndex, 2, v)}
+                      onSave={(v) => saveField(rowIndex, 3, v)}
                       type="assignee"
                       searchQuery={searchQuery}
-                      isSelected={selectedCells.has(cellKey(rowIndex, 2))}
-                      isEditing={editingCell?.row === rowIndex && editingCell?.col === 2}
-                      initialChar={editingCell?.row === rowIndex && editingCell?.col === 2 ? initialEditChar : undefined}
-                      onMouseDown={(e) => handleCellMouseDown(rowIndex, 2, e)}
-                      onMouseEnter={() => handleCellMouseEnter(rowIndex, 2)}
-                      onStartEditing={() => handleStartEditing(rowIndex, 2)}
+                      isSelected={selectedCells.has(cellKey(rowIndex, 3))}
+                      isEditing={editingCell?.row === rowIndex && editingCell?.col === 3}
+                      initialChar={editingCell?.row === rowIndex && editingCell?.col === 3 ? initialEditChar : undefined}
+                      onMouseDown={(e) => handleCellMouseDown(rowIndex, 3, e)}
+                      onMouseEnter={() => handleCellMouseEnter(rowIndex, 3)}
+                      onStartEditing={() => handleStartEditing(rowIndex, 3)}
                       onStopEditing={handleStopEditing}
                     />
                   ) : (
@@ -876,13 +975,25 @@ export function UnifiedSceneSheetView({
                       )}
                     </div>
                   </td>
-                  </motion.tr>
+                  </tr>
                 </Fragment>
               );
             })}
           </tbody>
         </table>
       </div>
+
+      {/* v1.16.0: 우클릭 컨텍스트 메뉴 — Portal 로 외부 렌더 (테이블 overflow/transform 영향 회피) */}
+      {ctxMenu && createPortal(
+        <SceneContextMenu
+          x={ctxMenu.x}
+          y={ctxMenu.y}
+          current={ctxMenu.merged.bgScene?.lengthChange ?? ctxMenu.merged.actScene?.lengthChange ?? null}
+          onSelect={(value) => handleSetLengthChange(ctxMenu.merged, value)}
+          onClose={() => setCtxMenu(null)}
+        />,
+        document.body,
+      )}
     </motion.div>
   );
 }

--- a/src/components/scenes/UnifiedSceneSheetView.tsx
+++ b/src/components/scenes/UnifiedSceneSheetView.tsx
@@ -667,9 +667,11 @@ export function UnifiedSceneSheetView({
         <table className="w-full text-sm border-collapse">
           {/* ── 헤더 ── */}
           <thead className="sticky top-0 z-10">
-            {/* 부서 구분 서브헤더 (상단) — v1.16.0: 메모 컬럼 분리에 맞춰 colSpan 조정 (2→3) */}
+            {/* 부서 구분 서브헤더 (상단) — v1.16.0: 메모 컬럼 분리에 맞춰 colSpan 조정 (2→3)
+                v1.16.0 fix (Codex 라운드 8): layout 모드 분기 제거 — 본문/두 번째 헤더는 18칸인데
+                여기만 19칸이 되어 sticky 2단 헤더 정렬이 깨졌음. 한솔 결정 1-B 에 따라 컬럼 수는
+                일반 모드와 동일하므로 별도 분기 불필요. */}
             <tr className="bg-bg-card border-b border-bg-border/50">
-              {sceneGroupMode === 'layout' && <th />}
               <th colSpan={3} />
               <th className="px-2 py-1" />
               <th colSpan={2} />

--- a/src/components/scenes/UnifiedSceneSheetView.tsx
+++ b/src/components/scenes/UnifiedSceneSheetView.tsx
@@ -377,26 +377,37 @@ export function UnifiedSceneSheetView({
   }, []);
 
   // 길이 변경 토글 (BG/ACT 양쪽 동기화)
-  // v1.16.0 fix #1: 직렬 await → Promise.all 병렬로 부분 실패 창 최소화
-  // v1.16.0 fix #2 (Codex 라운드 2): per-scene race fix — 같은 mergedKey 에 대한 동시 호출 직렬화.
-  //                                   다른 row 는 동시 처리 가능하도록 mergedKey Set 으로 관리.
+  // v1.16.0 fix #1: 직렬 await → Promise.all 병렬로 부분 실패 창 최소화.
+  // v1.16.0 fix #2 (Codex 라운드 2): per-mergedKey Set 으로 same-row 동시 호출 직렬화.
+  // v1.16.0 fix #3 (Codex 라운드 4): Promise.all reject 시 전체 롤백 → 부분 실패에서 성공한 DB 변경이 UI 에서 사라져 불일치.
+  //                                  Promise.allSettled + per-UUID 부분 롤백 (성공한 씬 유지).
   const lengthChangeInFlightRef = useRef<Set<string>>(new Set());
   const handleSetLengthChange = useCallback(async (merged: MergedScene, value: 'LD' | 'SD' | null) => {
     const key = merged.mergedKey;
     if (lengthChangeInFlightRef.current.has(key)) return;
     lengthChangeInFlightRef.current.add(key);
-    const prevEpisodes = useDataStore.getState().episodes;
     const valueStr = value ?? '';
+    // 변경 전 값 캐싱 (BG/ACT 별도)
+    const prevBg = merged.bgScene?.lengthChange ?? null;
+    const prevAct = merged.actScene?.lengthChange ?? null;
     if (merged.bgScene?.id) useDataStore.getState().updateSceneByUuid(merged.bgScene.id, { lengthChange: value });
     if (merged.actScene?.id) useDataStore.getState().updateSceneByUuid(merged.actScene.id, { lengthChange: value });
     try {
-      const tasks: Array<Promise<unknown>> = [];
-      if (merged.bgScene?.id) tasks.push(window.electronAPI?.supabaseUpdateSceneField?.(merged.bgScene.id, 'lengthChange', valueStr) ?? Promise.resolve());
-      if (merged.actScene?.id) tasks.push(window.electronAPI?.supabaseUpdateSceneField?.(merged.actScene.id, 'lengthChange', valueStr) ?? Promise.resolve());
-      await Promise.all(tasks);
-    } catch (err) {
-      useDataStore.getState().setEpisodes(prevEpisodes);
-      console.error('[lengthChange] 시트 저장 실패', err);
+      const targets: Array<{ uuid: string; prev: 'LD' | 'SD' | null }> = [];
+      if (merged.bgScene?.id) targets.push({ uuid: merged.bgScene.id, prev: prevBg });
+      if (merged.actScene?.id) targets.push({ uuid: merged.actScene.id, prev: prevAct });
+      const results = await Promise.allSettled(
+        targets.map((t) =>
+          window.electronAPI?.supabaseUpdateSceneField?.(t.uuid, 'lengthChange', valueStr) ?? Promise.resolve(),
+        ),
+      );
+      results.forEach((result, i) => {
+        if (result.status === 'rejected') {
+          const t = targets[i];
+          useDataStore.getState().updateSceneByUuid(t.uuid, { lengthChange: t.prev });
+          console.error(`[lengthChange] 시트 ${t.uuid} 저장 실패`, result.reason);
+        }
+      });
     } finally {
       lengthChangeInFlightRef.current.delete(key);
     }

--- a/src/components/scenes/UnifiedSceneSheetView.tsx
+++ b/src/components/scenes/UnifiedSceneSheetView.tsx
@@ -377,8 +377,14 @@ export function UnifiedSceneSheetView({
   }, []);
 
   // 길이 변경 토글 (BG/ACT 양쪽 동기화)
-  // v1.16.0 fix: 직렬 await → Promise.all 병렬로 부분 실패 창 최소화
+  // v1.16.0 fix #1: 직렬 await → Promise.all 병렬로 부분 실패 창 최소화
+  // v1.16.0 fix #2 (Codex 라운드 2): per-scene race fix — 같은 mergedKey 에 대한 동시 호출 직렬화.
+  //                                   다른 row 는 동시 처리 가능하도록 mergedKey Set 으로 관리.
+  const lengthChangeInFlightRef = useRef<Set<string>>(new Set());
   const handleSetLengthChange = useCallback(async (merged: MergedScene, value: 'LD' | 'SD' | null) => {
+    const key = merged.mergedKey;
+    if (lengthChangeInFlightRef.current.has(key)) return;
+    lengthChangeInFlightRef.current.add(key);
     const prevEpisodes = useDataStore.getState().episodes;
     const valueStr = value ?? '';
     if (merged.bgScene?.id) useDataStore.getState().updateSceneByUuid(merged.bgScene.id, { lengthChange: value });
@@ -391,6 +397,8 @@ export function UnifiedSceneSheetView({
     } catch (err) {
       useDataStore.getState().setEpisodes(prevEpisodes);
       console.error('[lengthChange] 시트 저장 실패', err);
+    } finally {
+      lengthChangeInFlightRef.current.delete(key);
     }
   }, []);
   // 드래그 판정 — 단순 클릭이 범위 선택(중복 선택)으로 오해되지 않도록 임계값 설정

--- a/src/index.css
+++ b/src/index.css
@@ -81,6 +81,9 @@
   --shadow-alpha: 0.35;
   /* 시멘틱: accent 버튼 위 텍스트 (항상 흰색) */
   --color-on-accent: 255 255 255;
+  /* 시멘틱: 씬 길이 변경 (LD = 늘어남 / SD = 줄어듦) */
+  --color-length-up: 52 211 153;     /* #34D399 emerald-400 */
+  --color-length-down: 251 113 133;   /* #FB7185 rose-400 */
 }
 
 /* ─── 라이트 모드 오버라이드 ─── */
@@ -96,6 +99,9 @@
   --color-shadow: 0 0 0;
   --shadow-alpha: 0.12;
   --color-on-accent: 255 255 255;
+  /* 라이트 모드 길이 변경 색 (대비 강화) */
+  --color-length-up: 5 150 105;      /* #059669 emerald-600 */
+  --color-length-down: 220 38 38;     /* #DC2626 red-600 */
 }
 
 /* 앱 전체 텍스트 선택 방지 (드래그 시 파란색 하이라이트 제거) */

--- a/src/styles/scene-effects.css
+++ b/src/styles/scene-effects.css
@@ -142,42 +142,150 @@
  * - 그룹 마지막 행: 아래쪽 3px 굵은 액센트 보더 + 추가 padding
  * - 행 양쪽: 얇은 액센트 보더로 카드 가장자리 흉내
  */
+/* v1.16.0 — 그룹 카드 디자인 개편 (한솔 결정):
+ * 좌우 보더 제거 → 빈 셀에서 보이던 짧은 세로선 사라짐.
+ * 대신 그룹 안 모든 행에 옅은 액센트 배경 → 한 덩어리로 묶여 보임.
+ * 그룹 위/아래 굵은 액센트 보더만 유지 → 그룹 단위 분리감 강화.
+ *
+ * Defensive reset: 그룹 행의 td/th에서 좌우 시각 분리(보더/아웃라인/그림자) 모두 제거.
+ * — 그룹 외 일반 행/헤더에는 영향 X (별도 셀렉터로 한정).
+ */
+.scene-group-header > td,
+.scene-group-header > th,
+.scene-row-group-mid > td,
+.scene-row-group-mid > th,
+.scene-row-group-last > td,
+.scene-row-group-last > th {
+  border-left: 0 !important;
+  border-right: 0 !important;
+  outline: 0 !important;
+  box-shadow: none !important;
+}
+
 .scene-group-header > td {
   background: rgb(var(--color-accent) / 0.18) !important;
   border-top: 3px solid rgb(var(--color-accent) / 0.85) !important;
   padding: 10px 12px !important;
 }
-.scene-group-header > td:first-child {
-  border-left: 2px solid rgb(var(--color-accent) / 0.6) !important;
-}
-.scene-group-header > td:last-child {
-  border-right: 2px solid rgb(var(--color-accent) / 0.6) !important;
-}
 
-.scene-row-group-mid > td:first-child {
-  border-left: 2px solid rgb(var(--color-accent) / 0.6) !important;
+.scene-row-group-mid {
+  border-bottom: none !important;
 }
-.scene-row-group-mid > td:last-child {
-  border-right: 2px solid rgb(var(--color-accent) / 0.6) !important;
+.scene-row-group-mid > td {
+  /* 그룹 내부 행 사이 가로/좌우 보더 모두 제거 → 한 덩어리 카드 느낌 */
+  border-bottom: none !important;
+  background: rgb(var(--color-accent) / 0.06) !important;
 }
 
 .scene-row-group-last > td {
   border-bottom: 3px solid rgb(var(--color-accent) / 0.85) !important;
   padding-bottom: 10px !important;
-}
-.scene-row-group-last > td:first-child {
-  border-left: 2px solid rgb(var(--color-accent) / 0.6) !important;
-  border-bottom-left-radius: 6px;
-}
-.scene-row-group-last > td:last-child {
-  border-right: 2px solid rgb(var(--color-accent) / 0.6) !important;
-  border-bottom-right-radius: 6px;
+  background: rgb(var(--color-accent) / 0.06) !important;
 }
 
-/* 그룹 사이 간격 — 빈 행으로 카드 분리감 */
+/* hover 시 그룹 행도 강조 (배경 미세하게 더 진하게) */
+.scene-row-group-mid:hover > td,
+.scene-row-group-last:hover > td {
+  background: rgb(var(--color-accent) / 0.12) !important;
+}
+
+/* 그룹 사이 간격 — 빈 행으로 카드 분리감 강화 (14→20px) */
 .scene-row-group-gap > td {
-  height: 14px !important;
+  height: 20px !important;
   padding: 0 !important;
   border: none !important;
   background: transparent !important;
+}
+
+/* ─────────────────────────────────────────────
+ * 씬 길이 변경 라벨 (LD = <-> 늘어남, SD = >-< 줄어듦)
+ * v1.16.0 — 한솔 결정: 영구 라벨, 카드/시트 우클릭 토글
+ * ───────────────────────────────────────────── */
+
+/* SVG 아이콘 베이스 (줄바꿈 안전 + 크기 고정) */
+.length-icon {
+  display: inline-block;
+  vertical-align: middle;
+  flex-shrink: 0;
+  width: 20px;
+  height: 10px;
+  overflow: visible;
+}
+.length-icon.sm { width: 16px; height: 8px; }
+.length-icon.lg { width: 26px; height: 13px; }
+
+/* 카드 헤더 우상단 칩 */
+.length-symbol {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 7px;
+  border-radius: 5px;
+  cursor: help;
+  user-select: none;
+  white-space: nowrap;
+  flex-shrink: 0;
+  line-height: 1.2;
+}
+.length-symbol.up {
+  color: rgb(var(--color-length-up));
+  background: rgb(var(--color-length-up) / 0.15);
+  border: 1px solid rgb(var(--color-length-up) / 0.3);
+}
+.length-symbol.down {
+  color: rgb(var(--color-length-down));
+  background: rgb(var(--color-length-down) / 0.15);
+  border: 1px solid rgb(var(--color-length-down) / 0.3);
+}
+.length-symbol .length-icon {
+  width: 20px;
+  height: 10px;
+}
+
+/* 시트 셀 안 작은 칩 — 절대 잘리지 않게 */
+.length-symbol-sheet {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 5px;
+  border-radius: 4px;
+  margin-right: 6px;
+  cursor: help;
+  user-select: none;
+  white-space: nowrap;
+  flex-shrink: 0;
+  line-height: 1.3;
+  vertical-align: middle;
+}
+.length-symbol-sheet.up {
+  color: rgb(var(--color-length-up));
+  background: rgb(var(--color-length-up) / 0.15);
+  border: 1px solid rgb(var(--color-length-up) / 0.28);
+}
+.length-symbol-sheet.down {
+  color: rgb(var(--color-length-down));
+  background: rgb(var(--color-length-down) / 0.15);
+  border: 1px solid rgb(var(--color-length-down) / 0.28);
+}
+.length-symbol-sheet .length-icon { width: 16px; height: 8px; }
+
+/* v1.16.0: 시트 뷰 리사이즈 중 transition 비활성화 (행 많을 때 렉 방지) */
+html.is-resizing .unified-scene-sheet,
+html.is-resizing .unified-scene-sheet *,
+html.is-resizing .unified-scene-sheet *::before,
+html.is-resizing .unified-scene-sheet *::after {
+  transition: none !important;
+  animation: none !important;
+}
+
+/* 시트 행 좌측 그라데이션 — 멀리서도 행 인지 */
+.sheet-row-length-up {
+  background: linear-gradient(90deg, rgb(var(--color-length-up) / 0.15) 0%, transparent 5%);
+}
+.sheet-row-length-down {
+  background: linear-gradient(90deg, rgb(var(--color-length-down) / 0.15) 0%, transparent 5%);
+}
+.sheet-row-length-up:hover {
+  background: linear-gradient(90deg, rgb(var(--color-length-up) / 0.18) 0%, rgb(var(--color-accent) / 0.04) 5%);
+}
+.sheet-row-length-down:hover {
+  background: linear-gradient(90deg, rgb(var(--color-length-down) / 0.18) 0%, rgb(var(--color-accent) / 0.04) 5%);
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -72,6 +72,14 @@ export interface Scene {
   png: boolean;
   completedBy?: string;  // 모든 단계 완료한 사용자 이름
   completedAt?: string;  // 완료 시각 (ISO 8601)
+  /**
+   * 씬 길이 변경 시각 라벨 (수동 토글, 영구 라벨 — 사용자가 해제 전까지 유지).
+   * - 'LD' = Long Duration (길이 늘어남, <-> SVG 라벨)
+   * - 'SD' = Short Duration (길이 줄어듦, >-< SVG 라벨)
+   * - null/undefined = 표시 없음
+   * 카드/시트 우클릭 메뉴로 토글.
+   */
+  lengthChange?: 'LD' | 'SD' | null;
 }
 
 // ─── 통합 씬 (BG + ACT 머지) ─────────────────

--- a/src/views/ScenesView.tsx
+++ b/src/views/ScenesView.tsx
@@ -21,6 +21,7 @@ import { EpisodeTreeNav } from '@/components/scenes/EpisodeTreeNav';
 import { SceneSheetView } from '@/components/scenes/SceneSheetView';
 import { UnifiedSceneCard } from '@/components/scenes/UnifiedSceneCard';
 import { UnifiedSceneSheetView } from '@/components/scenes/UnifiedSceneSheetView';
+import { LengthIcon } from '@/components/scenes/LengthIcon';
 import { UnifiedSceneDetailModal } from '@/components/scenes/UnifiedSceneDetailModal';
 import { BulkOperationStatus } from '@/components/scenes/BulkOperationStatus';
 import { useAuthStore } from '@/stores/useAuthStore';
@@ -2349,6 +2350,33 @@ export function ScenesView() {
     clearSelectedScenes();
   };
 
+  // v1.16.0: 선택된 씬들에 길이 변경 라벨 일괄 토글 (LD/SD/null)
+  // v1.16.0 fix: 다른 일괄 작업(stage/delete/edit) 진행 중에는 우회 방지
+  const handleBulkLengthChange = async (value: 'LD' | 'SD' | null) => {
+    if (isBulkInFlight) return;
+    const uuids = resolveSelectedUuids(selectedSceneIds, allMergedScenes, currentPart);
+    if (uuids.length === 0) return;
+
+    const prevEpisodes = useDataStore.getState().episodes;
+    const valueStr = value ?? '';
+
+    // 낙관적: 선택된 모든 씬(BG+ACT 양쪽 포함)에 즉시 적용
+    for (const uuid of uuids) {
+      useDataStore.getState().updateSceneByUuid(uuid, { lengthChange: value });
+    }
+
+    try {
+      await Promise.all(
+        uuids.map((uuid) =>
+          window.electronAPI?.supabaseUpdateSceneField?.(uuid, 'lengthChange', valueStr) ?? Promise.resolve(),
+        ),
+      );
+    } catch (err) {
+      useDataStore.getState().setEpisodes(prevEpisodes);
+      console.error('[bulk lengthChange] 저장 실패', err);
+    }
+  };
+
   // 일괄 편집: 선택된 씬들의 assignee/memo/layoutId를 RPC로 일괄 갱신 (Tasks 13-17)
   const handleBulkEditSubmit = async (
     payload: { assignee?: string; memo?: string; layoutId?: string },
@@ -3895,7 +3923,11 @@ export function ScenesView() {
             <div className="flex items-center gap-2 pr-3 border-r border-bg-border shrink-0">
               <CheckSquare size={14} className="text-accent" />
               <span className="text-xs font-medium text-text-primary whitespace-nowrap leading-none">
-                {selectedSceneIds.size}개 선택
+                {/* v1.16.0: 통합 뷰는 mergedKey 기준 unique count (BG+ACT 양쪽 동시 선택을 1개로 표시) */}
+                {selectedDepartment === 'all'
+                  ? new Set([...selectedSceneIds].map((id) => id.replace(/^(bg|act):/, ''))).size
+                  : selectedSceneIds.size
+                }개 선택
               </span>
             </div>
 
@@ -3960,6 +3992,39 @@ export function ScenesView() {
                 </button>
               ))
             )}
+
+            <div className="w-px h-5 bg-bg-border shrink-0" />
+
+            {/* v1.16.0: 길이 변경 일괄 토글 */}
+            <div className="flex items-center gap-1">
+              <span className="text-[11px] text-text-secondary leading-none whitespace-nowrap mr-0.5">길이</span>
+              <button
+                onClick={() => handleBulkLengthChange('LD')}
+                disabled={isBulkInFlight}
+                title="LD · Long Duration (길이 늘어남)"
+                className="h-7 px-2 text-[11px] font-medium rounded-md bg-length-up/10 text-length-up border border-length-up/30 hover:bg-length-up/20 transition-colors cursor-pointer leading-none whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1"
+              >
+                <LengthIcon kind="LD" size="sm" />
+                <span>LD</span>
+              </button>
+              <button
+                onClick={() => handleBulkLengthChange('SD')}
+                disabled={isBulkInFlight}
+                title="SD · Short Duration (길이 줄어듦)"
+                className="h-7 px-2 text-[11px] font-medium rounded-md bg-length-down/10 text-length-down border border-length-down/30 hover:bg-length-down/20 transition-colors cursor-pointer leading-none whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1"
+              >
+                <LengthIcon kind="SD" size="sm" />
+                <span>SD</span>
+              </button>
+              <button
+                onClick={() => handleBulkLengthChange(null)}
+                disabled={isBulkInFlight}
+                title="길이 변경 표시 해제"
+                className="h-7 px-2 text-[11px] font-medium rounded-md bg-bg-border/30 text-text-secondary border border-bg-border hover:bg-bg-border/50 transition-colors cursor-pointer leading-none whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                해제
+              </button>
+            </div>
 
             <div className="w-px h-5 bg-bg-border shrink-0" />
 

--- a/src/views/ScenesView.tsx
+++ b/src/views/ScenesView.tsx
@@ -2352,8 +2352,10 @@ export function ScenesView() {
 
   // v1.16.0: 선택된 씬들에 길이 변경 라벨 일괄 토글 (LD/SD/null)
   // v1.16.0 fix #1: 다른 일괄 작업(stage/delete/edit) 진행 중에는 우회 방지
-  // v1.16.0 fix #2 (Codex review): LD → SD 빠른 연타로 두 batch 가 동시 실행되어 out-of-order commit 되는 문제
-  //                                자체 in-flight ref 로 직렬화. ref 라 리렌더 트리거 X.
+  // v1.16.0 fix #2 (Codex 라운드 1): LD → SD 빠른 연타로 두 batch 가 동시 실행되어 out-of-order commit 되는 문제
+  //                                  자체 in-flight ref 로 직렬화. ref 라 리렌더 트리거 X.
+  // v1.16.0 fix #3 (Codex 라운드 3): Promise.all 첫 reject 시 즉시 전체 롤백 → 다른 성공한 호출이 DB 변경한 상태로 남아 UI↔DB 불일치.
+  //                                  Promise.allSettled 로 모두 끝나길 기다린 후 실패한 uuid 만 부분 롤백 (성공분은 유지).
   const lengthChangeBulkInFlightRef = useRef(false);
   const handleBulkLengthChange = async (value: 'LD' | 'SD' | null) => {
     if (isBulkInFlight || lengthChangeBulkInFlightRef.current) return;
@@ -2361,8 +2363,14 @@ export function ScenesView() {
     if (uuids.length === 0) return;
 
     lengthChangeBulkInFlightRef.current = true;
-    const prevEpisodes = useDataStore.getState().episodes;
     const valueStr = value ?? '';
+
+    // 변경 전 값 캐싱 (uuid 별 부분 롤백용)
+    const prevValues = new Map<string, 'LD' | 'SD' | null | undefined>();
+    for (const uuid of uuids) {
+      const scene = useDataStore.getState().findSceneByUuid(uuid);
+      prevValues.set(uuid, scene?.lengthChange ?? null);
+    }
 
     // 낙관적: 선택된 모든 씬(BG+ACT 양쪽 포함)에 즉시 적용
     for (const uuid of uuids) {
@@ -2370,14 +2378,24 @@ export function ScenesView() {
     }
 
     try {
-      await Promise.all(
+      const results = await Promise.allSettled(
         uuids.map((uuid) =>
           window.electronAPI?.supabaseUpdateSceneField?.(uuid, 'lengthChange', valueStr) ?? Promise.resolve(),
         ),
       );
-    } catch (err) {
-      useDataStore.getState().setEpisodes(prevEpisodes);
-      console.error('[bulk lengthChange] 저장 실패', err);
+      // 실패한 uuid 만 부분 롤백 — 성공분은 DB 반영된 상태 유지
+      const failedUuids: string[] = [];
+      results.forEach((result, i) => {
+        if (result.status === 'rejected') {
+          const uuid = uuids[i];
+          failedUuids.push(uuid);
+          const prev = prevValues.get(uuid) ?? null;
+          useDataStore.getState().updateSceneByUuid(uuid, { lengthChange: prev });
+        }
+      });
+      if (failedUuids.length > 0) {
+        console.error(`[bulk lengthChange] ${failedUuids.length}/${uuids.length} 저장 실패`, failedUuids);
+      }
     } finally {
       lengthChangeBulkInFlightRef.current = false;
     }

--- a/src/views/ScenesView.tsx
+++ b/src/views/ScenesView.tsx
@@ -2351,79 +2351,106 @@ export function ScenesView() {
   };
 
   // v1.16.0: 선택된 씬들에 길이 변경 라벨 일괄 토글 (LD/SD/null)
-  // v1.16.0 fix #1: isBulkInFlight 가드 (다른 일괄 작업과 충돌 방지)
-  // v1.16.0 fix #2 (Codex 라운드 1): self in-flight ref 로 LD↔SD 연타 race 방지
-  // v1.16.0 fix #3 (Codex 라운드 3): Promise.allSettled + 부분 롤백 (per-UUID)
-  // v1.16.0 fix #4 (Codex 라운드 7): unified mode 에서 mergedKey 가 BG/ACT 두 UUID 로 매핑 →
-  //                                  per-UUID 부분 롤백이 한 mergedKey 의 BG/ACT 를 split 가능 (예: BG=LD, ACT=null).
-  //                                  → mergedKey 단위 atomic: 한 쪽 실패하면 그 mergedKey 의 BG/ACT 둘 다 prev 롤백.
-  //                                    성공한 DB 호출은 best-effort reverse 로 정합성 회복.
+  // v1.16.0 fix #1: isBulkInFlight 가드
+  // v1.16.0 fix #2 (Codex 라운드 1): self in-flight ref
+  // v1.16.0 fix #3 (Codex 라운드 3): Promise.allSettled
+  // v1.16.0 fix #4 (Codex 라운드 7): unified 모드 mergedKey 단위 atomic
+  // v1.16.0 fix #5 (Codex 라운드 8): unified vs 단독 뷰 분기 — 단독 뷰는 selectedSceneIds 가 plain sceneId 라
+  //                                  prefix 제거만으로 mergedKey 매칭 실패 → bulk 가 동작 안 했음.
+  //                                  → 통합: mergedKey atomic, 단독: per-uuid 부분 롤백 (한 부서만 영향).
+  type Target = { uuid: string; prev: 'LD' | 'SD' | null };
   const lengthChangeBulkInFlightRef = useRef(false);
   const handleBulkLengthChange = async (value: 'LD' | 'SD' | null) => {
     if (isBulkInFlight || lengthChangeBulkInFlightRef.current) return;
-
-    // mergedKey unique 추출 (selectedSceneIds 의 'bg:'/'act:' prefix 제거)
-    const mergedKeys = new Set<string>();
-    for (const id of selectedSceneIds) {
-      mergedKeys.add(id.replace(/^(bg|act):/, ''));
-    }
-
-    // 각 mergedKey → BG/ACT { uuid, prev } 정보 수집
-    type Target = { uuid: string; prev: 'LD' | 'SD' | null };
-    type MergedTarget = { bg?: Target; act?: Target };
-    const mergedTargets = new Map<string, MergedTarget>();
-    for (const key of mergedKeys) {
-      const merged = allMergedScenes.find((m) => m.mergedKey === key);
-      if (!merged) continue;
-      const target: MergedTarget = {};
-      if (merged.bgScene?.id) target.bg = { uuid: merged.bgScene.id, prev: merged.bgScene.lengthChange ?? null };
-      if (merged.actScene?.id) target.act = { uuid: merged.actScene.id, prev: merged.actScene.lengthChange ?? null };
-      if (target.bg || target.act) mergedTargets.set(key, target);
-    }
-
-    if (mergedTargets.size === 0) return;
-
-    lengthChangeBulkInFlightRef.current = true;
     const valueStr = value ?? '';
 
-    // 낙관적: 모든 BG/ACT 즉시 적용
-    for (const t of mergedTargets.values()) {
-      if (t.bg) useDataStore.getState().updateSceneByUuid(t.bg.uuid, { lengthChange: value });
-      if (t.act) useDataStore.getState().updateSceneByUuid(t.act.uuid, { lengthChange: value });
-    }
+    if (selectedDepartment === 'all') {
+      // ─── 통합 뷰: mergedKey 단위 atomic (BG/ACT sync 보존) ───
+      type MergedTarget = { bg?: Target; act?: Target };
+      const mergedTargets = new Map<string, MergedTarget>();
+      for (const id of selectedSceneIds) {
+        if (!id.startsWith('bg:') && !id.startsWith('act:')) continue;
+        const mergedKey = id.replace(/^(bg|act):/, '');
+        if (mergedTargets.has(mergedKey)) continue;
+        const merged = allMergedScenes.find((m) => m.mergedKey === mergedKey);
+        if (!merged) continue;
+        const target: MergedTarget = {};
+        if (merged.bgScene?.id) target.bg = { uuid: merged.bgScene.id, prev: merged.bgScene.lengthChange ?? null };
+        if (merged.actScene?.id) target.act = { uuid: merged.actScene.id, prev: merged.actScene.lengthChange ?? null };
+        if (target.bg || target.act) mergedTargets.set(mergedKey, target);
+      }
+      if (mergedTargets.size === 0) return;
 
-    try {
-      // mergedKey 단위로 처리 — 각 mergedKey 의 BG/ACT 는 atomic
-      await Promise.all(
-        Array.from(mergedTargets.entries()).map(async ([, t]) => {
-          const targets: Target[] = [];
-          if (t.bg) targets.push(t.bg);
-          if (t.act) targets.push(t.act);
-          const results = await Promise.allSettled(
-            targets.map((tt) =>
-              window.electronAPI?.supabaseUpdateSceneField?.(tt.uuid, 'lengthChange', valueStr) ?? Promise.resolve(),
-            ),
-          );
-          const anyFailed = results.some((r) => r.status === 'rejected');
-          if (!anyFailed) return;
-          // BG/ACT sync 보존: 이 mergedKey 의 둘 다 prev 로 UI 롤백
-          for (const tt of targets) {
-            useDataStore.getState().updateSceneByUuid(tt.uuid, { lengthChange: tt.prev });
-          }
-          // 성공한 DB 호출은 best-effort reverse
-          results.forEach((r, i) => {
-            if (r.status === 'fulfilled') {
-              const tt = targets[i];
-              window.electronAPI?.supabaseUpdateSceneField?.(tt.uuid, 'lengthChange', tt.prev ?? '')
-                .catch((err) => console.error(`[bulk lengthChange] reverse 실패 ${tt.uuid}`, err));
-            } else {
-              console.error(`[bulk lengthChange] ${targets[i].uuid} 실패`, r.reason);
+      lengthChangeBulkInFlightRef.current = true;
+      // 낙관적
+      for (const t of mergedTargets.values()) {
+        if (t.bg) useDataStore.getState().updateSceneByUuid(t.bg.uuid, { lengthChange: value });
+        if (t.act) useDataStore.getState().updateSceneByUuid(t.act.uuid, { lengthChange: value });
+      }
+
+      try {
+        await Promise.all(
+          Array.from(mergedTargets.values()).map(async (t) => {
+            const targets: Target[] = [];
+            if (t.bg) targets.push(t.bg);
+            if (t.act) targets.push(t.act);
+            const results = await Promise.allSettled(
+              targets.map((tt) =>
+                window.electronAPI?.supabaseUpdateSceneField?.(tt.uuid, 'lengthChange', valueStr) ?? Promise.resolve(),
+              ),
+            );
+            const anyFailed = results.some((r) => r.status === 'rejected');
+            if (!anyFailed) return;
+            // BG/ACT sync 보존: 둘 다 prev 로 UI 롤백
+            for (const tt of targets) {
+              useDataStore.getState().updateSceneByUuid(tt.uuid, { lengthChange: tt.prev });
             }
-          });
-        }),
-      );
-    } finally {
-      lengthChangeBulkInFlightRef.current = false;
+            // 성공한 DB 호출은 best-effort reverse
+            results.forEach((r, i) => {
+              if (r.status === 'fulfilled') {
+                const tt = targets[i];
+                window.electronAPI?.supabaseUpdateSceneField?.(tt.uuid, 'lengthChange', tt.prev ?? '')
+                  .catch((err) => console.error(`[bulk lengthChange] reverse 실패 ${tt.uuid}`, err));
+              } else {
+                console.error(`[bulk lengthChange] ${targets[i].uuid} 실패`, r.reason);
+              }
+            });
+          }),
+        );
+      } finally {
+        lengthChangeBulkInFlightRef.current = false;
+      }
+    } else {
+      // ─── 단독 뷰 (BG 또는 ACT only): plain sceneId → Scene → uuid, per-uuid 부분 롤백 ───
+      // 단독 뷰는 한 부서만 영향이라 mergedKey atomic 무의미.
+      const scenes = resolveSelectedScenes(selectedSceneIds, allMergedScenes, selectedDepartment as 'bg' | 'acting', currentPart);
+      const targets: Target[] = scenes
+        .filter((s) => !!s.id)
+        .map((s) => ({ uuid: s.id!, prev: s.lengthChange ?? null }));
+      if (targets.length === 0) return;
+
+      lengthChangeBulkInFlightRef.current = true;
+      // 낙관적
+      for (const t of targets) {
+        useDataStore.getState().updateSceneByUuid(t.uuid, { lengthChange: value });
+      }
+
+      try {
+        const results = await Promise.allSettled(
+          targets.map((t) =>
+            window.electronAPI?.supabaseUpdateSceneField?.(t.uuid, 'lengthChange', valueStr) ?? Promise.resolve(),
+          ),
+        );
+        results.forEach((r, i) => {
+          if (r.status === 'rejected') {
+            const t = targets[i];
+            useDataStore.getState().updateSceneByUuid(t.uuid, { lengthChange: t.prev });
+            console.error(`[bulk lengthChange] (단독) ${t.uuid} 실패`, r.reason);
+          }
+        });
+      } finally {
+        lengthChangeBulkInFlightRef.current = false;
+      }
     }
   };
 

--- a/src/views/ScenesView.tsx
+++ b/src/views/ScenesView.tsx
@@ -2351,12 +2351,16 @@ export function ScenesView() {
   };
 
   // v1.16.0: 선택된 씬들에 길이 변경 라벨 일괄 토글 (LD/SD/null)
-  // v1.16.0 fix: 다른 일괄 작업(stage/delete/edit) 진행 중에는 우회 방지
+  // v1.16.0 fix #1: 다른 일괄 작업(stage/delete/edit) 진행 중에는 우회 방지
+  // v1.16.0 fix #2 (Codex review): LD → SD 빠른 연타로 두 batch 가 동시 실행되어 out-of-order commit 되는 문제
+  //                                자체 in-flight ref 로 직렬화. ref 라 리렌더 트리거 X.
+  const lengthChangeBulkInFlightRef = useRef(false);
   const handleBulkLengthChange = async (value: 'LD' | 'SD' | null) => {
-    if (isBulkInFlight) return;
+    if (isBulkInFlight || lengthChangeBulkInFlightRef.current) return;
     const uuids = resolveSelectedUuids(selectedSceneIds, allMergedScenes, currentPart);
     if (uuids.length === 0) return;
 
+    lengthChangeBulkInFlightRef.current = true;
     const prevEpisodes = useDataStore.getState().episodes;
     const valueStr = value ?? '';
 
@@ -2374,6 +2378,8 @@ export function ScenesView() {
     } catch (err) {
       useDataStore.getState().setEpisodes(prevEpisodes);
       console.error('[bulk lengthChange] 저장 실패', err);
+    } finally {
+      lengthChangeBulkInFlightRef.current = false;
     }
   };
 

--- a/src/views/ScenesView.tsx
+++ b/src/views/ScenesView.tsx
@@ -2351,51 +2351,77 @@ export function ScenesView() {
   };
 
   // v1.16.0: 선택된 씬들에 길이 변경 라벨 일괄 토글 (LD/SD/null)
-  // v1.16.0 fix #1: 다른 일괄 작업(stage/delete/edit) 진행 중에는 우회 방지
-  // v1.16.0 fix #2 (Codex 라운드 1): LD → SD 빠른 연타로 두 batch 가 동시 실행되어 out-of-order commit 되는 문제
-  //                                  자체 in-flight ref 로 직렬화. ref 라 리렌더 트리거 X.
-  // v1.16.0 fix #3 (Codex 라운드 3): Promise.all 첫 reject 시 즉시 전체 롤백 → 다른 성공한 호출이 DB 변경한 상태로 남아 UI↔DB 불일치.
-  //                                  Promise.allSettled 로 모두 끝나길 기다린 후 실패한 uuid 만 부분 롤백 (성공분은 유지).
+  // v1.16.0 fix #1: isBulkInFlight 가드 (다른 일괄 작업과 충돌 방지)
+  // v1.16.0 fix #2 (Codex 라운드 1): self in-flight ref 로 LD↔SD 연타 race 방지
+  // v1.16.0 fix #3 (Codex 라운드 3): Promise.allSettled + 부분 롤백 (per-UUID)
+  // v1.16.0 fix #4 (Codex 라운드 7): unified mode 에서 mergedKey 가 BG/ACT 두 UUID 로 매핑 →
+  //                                  per-UUID 부분 롤백이 한 mergedKey 의 BG/ACT 를 split 가능 (예: BG=LD, ACT=null).
+  //                                  → mergedKey 단위 atomic: 한 쪽 실패하면 그 mergedKey 의 BG/ACT 둘 다 prev 롤백.
+  //                                    성공한 DB 호출은 best-effort reverse 로 정합성 회복.
   const lengthChangeBulkInFlightRef = useRef(false);
   const handleBulkLengthChange = async (value: 'LD' | 'SD' | null) => {
     if (isBulkInFlight || lengthChangeBulkInFlightRef.current) return;
-    const uuids = resolveSelectedUuids(selectedSceneIds, allMergedScenes, currentPart);
-    if (uuids.length === 0) return;
+
+    // mergedKey unique 추출 (selectedSceneIds 의 'bg:'/'act:' prefix 제거)
+    const mergedKeys = new Set<string>();
+    for (const id of selectedSceneIds) {
+      mergedKeys.add(id.replace(/^(bg|act):/, ''));
+    }
+
+    // 각 mergedKey → BG/ACT { uuid, prev } 정보 수집
+    type Target = { uuid: string; prev: 'LD' | 'SD' | null };
+    type MergedTarget = { bg?: Target; act?: Target };
+    const mergedTargets = new Map<string, MergedTarget>();
+    for (const key of mergedKeys) {
+      const merged = allMergedScenes.find((m) => m.mergedKey === key);
+      if (!merged) continue;
+      const target: MergedTarget = {};
+      if (merged.bgScene?.id) target.bg = { uuid: merged.bgScene.id, prev: merged.bgScene.lengthChange ?? null };
+      if (merged.actScene?.id) target.act = { uuid: merged.actScene.id, prev: merged.actScene.lengthChange ?? null };
+      if (target.bg || target.act) mergedTargets.set(key, target);
+    }
+
+    if (mergedTargets.size === 0) return;
 
     lengthChangeBulkInFlightRef.current = true;
     const valueStr = value ?? '';
 
-    // 변경 전 값 캐싱 (uuid 별 부분 롤백용)
-    const prevValues = new Map<string, 'LD' | 'SD' | null | undefined>();
-    for (const uuid of uuids) {
-      const scene = useDataStore.getState().findSceneByUuid(uuid);
-      prevValues.set(uuid, scene?.lengthChange ?? null);
-    }
-
-    // 낙관적: 선택된 모든 씬(BG+ACT 양쪽 포함)에 즉시 적용
-    for (const uuid of uuids) {
-      useDataStore.getState().updateSceneByUuid(uuid, { lengthChange: value });
+    // 낙관적: 모든 BG/ACT 즉시 적용
+    for (const t of mergedTargets.values()) {
+      if (t.bg) useDataStore.getState().updateSceneByUuid(t.bg.uuid, { lengthChange: value });
+      if (t.act) useDataStore.getState().updateSceneByUuid(t.act.uuid, { lengthChange: value });
     }
 
     try {
-      const results = await Promise.allSettled(
-        uuids.map((uuid) =>
-          window.electronAPI?.supabaseUpdateSceneField?.(uuid, 'lengthChange', valueStr) ?? Promise.resolve(),
-        ),
+      // mergedKey 단위로 처리 — 각 mergedKey 의 BG/ACT 는 atomic
+      await Promise.all(
+        Array.from(mergedTargets.entries()).map(async ([, t]) => {
+          const targets: Target[] = [];
+          if (t.bg) targets.push(t.bg);
+          if (t.act) targets.push(t.act);
+          const results = await Promise.allSettled(
+            targets.map((tt) =>
+              window.electronAPI?.supabaseUpdateSceneField?.(tt.uuid, 'lengthChange', valueStr) ?? Promise.resolve(),
+            ),
+          );
+          const anyFailed = results.some((r) => r.status === 'rejected');
+          if (!anyFailed) return;
+          // BG/ACT sync 보존: 이 mergedKey 의 둘 다 prev 로 UI 롤백
+          for (const tt of targets) {
+            useDataStore.getState().updateSceneByUuid(tt.uuid, { lengthChange: tt.prev });
+          }
+          // 성공한 DB 호출은 best-effort reverse
+          results.forEach((r, i) => {
+            if (r.status === 'fulfilled') {
+              const tt = targets[i];
+              window.electronAPI?.supabaseUpdateSceneField?.(tt.uuid, 'lengthChange', tt.prev ?? '')
+                .catch((err) => console.error(`[bulk lengthChange] reverse 실패 ${tt.uuid}`, err));
+            } else {
+              console.error(`[bulk lengthChange] ${targets[i].uuid} 실패`, r.reason);
+            }
+          });
+        }),
       );
-      // 실패한 uuid 만 부분 롤백 — 성공분은 DB 반영된 상태 유지
-      const failedUuids: string[] = [];
-      results.forEach((result, i) => {
-        if (result.status === 'rejected') {
-          const uuid = uuids[i];
-          failedUuids.push(uuid);
-          const prev = prevValues.get(uuid) ?? null;
-          useDataStore.getState().updateSceneByUuid(uuid, { lengthChange: prev });
-        }
-      });
-      if (failedUuids.length > 0) {
-        console.error(`[bulk lengthChange] ${failedUuids.length}/${uuids.length} 저장 실패`, failedUuids);
-      }
     } finally {
       lengthChangeBulkInFlightRef.current = false;
     }

--- a/src/views/WidgetPopup.tsx
+++ b/src/views/WidgetPopup.tsx
@@ -396,9 +396,11 @@ export function WidgetPopup({ widgetId, extraParams }: { widgetId: string; extra
         }
       }
       if (data.event === 'scene-field-update') {
-        const { sceneUuid, field, value } = data.payload as { sceneUuid: string; field: string; value: string };
+        const { sceneUuid, field, value } = data.payload as { sceneUuid: string; field: string; value: string | null };
         if (sceneUuid && field) {
-          useDataStore.getState().updateSceneByUuid(sceneUuid, { [field]: value });
+          // v1.16.0: lengthChange 안전망 (송신부에서 normalize 하지만 이중 보호)
+          const normalized = (field === 'lengthChange' && value === '') ? null : value;
+          useDataStore.getState().updateSceneByUuid(sceneUuid, { [field]: normalized });
           return;
         }
       }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,9 @@ module.exports = {
         },
         accent: 'rgb(var(--color-accent) / <alpha-value>)',
         'accent-sub': 'rgb(var(--color-accent-sub) / <alpha-value>)',
+        // 씬 길이 변경 (LD/SD)
+        'length-up': 'rgb(var(--color-length-up) / <alpha-value>)',
+        'length-down': 'rgb(var(--color-length-down) / <alpha-value>)',
         // 시멘틱 컬러 (라이트/다크 자동 대응)
         overlay: 'rgb(var(--color-overlay) / <alpha-value>)',
         'on-accent': 'rgb(var(--color-on-accent) / <alpha-value>)',


### PR DESCRIPTION
## 📋 업데이트 요약

> 이번 업데이트에서 달라진 점을 간략하게 정리했습니다.

- ✨ **카드/시트 뷰에서 BG와 ACT 메모를 동시에** 볼 수 있게 됐어요. 이전엔 BG가 있으면 ACT 메모가 가려졌는데, 이제 둘 다 라벨 칩(`BG`/`ACT`)으로 구분되어 보입니다.
- ✨ **씬 길이가 늘었는지 줄었는지 표시하는 라벨** 추가. 카드/시트 행을 우클릭하면 메뉴가 뜨고 거기서 토글할 수 있어요.
  - `<->` (LD, 초록) = 길이 늘어남
  - `>-<` (SD, 빨강) = 길이 줄어듦
  - 한 번 켜면 직접 끌 때까지 영구 표시
- ✨ **여러 씬 선택 시 LD/SD를 한 번에 일괄 적용** 가능 (하단 토스트의 새 버튼)
- ✨ **메모 안의 G드라이브 경로가 클릭 가능한 버튼**이 됐어요. 클릭하면 탐색기에서 바로 열립니다 (상세 모달과 동일한 동작).
- 🐛 통합 뷰에서 카드 1개를 선택했는데 "2개 선택"으로 표시되던 문제 수정
- 🐛 카드를 우클릭해도 메뉴가 안 뜨던 문제 수정
- 🐛 시트 뷰에서 BG/ACT 메모 컬럼이 화면 절반 이상 차지하던 문제 수정
- ⚡ 시트 뷰 창 크기 조절 시의 렉 일부 감소
- ⚡ 시트 뷰 레이아웃별 보기에서 그룹이 한 덩어리 카드처럼 보이게 디자인 개선

---

## 🔧 상세 기술 설명

### 데이터 모델 + Supabase 마이그레이션
- `Scene` 인터페이스에 `lengthChange?: 'LD' | 'SD' | null` 필드 추가 (`src/types/index.ts`)
- Supabase `scenes.length_change` 컬럼 추가 (`text NULLABLE`, `CHECK (NULL OR 'LD' OR 'SD')`) — 마이그레이션은 이미 적용됨
- `electron/supabase.ts`: `fieldMap`에 `lengthChange → length_change`, scenes select에 컬럼 추가, 빈 문자열을 NULL로 변환

### 카드/시트 메모 동시 노출 (한솔 결정 A1 + B2)
- **카드 (`UnifiedSceneCard.tsx`)**: 메모 영역을 BG/ACT 두 줄로. 각 줄 앞 라벨 칩(파란 `BG` / 핑크 `ACT`)
- **시트 (`UnifiedSceneSheetView.tsx`)**: 단일 메모 컬럼 → `bgMemo` / `actMemo` 두 컬럼 분리. `EDITABLE_FIELDS` 인덱스 시프트(BG담당 1→2, ACT담당 2→3). thead 부서 서브헤더 colSpan 조정(2→3)
- **메모 너비**: `SheetEditableCell`의 `isMemo` 조건이 `'memo'` 만 매칭하던 버그 수정(`'bgMemo' || 'actMemo'`로 변경) + `max-w-[20rem] min-w-[3.5rem]` 적용 + truncate + `title` 툴팁

### 씬 길이 변경 라벨 (LD/SD)
- **SVG 아이콘**: `SvgIconDefs.tsx`에 `<symbol id=\"ic-ld\">` / `<symbol id=\"ic-sd\">` 정의(앱 root에 한 번 마운트). `<LengthIcon kind=\"LD|SD\" size=\"sm|md|lg\" />` 컴포넌트로 어디서든 재사용. 텍스트 분해 위험 없음.
- **표시 위치**: 카드 우상단(% 옆) + 시트 행 좌측 그라데이션 + 씬번호 옆 칩
- **우클릭 메뉴 (`SceneContextMenu.tsx`)**: 카드/시트 공용. `createPortal`로 `document.body`에 렌더(motion.div transform이 만드는 stacking context 영향 회피)
- **색상 토큰**: `--color-length-up` (다크 #34D399 / 라이트 #059669), `--color-length-down` (다크 #FB7185 / 라이트 #DC2626) — 다크/라이트 모드 자동 대응
- **양쪽 동기화**: BG/ACT 둘 다 있으면 두 Scene UUID에 동일한 lengthChange 적용 (mergedKey 단위)

### 토스트 LD/SD 일괄 토글
- `handleBulkLengthChange(value)` 핸들러 (`ScenesView.tsx`): 선택된 모든 씬(BG+ACT)에 낙관적 적용 + `Promise.all` 병렬 IPC + 실패 시 롤백
- `isBulkInFlight` 가드로 다른 일괄 작업과 충돌 방지
- 토스트 UI: 일괄 스테이지 토글 옆에 \"길이\" 그룹(LD/SD/해제 + 툴팁)

### G드라이브 경로 버튼
- 기존 `PathLinkifiedText` + `PathBadge` 재사용 (메모/댓글/리비전과 동일한 컴포넌트)
- `renderTextSegment` prop으로 검색어 강조(`HighlightText`)도 함께 적용

### 시트 리사이즈 렉 fix (가설 적용)
- `motion.tr` → 일반 `tr`: 행 200~400개의 framer-motion 인스턴스 오버헤드 제거
- `is-resizing` 클래스 패턴: 리사이즈 중 transition 비활성화 (background/border/box-shadow의 누적 부하 회피)
- 결과: 일부 감소 확인. 한솔 환경에 따라 추가 최적화(가상 스크롤 등)는 후속 PR에서 검토

### 그룹 카드 디자인 개편
- 그룹 안 행의 좌우 보더 제거 + 모든 행에 옅은 액센트 배경(0.06)으로 한 덩어리 인식
- 그룹 위/아래 굵은 액센트 보더만 유지(분리감 강화) + 그룹 사이 gap 14→20px
- defensive reset: `.scene-group-header / .scene-row-group-mid / .scene-row-group-last`의 모든 td/th에 `border-left: 0`, `border-right: 0`, `outline: 0`, `box-shadow: none` 강제

### 데이터 무결성 fix (멀티 에이전트 리뷰 후 발견)
- **`App.tsx`**: scene-field-update broadcast 수신 시 `lengthChange` 값이 `''`일 때 `null`로 정규화. 이전엔 자기 앱은 낙관적 업데이트로 `null`이지만 broadcast 수신 측은 `''`가 박혀 store가 silent하게 오염됐음.
- **`UnifiedSceneCard.tsx` / `UnifiedSceneSheetView.tsx`**: BG/ACT 동시 저장을 `Promise.all` 병렬로. 이전엔 직렬 await에서 BG 성공 후 ACT 실패 시 DB(BG=LD) ↔ UI(롤백) 영구 불일치 발생 가능했음.
- **`ScenesView.tsx`**: `handleBulkLengthChange` 진입부에 `isBulkInFlight` 가드. 다른 일괄 작업 진행 중 LD/SD 누르면 race로 상태 뒤섞이던 문제 차단.

---

## 🚧 개발 난항

### 시트 메모 컬럼 너비 (1차)
- **문제**: 메모를 BG/ACT 두 컬럼으로 분리했더니 메모 셀이 무한 확장
- **원인**: `SheetEditableCell` 안의 `isMemo = field === 'memo'` 조건이 'memo' 정확 매칭이라 'bgMemo'/'actMemo'에서 max-w-0이 적용 안 됨
- **해결**: 조건을 `'bgMemo' || 'actMemo'`로 변경 + `max-w-0` → `max-w-[20rem]`로 (max-w-0은 컨텐츠 무시했지만 분리 후엔 적정 max-width 필요)
- **교훈**: 기존 인라인 편집 셀이 prop 기반 분기를 가질 때, 새 필드명 추가 시 모든 분기 셀렉터 검토 필수

### 카드 우클릭 메뉴가 안 떴던 문제
- **문제**: 카드 우클릭 시 메뉴가 화면에 안 보임. 시트는 정상.
- **원인**: 카드 root의 `motion.div`(framer-motion)가 transform을 사용하면서 stacking context를 형성. 그 자식의 `position: fixed`가 viewport 기준이 아니라 motion.div 기준으로 잡혀서 메뉴가 화면 밖에 그려짐.
- **해결**: 시트와 마찬가지로 `createPortal`로 `document.body`에 렌더링
- **교훈**: framer-motion 컴포넌트 자식에서 fixed positioning이 필요할 때는 항상 portal 사용

### 시트 그룹 분리감 (다회 시도)
- 1차: 그룹 안 행 사이 가로선 제거 → 부족
- 2차: 좌우 보더 제거 + 배경 통일 → 한솔 환경에서 여전히 보임
- 3차: outline/box-shadow까지 reset → 한솔 환경에서 그래도 보임
- **현재**: 디자인은 후속 작업으로 미룸 (한솔 명시). 빌드 검증으로 코드 차원 문제 없음 확인.

### `<->` `>-<` 텍스트 분해 위험
- **문제**: 좁은 셀에서 텍스트가 wrap되면 `<` `-` `>`가 따로 분리될 가능성
- **해결**: SVG 라인+화살촉으로 그려 atomic 단위 보장. `defs+use` 패턴으로 메모리 효율도 확보.

### 멀티 에이전트 리뷰
- self-review로 잡은 3개 critical/important 이슈 (broadcast '' 정규화 / Promise.all 병렬 / isBulkInFlight 가드) fix 후 클라우드 멀티 에이전트 리뷰(`/ultrareview`) 통과 — 추가 발견 0건.

---

## ✅ 테스트 가이드

### 사용자 테스트
> 아래 시나리오를 직접 실행해서 정상 동작을 확인해주세요.

1. **카드 뷰 BG/ACT 메모 동시 표시**
   - 통합(전체) 뷰에서 BG/ACT 둘 다 메모가 입력된 씬 카드를 봄
   - ✅ 카드에 두 줄로 메모 표시. 각 줄 앞에 작은 `BG` / `ACT` 라벨 칩
   - ❌ 한쪽만 보이거나 라벨이 안 보임

2. **시트 뷰 메모 컬럼 분리**
   - 시트 뷰로 전환
   - ✅ \"BG 메모\" / \"ACT 메모\" 컬럼이 각각 따로 있음
   - ✅ 메모가 길면 끝부분 `...` 표시 + 마우스 올리면 툴팁으로 전체 텍스트
   - ❌ 메모 컬럼이 화면 절반 이상 차지

3. **씬 길이 변경 라벨 (단일)**
   - 카드 또는 시트 행 아무거나 우클릭
   - ✅ \"씬 길이 변경\" 메뉴가 뜸 (LD / SD / 해제)
   - \"길이 늘어남(LD)\" 클릭 → ✅ 카드 우상단(또는 시트 씬번호 옆)에 초록 `<->` 아이콘 표시
   - \"표시 해제\" → ✅ 아이콘 사라짐
   - ❌ 메뉴 자체가 안 뜸

4. **토스트 LD/SD 일괄 토글**
   - 카드/씬 여러 개 선택 (Ctrl+클릭)
   - ✅ 하단 토스트에 \"길이\" 그룹의 LD/SD/해제 버튼이 보임
   - LD 클릭 → ✅ 선택된 모든 씬에 `<->` 표시

5. **G드라이브 경로 클릭**
   - 메모에 `G:\공유 드라이브\...` 같은 경로가 있는 씬
   - ✅ 그 경로가 메모 안에서 파란 폴더 아이콘 + 짧은 경로 텍스트의 작은 버튼으로 변환됨
   - 클릭 → ✅ 파일 탐색기에서 바로 그 경로 열림

6. **통합 뷰 1개 선택 카운트**
   - 통합 뷰에서 카드 1개 클릭
   - ✅ 토스트에 \"1개 선택\"
   - ❌ \"2개 선택\"

7. **Realtime 전파**
   - 두 사람이 같은 에피소드를 동시에 열고, 한쪽에서 LD 토글
   - ✅ 다른 쪽에서 ~100ms 안에 `<->` 아이콘 보임

### 개발자 테스트
\`\`\`bash
# 타입 체크
npx tsc --noEmit

# 빌드
npx vite build
\`\`\`

수동 확인 권장:
- LD/SD 토글 후 새로고침 → 유지되는지 (Supabase 영구 저장)
- 카드 + 시트 양쪽 모두 우클릭 메뉴 정상
- 시트 행 200+개에서 창 크기 조절 시 렉 정도 (이전 대비 감소 확인)
- BG/ACT 한쪽만 있는 씬도 토글 정상 작동

🤖 Generated with [Claude Code](https://claude.com/claude-code)