### PR TITLE
[v1.21.0] 자동 업데이트 시스템 — G드라이브 직접 실행 → 로컬 PC 본체 + 백그라운드 swap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 > **프로젝트**: Studio JBBJ 프로덕션 진행 현황 대시보드 (BG + 액팅)
 > **타입**: Electron + React + TypeScript 독립 앱
-> **현재 상태**: Phase 0-1~0-3 완료, Phase 1~2 완료, Phase 4-1~4-3 완료, Phase 6 Step 1~4 완료, Phase 7-1~7-5 완료, Phase 8-0~8-1, 8-3~8-5 완료, Phase 9 M-0~M-5 완료, M-6 준비 완료 (빌드/배포만 남음). v1.18.0 — 리비전 전면 재설계(알림 통합·댓글 통합·컴포지터 역할) 완료.
+> **현재 상태**: Phase 0-1~0-3 완료, Phase 1~2 완료, Phase 4-1~4-3 완료, Phase 6 Step 1~4 완료, Phase 7-1~7-5 완료, Phase 8-0~8-1, 8-3~8-5 완료, Phase 9 M-0~M-5 완료, M-6 준비 완료 (빌드/배포만 남음)
 > **로드맵**: `ROADMAP.md` 참조 | **세션 가이드**: `CONTEXT.md` 참조
 >
 > **이력**: 원래 BG(배경) 전용 현황판(`Bflow-BGonly`)으로 시작했으나, 액팅까지 포함한 통합 앱이 되면서 정식 명칭 **B flow**로 전환됨. 레포 이름(`Bflow-BGonly`)과 `app.name`은 기존 사용자 데이터 경로(`%APPDATA%\Bflow-BGonly\`) 호환을 위해 유지.
@@ -97,9 +97,11 @@ Electron + React 18 + TypeScript + Tailwind CSS + Zustand + react-grid-layout + 
 
 - **`CONTEXT.md`** — 세션 컨텍스트 가이드 (아키텍처, 파일 맵, 알려진 이슈, 스킬 활용법)
 - **`ROADMAP.md`** — 전체 개발 로드맵 (Phase 0~9, 기능별 상세 스펙)
+- **`DEVLOG/DEPLOYMENT.md`** — 배포 가이드 (배포 목적/경로/방식, 한솔 워크플로우, 자동 업데이트 시스템)
 - `tasks/lessons.md` — 과거 실수/패턴 기록 (세션 시작 시 검토)
 - `DEVLOG/supabase-migration-plan.md` — Supabase 마이그레이션 상세 계획서
 - `DEVLOG/supabase-init.sql` — Supabase DB 스키마 초기화 SQL
+- `DEVLOG/migrations/` — 라이브 DB 적용된 SQL 마이그레이션 기록
 - `BG_DASHBOARD_PLAN.md` — 초기 구현 계획서
 - Bflow 원본 (`/home/user/Bflow`) — 패턴 참고만 (읽기 전용, 수정 금지)
 

--- a/DEVLOG/DEPLOYMENT.md
+++ b/DEVLOG/DEPLOYMENT.md
@@ -1,0 +1,163 @@
+# B flow — 배포 가이드
+
+> 다른 Claude 세션 또는 신규 합류자가 이 프로젝트의 배포 구조를 빠르게 이해하기 위한 문서.
+> 마지막 갱신: 2026-05-01
+
+---
+
+## 1. 배포 목적
+
+Studio JBBJ 팀(~20명)이 *동일한 빌드*를 *항상 최신 상태로* 사용하게 하기 위해.
+
+- **자주 업데이트**: 한솔이 매일 여러 번 hotfix/기능 push 하는 워크플로우
+- **단일 진실 공급원(SSOT)**: 팀원 모두가 같은 버전을 쓰지 않으면 협업 데이터(Supabase)와 불일치
+- **수동 설치 비용 0**: 한솔이 매번 빌드 → 팀원 자동 반영 (각자 installer 돌리는 워크플로우는 거부)
+
+→ **G드라이브 공유 폴더**가 배포 채널의 핵심. 모든 팀원이 G드라이브 동기화를 사용 중이라 자연스러운 채널이 됨.
+
+---
+
+## 2. 배포 경로 (절대 경로)
+
+| 구분 | 경로 |
+|------|------|
+| **개발 (한솔 PC)** | `C:\Bflow-BGonly\` |
+| **빌드 결과물 (로컬)** | `C:\Bflow-BGonly\dist\` |
+| **배포 채널 (G드라이브)** | `G:\공유 드라이브\JBBJ 자료실\한솔이의 두근두근 실험실\Bflow-BGonly\dist\` |
+| **사용자 데이터 (팀원 PC)** | `%APPDATA%\Bflow-BGonly\` (`layout.json`, `preferences.json`, `notification-state.json` 등) |
+| **로컬 캐시 이미지 (팀원 PC)** | `%APPDATA%\Bflow-BGonly\images\` |
+
+> 한글 경로 주의: 배포 경로에 한글이 포함되어 있어 Node.js `path` 모듈을 반드시 사용. 경로 하드코딩 금지.
+
+---
+
+## 3. 빌드 산출물 구조
+
+`npm run build` (= `tsc + vite build + electron-builder`) 결과:
+
+```
+dist/
+├── BFLOW.exe              ← portable 단일 exe (157MB, 임시 폴더에 압축 풀어 실행)
+├── builder-debug.yml
+├── index.html             ← Vite renderer 진입점
+├── assets/                ← Vite 빌드 청크 (~30개 .js)
+├── splash/                ← 스플래시 HTML + opening_image_cropped.png
+└── win-unpacked/          ← 풀린 형태 (188MB)
+    ├── BFLOW.exe          ← ★ 팀원이 실제 실행하는 exe
+    ├── chrome_*.pak       ← electron 33의 chromium 리소스
+    ├── locales/           ← 다국어 리소스
+    ├── resources/app/     ← 앱 코드(dist + dist-electron) + node_modules
+    └── *.dll              ← electron 의존 dll들
+```
+
+**핵심**: `package.json` 의 `"asar": false` 설정으로 모든 파일이 풀린 상태. 이전에 모듈 누락 이슈로 명시적으로 끈 결정 (커밋 `08656e0`).
+
+---
+
+## 4. 배포 방식 (현재)
+
+### 한솔 워크플로우
+```bash
+npm run build                                                  # 빌드
+robocopy <local dist> <G드라이브 dist> /MIR /R:1 /W:1          # G드라이브 동기화
+# 또는 PowerShell wrapper로 자동 실행
+```
+
+`/MIR` = mirror. G드라이브에서 source에 없는 파일은 자동 삭제 (옛 빌드 잔재 정리). ExitCode 0~7 = 정상.
+
+### 팀원 워크플로우 (현재 = 변경 *예정*)
+
+1. 신규 팀원: G드라이브 `dist\win-unpacked\BFLOW.exe` 의 바로가기를 바탕화면에 복사 (한솔이 사전에 만들어 둔 .lnk 파일을 공유)
+2. 매 사용: 바탕화면 바로가기 더블클릭 → G드라이브의 BFLOW.exe 직접 실행
+3. 자동 업데이트: Google Drive 동기화가 알아서 새 빌드를 PC로 sync. 다음에 바로가기로 다시 켜면 새 버전.
+
+### 현재 방식의 한계 (2026-05-01 측정)
+
+| 측정 | 1차 실행 | 2차 실행 |
+|---|---|---|
+| G드라이브에서 직접 실행 | 17.3초 | 14.6초 (캐시 거의 없음) |
+| 로컬 디스크에서 실행 | 14.7초 | **1.6초** ⚡ |
+
+→ G드라이브 동기화가 BFLOW.exe 의 mtime 을 미세하게 갱신해 Windows Defender 캐시를 무력화. 결과적으로 매번 13초+ 의 cold start 비용을 치름. **로컬 실행으로 옮기면 재시작 1~2초로 단축됨**.
+
+---
+
+## 5. 새 배포 방식 — 자동 업데이트 시스템 (도입 예정, 2026-05-01~)
+
+자세한 디자인: `docs/superpowers/specs/2026-05-01-auto-update-design.md`
+
+### 컨셉
+- **G드라이브** = 한솔의 "배포 창고" (변경 0)
+- **팀원 PC 로컬 폴더** = 실행 환경 (새로 도입)
+- 앱이 *백그라운드로* G드라이브 폴더를 모니터링 → 새 버전 감지 → 로컬 임시 폴더로 복사 → 다음 재시작 시 swap
+
+### 한솔 워크플로우 (변경 0)
+```bash
+npm run build              # 빌드 시 manifest.json 자동 추가 생성
+robocopy ... dist ...      # G드라이브 동기화 (지금 그대로)
+```
+
+### 팀원 첫 설치 (한 번만)
+1. 기존 바로가기(G드라이브 가리키는 것) 또는 G드라이브의 BFLOW.exe 더블클릭
+2. 앱이 "처음 실행" 감지 → 자기를 `%LOCALAPPDATA%\Bflow-BGonly\app\` 에 복사 → 바탕화면에 새 바로가기 자동 생성 → 새 위치에서 재시작
+3. (옵션) Windows Defender 제외 등록 dialog 한 번 노출 → "허용" 클릭 시 새 빌드 받은 직후 첫 실행도 빠름
+
+### 팀원 일상 사용
+1. **바탕화면 새 바로가기** (자동 생성된 것, 로컬 본체 가리킴) 더블클릭 → 1~2초 시작
+2. 백그라운드: 앱이 PC의 G드라이브 폴더에서 manifest.json 읽기 → 자기 버전과 비교 → 새 버전이면 `%LOCALAPPDATA%\Bflow-BGonly\pending\` 에 다운로드
+3. 다음 종료 시 swap (`pending\` ↔ `app\`)
+4. 다음 실행 = 새 버전 (또 1~2초)
+
+### 옛 바로가기 (한솔이 사전에 만든 G드라이브 가리키는 .lnk)
+- 폐기. 누군가 다시 눌러도 self-installer 가 "이미 설치되어 있음" 감지 → 로컬 본체 자동 실행 + 안내. 사고 없음.
+
+---
+
+## 6. 버전 관리 규칙
+
+- `package.json` 의 `version` 필드가 SSOT (예: `1.15.13`)
+- **기능 추가 → minor** (1.15 → 1.16)
+- **버그 수정 → patch** (1.15.12 → 1.15.13)
+- 커밋 메시지 첫 줄: `[v<버전>] 한 줄 설명` 또는 `fix(v<버전>): ...`
+- PR 제목: `[v<버전>] 변경 요약`
+
+---
+
+## 7. Supabase 연결 (배포본 안)
+
+`electron/supabase.ts:64` 의 `SUPABASE_URL = 'https://mpqifkpxalwxgcrddchv.supabase.co'` + anon key가 빌드에 박힘. 모든 팀원이 같은 Supabase 프로젝트(`mpqifkpxalwxgcrddchv`)에 접속.
+
+DB 스키마 변경 시:
+- supabase MCP `apply_migration` 으로 라이브 DB 에 적용
+- 변경 내용은 `DEVLOG/migrations/YYYY-MM-DD_<name>.sql` 로 기록 (재현용)
+
+---
+
+## 8. 배포 시 주의사항
+
+1. **빌드 검증**: 변경 후 반드시 `tsc --noEmit` + `vite build` 통과 확인 (CLAUDE.md 규칙)
+2. **G드라이브 락**: 팀원이 BFLOW.exe 켜놓은 상태면 robocopy 가 일부 `.pak` 파일에서 락 에러. 다만 chromium 33 동일이라 src/dst 내용 같아 무시 가능.
+3. **node_modules in worktree**: git worktree 에는 node_modules 가 없음. `mklink /J node_modules C:\Bflow-BGonly\node_modules` (Windows junction) 으로 메인 디렉토리와 연결 후 빌드.
+4. **자동 머지/배포 금지** (메모리): PR 생성/G드라이브 robocopy/슬랙 게시는 한솔이 명시적으로 요청한 경우만.
+
+---
+
+## 9. 비상 시 롤백
+
+라이브 DB 안 건드린 단순 코드 롤백:
+1. G드라이브의 `dist.bak.YYYYMMDD_HHMMSS` 폴더 (자동 백업이 있다면) 의 내용을 `dist\` 로 복사
+2. 또는 git 에서 이전 태그/커밋 checkout → `npm run build` → 다시 robocopy
+
+DB 스키마 롤백:
+- `DEVLOG/migrations/` 의 SQL 을 역순으로 작성해 적용 (DROP FUNCTION, DROP COLUMN 등)
+- 사고 발생 시 supabase MCP `execute_sql` 로 즉시 응급 처리
+
+---
+
+## 10. 참조
+
+- [CLAUDE.md](../CLAUDE.md) — 프로젝트 전체 규칙
+- [ROADMAP.md](../ROADMAP.md) — 개발 로드맵
+- [supabase-init.sql](./supabase-init.sql) — DB 초기 스키마
+- [supabase-migration-plan.md](./supabase-migration-plan.md) — Supabase 마이그레이션 상세
+- `docs/superpowers/specs/2026-05-01-auto-update-design.md` — 자동 업데이트 시스템 디자인 (작성 예정)

--- a/docs/superpowers/plans/2026-05-07-auto-update-implementation.md
+++ b/docs/superpowers/plans/2026-05-07-auto-update-implementation.md
@@ -1,0 +1,1154 @@
+# Auto-Update System Implementation Plan (v1.21.0)
+
+> **For agentic workers:** Use superpowers:executing-plans (subagent-driven-development는 상태 공유가 많은 main.ts 통합 작업이라 단일 세션이 안전). Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** B flow를 G드라이브 직접 실행에서 → 로컬 PC 실행으로 옮긴다. 매 실행 13초+(Defender 캐시 무력) → **재실행 1~2초**. 새 빌드는 G드라이브에서 백그라운드로 받아 종료 시 swap.
+
+**Architecture:** 빌드 산출물에 `manifest.json` 추가 → 로컬 본체가 G드라이브 manifest를 모니터링 → 새 버전이면 `pending/`으로 복사 → 종료 시 `app/` ↔ `pending/` swap. 첫 실행은 portable BFLOW.exe가 self-installer로 동작해 `%LOCALAPPDATA%\Bflow-BGonly\app\`에 자기 자신을 복사.
+
+**Tech Stack:** Electron 33 + Node fs/path/child_process. 새 의존성 0 (네이티브 모듈만 사용). 자동 테스트 인프라 X — 우리 프로젝트 표준대로 `tsc --noEmit` + `vite build` + 수동 시나리오 검증.
+
+**Spec reference:** [`docs/superpowers/specs/2026-05-01-auto-update-design.md`](../specs/2026-05-01-auto-update-design.md)
+
+**Pre-existing changes in this worktree (이 plan 시작 전 이미 적용된 변경 — 별도 chunk 아님)**
+- `electron/main.ts`: splash를 gotTheLock 직후로 앞당기고 `cleanupImageCache`를 메인 창 로드 후 5초 백그라운드로 미룸 (gifted-darwin-99908d 964241d 포트)
+- `src/components/widgets/OverallProgressWidget.tsx`: RANDOM_MESSAGES 명언 2개 제거
+- `CLAUDE.md`: 참조 섹션에 DEPLOYMENT.md 추가
+- `DEVLOG/DEPLOYMENT.md`: 배포 가이드 신규
+- `docs/superpowers/specs/2026-05-01-auto-update-design.md`: 자동 업데이트 시스템 디자인
+
+이 plan은 그 위에 자동 업데이트 시스템을 더해서 **하나의 PR로** 머지한다.
+
+---
+
+## File Structure
+
+### 신규 파일
+
+| 파일 | 책임 |
+|---|---|
+| `electron/autoUpdate/paths.ts` | 모든 경로 상수 + G드라이브 폴더 추정. **순수 함수만** — 다른 모듈이 import해 사용. |
+| `electron/autoUpdate/manifest.ts` | manifest.json 읽기/쓰기 헬퍼 + 버전 비교. 단일 책임. |
+| `electron/autoUpdate/installer.ts` | 첫 실행 감지(`process.execPath`가 G드라이브) + self-installer dialog + `app/`로 복사 + 바로가기 + Defender 등록. |
+| `electron/autoUpdate/checker.ts` | 메인 창 로드 후 백그라운드: G드라이브 manifest 읽기 → 자기 버전과 비교 → `pending/`으로 변경분 복사 + `.ready` 마커. |
+| `electron/autoUpdate/swapper.ts` | `before-quit` hook: `pending/.ready`가 있으면 `app/` → `backup/`, `pending/` → `app/` 으로 swap. |
+| `electron/autoUpdate/index.ts` | 위 모듈을 묶는 단일 진입점 (`runFirstInstallIfNeeded`, `scheduleUpdateCheck`, `swapIfPending`). main.ts는 이 한 파일만 import. |
+| `scripts/generate-manifest.js` | `npm run build` 마지막 단계. `dist/manifest.json` = `{ version, buildAt }` 작성. |
+
+### 변경 파일
+
+| 파일 | 변경 |
+|---|---|
+| `package.json` | `scripts.build` 끝에 `&& node scripts/generate-manifest.js` 추가. 의존성 변경 0. |
+| `electron/main.ts` | `app.whenReady()` 시작에 `runFirstInstallIfNeeded` → 이미 설치돼있고 자기가 G드라이브에서 실행됐으면 즉시 종료(로컬 BFLOW를 spawn). 이후 `did-finish-load`에서 5초 후 `scheduleUpdateCheck`. `app.on('before-quit')`에서 `swapIfPending`. |
+| `electron/preload.ts` | (변경 없음 — autoUpdate는 메인 프로세스 전용) |
+
+---
+
+## Chunk 1: 경로/매니페스트 기반 (paths.ts + manifest.ts + manifest 생성기)
+
+이 chunk는 **순수 데이터** 계층. 다른 chunk가 import만 함. 사이드 이펙트 없음.
+
+### Task 1.1: `electron/autoUpdate/paths.ts`
+
+**Files:**
+- Create: `electron/autoUpdate/paths.ts`
+
+- [ ] **Step 1: 파일 작성** — 전체 코드:
+
+```ts
+/**
+ * v1.21.0 자동 업데이트 — 모든 경로 상수 + G드라이브 폴더 추정.
+ * 순수 함수만. fs 사이드 이펙트 X (existsSync 같은 lookup만).
+ */
+import { app } from 'electron';
+import { existsSync, statSync } from 'fs';
+import path from 'path';
+
+/** 로컬 본체 루트 — `%LOCALAPPDATA%\Bflow-BGonly\` */
+export function localRoot(): string {
+  // app.getPath('userData') = %APPDATA%\Bflow-BGonly (Roaming) — 사용자 데이터용
+  // 우리는 LocalAppData를 별도로 — sync 안 됨 + Roaming보다 디스크 빠름
+  const localAppData = process.env.LOCALAPPDATA
+    || path.join(process.env.USERPROFILE || '', 'AppData', 'Local');
+  return path.join(localAppData, 'Bflow-BGonly');
+}
+
+export const APP_DIR_NAME = 'app';
+export const PENDING_DIR_NAME = 'pending';
+export const BACKUP_DIR_NAME = 'backup';
+export const READY_MARKER = '.ready';
+
+export function localAppDir(): string { return path.join(localRoot(), APP_DIR_NAME); }
+export function localPendingDir(): string { return path.join(localRoot(), PENDING_DIR_NAME); }
+export function localBackupDir(): string { return path.join(localRoot(), BACKUP_DIR_NAME); }
+export function localReadyMarker(): string { return path.join(localPendingDir(), READY_MARKER); }
+
+/** `app/BFLOW.exe` */
+export function localBflowExe(): string {
+  return path.join(localAppDir(), 'BFLOW.exe');
+}
+
+/**
+ * 현재 실행 파일이 G드라이브 경로 하위에 있는지 추정.
+ * 한글 경로 안전성 — path 모듈만 사용 (정규식 직접 비교 X).
+ */
+export function isRunningFromGoogleDrive(): boolean {
+  const exe = process.execPath;
+  const candidates = guessGoogleDriveRoots();
+  for (const root of candidates) {
+    if (exe.toLowerCase().startsWith(root.toLowerCase())) return true;
+  }
+  return false;
+}
+
+/**
+ * G드라이브 desktop 동기화 루트 후보. Drive desktop 의 standard mount letter 후보들 +
+ * 사용자 홈의 'Google Drive' 폴더(레거시). 존재하지 않는 후보는 자동 skip.
+ */
+export function guessGoogleDriveRoots(): string[] {
+  const candidates: string[] = [];
+  // Drive desktop의 가상 마운트 (보통 G:, 일부 사용자는 H: 또는 다른 letter)
+  for (const letter of ['G', 'H', 'I', 'J']) {
+    candidates.push(`${letter}:\\`);
+  }
+  // 레거시 데스크톱 sync 폴더 (~\Google Drive)
+  if (process.env.USERPROFILE) {
+    candidates.push(path.join(process.env.USERPROFILE, 'Google Drive'));
+    candidates.push(path.join(process.env.USERPROFILE, 'GoogleDrive'));
+  }
+  return candidates.filter((c) => {
+    try { return existsSync(c) && statSync(c).isDirectory(); } catch { return false; }
+  });
+}
+
+/**
+ * 우리 dist 가 들어있는 G드라이브 경로 추정. 후보를 스캔해 manifest.json + BFLOW.exe 가
+ * 같이 있는 폴더를 찾아 그 폴더 경로 반환. 없으면 null.
+ */
+export function findRemoteDistRoot(): string | null {
+  const drives = guessGoogleDriveRoots();
+  // Studio JBBJ 표준 경로 (DEVLOG/DEPLOYMENT.md §2)
+  const SUFFIX = path.join('공유 드라이브', 'JBBJ 자료실', '한솔이의 두근두근 실험실', 'Bflow-BGonly', 'dist');
+  for (const drive of drives) {
+    const candidate = path.join(drive, SUFFIX);
+    if (existsSync(path.join(candidate, 'manifest.json')) && existsSync(path.join(candidate, 'win-unpacked', 'BFLOW.exe'))) {
+      return candidate;
+    }
+  }
+  // Drive desktop 마운트가 다르면 사용자 홈/GoogleDrive 안에서도 한 번 scan
+  for (const drive of drives) {
+    if (drive.endsWith(':\\')) continue;
+    // 단순 추정 — 깊은 scan은 비용 ↑, 표준 suffix만 시도
+    const candidate = path.join(drive, SUFFIX);
+    if (existsSync(path.join(candidate, 'manifest.json'))) return candidate;
+  }
+  return null;
+}
+
+/** G드라이브 dist의 win-unpacked 경로 (없으면 null) */
+export function findRemoteWinUnpacked(): string | null {
+  const root = findRemoteDistRoot();
+  return root ? path.join(root, 'win-unpacked') : null;
+}
+
+/** G드라이브 manifest.json 경로 (없으면 null) */
+export function findRemoteManifest(): string | null {
+  const root = findRemoteDistRoot();
+  if (!root) return null;
+  const m = path.join(root, 'manifest.json');
+  return existsSync(m) ? m : null;
+}
+
+/** 현재 실행 중인 BFLOW의 self version (package.json) */
+export function getOwnVersion(): string {
+  return app.getVersion();
+}
+```
+
+- [ ] **Step 2: tsc 타입 체크**
+
+```bash
+npx tsc --noEmit
+```
+Expected: PASS (새 파일이라 import 없음 — 단순 통과).
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add electron/autoUpdate/paths.ts
+git commit -m "feat(autoUpdate): 경로 추정 + 로컬/원격 경로 상수 (paths.ts)"
+```
+
+---
+
+### Task 1.2: `electron/autoUpdate/manifest.ts`
+
+**Files:**
+- Create: `electron/autoUpdate/manifest.ts`
+
+- [ ] **Step 1: 파일 작성**
+
+```ts
+/**
+ * manifest.json 읽기/쓰기 + 버전 비교.
+ * spec §3 빌드 산출물 형식: { version: "1.21.0", buildAt: "2026-05-07T...Z" }
+ */
+import { promises as fsp } from 'fs';
+
+export interface Manifest {
+  version: string;       // semver string
+  buildAt: string;       // ISO 8601
+}
+
+/** 안전 read — 파일 없으면 null. JSON 깨졌으면 null + console.warn. */
+export async function readManifest(filePath: string): Promise<Manifest | null> {
+  try {
+    const text = await fsp.readFile(filePath, 'utf-8');
+    const parsed = JSON.parse(text);
+    if (typeof parsed?.version !== 'string') return null;
+    return { version: parsed.version, buildAt: typeof parsed.buildAt === 'string' ? parsed.buildAt : '' };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    console.warn('[autoUpdate] manifest 읽기 실패:', filePath, err);
+    return null;
+  }
+}
+
+/**
+ * semver 문자열 비교. major.minor.patch만 — pre-release 태그 무시.
+ * a > b면 1, a == b면 0, a < b면 -1.
+ */
+export function compareVersions(a: string, b: string): number {
+  const pa = a.split('.').map((n) => parseInt(n, 10) || 0);
+  const pb = b.split('.').map((n) => parseInt(n, 10) || 0);
+  for (let i = 0; i < 3; i++) {
+    const da = pa[i] ?? 0;
+    const db = pb[i] ?? 0;
+    if (da > db) return 1;
+    if (da < db) return -1;
+  }
+  return 0;
+}
+```
+
+- [ ] **Step 2: tsc 타입 체크 + 커밋**
+
+```bash
+npx tsc --noEmit
+git add electron/autoUpdate/manifest.ts
+git commit -m "feat(autoUpdate): manifest 읽기 + 버전 비교 (manifest.ts)"
+```
+
+---
+
+### Task 1.3: `scripts/generate-manifest.js`
+
+**Files:**
+- Create: `scripts/generate-manifest.js`
+
+- [ ] **Step 1: 파일 작성**
+
+```js
+#!/usr/bin/env node
+/**
+ * v1.21.0 자동 업데이트 — 빌드 후 dist/manifest.json 생성.
+ * `npm run build` 마지막 step. 한솔 손 거치지 않음.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf-8'));
+
+const distDir = path.join(root, 'dist');
+if (!fs.existsSync(distDir)) {
+  console.error('[generate-manifest] dist/ 가 없음. vite build 먼저 실행하세요.');
+  process.exit(1);
+}
+
+const manifest = {
+  version: pkg.version,
+  buildAt: new Date().toISOString(),
+};
+
+const out = path.join(distDir, 'manifest.json');
+fs.writeFileSync(out, JSON.stringify(manifest, null, 2) + '\n');
+console.log(`[generate-manifest] ${out} 생성 — v${manifest.version} @ ${manifest.buildAt}`);
+```
+
+- [ ] **Step 2: 실행 권한 (Windows는 무관, Linux/Mac CI 호환)**
+
+스크립트 자체는 node로 실행되므로 chmod 불필요. node 명령어로 호출.
+
+- [ ] **Step 3: package.json build script 수정**
+
+`package.json`의 `"scripts"` 안:
+
+```diff
+-    "build": "tsc && vite build && electron-builder",
+-    "build:vite": "tsc && vite build",
++    "build": "tsc && vite build && electron-builder && node scripts/generate-manifest.js",
++    "build:vite": "tsc && vite build && node scripts/generate-manifest.js",
+```
+
+`build:vite`는 자동 업데이트 코드 검증용 — vite + manifest까지만 (electron-builder 생략).
+
+- [ ] **Step 4: 빌드 검증**
+
+```bash
+npm run build:vite
+ls dist/manifest.json
+```
+Expected: `dist/manifest.json` 생성됨. 내용에 `"version": "1.20.0"` (현재 버전, bump 전).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add scripts/generate-manifest.js package.json
+git commit -m "feat(autoUpdate): 빌드 후 manifest.json 자동 생성"
+```
+
+---
+
+## Chunk 2: Self-Installer (첫 실행 진입점)
+
+### Task 2.1: `electron/autoUpdate/installer.ts`
+
+**Files:**
+- Create: `electron/autoUpdate/installer.ts`
+
+- [ ] **Step 1: 파일 작성**
+
+```ts
+/**
+ * v1.21.0 self-installer — 첫 실행 시 G드라이브 BFLOW.exe가 자기 자신을
+ * `%LOCALAPPDATA%\Bflow-BGonly\app\` 로 복사하고 바로가기 생성 + Defender 옵션.
+ *
+ * spec §4.3, §4.4 참조.
+ */
+import { app, dialog, shell, BrowserWindow } from 'electron';
+import { promises as fsp, existsSync } from 'fs';
+import path from 'path';
+import { spawn } from 'child_process';
+import {
+  isRunningFromGoogleDrive,
+  findRemoteWinUnpacked,
+  localRoot,
+  localAppDir,
+  localBflowExe,
+} from './paths';
+import { copyDirMirror } from './copy';
+
+export interface InstallResult {
+  /** 호출자가 자기 종료해야 하는지 (self-installer가 새 위치에서 spawn 했음) */
+  exited: boolean;
+}
+
+/**
+ * main.ts의 app.whenReady 진입 직후 한 번 호출.
+ * - G드라이브에서 실행됐고 로컬 본체 없으면 → 첫 설치 (dialog → 복사 → spawn).
+ * - G드라이브에서 실행됐고 로컬 본체 있으면 → 토스트 안내 + 로컬 spawn (옛 바로가기 폴백).
+ * - 로컬에서 실행됐으면 → 그냥 정상 진행 (return { exited: false }).
+ */
+export async function runFirstInstallIfNeeded(): Promise<InstallResult> {
+  // 로컬에서 실행 중이면 자동 업데이트 흐름 — 여긴 통과
+  if (!isRunningFromGoogleDrive()) {
+    return { exited: false };
+  }
+
+  const localExe = localBflowExe();
+  const alreadyInstalled = existsSync(localExe);
+
+  if (alreadyInstalled) {
+    // 옛 바로가기 폴백 — 로컬 본체로 spawn하고 자기는 종료
+    spawnDetached(localExe);
+    app.exit(0);
+    return { exited: true };
+  }
+
+  // 첫 설치 dialog
+  const win = BrowserWindow.getFocusedWindow() ?? undefined;
+  const choice = await dialog.showMessageBox(win!, {
+    type: 'info',
+    title: 'B flow 첫 실행',
+    message: 'B flow 를 PC에 설치합니다 (한 번만, ~5초)',
+    detail:
+      '실행 속도를 위해 B flow 본체를 사용자 PC 폴더로 복사합니다.\n'
+      + '설치 후 자동으로 새 위치에서 실행됩니다. 다음부터는 바탕화면 바로가기를 사용해주세요.',
+    buttons: ['설치', '취소'],
+    defaultId: 0,
+    cancelId: 1,
+  });
+  if (choice.response !== 0) {
+    app.exit(0);
+    return { exited: true };
+  }
+
+  try {
+    await install();
+  } catch (err) {
+    console.error('[installer] 설치 실패:', err);
+    await dialog.showMessageBox(win!, {
+      type: 'error',
+      title: 'B flow 설치 실패',
+      message: '설치 중 오류가 발생했습니다',
+      detail: String((err as Error).message ?? err),
+      buttons: ['확인'],
+    });
+    app.exit(1);
+    return { exited: true };
+  }
+
+  // Defender 제외 등록 (옵션, UAC 동의)
+  await offerDefenderExclusion(win);
+
+  // 새 위치에서 spawn + 자기 종료
+  spawnDetached(localExe);
+  app.exit(0);
+  return { exited: true };
+}
+
+async function install(): Promise<void> {
+  const remote = findRemoteWinUnpacked();
+  if (!remote) {
+    throw new Error('G드라이브 폴더에서 B flow 빌드를 찾을 수 없습니다. Drive desktop이 켜져있는지 확인해주세요.');
+  }
+  await fsp.mkdir(localRoot(), { recursive: true });
+  await fsp.mkdir(localAppDir(), { recursive: true });
+  await copyDirMirror(remote, localAppDir());
+  await createDesktopShortcut();
+  await createStartMenuShortcut();
+}
+
+async function createDesktopShortcut(): Promise<void> {
+  const desktop = path.join(process.env.USERPROFILE || '', 'Desktop');
+  if (!existsSync(desktop)) return;
+  await createShortcut(path.join(desktop, 'B flow.lnk'));
+}
+
+async function createStartMenuShortcut(): Promise<void> {
+  const startMenu = path.join(
+    process.env.APPDATA || '',
+    'Microsoft', 'Windows', 'Start Menu', 'Programs',
+  );
+  if (!existsSync(startMenu)) return;
+  await createShortcut(path.join(startMenu, 'B flow.lnk'));
+}
+
+/**
+ * Electron의 shell.writeShortcutLink는 Windows에서만 작동. asar 안 쓰니
+ * iconPath/iconIndex로 BFLOW.exe 자체 아이콘 사용.
+ */
+async function createShortcut(lnkPath: string): Promise<void> {
+  const exe = localBflowExe();
+  const ok = shell.writeShortcutLink(lnkPath, 'create', {
+    target: exe,
+    icon: exe,
+    iconIndex: 0,
+    description: 'B flow — Studio JBBJ 워크플로우 대시보드',
+  });
+  if (!ok) console.warn('[installer] 바로가기 생성 실패:', lnkPath);
+}
+
+async function offerDefenderExclusion(parent: BrowserWindow | undefined): Promise<void> {
+  const choice = await dialog.showMessageBox(parent!, {
+    type: 'question',
+    title: 'B flow — 빠른 시작 옵션',
+    message: 'Windows 보안에 검사 제외 등록 (선택)',
+    detail:
+      'B flow 폴더를 Windows Defender 검사 제외로 등록하면 새 빌드를 받은 직후 첫 실행도 빠릅니다.\n'
+      + '(허용 시 관리자 권한 한 번 요청)\n'
+      + '\n'
+      + '제외 폴더: ' + localRoot(),
+    buttons: ['허용', '나중에'],
+    defaultId: 0,
+    cancelId: 1,
+  });
+  if (choice.response !== 0) return;
+  // PowerShell Add-MpPreference (UAC 자동) — 실패 시 그냥 진행
+  const ps = `Start-Process powershell -Verb RunAs -ArgumentList '-NoProfile','-Command','Add-MpPreference -ExclusionPath ''${localAppDir()}''; Add-MpPreference -ExclusionPath ''${path.join(localRoot(), 'pending')}'''`;
+  try {
+    spawn('powershell.exe', ['-NoProfile', '-Command', ps], { detached: true, stdio: 'ignore' }).unref();
+  } catch (err) {
+    console.warn('[installer] Defender 제외 등록 실패:', err);
+  }
+}
+
+function spawnDetached(exe: string): void {
+  spawn(exe, [], { detached: true, stdio: 'ignore' }).unref();
+}
+```
+
+- [ ] **Step 2: 의존: `copy.ts` 작성** (다음 task에서 만듦) — 일단 import만 두고 다음 step.
+
+- [ ] **Step 3: 커밋** — copy.ts 만든 후 같이.
+
+---
+
+### Task 2.2: `electron/autoUpdate/copy.ts` (디렉토리 mirror 헬퍼)
+
+**Files:**
+- Create: `electron/autoUpdate/copy.ts`
+
+- [ ] **Step 1: 파일 작성**
+
+```ts
+/**
+ * 디렉토리 mirror — robocopy 패턴(변경된 파일만 복사 + 사라진 파일 제거).
+ * Node fs API로 직접 구현 — 외부 robocopy.exe 의존성 X (CI/Mac 호환).
+ *
+ * 1억 byte 미만 — 우리 win-unpacked는 ~188MB이라 충분히 메모리/시간 OK.
+ */
+import { promises as fsp, existsSync, statSync } from 'fs';
+import path from 'path';
+
+/**
+ * src의 모든 파일을 dst로 복사. dst에만 있는 파일은 제거 (mirror).
+ * 같은 size + mtime이면 skip (빠른 변경분-only 복사).
+ *
+ * 진행률 콜백: 옵션. 없으면 조용히 복사.
+ */
+export async function copyDirMirror(
+  src: string,
+  dst: string,
+  onProgress?: (relPath: string, copied: number, total: number) => void,
+): Promise<void> {
+  if (!existsSync(src)) throw new Error(`source 없음: ${src}`);
+  await fsp.mkdir(dst, { recursive: true });
+
+  const allFiles = await collectFiles(src);
+  let copied = 0;
+  for (const rel of allFiles) {
+    const srcFile = path.join(src, rel);
+    const dstFile = path.join(dst, rel);
+    await fsp.mkdir(path.dirname(dstFile), { recursive: true });
+
+    if (existsSync(dstFile)) {
+      const ss = statSync(srcFile);
+      const ds = statSync(dstFile);
+      if (ss.size === ds.size && Math.abs(ss.mtimeMs - ds.mtimeMs) < 2000) {
+        copied++;
+        onProgress?.(rel, copied, allFiles.length);
+        continue;
+      }
+    }
+    await fsp.copyFile(srcFile, dstFile);
+    copied++;
+    onProgress?.(rel, copied, allFiles.length);
+  }
+
+  // dst 청소: src에 없는 파일 제거 (mirror)
+  await pruneOrphans(src, dst);
+}
+
+async function collectFiles(root: string, prefix = ''): Promise<string[]> {
+  const entries = await fsp.readdir(path.join(root, prefix), { withFileTypes: true });
+  const out: string[] = [];
+  for (const e of entries) {
+    const rel = path.join(prefix, e.name);
+    if (e.isDirectory()) {
+      out.push(...await collectFiles(root, rel));
+    } else {
+      out.push(rel);
+    }
+  }
+  return out;
+}
+
+async function pruneOrphans(src: string, dst: string, prefix = ''): Promise<void> {
+  const dstHere = path.join(dst, prefix);
+  if (!existsSync(dstHere)) return;
+  const entries = await fsp.readdir(dstHere, { withFileTypes: true });
+  for (const e of entries) {
+    const rel = path.join(prefix, e.name);
+    const srcCounterpart = path.join(src, rel);
+    if (e.isDirectory()) {
+      if (!existsSync(srcCounterpart)) {
+        await fsp.rm(path.join(dstHere, e.name), { recursive: true, force: true });
+      } else {
+        await pruneOrphans(src, dst, rel);
+      }
+    } else {
+      if (!existsSync(srcCounterpart)) {
+        await fsp.unlink(path.join(dstHere, e.name)).catch(() => { /* 락 무시 */ });
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 2: tsc 타입 체크 + 커밋 (installer + copy 같이)**
+
+```bash
+npx tsc --noEmit
+git add electron/autoUpdate/installer.ts electron/autoUpdate/copy.ts
+git commit -m "feat(autoUpdate): self-installer + mirror copy 헬퍼"
+```
+
+---
+
+## Chunk 3: 백그라운드 체크 + 다운로드
+
+### Task 3.1: `electron/autoUpdate/checker.ts`
+
+**Files:**
+- Create: `electron/autoUpdate/checker.ts`
+
+- [ ] **Step 1: 파일 작성**
+
+```ts
+/**
+ * v1.21.0 자동 업데이트 — 메인 창 로드 후 5초 뒤 한 번 호출.
+ * G드라이브 manifest와 자기 버전 비교 → 새 버전이면 pending/으로 변경분 복사
+ * + .ready 마커 생성. swap은 swapper.ts가 종료 시 처리.
+ */
+import { promises as fsp, existsSync } from 'fs';
+import {
+  findRemoteWinUnpacked,
+  findRemoteManifest,
+  localPendingDir,
+  localReadyMarker,
+  getOwnVersion,
+} from './paths';
+import { readManifest, compareVersions } from './manifest';
+import { copyDirMirror } from './copy';
+
+/**
+ * 백그라운드 체크 — 한 번만 실행. 실패는 console.warn만 (사용자 알림 X).
+ * spec §4.2 일상 사용 시나리오.
+ */
+export async function scheduleUpdateCheck(): Promise<void> {
+  try {
+    const remoteManifestPath = findRemoteManifest();
+    if (!remoteManifestPath) {
+      console.log('[autoUpdate] G드라이브 manifest 없음 — skip');
+      return;
+    }
+    const remote = await readManifest(remoteManifestPath);
+    if (!remote) {
+      console.log('[autoUpdate] G드라이브 manifest 읽기 실패 — skip');
+      return;
+    }
+    const own = getOwnVersion();
+    const cmp = compareVersions(remote.version, own);
+    if (cmp <= 0) {
+      console.log(`[autoUpdate] 최신 (own=${own}, remote=${remote.version})`);
+      return;
+    }
+    console.log(`[autoUpdate] 새 버전 감지: ${own} → ${remote.version}. 백그라운드 다운로드 시작.`);
+    await downloadToPending();
+    console.log(`[autoUpdate] 다운로드 완료. 다음 종료 시 swap.`);
+  } catch (err) {
+    console.warn('[autoUpdate] 체크 실패:', err);
+  }
+}
+
+async function downloadToPending(): Promise<void> {
+  const remoteWinUnpacked = findRemoteWinUnpacked();
+  if (!remoteWinUnpacked) throw new Error('원격 win-unpacked 없음');
+
+  // pending이 .ready 상태(이전 다운로드 완료)인 경우는 그대로 둠 — swap만 기다림
+  const ready = localReadyMarker();
+  if (existsSync(ready)) {
+    console.log('[autoUpdate] pending이 이미 ready 상태 — 추가 다운로드 skip');
+    return;
+  }
+
+  const pending = localPendingDir();
+  await fsp.mkdir(pending, { recursive: true });
+
+  // mirror 복사 (변경된 파일만)
+  await copyDirMirror(remoteWinUnpacked, pending);
+
+  // .ready 마커 — swapper가 이걸 보고 swap 실행
+  await fsp.writeFile(ready, new Date().toISOString(), 'utf-8');
+}
+```
+
+- [ ] **Step 2: tsc + 커밋**
+
+```bash
+npx tsc --noEmit
+git add electron/autoUpdate/checker.ts
+git commit -m "feat(autoUpdate): 백그라운드 체크 + pending 다운로드"
+```
+
+---
+
+## Chunk 4: 종료 시 swap
+
+### Task 4.1: `electron/autoUpdate/swapper.ts`
+
+**Files:**
+- Create: `electron/autoUpdate/swapper.ts`
+
+- [ ] **Step 1: 파일 작성**
+
+```ts
+/**
+ * v1.21.0 자동 업데이트 — before-quit hook에서 호출.
+ * pending/.ready 가 있으면 app/ → backup/ , pending/ → app/ 으로 swap.
+ *
+ * 락 안전성: app/은 현재 실행 중 BFLOW.exe라 락 걸려있으나, 우리는 종료 시점에
+ * 호출. before-quit → app.exit 사이에 한순간 더 락이 풀리는 시점이 필요.
+ * → before-quit에서 event.preventDefault → 약간 지연 후 swap → app.exit.
+ *
+ * spec §4.2 step 6, §6 swap 실패 처리.
+ */
+import { promises as fsp, existsSync, renameSync } from 'fs';
+import path from 'path';
+import {
+  localAppDir, localPendingDir, localBackupDir, localReadyMarker,
+} from './paths';
+
+export async function hasPending(): Promise<boolean> {
+  return existsSync(localReadyMarker());
+}
+
+/**
+ * 동기로 진행 — before-quit hook 안에서 호출되니 짧고 결정론적이어야 함.
+ * 실패 시 throw — 호출자가 catch.
+ */
+export async function swapIfPending(): Promise<{ ok: boolean; reason?: string }> {
+  const ready = localReadyMarker();
+  if (!existsSync(ready)) return { ok: false, reason: 'no-pending' };
+
+  const app_ = localAppDir();
+  const pending_ = localPendingDir();
+  const backup_ = localBackupDir();
+
+  // 이전 backup 정리 (이전 buggy 버전 보관 — 1개만 유지하니 통째로 지움)
+  try {
+    if (existsSync(backup_)) {
+      await fsp.rm(backup_, { recursive: true, force: true });
+    }
+  } catch (err) {
+    console.warn('[swapper] backup 정리 실패 (무시):', err);
+  }
+
+  // app/ → backup/
+  try {
+    if (existsSync(app_)) {
+      renameSync(app_, backup_);
+    }
+  } catch (err) {
+    return { ok: false, reason: `app→backup rename 실패: ${(err as Error).message}` };
+  }
+
+  // pending/ → app/
+  try {
+    renameSync(pending_, app_);
+  } catch (err) {
+    // 복구 시도: backup → app으로 되돌림
+    try { renameSync(backup_, app_); } catch { /* 더 이상 할 게 없음 */ }
+    return { ok: false, reason: `pending→app rename 실패: ${(err as Error).message}` };
+  }
+
+  // .ready 마커는 pending 안에 있어 자동으로 app/.ready가 됨 — 정리
+  try {
+    const stale = path.join(app_, '.ready');
+    if (existsSync(stale)) await fsp.unlink(stale);
+  } catch { /* 무시 */ }
+
+  return { ok: true };
+}
+```
+
+- [ ] **Step 2: tsc + 커밋**
+
+```bash
+npx tsc --noEmit
+git add electron/autoUpdate/swapper.ts
+git commit -m "feat(autoUpdate): 종료 시 pending → app swap (rollback 안전)"
+```
+
+---
+
+## Chunk 5: 통합 모듈 + main.ts 연결
+
+### Task 5.1: `electron/autoUpdate/index.ts` (단일 진입점)
+
+**Files:**
+- Create: `electron/autoUpdate/index.ts`
+
+- [ ] **Step 1: 파일 작성**
+
+```ts
+/**
+ * v1.21.0 자동 업데이트 — main.ts가 import하는 단일 진입점.
+ * 다른 모듈은 main.ts가 직접 import하지 않음.
+ */
+export { runFirstInstallIfNeeded } from './installer';
+export type { InstallResult } from './installer';
+export { scheduleUpdateCheck } from './checker';
+export { swapIfPending, hasPending } from './swapper';
+```
+
+- [ ] **Step 2: tsc + 커밋**
+
+```bash
+npx tsc --noEmit
+git add electron/autoUpdate/index.ts
+git commit -m "feat(autoUpdate): 단일 진입점 index.ts"
+```
+
+---
+
+### Task 5.2: `electron/main.ts` 통합
+
+**Files:**
+- Modify: `electron/main.ts`
+
+- [ ] **Step 1: import 추가** — 기존 import 블록 끝에:
+
+```ts
+import {
+  runFirstInstallIfNeeded,
+  scheduleUpdateCheck,
+  hasPending,
+  swapIfPending,
+} from './autoUpdate';
+```
+
+- [ ] **Step 2: app.whenReady 진입 직후에 self-installer 진입점 추가**
+
+기존 코드 (Pre-existing perf 변경된 상태):
+```ts
+app.whenReady().then(async () => {
+  // 두 번째 인스턴스면 초기화하지 않고 종료
+  if (!gotTheLock) return;
+
+  // ★ v1.20.x perf: 스플래시를 가장 먼저 띄움
+  createSplashWindow();
+  console.time('splash-to-main');
+
+  // 메인 창 bounds 미리 로드 …
+  await preloadMainWindowBounds();
+```
+
+수정 — `gotTheLock` 체크 직후 + splash 호출 *전*에 self-installer:
+
+```ts
+app.whenReady().then(async () => {
+  // 두 번째 인스턴스면 초기화하지 않고 종료
+  if (!gotTheLock) return;
+
+  // v1.21.0 자동 업데이트: G드라이브 BFLOW.exe로 첫 실행이면 로컬에 설치 후 새 위치에서 spawn.
+  // 이미 로컬에서 실행 중이면 즉시 통과.
+  const installResult = await runFirstInstallIfNeeded();
+  if (installResult.exited) return; // 자기 종료 — 새 위치 BFLOW가 마운트됨
+
+  // ★ v1.20.x perf: 스플래시를 가장 먼저 띄움
+  createSplashWindow();
+  // … 이하 기존 그대로
+```
+
+- [ ] **Step 3: did-finish-load 후 5초 백그라운드 체크**
+
+기존 main 창 생성 코드에서 `did-finish-load` 핸들러를 찾아 안에 추가:
+
+```ts
+mainWindow.webContents.once('did-finish-load', () => {
+  // … 기존 hooks (mainLoadedOk = true 등)
+
+  // v1.21.0: 5초 후 백그라운드 업데이트 체크 (한 번만)
+  setTimeout(() => {
+    scheduleUpdateCheck().catch((err) => console.warn('[autoUpdate] 체크 실패:', err));
+  }, 5_000);
+});
+```
+
+(정확한 anchor는 `did-finish-load`의 기존 콜백. 거기 본문 끝에 setTimeout 한 줄 추가)
+
+- [ ] **Step 4: before-quit hook 추가 (swap)**
+
+`app.on('before-quit', ...)`이 이미 있는지 확인. 없으면 신설:
+
+```ts
+let swapInFlight = false;
+app.on('before-quit', async (event) => {
+  if (swapInFlight) return; // 무한 루프 방지
+  if (!(await hasPending())) return;
+
+  event.preventDefault();
+  swapInFlight = true;
+  try {
+    const result = await swapIfPending();
+    if (!result.ok) console.warn('[autoUpdate] swap 실패:', result.reason);
+    else console.log('[autoUpdate] swap 완료 — 다음 실행 = 새 버전');
+  } catch (err) {
+    console.warn('[autoUpdate] swap 예외:', err);
+  } finally {
+    setImmediate(() => app.exit(0));
+  }
+});
+```
+
+이미 있는 경우는 기존 로직 끝에 swap 호출 추가.
+
+- [ ] **Step 5: tsc + 빌드 검증**
+
+```bash
+npx tsc --noEmit
+npm run build:vite
+ls dist/manifest.json dist-electron/main.js
+```
+Expected: 모두 PASS.
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add electron/main.ts
+git commit -m "feat(autoUpdate): main.ts 통합 — 첫 실행 self-installer + 백그라운드 체크 + 종료 swap"
+```
+
+---
+
+## Chunk 6: 자가 검증 + 롤백 안전장치
+
+spec §6: "새 버전 깨졌음 (앱 시작 실패) → backup\ 의 이전 버전을 자동으로 app\ 으로 되돌리는 안전장치 (5초 안에 메인 창 못 띄우면 롤백)"
+
+### Task 6.1: `electron/autoUpdate/healthCheck.ts`
+
+**Files:**
+- Create: `electron/autoUpdate/healthCheck.ts`
+
+- [ ] **Step 1: 파일 작성**
+
+```ts
+/**
+ * v1.21.0 자가 검증 — 앱 시작 실패 시 backup/ 자동 롤백.
+ *
+ * 메커니즘: 시작 시 .start-attempt 마커 작성 → 메인 창 did-finish-load 시점에
+ * 마커 삭제. 다음 시작 때 마커가 남아있으면 = 이전 시작이 도중 실패 → 롤백.
+ *
+ * 5초 타임아웃은 main.ts의 기존 30초 timeout과 별개 — healthCheck는 더 빨리 fail.
+ * 단, 우리는 메인 창 띄우기까지 기다리고 timeout 정책은 main.ts에 위임.
+ *
+ * spec §6 "swap 실패 / 새 버전 깨짐" 처리.
+ */
+import { promises as fsp, existsSync, renameSync } from 'fs';
+import path from 'path';
+import { localAppDir, localBackupDir, localRoot } from './paths';
+
+const ATTEMPT_MARKER = path.join(localRoot(), '.start-attempt');
+
+/**
+ * app.whenReady 직후 — 마커 검사 + 롤백 + 새 마커 작성.
+ * 호출자: runFirstInstallIfNeeded 다음, 메인 창 생성 전.
+ *
+ * @returns rolledBack: true면 backup → app으로 되돌렸음 (현재 실행은 옛 버전이 아니라
+ *          기존 v 그대로 — 이미 main process는 옛 코드로 evaluate됨. 롤백은 *다음 실행*용).
+ *          단 옛 버전이 *현재 실행 중인 코드*는 아닐 수 있음 (swap 직후 실행). 위험 있음 →
+ *          현 단계에선 단순 롤백만 하고 사용자에게 dialog로 안내.
+ */
+export async function checkLastStartAndRollback(): Promise<{ rolledBack: boolean }> {
+  const hadFailure = existsSync(ATTEMPT_MARKER);
+  if (hadFailure) {
+    // 이전 시작이 메인 창까지 못 갔음 → 새 빌드 깨짐 가능성
+    const app_ = localAppDir();
+    const backup_ = localBackupDir();
+    if (existsSync(backup_)) {
+      try {
+        // app/ → tmp 로 옮김 (실패한 빌드는 보존, 진단용)
+        const corrupt = path.join(localRoot(), '.corrupt-' + Date.now());
+        if (existsSync(app_)) renameSync(app_, corrupt);
+        renameSync(backup_, app_);
+        await fsp.unlink(ATTEMPT_MARKER).catch(() => {});
+        console.warn('[healthCheck] 이전 시작 실패 감지 → backup/ 으로 롤백 완료. 손상된 빌드는', corrupt);
+        return { rolledBack: true };
+      } catch (err) {
+        console.error('[healthCheck] 롤백 실패:', err);
+      }
+    } else {
+      console.warn('[healthCheck] 이전 시작 실패 감지했으나 backup 없음 — 롤백 불가');
+    }
+  }
+  // 새 마커 작성 — did-finish-load 시 markStartSucceeded()로 삭제
+  try {
+    await fsp.mkdir(localRoot(), { recursive: true });
+    await fsp.writeFile(ATTEMPT_MARKER, new Date().toISOString(), 'utf-8');
+  } catch (err) {
+    console.warn('[healthCheck] 마커 쓰기 실패:', err);
+  }
+  return { rolledBack: false };
+}
+
+/** 메인 창 did-finish-load 시 호출 — 정상 시작 표시. */
+export async function markStartSucceeded(): Promise<void> {
+  try {
+    if (existsSync(ATTEMPT_MARKER)) await fsp.unlink(ATTEMPT_MARKER);
+  } catch (err) {
+    console.warn('[healthCheck] 마커 삭제 실패:', err);
+  }
+}
+```
+
+- [ ] **Step 2: index.ts에 export 추가**
+
+```ts
+export { checkLastStartAndRollback, markStartSucceeded } from './healthCheck';
+```
+
+- [ ] **Step 3: main.ts 통합**
+
+`runFirstInstallIfNeeded` 직후에 추가:
+
+```ts
+const installResult = await runFirstInstallIfNeeded();
+if (installResult.exited) return;
+
+// v1.21.0: 이전 시작 실패 감지 + 자동 롤백
+await checkLastStartAndRollback();
+```
+
+`did-finish-load` 콜백 안에:
+
+```ts
+mainWindow.webContents.once('did-finish-load', () => {
+  markStartSucceeded().catch(() => {});
+  // ... 기존 hooks
+  setTimeout(() => scheduleUpdateCheck().catch(...), 5_000);
+});
+```
+
+- [ ] **Step 4: tsc + 빌드 + 커밋**
+
+```bash
+npx tsc --noEmit
+npm run build:vite
+git add electron/autoUpdate/healthCheck.ts electron/autoUpdate/index.ts electron/main.ts
+git commit -m "feat(autoUpdate): 자가 검증 + 시작 실패 시 backup 자동 롤백"
+```
+
+---
+
+## Chunk 7: 빌드 + 수동 검증 + 버전 + PR
+
+### Task 7.1: 풀 빌드 + manifest 확인
+
+- [ ] **Step 1: 버전 bump**
+
+`package.json` version → `1.21.0` (spec §1, §3에 명시된 형식).
+
+- [ ] **Step 2: 풀 electron-builder 빌드**
+
+```bash
+npm run build
+```
+Expected:
+- `dist/BFLOW.exe` (portable, 자동 self-installer 진입점)
+- `dist/win-unpacked/BFLOW.exe` (로컬 본체용)
+- `dist/manifest.json` (`{ "version": "1.21.0", "buildAt": "..." }`)
+- `dist-electron/main.js` 등
+
+- [ ] **Step 3: 산출물 검증**
+
+```bash
+cat dist/manifest.json
+ls dist/win-unpacked/BFLOW.exe dist/BFLOW.exe
+```
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add package.json
+git commit -m "chore(release): v1.21.0 — 자동 업데이트 시스템"
+```
+
+---
+
+### Task 7.2: 수동 시나리오 테스트
+
+**한솔 PC에서 직접 — 빌드 직후 (G드라이브 동기화 *하지 말고* 먼저 검증):**
+
+- [ ] **시나리오 A: 첫 설치**
+  - `dist/BFLOW.exe` (portable) 더블클릭 → "B flow 를 PC에 설치합니다 (한 번만, ~5초)" dialog
+  - 설치 클릭 → 5~30초 후 새 위치에서 BFLOW 실행 (스플래시 → 메인 창 1~2초)
+  - `%LOCALAPPDATA%\Bflow-BGonly\app\BFLOW.exe` 존재 확인
+  - 바탕화면에 "B flow.lnk" 생성 확인
+  - Defender 제외 dialog 등장 → "허용" 클릭 → UAC → PowerShell 백그라운드 실행
+
+- [ ] **시나리오 B: 일상 사용**
+  - 바탕화면 "B flow" 더블클릭 → 1~2초 시작 (Defender 캐시)
+  - 알림 패널의 🐢 시작 시간 분석에서 측정값 확인 (이게 1~2초 나오는지)
+  - 메인 창 정상 동작 확인
+
+- [ ] **시나리오 C: 옛 바로가기 폴백 (이미 설치된 후 G드라이브 BFLOW 클릭)**
+  - `dist/BFLOW.exe` 다시 더블클릭
+  - 토스트 또는 즉시 종료 후 로컬 BFLOW 실행 (사고 없음)
+
+- [ ] **시나리오 D: 백그라운드 업데이트** (G드라이브 동기화 후)
+  - 한솔이 v1.21.0 빌드 + G드라이브에 robocopy
+  - 로컬 BFLOW 켜진 상태에서 v1.21.1로 코드 변경 + 다시 빌드 + robocopy
+  - 다음 메인 창 로드 후 5초쯤 console에 "새 버전 감지: 1.21.0 → 1.21.1" log
+  - `%LOCALAPPDATA%\Bflow-BGonly\pending\.ready` 존재 확인
+  - BFLOW 종료 → swap 진행 (10초 내) → app.exit
+  - 다시 켜면 v1.21.1 (메인 창에 버전 표시 또는 alert로 확인)
+  - `backup\` 폴더에 v1.21.0 존재 확인
+
+- [ ] **시나리오 E: G드라이브 sync 안 끝남**
+  - G드라이브에 v1.21.1 partial 상태 (manifest는 있는데 파일 일부 없음)
+  - 백그라운드 다운로드 중 mirror copy 일부 실패 → console.warn만, pending/.ready 안 만들어짐
+  - 종료 → swap 안 됨 → 다음 실행 = 자기 버전 그대로
+
+- [ ] **시나리오 F: 새 버전 깨짐 (롤백)**
+  - pending에 일부러 corrupt BFLOW.exe 넣고 swap → 다음 실행 메인 창 못 띄움
+  - 다음 실행 (3번째) 시 .start-attempt 마커 감지 → backup → app 롤백 → corrupt 빌드는 `.corrupt-<ts>`로 보존
+
+- [ ] **시나리오 G: Defender 제외 거부**
+  - 첫 설치 시 Defender dialog "나중에" 클릭 → 정상 진행
+  - 새 빌드 직후 첫 실행 약 10초 (Defender 풀 스캔), 이후 1~2초
+
+각 시나리오 검증 결과를 PR 본문 테스트 가이드에 체크리스트로 포함.
+
+---
+
+### Task 7.3: 한솔 검증 + G드라이브 배포
+
+⚠️ **한솔 명시 시에만 진행** (메모: PR 머지 자제 / G드라이브 robocopy 자제).
+
+- [ ] **Step 1: PR 생성** (한솔 review용)
+
+- [ ] **Step 2: 한솔이 머지 명시 시 — main에 머지**
+
+- [ ] **Step 3: 한솔이 G드라이브 배포 명시 시 — robocopy**
+
+```bash
+robocopy <local dist> <G드라이브 dist> /MIR /R:1 /W:1
+```
+
+- [ ] **Step 4: 팀원 마이그레이션 검증** — spec §9
+  - 팀원 1명에게 옛 바로가기 클릭 부탁
+  - self-installer dialog → 설치 → 새 바로가기 자동 생성 확인
+  - 다음 실행 1~2초 확인
+
+---
+
+## 완료 기준
+
+- ✅ 모든 chunk 빌드 통과 (tsc --noEmit + vite build + electron-builder)
+- ✅ 시나리오 A~F 한솔 PC에서 수동 검증 통과
+- ✅ `dist/manifest.json` 자동 생성
+- ✅ `%LOCALAPPDATA%\Bflow-BGonly\` 디렉토리 구조 (`app/`, `pending/`, `backup/`) 정상 동작
+- ✅ 첫 실행 dialog "B flow 를 PC에 설치합니다 (한 번만, ~5초)" 그대로
+- ✅ Defender 제외 등록 옵션 dialog 정상
+- ✅ 백그라운드 업데이트 후 swap → 다음 실행 새 버전
+- ✅ 시작 실패 시 backup 자동 롤백
+- ✅ 옛 바로가기 폴백 (이미 설치된 후 G드라이브 BFLOW 클릭) 사고 없음
+
+## 영향 받지 않는 영역 (변경 없음)
+
+- 사용자 데이터(`%APPDATA%\Bflow-BGonly\`) — 설정/이미지 그대로
+- Supabase 통신
+- 빌드 워크플로우 (`npm run build`만 실행 step 1줄 추가)
+- G드라이브 robocopy 흐름
+
+## 진단 코드 처리 (이 plan에서는 X — 별도 commit/PR)
+
+spec §10대로, 자동 업데이트로 1~2초 검증 후 한솔이 직접 명시할 때 진단 코드(electron/main.ts의 `__t_*` 변수, preload.ts의 `onStartupPerf`, types/index.ts, App.tsx의 useEffect) 별도 commit으로 제거.
+
+---
+
+*Plan 끝. 실행은 위에서 아래로 순차. chunk별로 빌드 검증 + 커밋. 한솔 review 후 구현 시작.*

--- a/docs/superpowers/specs/2026-05-01-auto-update-design.md
+++ b/docs/superpowers/specs/2026-05-01-auto-update-design.md
@@ -1,0 +1,348 @@
+# Auto-Update System Design — B flow
+
+> 작성: 2026-05-01
+> 상태: 디자인 (한솔 review 대기)
+> 관련 문서: [DEVLOG/DEPLOYMENT.md](../../../DEVLOG/DEPLOYMENT.md)
+
+---
+
+## 1. 목적
+
+현재 G드라이브에서 직접 BFLOW.exe 를 실행하는 방식은, G드라이브 동기화가 BFLOW.exe 의 mtime 을 갱신해 Windows Defender 캐시를 무력화함에 따라 매 실행마다 13초+ 의 cold start 비용을 부담한다.
+
+**측정 결과 (한솔 PC, 2026-05-01)**:
+
+| 실행 환경 | 1차 | 2차 (재실행) |
+|---|---|---|
+| G드라이브 직접 | 17.3초 | 14.6초 (캐시 거의 없음) |
+| 로컬 디스크 | 14.7초 | **1.6초** ⚡ |
+
+**처방**: 사용자 PC 에 BFLOW 본체를 한 번 복사해 두고 *로컬에서 실행*. 새 빌드는 G드라이브에서 *백그라운드로 받아 swap*. Defender 가 같은 파일 (mtime 안정) 을 캐시 효과적으로 인식 → 재실행 1~2초.
+
+부수 목표:
+- 한솔 워크플로우 변경 0 (지금처럼 빌드 + G드라이브 robocopy)
+- 신규 팀원도 추가 액션 거의 0 (G드라이브 BFLOW 한 번 더블클릭이 그대로 self-installer)
+- Windows Defender 제외 등록 자동 안내로 *첫 실행 cold start* 도 단축
+
+---
+
+## 2. 결정사항 (한솔과 정렬 완료)
+
+| 항목 | 결정 |
+|---|---|
+| UX 패턴 | A. 조용히 알아서, 다음 재시작 시 적용 |
+| 다운로드 위치 | G드라이브 그대로 (한솔 워크플로우 변경 0) |
+| 전달 방식 | PC의 G드라이브 동기화에 맡김 (앱이 PC의 G드라이브 폴더 모니터링) |
+| 첫 설치 | 첫 실행 시 PC에 자동 설치 (self-installer 패턴) |
+| 체크 시점 | 앱 켤 때만 (단순) |
+| 사용자 알림 | 무알림 (G드라이브 패턴과 체감 동일) |
+| Defender | 첫 설치 시 제외 등록 dialog 한 번 (옵션) |
+
+---
+
+## 3. 컴포넌트 구성
+
+```
+┌────────────────────────────────────────────────────────────┐
+│                       팀원 PC 측                            │
+│                                                             │
+│  ┌──────────────────────┐    ┌──────────────────────────┐  │
+│  │  G드라이브 폴더      │    │  로컬 BFLOW 본체         │  │
+│  │  (Drive sync 결과)   │    │  %LOCALAPPDATA%\         │  │
+│  │                      │    │   Bflow-BGonly\app\      │  │
+│  │  win-unpacked/       │    │   ↑                      │  │
+│  │  ├ BFLOW.exe         │───→│  팀원이 실행하는 본체    │  │
+│  │  └ manifest.json     │    │                          │  │
+│  └──────────────────────┘    │  pending\                │  │
+│           ↑ 모니터링            (다음 시작 시 swap)     │  │
+│                              └──────────────────────────┘  │
+└────────────────────────────────────────────────────────────┘
+                                     ↑
+                         바탕화면 바로가기 (.lnk)
+                       자동 생성, 로컬 본체 가리킴
+```
+
+### 디렉토리 레이아웃
+
+| 경로 | 역할 |
+|---|---|
+| `%LOCALAPPDATA%\Bflow-BGonly\app\` | 현재 사용 중인 BFLOW 본체 (win-unpacked 통째로) |
+| `%LOCALAPPDATA%\Bflow-BGonly\pending\` | 백그라운드로 받은 새 버전 (종료 시 swap 대기) |
+| `%LOCALAPPDATA%\Bflow-BGonly\backup\` | 이전 버전 1개 보관 (긴급 롤백용) |
+| `%APPDATA%\Bflow-BGonly\` | 사용자 데이터 (기존 — 변경 없음) |
+
+`%LOCALAPPDATA%` 와 `%APPDATA%` 분리 이유: 본체는 *로컬* 이라 sync 안 됨 (LocalAppData), 사용자 설정은 그대로 유지 (Roaming AppData).
+
+### 빌드 산출물 (한솔 PC)
+
+기존 산출물에 manifest 만 추가:
+
+```
+dist/
+├── BFLOW.exe                  ← 변경 없음 (portable)
+├── win-unpacked/              ← 변경 없음
+└── manifest.json              ← 추가. {"version": "1.15.14", "buildAt": "..."}
+```
+
+`npm run build` 의 마지막 step 으로 `scripts/generate-manifest.js` 가 자동 실행 → `dist/manifest.json` 생성. 한솔 손 거치지 않음.
+
+---
+
+## 4. 데이터 흐름
+
+### 4.1 한솔 빌드 (변경 0)
+
+```
+npm run build
+ ├ tsc --noEmit
+ ├ vite build
+ ├ vite build (electron main)
+ ├ vite build (electron preload)
+ ├ electron-builder (portable + win-unpacked)
+ └ scripts/generate-manifest.js  ← 추가
+                                   dist/manifest.json 생성
+
+robocopy <local dist> <G드라이브 dist> /MIR
+ → G드라이브 sync → 모든 팀원 PC 의 G드라이브 폴더에 도착
+```
+
+### 4.2 팀원 실행 (정상 동작)
+
+```
+1. 바탕화면 바로가기 더블클릭
+2. → %LOCALAPPDATA%\Bflow-BGonly\app\BFLOW.exe 실행 (1~2초, Defender 캐시됨)
+3. 메인 창 로드
+4. [백그라운드] checkUpdate() — 5초 후 한 번 호출
+   ├ G드라이브 폴더 경로 추정 (Drive desktop 표준 경로 후보)
+   ├ <G드라이브 폴더>/manifest.json 읽기
+   ├ 자기 버전(package.json) 과 비교
+   └ 새 버전이면 → downloadUpdate()
+        ├ <G드라이브 win-unpacked>/* → %LOCALAPPDATA%\...\pending\* 로 복사 (변경분만, robocopy 패턴)
+        └ pending\.ready 마커 파일 생성 (swap 신호)
+5. 사용자 작업 — 영향 없음
+6. 종료 (트레이 종료 또는 X)
+   ├ swapIfPending() — quit hook
+   │   ├ pending\.ready 존재 시
+   │   ├ app\ → backup\ (이전 버전 보관)
+   │   └ pending\ → app\ (새 버전 활성화)
+   └ 종료
+7. 다음 실행 = 새 버전 (또 1~2초)
+```
+
+### 4.3 첫 실행 (self-installer)
+
+```
+1. 신규 팀원 — G드라이브의 BFLOW.exe 더블클릭 (또는 한솔이 만든 옛 바로가기)
+2. process.execPath 검사 → G드라이브 경로면 self-installer 모드
+3. 작은 dialog: "B flow 를 PC에 설치합니다 (한 번만, ~5초)"
+4. 사용자가 OK
+5. install():
+    ├ %LOCALAPPDATA%\Bflow-BGonly\app\ 생성
+    ├ G드라이브 win-unpacked/* → app\* 복사
+    ├ 바탕화면에 "B flow.lnk" 생성 (가리키는 곳: app\BFLOW.exe)
+    ├ 시작 메뉴에 "B flow.lnk" 생성
+    └ Defender 제외 등록 dialog (옵션):
+       ├ "Windows 보안에서 B flow 폴더를 검사 제외로 등록하면 시작이 더 빨라집니다"
+       └ "허용" 클릭 시 PowerShell `Add-MpPreference -ExclusionPath` (관리자 권한 UAC 요청)
+6. app\BFLOW.exe 실행 + 자기는 종료
+```
+
+### 4.4 이미 설치되어 있는데 G드라이브 BFLOW 다시 클릭
+
+```
+1. process.execPath 검사 → G드라이브 경로
+2. %LOCALAPPDATA%\Bflow-BGonly\app\BFLOW.exe 존재 확인
+3. 존재하면 → 작은 토스트: "이미 설치되어 있어요. 바탕화면 바로가기를 사용해주세요."
+4. app\BFLOW.exe 실행 + 자기는 종료
+```
+
+→ 한솔이 사전에 만들어 둔 옛 바로가기를 누군가 다시 클릭해도 사고 없음.
+
+---
+
+## 5. 코드 구성
+
+### 5.1 새 파일
+
+| 파일 | 역할 |
+|---|---|
+| `electron/autoUpdate/installer.ts` | self-installer (G드라이브 → 로컬 복사, 바로가기, Defender) |
+| `electron/autoUpdate/checker.ts` | 새 버전 감지 + 백그라운드 다운로드 |
+| `electron/autoUpdate/swapper.ts` | quit 시 pending → app swap |
+| `electron/autoUpdate/paths.ts` | G드라이브 경로 추정 + 로컬 경로 상수 |
+| `scripts/generate-manifest.js` | 빌드 후 dist/manifest.json 생성 (한솔 손 안 거침) |
+
+### 5.2 main.ts 통합 지점
+
+```ts
+// app.whenReady 안
+import { runFirstInstallIfNeeded } from './autoUpdate/installer';
+import { scheduleUpdateCheck } from './autoUpdate/checker';
+import { swapIfPending } from './autoUpdate/swapper';
+
+// 1. 첫 실행 감지 + self-installer (재실행 시 자기 종료)
+const installResult = await runFirstInstallIfNeeded();
+if (installResult.exited) return; // self-installer 가 새 위치에서 재실행하고 자기는 종료
+
+// 2. 메인 창 띄움 (기존)
+createSplashWindow();
+// ...
+
+// 3. 메인 로드 후 5초 뒤 백그라운드 업데이트 체크
+mainWindow.webContents.once('did-finish-load', () => {
+  setTimeout(() => scheduleUpdateCheck().catch((err) => console.warn('[autoUpdate]', err)), 5_000);
+});
+
+// 4. 종료 시 swap
+app.on('before-quit', async (event) => {
+  if (await hasPending()) {
+    event.preventDefault();
+    await swapIfPending();
+    app.exit(0);
+  }
+});
+```
+
+---
+
+## 6. 에러 처리 / 엣지 케이스
+
+| 케이스 | 처리 |
+|---|---|
+| G드라이브 폴더 못 찾음 (사용자가 Drive 안 켰거나 경로 다름) | 그냥 자기 버전으로 실행. `console.warn` 만. 사용자 알림 X. |
+| manifest.json 못 읽음 (sync 진행중, 파일 깨짐) | 같음 — fallback 으로 자기 버전 실행 |
+| 다운로드 중 네트워크/Drive sync 끊김 | pending\ 에 부분 파일 남을 수 있음 → 다음 시작 시 정합성 검사 (`.ready` 마커 없으면 폐기) |
+| swap 실패 (락) | app\ 그대로 두고 pending\ 도 그대로. 다음 종료 시 재시도. |
+| 새 버전 깨졌음 (앱 시작 실패) | `backup\` 의 이전 버전을 자동으로 `app\` 으로 되돌리는 안전장치 (5초 안에 메인 창 못 띄우면 롤백) |
+| Defender 제외 등록 거부 | 그냥 진행. 다음에 설정에서 다시 시도 가능. |
+| 권한 부족 (LocalAppData 쓰기 불가, 매우 드뭄) | 사용자에게 명확한 에러 메시지 + 폴백으로 G드라이브 실행 |
+
+---
+
+## 7. Windows Defender 제외 등록 (옵션)
+
+### 왜 필요한가
+새 빌드를 받은 *직후* 첫 실행은 Defender 가 처음 보는 파일이라 풀 스캔 (~10초+). 제외 등록되면 즉시 캐시.
+
+### 어떻게
+PowerShell:
+```powershell
+Add-MpPreference -ExclusionPath "$env:LOCALAPPDATA\Bflow-BGonly\app"
+Add-MpPreference -ExclusionPath "$env:LOCALAPPDATA\Bflow-BGonly\pending"
+```
+
+이 명령은 *관리자 권한* 필요 → UAC 프롬프트 한 번. 사용자가 거부하면 그냥 진행.
+
+### 보안 고려
+- 폴더 단위 제외는 일반적이지만 사용자 동의 필수
+- B flow 외 다른 exe 가 그 폴더에 들어가면 그것도 스캔 안 됨 — 폴더는 앱 전용이라 위험 낮음
+- 사용자에게 이 사실을 dialog 에 명확히 표시
+
+---
+
+## 8. 빌드 / 배포 워크플로 변경
+
+### 한솔 측 (`npm run build`)
+기존 흐름에 1줄 step 추가:
+
+```json
+// package.json
+"scripts": {
+  "build": "tsc && vite build && electron-builder && node scripts/generate-manifest.js"
+}
+```
+
+`generate-manifest.js`:
+```js
+// dist/manifest.json 자동 생성
+const fs = require('fs');
+const pkg = require('../package.json');
+const manifest = {
+  version: pkg.version,
+  buildAt: new Date().toISOString(),
+};
+fs.writeFileSync('dist/manifest.json', JSON.stringify(manifest, null, 2));
+```
+
+### G드라이브 동기화 (변경 0)
+지금처럼 robocopy. dist/manifest.json 도 같이 sync 됨.
+
+---
+
+## 9. 마이그레이션 (현재 사용자 → 새 시스템)
+
+기존에 G드라이브 BFLOW.exe 직접 실행하던 팀원들의 첫 한 번:
+
+1. 한솔이 새 시스템 포함된 빌드 push
+2. 팀원이 평소처럼 옛 바로가기 (G드라이브 가리키는 거) 더블클릭
+3. → 새 코드의 self-installer 가 첫 실행 감지 → "PC 에 설치합니다" dialog
+4. 설치 완료 → 바탕화면에 새 바로가기 자동 생성 → 자동 재실행
+5. 이후 팀원은 *바탕화면 새 바로가기* 사용
+
+→ 한솔이 따로 안내할 거 없음. 사용자 PC 에 폐기될 옛 바로가기는 그대로 둬도 폴백 동작 (이미 설치 감지 + 로컬 본체 실행).
+
+---
+
+## 10. 진단 코드 처리
+
+현재 알림 패널에 띄우는 "🐢 시작 시간 분석" 코드 (electron/main.ts + App.tsx):
+- 자동 업데이트 시스템 *적용 후* 효과 검증용으로 며칠 더 유지
+- 한솔이 "1~2초로 줄었네" 확인되면 한 번에 제거 (별도 commit)
+
+---
+
+## 11. 테스트 시나리오
+
+| 시나리오 | 기대 결과 |
+|---|---|
+| 신규 팀원 — G드라이브 BFLOW 첫 클릭 | self-installer dialog → PC 설치 → 자동 재실행 → 로그인 화면 |
+| 일상 사용 — 바탕화면 바로가기 더블클릭 | 1~2초 시작 (Defender 캐시) |
+| 한솔이 새 빌드 push 직후 | 백그라운드 다운로드, 사용자 작업 영향 없음. 다음 종료 시 swap. 그 다음 실행 = 새 버전 |
+| G드라이브 sync 안 끝남 | 그냥 자기 버전으로 실행 (sync 끝난 다음 실행 시 받음) |
+| 새 버전 깨짐 (앱 시작 실패) | `backup\` 자동 롤백, 다음 실행 = 이전 버전 |
+| 옛 바로가기 (G드라이브 가리키는 거) 클릭 — 이미 설치된 경우 | 토스트 안내 + 로컬 본체 실행 |
+| Defender 제외 등록 거부 | 정상 동작. 새 빌드 직후 첫 실행만 약간 느림 (~10초). 이후 정상 (1~2초) |
+
+---
+
+## 12. 작업 단계 (구현 plan 별도 작성 예정)
+
+1. `scripts/generate-manifest.js` + `package.json` build script 수정
+2. `electron/autoUpdate/paths.ts` (G드라이브 경로 추정)
+3. `electron/autoUpdate/installer.ts` (self-installer)
+4. `electron/autoUpdate/checker.ts` (백그라운드 체크 + 다운로드)
+5. `electron/autoUpdate/swapper.ts` (quit hook + swap)
+6. `electron/main.ts` 통합
+7. 첫 실행 dialog UI (electron dialog or BrowserWindow)
+8. Defender 제외 등록 (옵션 dialog + PowerShell 호출)
+9. 자가 검증 (앱 시작 실패 시 backup 롤백)
+10. 빌드/배포/한솔 검증
+
+---
+
+## 13. Protocol Handler (슬랙 딥링크 `bflow://`)
+
+### 동작 원리
+Windows registry 에 등록된 `bflow://` 핸들러 BFLOW.exe 경로가 OS 가 슬랙 딥링크 클릭 시 호출하는 대상. `electron/main.ts:2552` 의 `app.setAsDefaultProtocolClient(PROTOCOL)` 가 인자 없이 호출되면 현재 실행 중인 BFLOW.exe 의 `process.execPath` 를 자동 등록.
+
+### 새 시스템에서의 자동 갱신
+- self-installer 가 로컬 BFLOW.exe 를 실행하는 시점에 setAsDefaultProtocolClient 가 호출되어 registry 가 로컬 경로로 갱신됨 → 이후 슬랙 딥링크 클릭 시 로컬 BFLOW.exe 가 실행 (1~2초)
+- 자동 업데이트 swap 은 `app\` 폴더 *안의 파일만* 갈아끼우므로 registry path 는 영원히 같음 → swap 후에도 자동으로 새 버전이 슬랙 딥링크에 반응
+
+### 엣지 케이스
+| 케이스 | 결과 |
+|---|---|
+| 마이그레이션 직전 — registry 에 옛 G드라이브 경로가 박혀있고 슬랙 딥링크 누름 | 옛 G드라이브 BFLOW 가 실행되지만 그 안의 self-installer 코드가 동작 → 한 번에 마이그레이션 + 딥링크 처리 |
+| swap 직후 첫 실행 | 같은 경로의 새 파일이 실행 + setAsDefaultProtocolClient 재호출 (no-op, 안전) |
+| 사용자가 `app\` 폴더를 수동 이동/삭제 | 다음 실행 실패 → 안전장치(`backup\` 폴백 또는 옛 G드라이브 바로가기로 self-installer 재진입) |
+
+### 코드 변경 필요
+없음. 기존 `setAsDefaultProtocolClient` 호출이 이미 process.execPath 자동 등록이라 self-installer 가 새 위치에서 재실행하는 것만으로 충분.
+
+---
+
+## 14. 결정 보류 / 후속 검토
+
+- **코드 서명 인증서** (연 100$+): SmartScreen 우회로 첫 실행도 즉시 빠름. 도입 비용/필요성 검토.
+- **manifest.json 형식 확장**: 변경 사항 (changelog) 등 추가 메타. 지금은 version + buildAt 만.
+- **여러 환경 지원**: 한솔 PC 외에 외근 (Drive sync 안 됨) 등에서도 받게 하려면 Supabase Storage 옵션 추가 검토 (현재 scope 밖).

--- a/electron/autoUpdate/checker.ts
+++ b/electron/autoUpdate/checker.ts
@@ -1,0 +1,70 @@
+/**
+ * v1.21.0 자동 업데이트 — 메인 창 로드 후 5초 뒤 한 번 호출.
+ * G드라이브 manifest와 자기 버전 비교 → 새 버전이면 pending/으로 변경분 복사
+ * + .ready 마커 생성. swap은 swapper.ts가 종료 시 처리.
+ *
+ * spec §4.2 일상 사용 시나리오 step 4.
+ */
+import { promises as fsp, existsSync } from 'fs';
+import {
+  findRemoteWinUnpacked,
+  findRemoteManifest,
+  localPendingDir,
+  localReadyMarker,
+  getOwnVersion,
+} from './paths';
+import { readManifest, compareVersions } from './manifest';
+import { copyDirMirror } from './copy';
+
+/**
+ * 백그라운드 체크 — 한 번만 실행. 실패는 console.warn만 (사용자 알림 X — UX 패턴 A).
+ *
+ * 호출자: main.ts의 mainWindow.webContents.once('did-finish-load') → setTimeout 5초 후.
+ */
+export async function scheduleUpdateCheck(): Promise<void> {
+  try {
+    const remoteManifestPath = findRemoteManifest();
+    if (!remoteManifestPath) {
+      console.log('[autoUpdate] G드라이브 manifest 없음 — skip');
+      return;
+    }
+    const remote = await readManifest(remoteManifestPath);
+    if (!remote) {
+      console.log('[autoUpdate] G드라이브 manifest 읽기 실패 — skip');
+      return;
+    }
+    const own = getOwnVersion();
+    const cmp = compareVersions(remote.version, own);
+    if (cmp <= 0) {
+      console.log(`[autoUpdate] 최신 (own=${own}, remote=${remote.version})`);
+      return;
+    }
+    console.log(`[autoUpdate] 새 버전 감지: ${own} → ${remote.version}. 백그라운드 다운로드 시작.`);
+    await downloadToPending();
+    console.log(`[autoUpdate] 다운로드 완료. 다음 종료 시 swap.`);
+  } catch (err) {
+    console.warn('[autoUpdate] 체크 실패:', err);
+  }
+}
+
+async function downloadToPending(): Promise<void> {
+  const remoteWinUnpacked = findRemoteWinUnpacked();
+  if (!remoteWinUnpacked) throw new Error('원격 win-unpacked 없음');
+
+  // pending이 .ready 상태(이전 다운로드 완료)인 경우는 그대로 둠 — swap만 기다림.
+  // 사용자가 종료-재실행을 안 거친 사이에 또 새 버전 push되면 다음 cycle에서 pick.
+  const ready = localReadyMarker();
+  if (existsSync(ready)) {
+    console.log('[autoUpdate] pending이 이미 ready 상태 — 추가 다운로드 skip');
+    return;
+  }
+
+  const pending = localPendingDir();
+  await fsp.mkdir(pending, { recursive: true });
+
+  // mirror 복사 (변경된 파일만)
+  await copyDirMirror(remoteWinUnpacked, pending);
+
+  // .ready 마커 — swapper가 이걸 보고 swap 실행
+  await fsp.writeFile(ready, new Date().toISOString(), 'utf-8');
+}

--- a/electron/autoUpdate/checker.ts
+++ b/electron/autoUpdate/checker.ts
@@ -6,6 +6,7 @@
  * spec §4.2 일상 사용 시나리오 step 4.
  */
 import { promises as fsp, existsSync } from 'fs';
+import path from 'path';
 import {
   findRemoteWinUnpacked,
   findRemoteManifest,
@@ -13,7 +14,7 @@ import {
   localReadyMarker,
   getOwnVersion,
 } from './paths';
-import { readManifest, compareVersions } from './manifest';
+import { readManifest, compareVersions, countFilesAndBytes, type Manifest } from './manifest';
 import { copyDirMirror } from './copy';
 
 /**
@@ -40,22 +41,45 @@ export async function scheduleUpdateCheck(): Promise<void> {
       return;
     }
     console.log(`[autoUpdate] 새 버전 감지: ${own} → ${remote.version}. 백그라운드 다운로드 시작.`);
-    await downloadToPending();
+    await downloadToPending(remote);
     console.log(`[autoUpdate] 다운로드 완료. 다음 종료 시 swap.`);
   } catch (err) {
     console.warn('[autoUpdate] 체크 실패:', err);
   }
 }
 
-async function downloadToPending(): Promise<void> {
+async function downloadToPending(remoteManifest: Manifest): Promise<void> {
   const remoteWinUnpacked = findRemoteWinUnpacked();
   if (!remoteWinUnpacked) throw new Error('원격 win-unpacked 없음');
 
   // pending이 .ready 상태(이전 다운로드 완료)인 경우는 그대로 둠 — swap만 기다림.
-  // 사용자가 종료-재실행을 안 거친 사이에 또 새 버전 push되면 다음 cycle에서 pick.
   const ready = localReadyMarker();
   if (existsSync(ready)) {
     console.log('[autoUpdate] pending이 이미 ready 상태 — 추가 다운로드 skip');
+    return;
+  }
+
+  // Codex 9차 P1: 원격 sync 완전성 사전 검증.
+  // Drive sync는 비동기 — manifest.json이 win-unpacked의 큰 파일들보다 먼저 도착 가능.
+  // partial 상태에서 mirror copy + .ready 작성하면 broken app으로 swap됨.
+  const expected = remoteManifest.fileCount != null && remoteManifest.totalBytes != null
+    ? { fileCount: remoteManifest.fileCount, totalBytes: remoteManifest.totalBytes }
+    : null;
+
+  if (expected) {
+    const remoteActual = countFilesAndBytes(remoteWinUnpacked);
+    if (remoteActual.fileCount !== expected.fileCount || remoteActual.totalBytes !== expected.totalBytes) {
+      console.log(
+        `[autoUpdate] G드라이브 sync 미완료 (manifest: ${expected.fileCount}files/`
+        + `${expected.totalBytes}B, 실제: ${remoteActual.fileCount}files/${remoteActual.totalBytes}B). `
+        + `다음 체크 cycle에서 재시도.`,
+      );
+      return; // .ready 작성 X
+    }
+  }
+  // 호환 폴백 — 옛 manifest(fileCount 없음)는 핵심 파일 (BFLOW.exe) 존재만 검증
+  if (!expected && !existsSync(path.join(remoteWinUnpacked, 'BFLOW.exe'))) {
+    console.log('[autoUpdate] G드라이브 win-unpacked에 BFLOW.exe 없음 — sync 미완료, 다음 cycle 재시도');
     return;
   }
 
@@ -64,6 +88,19 @@ async function downloadToPending(): Promise<void> {
 
   // mirror 복사 (변경된 파일만)
   await copyDirMirror(remoteWinUnpacked, pending);
+
+  // 사후 검증: 로컬 pending이 원격 manifest와 일치하는지 — copy 도중 네트워크 끊김 등 partial 케이스 차단.
+  if (expected) {
+    const localActual = countFilesAndBytes(pending);
+    if (localActual.fileCount !== expected.fileCount || localActual.totalBytes !== expected.totalBytes) {
+      console.warn(
+        `[autoUpdate] mirror copy partial — 로컬 pending(${localActual.fileCount}files/`
+        + `${localActual.totalBytes}B) ≠ manifest(${expected.fileCount}files/`
+        + `${expected.totalBytes}B). .ready 작성 skip — 다음 cycle 재시도.`,
+      );
+      return; // .ready 작성 X
+    }
+  }
 
   // .ready 마커 — swapper가 이걸 보고 swap 실행
   await fsp.writeFile(ready, new Date().toISOString(), 'utf-8');

--- a/electron/autoUpdate/copy.ts
+++ b/electron/autoUpdate/copy.ts
@@ -32,17 +32,27 @@ export async function copyDirMirror(
     await fsp.mkdir(path.dirname(dstFile), { recursive: true });
 
     let needCopy = true;
-    if (existsSync(dstFile)) {
+    let srcStat: import('fs').Stats | null = null;
+    try { srcStat = statSync(srcFile); } catch { /* skip; copy 시점에 throw */ }
+
+    if (existsSync(dstFile) && srcStat) {
       try {
-        const ss = statSync(srcFile);
         const ds = statSync(dstFile);
-        if (ss.size === ds.size && Math.abs(ss.mtimeMs - ds.mtimeMs) < 2000) {
+        if (srcStat.size === ds.size && Math.abs(srcStat.mtimeMs - ds.mtimeMs) < 2000) {
           needCopy = false;
         }
       } catch { /* stat 실패면 그냥 복사 */ }
     }
     if (needCopy) {
       await fsp.copyFile(srcFile, dstFile);
+      // Codex 4차 P2: copyFile 후 dst의 mtime이 현재 시각으로 새로 생성됨 → 다음 동기화에
+      // unchanged file이 changed로 인식되어 win-unpacked 188MB 매번 풀 카피되던 문제 수정.
+      // src의 atime/mtime을 그대로 복사해 mirror 비교가 안정적으로 동작.
+      if (srcStat) {
+        try { await fsp.utimes(dstFile, srcStat.atime, srcStat.mtime); } catch {
+          /* utimes 실패는 무시 — 다음 동기화 효율만 영향 (correctness 영향 X) */
+        }
+      }
     }
     copied++;
     onProgress?.(rel, copied, allFiles.length);

--- a/electron/autoUpdate/copy.ts
+++ b/electron/autoUpdate/copy.ts
@@ -1,0 +1,90 @@
+/**
+ * v1.21.0 자동 업데이트 — 디렉토리 mirror.
+ * robocopy 패턴(변경된 파일만 복사 + 사라진 파일 제거)을 Node fs로 직접 구현.
+ * 외부 robocopy.exe 의존성 X — CI/Mac 호환.
+ *
+ * 우리 win-unpacked는 ~188MB이라 메모리·시간 OK. 변경분만 복사라 일상 update에서는 보통
+ * 0~수 MB만 실제 I/O.
+ */
+import { promises as fsp, existsSync, statSync } from 'fs';
+import path from 'path';
+
+/**
+ * src의 모든 파일을 dst로 복사. dst에만 있는 파일은 제거 (mirror).
+ * 같은 size + (mtime 차이 < 2초)면 skip — 빠른 변경분-only 복사.
+ *
+ * @param onProgress 옵션 — 진행률 콜백 (relPath, copiedSoFar, total)
+ * @throws src 없으면 Error.
+ */
+export async function copyDirMirror(
+  src: string,
+  dst: string,
+  onProgress?: (relPath: string, copied: number, total: number) => void,
+): Promise<void> {
+  if (!existsSync(src)) throw new Error(`source 없음: ${src}`);
+  await fsp.mkdir(dst, { recursive: true });
+
+  const allFiles = await collectFiles(src);
+  let copied = 0;
+  for (const rel of allFiles) {
+    const srcFile = path.join(src, rel);
+    const dstFile = path.join(dst, rel);
+    await fsp.mkdir(path.dirname(dstFile), { recursive: true });
+
+    let needCopy = true;
+    if (existsSync(dstFile)) {
+      try {
+        const ss = statSync(srcFile);
+        const ds = statSync(dstFile);
+        if (ss.size === ds.size && Math.abs(ss.mtimeMs - ds.mtimeMs) < 2000) {
+          needCopy = false;
+        }
+      } catch { /* stat 실패면 그냥 복사 */ }
+    }
+    if (needCopy) {
+      await fsp.copyFile(srcFile, dstFile);
+    }
+    copied++;
+    onProgress?.(rel, copied, allFiles.length);
+  }
+
+  // dst 청소: src에 없는 파일 제거 (mirror)
+  await pruneOrphans(src, dst);
+}
+
+async function collectFiles(root: string, prefix = ''): Promise<string[]> {
+  const entries = await fsp.readdir(path.join(root, prefix), { withFileTypes: true });
+  const out: string[] = [];
+  for (const e of entries) {
+    const rel = path.join(prefix, e.name);
+    if (e.isDirectory()) {
+      out.push(...await collectFiles(root, rel));
+    } else if (e.isFile()) {
+      out.push(rel);
+    }
+    // symlink/그 외는 skip — Electron 본체엔 없음
+  }
+  return out;
+}
+
+async function pruneOrphans(src: string, dst: string, prefix = ''): Promise<void> {
+  const dstHere = path.join(dst, prefix);
+  if (!existsSync(dstHere)) return;
+  const entries = await fsp.readdir(dstHere, { withFileTypes: true });
+  for (const e of entries) {
+    const rel = path.join(prefix, e.name);
+    const srcCounterpart = path.join(src, rel);
+    if (e.isDirectory()) {
+      if (!existsSync(srcCounterpart)) {
+        await fsp.rm(path.join(dstHere, e.name), { recursive: true, force: true });
+      } else {
+        await pruneOrphans(src, dst, rel);
+      }
+    } else {
+      if (!existsSync(srcCounterpart)) {
+        // 실행 중 락 가능성 — 무시
+        await fsp.unlink(path.join(dstHere, e.name)).catch(() => { /* noop */ });
+      }
+    }
+  }
+}

--- a/electron/autoUpdate/healthCheck.ts
+++ b/electron/autoUpdate/healthCheck.ts
@@ -1,0 +1,76 @@
+/**
+ * v1.21.0 자가 검증 — 앱 시작 실패 시 backup/ 자동 롤백.
+ *
+ * 메커니즘:
+ *   시작 시 .start-attempt 마커 작성 → 메인 창 did-finish-load 시점에 마커 삭제.
+ *   다음 시작 때 마커가 *남아있으면* = 이전 시작이 도중 실패 → backup → app 롤백.
+ *
+ * spec §6 "swap 실패 / 새 버전 깨짐" 처리.
+ */
+import { promises as fsp, existsSync, renameSync } from 'fs';
+import path from 'path';
+import { localAppDir, localBackupDir, localRoot } from './paths';
+
+const ATTEMPT_MARKER = path.join(localRoot(), '.start-attempt');
+
+export interface HealthResult {
+  /** 이전 시작 실패 감지 → backup → app 롤백 했는지 */
+  rolledBack: boolean;
+}
+
+/**
+ * app.whenReady 직후 — 마커 검사 + (필요 시) 롤백 + 새 마커 작성.
+ * 호출자: runFirstInstallIfNeeded 다음, 메인 창 생성 전.
+ *
+ * 주의: 롤백은 *다음 실행*용. 현재 main process는 이미 새(깨진) 코드로 시작됐을 가능성이
+ * 있어, 메인 창 생성 시점까지 못 가면 어차피 다음 실행에서 영향. 이 함수가 만든 새 마커
+ * 가 다음 시작 시 또 발견되면 backup도 깨졌다는 뜻이라 롤백 무한 루프 방지를 위해
+ * backup이 없으면 그냥 진행.
+ */
+export async function checkLastStartAndRollback(): Promise<HealthResult> {
+  const hadFailure = existsSync(ATTEMPT_MARKER);
+  let rolledBack = false;
+
+  if (hadFailure) {
+    const app_ = localAppDir();
+    const backup_ = localBackupDir();
+    if (existsSync(backup_)) {
+      try {
+        // app/ → .corrupt-<ts>/ 로 보존 (진단용, 다음 swap 시 정리됨)
+        const corrupt = path.join(localRoot(), '.corrupt-' + Date.now());
+        if (existsSync(app_)) renameSync(app_, corrupt);
+        renameSync(backup_, app_);
+        await fsp.unlink(ATTEMPT_MARKER).catch(() => { /* noop */ });
+        console.warn(
+          '[healthCheck] 이전 시작 실패 감지 → backup/ 으로 롤백 완료. '
+          + `손상된 빌드는 ${corrupt} 에 보존됨.`,
+        );
+        rolledBack = true;
+      } catch (err) {
+        console.error('[healthCheck] 롤백 실패:', err);
+      }
+    } else {
+      console.warn('[healthCheck] 이전 시작 실패 감지했으나 backup 없음 — 롤백 불가');
+    }
+  }
+
+  // 새 마커 작성 — markStartSucceeded()가 메인 창 로드 시 삭제.
+  // 마커 못 쓰면 자가 검증 비활성 — 그냥 진행.
+  try {
+    await fsp.mkdir(localRoot(), { recursive: true });
+    await fsp.writeFile(ATTEMPT_MARKER, new Date().toISOString(), 'utf-8');
+  } catch (err) {
+    console.warn('[healthCheck] 마커 쓰기 실패:', err);
+  }
+
+  return { rolledBack };
+}
+
+/** 메인 창 did-finish-load 시 호출 — 정상 시작 표시. */
+export async function markStartSucceeded(): Promise<void> {
+  try {
+    if (existsSync(ATTEMPT_MARKER)) await fsp.unlink(ATTEMPT_MARKER);
+  } catch (err) {
+    console.warn('[healthCheck] 마커 삭제 실패:', err);
+  }
+}

--- a/electron/autoUpdate/healthCheck.ts
+++ b/electron/autoUpdate/healthCheck.ts
@@ -1,15 +1,23 @@
 /**
  * v1.21.0 자가 검증 — 앱 시작 실패 시 backup/ 자동 롤백.
  *
- * 메커니즘:
- *   시작 시 .start-attempt 마커 작성 → 메인 창 did-finish-load 시점에 마커 삭제.
- *   다음 시작 때 마커가 *남아있으면* = 이전 시작이 도중 실패 → backup → app 롤백.
+ * 메커니즘 (Codex 6차 P1 수정 후):
+ *   1. swap 직후 swapper가 .pending-verification 마커 작성 = "다음 실행은 검증 대상"
+ *   2. 시작 시 .pending-verification 있으면 → 검증 모드 → .start-attempt 작성
+ *   3. 메인 창 did-finish-load 도달 → 두 마커 모두 삭제
+ *   4. 다음 시작 시 .pending-verification + .start-attempt 둘 다 잔존 → 이전 시작 실패 →
+ *      backup → app 롤백 + .corrupt-<ts>로 손상 빌드 보존
+ *
+ * 주된 변화: 일반 강제 종료·시스템 kill·재부팅 등은 .pending-verification 없으니 검증
+ * 비활성 → 의도치 않은 다운그레이드 방지.
  *
  * spec §6 "swap 실패 / 새 버전 깨짐" 처리.
  */
 import { promises as fsp, existsSync, renameSync } from 'fs';
 import path from 'path';
-import { localAppDir, localBackupDir, localRoot } from './paths';
+import {
+  localAppDir, localBackupDir, localRoot, localPendingVerificationMarker,
+} from './paths';
 
 const ATTEMPT_MARKER = path.join(localRoot(), '.start-attempt');
 
@@ -21,56 +29,71 @@ export interface HealthResult {
 /**
  * app.whenReady 직후 — 마커 검사 + (필요 시) 롤백 + 새 마커 작성.
  * 호출자: runFirstInstallIfNeeded 다음, 메인 창 생성 전.
- *
- * 주의: 롤백은 *다음 실행*용. 현재 main process는 이미 새(깨진) 코드로 시작됐을 가능성이
- * 있어, 메인 창 생성 시점까지 못 가면 어차피 다음 실행에서 영향. 이 함수가 만든 새 마커
- * 가 다음 시작 시 또 발견되면 backup도 깨졌다는 뜻이라 롤백 무한 루프 방지를 위해
- * backup이 없으면 그냥 진행.
  */
 export async function checkLastStartAndRollback(): Promise<HealthResult> {
-  const hadFailure = existsSync(ATTEMPT_MARKER);
+  const verificationMarker = localPendingVerificationMarker();
+  const inVerificationMode = existsSync(verificationMarker);
+
+  // Codex 6차 P1: 일반 실행은 검증 비활성 — 강제 종료/시스템 kill로 인한 의도치 않은
+  // rollback 차단. swap 직후 첫 실행에만 (= .pending-verification 있을 때만) 검증.
+  if (!inVerificationMode) {
+    return { rolledBack: false };
+  }
+
+  const previousAttemptFailed = existsSync(ATTEMPT_MARKER);
   let rolledBack = false;
 
-  if (hadFailure) {
+  if (previousAttemptFailed) {
     const app_ = localAppDir();
     const backup_ = localBackupDir();
     if (existsSync(backup_)) {
       try {
-        // app/ → .corrupt-<ts>/ 로 보존 (진단용, 다음 swap 시 정리됨)
+        // app/ → .corrupt-<ts>/ 로 보존 (진단용)
         const corrupt = path.join(localRoot(), '.corrupt-' + Date.now());
         if (existsSync(app_)) renameSync(app_, corrupt);
         renameSync(backup_, app_);
         await fsp.unlink(ATTEMPT_MARKER).catch(() => { /* noop */ });
+        await fsp.unlink(verificationMarker).catch(() => { /* noop */ });
         console.warn(
-          '[healthCheck] 이전 시작 실패 감지 → backup/ 으로 롤백 완료. '
+          '[healthCheck] swap 직후 첫 실행 실패 감지 → backup/ 으로 롤백 완료. '
           + `손상된 빌드는 ${corrupt} 에 보존됨.`,
         );
         rolledBack = true;
+        // 롤백된 backup은 이미 정상 검증된 빌드 → 새 .start-attempt 작성 X (정상 시작 가정)
+        return { rolledBack };
       } catch (err) {
         console.error('[healthCheck] 롤백 실패:', err);
       }
     } else {
-      console.warn('[healthCheck] 이전 시작 실패 감지했으나 backup 없음 — 롤백 불가');
+      console.warn('[healthCheck] swap 직후 첫 실행 실패 감지했으나 backup 없음 — 롤백 불가');
     }
   }
 
-  // 새 마커 작성 — markStartSucceeded()가 메인 창 로드 시 삭제.
-  // 마커 못 쓰면 자가 검증 비활성 — 그냥 진행.
+  // 검증 모드 + 이전 실패 없음 → 새 .start-attempt 작성. did-finish-load 시 삭제됨.
   try {
     await fsp.mkdir(localRoot(), { recursive: true });
     await fsp.writeFile(ATTEMPT_MARKER, new Date().toISOString(), 'utf-8');
   } catch (err) {
-    console.warn('[healthCheck] 마커 쓰기 실패:', err);
+    console.warn('[healthCheck] .start-attempt 마커 쓰기 실패:', err);
   }
 
   return { rolledBack };
 }
 
-/** 메인 창 did-finish-load 시 호출 — 정상 시작 표시. */
+/**
+ * 메인 창 did-finish-load 시 호출 — 정상 시작 표시.
+ * .start-attempt + .pending-verification 모두 삭제 (검증 통과 표시).
+ */
 export async function markStartSucceeded(): Promise<void> {
   try {
     if (existsSync(ATTEMPT_MARKER)) await fsp.unlink(ATTEMPT_MARKER);
   } catch (err) {
-    console.warn('[healthCheck] 마커 삭제 실패:', err);
+    console.warn('[healthCheck] .start-attempt 삭제 실패:', err);
+  }
+  try {
+    const v = localPendingVerificationMarker();
+    if (existsSync(v)) await fsp.unlink(v);
+  } catch (err) {
+    console.warn('[healthCheck] .pending-verification 삭제 실패:', err);
   }
 }

--- a/electron/autoUpdate/index.ts
+++ b/electron/autoUpdate/index.ts
@@ -1,0 +1,11 @@
+/**
+ * v1.21.0 자동 업데이트 — main.ts가 import하는 단일 진입점.
+ * 다른 모듈은 main.ts가 직접 import하지 않음 — index만 import.
+ */
+export { runFirstInstallIfNeeded } from './installer';
+export type { InstallResult } from './installer';
+export { scheduleUpdateCheck } from './checker';
+export { swapIfPending, hasPending } from './swapper';
+export type { SwapResult } from './swapper';
+export { checkLastStartAndRollback, markStartSucceeded } from './healthCheck';
+export type { HealthResult } from './healthCheck';

--- a/electron/autoUpdate/installer.ts
+++ b/electron/autoUpdate/installer.ts
@@ -179,6 +179,16 @@ async function offerDefenderExclusion(): Promise<void> {
   }
 }
 
+/**
+ * Codex 1차 P1: process.argv 전체를 forward.
+ * Windows에서 bflow:// 프로토콜 링크는 launch arguments로 전달되므로, 옛 G드라이브
+ * 바로가기로 슬랙 딥링크 클릭 시(spec §13 폴백) deep-link payload가 손실되지 않도록
+ * 사용자가 넘긴 args를 그대로 전달한다.
+ *
+ * process.argv[0] = self exe path, process.argv[1..] = 사용자 인자.
+ * 내부 Electron 플래그는 그대로 둬도 BFLOW가 무시 (electron-builder portable이 알아서).
+ */
 function spawnDetached(exe: string): void {
-  spawn(exe, [], { detached: true, stdio: 'ignore' }).unref();
+  const args = process.argv.slice(1);
+  spawn(exe, args, { detached: true, stdio: 'ignore' }).unref();
 }

--- a/electron/autoUpdate/installer.ts
+++ b/electron/autoUpdate/installer.ts
@@ -15,6 +15,7 @@ import {
   localAppDir,
   localPendingDir,
   localBflowExe,
+  localInstalledMarker,
 } from './paths';
 import { copyDirMirror } from './copy';
 
@@ -35,12 +36,26 @@ export async function runFirstInstallIfNeeded(): Promise<InstallResult> {
   }
 
   const localExe = localBflowExe();
-  const alreadyInstalled = existsSync(localExe);
+  // Codex 5차 P1: existsSync(BFLOW.exe)만으로 "이미 설치됨" 판단하면 mid-copy 실패한
+  // partial install이 무한 startup failure trap이 됨. .installed 마커가 *함께* 있을 때만
+  // 진짜 설치 완료로 간주. partial install 감지 시 깨끗이 정리 후 새 설치 흐름 진입.
+  const installedMarker = localInstalledMarker();
+  const fullyInstalled = existsSync(localExe) && existsSync(installedMarker);
+  const partialInstall = existsSync(localExe) && !existsSync(installedMarker);
 
-  if (alreadyInstalled) {
+  if (fullyInstalled) {
     // spec §4.4: 옛 바로가기 폴백. 로컬 본체로 spawn하고 자기는 종료.
     relaunchAndExit(localExe);
     return { exited: true };
+  }
+
+  if (partialInstall) {
+    console.warn('[installer] partial install 감지 (BFLOW.exe 있으나 .installed 마커 없음) → 정리 후 재설치');
+    try {
+      await fsp.rm(localAppDir(), { recursive: true, force: true });
+    } catch (err) {
+      console.warn('[installer] partial install 정리 실패 (무시, install이 mirror로 덮어씀):', err);
+    }
   }
 
   // 첫 설치 dialog (BrowserWindow 없이 standalone modal — 첫 실행이라 창 없음)
@@ -97,7 +112,15 @@ async function install(): Promise<void> {
   await fsp.mkdir(localAppDir(), { recursive: true });
   await copyDirMirror(remote, localAppDir());
 
-  // 바로가기 자동 생성 (실패해도 설치는 성공으로 간주)
+  // Codex 5차 P1: 모든 파일 mirror copy 완료 후에만 .installed 마커 작성. mid-copy 실패
+  // 시 throw로 빠져나가서 마커는 안 만들어짐 → 다음 실행 시 partial install로 인식.
+  await fsp.writeFile(
+    localInstalledMarker(),
+    new Date().toISOString() + '\n',
+    'utf-8',
+  );
+
+  // 바로가기 자동 생성 (실패해도 설치는 성공으로 간주 — 마커는 위에서 이미 작성)
   await createDesktopShortcut();
   await createStartMenuShortcut();
 }

--- a/electron/autoUpdate/installer.ts
+++ b/electron/autoUpdate/installer.ts
@@ -39,8 +39,7 @@ export async function runFirstInstallIfNeeded(): Promise<InstallResult> {
 
   if (alreadyInstalled) {
     // spec §4.4: 옛 바로가기 폴백. 로컬 본체로 spawn하고 자기는 종료.
-    spawnDetached(localExe);
-    app.exit(0);
+    relaunchAndExit(localExe);
     return { exited: true };
   }
 
@@ -82,8 +81,7 @@ export async function runFirstInstallIfNeeded(): Promise<InstallResult> {
   await offerDefenderExclusion();
 
   // 새 위치에서 spawn + 자기 종료
-  spawnDetached(localExe);
-  app.exit(0);
+  relaunchAndExit(localExe);
   return { exited: true };
 }
 
@@ -180,15 +178,21 @@ async function offerDefenderExclusion(): Promise<void> {
 }
 
 /**
- * Codex 1차 P1: process.argv 전체를 forward.
- * Windows에서 bflow:// 프로토콜 링크는 launch arguments로 전달되므로, 옛 G드라이브
- * 바로가기로 슬랙 딥링크 클릭 시(spec §13 폴백) deep-link payload가 손실되지 않도록
- * 사용자가 넘긴 args를 그대로 전달한다.
+ * 자식 BFLOW.exe spawn → single-instance lock release → self 종료.
+ *
+ * Codex 1차 P1: process.argv를 forward — Windows에서 bflow:// 프로토콜 링크는 launch
+ * arguments로 전달되므로, 옛 G드라이브 바로가기로 슬랙 딥링크 클릭 시(spec §13 폴백)
+ * deep-link payload가 손실되지 않도록 사용자가 넘긴 args를 그대로 전달한다.
+ *
+ * Codex 3차 P2: app.releaseSingleInstanceLock() 호출 — 자식 process가 시작 시
+ * requestSingleInstanceLock()이 false 반환받아 "second instance"로 거부되는 상황 방지.
+ * parent가 아직 완전 exit 전이라도 lock은 명시적으로 해제하면 자식이 정상 lock 획득.
  *
  * process.argv[0] = self exe path, process.argv[1..] = 사용자 인자.
- * 내부 Electron 플래그는 그대로 둬도 BFLOW가 무시 (electron-builder portable이 알아서).
  */
-function spawnDetached(exe: string): void {
+function relaunchAndExit(exe: string): void {
   const args = process.argv.slice(1);
   spawn(exe, args, { detached: true, stdio: 'ignore' }).unref();
+  try { app.releaseSingleInstanceLock(); } catch { /* noop — lock 없을 수도 있음 */ }
+  app.exit(0);
 }

--- a/electron/autoUpdate/installer.ts
+++ b/electron/autoUpdate/installer.ts
@@ -1,0 +1,184 @@
+/**
+ * v1.21.0 self-installer — 첫 실행 시 G드라이브 BFLOW.exe가 자기 자신을
+ * `%LOCALAPPDATA%\Bflow-BGonly\app\` 로 복사하고 바로가기 + Defender 옵션.
+ *
+ * spec §4.3 (첫 실행), §4.4 (옛 바로가기 폴백) 참조.
+ */
+import { app, dialog, shell } from 'electron';
+import { promises as fsp, existsSync } from 'fs';
+import path from 'path';
+import { spawn } from 'child_process';
+import {
+  isRunningFromGoogleDrive,
+  findRemoteWinUnpacked,
+  localRoot,
+  localAppDir,
+  localPendingDir,
+  localBflowExe,
+} from './paths';
+import { copyDirMirror } from './copy';
+
+export interface InstallResult {
+  /** 호출자가 자기 종료해야 하는지 (self-installer가 새 위치에서 spawn 했음) */
+  exited: boolean;
+}
+
+/**
+ * main.ts의 app.whenReady 진입 직후 한 번 호출.
+ * - G드라이브에서 실행됐고 로컬 본체 없으면 → 첫 설치 (dialog → 복사 → spawn).
+ * - G드라이브에서 실행됐고 로컬 본체 있으면 → 즉시 로컬 spawn (옛 바로가기 폴백).
+ * - 로컬에서 실행됐으면 → 그냥 정상 진행 (return { exited: false }).
+ */
+export async function runFirstInstallIfNeeded(): Promise<InstallResult> {
+  if (!isRunningFromGoogleDrive()) {
+    return { exited: false };
+  }
+
+  const localExe = localBflowExe();
+  const alreadyInstalled = existsSync(localExe);
+
+  if (alreadyInstalled) {
+    // spec §4.4: 옛 바로가기 폴백. 로컬 본체로 spawn하고 자기는 종료.
+    spawnDetached(localExe);
+    app.exit(0);
+    return { exited: true };
+  }
+
+  // 첫 설치 dialog (BrowserWindow 없이 standalone modal — 첫 실행이라 창 없음)
+  const choice = await dialog.showMessageBox({
+    type: 'info',
+    title: 'B flow 첫 실행',
+    message: 'B flow 를 PC에 설치합니다 (한 번만, ~5초)',
+    detail:
+      '실행 속도를 위해 B flow 본체를 사용자 PC 폴더로 복사합니다.\n'
+      + '설치 후 자동으로 새 위치에서 실행됩니다. 다음부터는 바탕화면 바로가기를 사용해주세요.\n'
+      + '\n'
+      + '설치 경로: ' + localAppDir(),
+    buttons: ['설치', '취소'],
+    defaultId: 0,
+    cancelId: 1,
+  });
+  if (choice.response !== 0) {
+    app.exit(0);
+    return { exited: true };
+  }
+
+  try {
+    await install();
+  } catch (err) {
+    console.error('[installer] 설치 실패:', err);
+    await dialog.showMessageBox({
+      type: 'error',
+      title: 'B flow 설치 실패',
+      message: '설치 중 오류가 발생했습니다',
+      detail: String((err as Error).message ?? err),
+      buttons: ['확인'],
+    });
+    app.exit(1);
+    return { exited: true };
+  }
+
+  // Defender 제외 등록 (옵션, UAC 동의)
+  await offerDefenderExclusion();
+
+  // 새 위치에서 spawn + 자기 종료
+  spawnDetached(localExe);
+  app.exit(0);
+  return { exited: true };
+}
+
+async function install(): Promise<void> {
+  const remote = findRemoteWinUnpacked();
+  if (!remote) {
+    throw new Error(
+      'G드라이브 폴더에서 B flow 빌드를 찾을 수 없습니다. '
+      + 'Google Drive desktop이 켜져있는지, sync가 끝났는지 확인해주세요.',
+    );
+  }
+  await fsp.mkdir(localRoot(), { recursive: true });
+  await fsp.mkdir(localAppDir(), { recursive: true });
+  await copyDirMirror(remote, localAppDir());
+
+  // 바로가기 자동 생성 (실패해도 설치는 성공으로 간주)
+  await createDesktopShortcut();
+  await createStartMenuShortcut();
+}
+
+async function createDesktopShortcut(): Promise<void> {
+  const desktop = path.join(process.env.USERPROFILE || '', 'Desktop');
+  if (!existsSync(desktop)) return;
+  await createShortcut(path.join(desktop, 'B flow.lnk'));
+}
+
+async function createStartMenuShortcut(): Promise<void> {
+  const startMenu = path.join(
+    process.env.APPDATA || '',
+    'Microsoft', 'Windows', 'Start Menu', 'Programs',
+  );
+  if (!existsSync(startMenu)) return;
+  await createShortcut(path.join(startMenu, 'B flow.lnk'));
+}
+
+/**
+ * Electron의 shell.writeShortcutLink는 Windows에서만 작동. iconPath를 BFLOW.exe로 설정해
+ * BFLOW 자체 아이콘 사용.
+ */
+async function createShortcut(lnkPath: string): Promise<void> {
+  const exe = localBflowExe();
+  try {
+    const ok = shell.writeShortcutLink(lnkPath, 'create', {
+      target: exe,
+      icon: exe,
+      iconIndex: 0,
+      description: 'B flow — Studio JBBJ 워크플로우 대시보드',
+    });
+    if (!ok) console.warn('[installer] 바로가기 생성 실패:', lnkPath);
+  } catch (err) {
+    console.warn('[installer] 바로가기 예외:', lnkPath, err);
+  }
+}
+
+/**
+ * Defender 제외 등록 옵션 dialog. 사용자가 허용하면 elevated PowerShell로 Add-MpPreference.
+ * 거부 시 그냥 진행 (정상 동작, 새 빌드 직후 첫 실행만 약간 느림).
+ */
+async function offerDefenderExclusion(): Promise<void> {
+  const choice = await dialog.showMessageBox({
+    type: 'question',
+    title: 'B flow — 빠른 시작 옵션',
+    message: 'Windows 보안에 검사 제외 등록 (선택)',
+    detail:
+      'B flow 폴더를 Windows Defender 검사 제외로 등록하면 새 빌드를 받은 직후 첫 실행도 빠릅니다.\n'
+      + '(허용 시 관리자 권한 한 번 요청)\n'
+      + '\n'
+      + '제외 폴더: ' + localRoot(),
+    buttons: ['허용', '나중에'],
+    defaultId: 0,
+    cancelId: 1,
+  });
+  if (choice.response !== 0) return;
+
+  // PowerShell elevated — UAC 자동. 실패 시 그냥 진행.
+  const appExclusion = localAppDir();
+  const pendingExclusion = localPendingDir();
+  // single quote escape: PowerShell single-quoted string은 ''로 single quote 표현
+  const escAppPath = appExclusion.replace(/'/g, "''");
+  const escPendingPath = pendingExclusion.replace(/'/g, "''");
+  const innerCommand =
+    `Add-MpPreference -ExclusionPath '${escAppPath}'; `
+    + `Add-MpPreference -ExclusionPath '${escPendingPath}'`;
+  // -Verb RunAs로 UAC. 부모 BFLOW가 종료돼도 detached로 살아남음.
+  const psArgs = [
+    '-NoProfile', '-Command',
+    `Start-Process powershell -Verb RunAs -ArgumentList '-NoProfile','-Command',"${innerCommand}"`,
+  ];
+  try {
+    spawn('powershell.exe', psArgs, { detached: true, stdio: 'ignore' }).unref();
+  } catch (err) {
+    console.warn('[installer] Defender 제외 등록 실패:', err);
+  }
+}
+
+function spawnDetached(exe: string): void {
+  spawn(exe, [], { detached: true, stdio: 'ignore' }).unref();
+}

--- a/electron/autoUpdate/manifest.ts
+++ b/electron/autoUpdate/manifest.ts
@@ -2,11 +2,16 @@
  * v1.21.0 자동 업데이트 — manifest.json 읽기 + 버전 비교.
  * spec §3 빌드 산출물 형식: { version: "1.21.0", buildAt: "2026-05-07T...Z" }
  */
-import { promises as fsp } from 'fs';
+import { promises as fsp, statSync } from 'fs';
+import path from 'path';
 
 export interface Manifest {
   version: string;       // semver string
   buildAt: string;       // ISO 8601
+  /** Codex 9차 P1: 빌드 시점의 win-unpacked 파일 수 (sync 완전성 검증용). 옛 빌드 호환을 위해 optional. */
+  fileCount?: number;
+  /** 빌드 시점의 win-unpacked 총 byte 수 (sync 완전성 검증용). optional. */
+  totalBytes?: number;
 }
 
 /**
@@ -47,4 +52,29 @@ export function compareVersions(a: string, b: string): number {
     if (da < db) return -1;
   }
   return 0;
+}
+
+/**
+ * 디렉토리 안 모든 파일을 재귀로 세고 총 byte 합 계산.
+ * Codex 9차 P1: G드라이브 sync 완전성 검증 + mirror copy 사후 검증에 사용.
+ */
+export function countFilesAndBytes(root: string): { fileCount: number; totalBytes: number } {
+  let fileCount = 0;
+  let totalBytes = 0;
+  function walk(dir: string): void {
+    let entries;
+    try { entries = require('fs').readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    for (const e of entries) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) walk(full);
+      else if (e.isFile()) {
+        try {
+          fileCount++;
+          totalBytes += statSync(full).size;
+        } catch { /* skip 잠금/race */ }
+      }
+    }
+  }
+  walk(root);
+  return { fileCount, totalBytes };
 }

--- a/electron/autoUpdate/manifest.ts
+++ b/electron/autoUpdate/manifest.ts
@@ -1,0 +1,50 @@
+/**
+ * v1.21.0 자동 업데이트 — manifest.json 읽기 + 버전 비교.
+ * spec §3 빌드 산출물 형식: { version: "1.21.0", buildAt: "2026-05-07T...Z" }
+ */
+import { promises as fsp } from 'fs';
+
+export interface Manifest {
+  version: string;       // semver string
+  buildAt: string;       // ISO 8601
+}
+
+/**
+ * 안전 read — 파일 없으면 null. JSON 깨졌으면 null + console.warn.
+ * G드라이브 sync 진행 중에 파일이 한순간 partial일 수 있어 throw 안 함.
+ */
+export async function readManifest(filePath: string): Promise<Manifest | null> {
+  try {
+    const text = await fsp.readFile(filePath, 'utf-8');
+    const parsed = JSON.parse(text);
+    if (typeof parsed?.version !== 'string') return null;
+    return {
+      version: parsed.version,
+      buildAt: typeof parsed.buildAt === 'string' ? parsed.buildAt : '',
+    };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    console.warn('[autoUpdate] manifest 읽기 실패:', filePath, err);
+    return null;
+  }
+}
+
+/**
+ * semver 문자열 비교. major.minor.patch만 — pre-release 태그 무시.
+ * a > b면 1, a == b면 0, a < b면 -1.
+ *
+ * 예: compareVersions("1.21.0", "1.20.5") === 1
+ *     compareVersions("1.20.0", "1.20.0") === 0
+ *     compareVersions("1.19.7", "1.20.0") === -1
+ */
+export function compareVersions(a: string, b: string): number {
+  const pa = a.split('.').map((n) => parseInt(n, 10) || 0);
+  const pb = b.split('.').map((n) => parseInt(n, 10) || 0);
+  for (let i = 0; i < 3; i++) {
+    const da = pa[i] ?? 0;
+    const db = pb[i] ?? 0;
+    if (da > db) return 1;
+    if (da < db) return -1;
+  }
+  return 0;
+}

--- a/electron/autoUpdate/manifest.ts
+++ b/electron/autoUpdate/manifest.ts
@@ -23,9 +23,13 @@ export async function readManifest(filePath: string): Promise<Manifest | null> {
     const text = await fsp.readFile(filePath, 'utf-8');
     const parsed = JSON.parse(text);
     if (typeof parsed?.version !== 'string') return null;
+    // Codex 10차 P1: fileCount/totalBytes도 parse — 9차 통합성 검증이 silent 비활성되던 문제.
+    // 옛 manifest(필드 없음)는 undefined로 두고 checker에서 호환 폴백.
     return {
       version: parsed.version,
       buildAt: typeof parsed.buildAt === 'string' ? parsed.buildAt : '',
+      fileCount: typeof parsed.fileCount === 'number' ? parsed.fileCount : undefined,
+      totalBytes: typeof parsed.totalBytes === 'number' ? parsed.totalBytes : undefined,
     };
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;

--- a/electron/autoUpdate/paths.ts
+++ b/electron/autoUpdate/paths.ts
@@ -47,6 +47,18 @@ export function localInstalledMarker(): string {
 }
 
 /**
+ * Swap 직후 첫 실행 검증 마커 — swapper가 swap 완료 후 작성, healthCheck가 해당 실행이
+ * 정상 메인 창 도달하면 삭제.
+ *
+ * Codex 6차 P1: 이전엔 .start-attempt만으로 rollback 트리거 → 강제 종료·시스템 kill 등
+ * 비손상 interruption도 bad build로 오인되어 backup 다운그레이드. 이 마커가 함께 있을
+ * 때 (= swap 직후 첫 실행)만 rollback 활성화.
+ */
+export function localPendingVerificationMarker(): string {
+  return path.join(localRoot(), '.pending-verification');
+}
+
+/**
  * Drive desktop 가상 마운트의 표준 마커 폴더 — Drive 마운트 root에는 항상 이 중 하나가 있음.
  *  - 한국어 로케일: "공유 드라이브", "내 드라이브"
  *  - 영어 로케일:   "Shared drives", "My Drive"

--- a/electron/autoUpdate/paths.ts
+++ b/electron/autoUpdate/paths.ts
@@ -45,17 +45,29 @@ export function localBflowExe(): string {
 const DRIVE_MOUNT_MARKERS = ['공유 드라이브', '내 드라이브', 'Shared drives', 'My Drive'];
 
 /**
+ * 현재 실행 *진입점* 경로 — portable 빌드 / 일반 빌드 모두 정확히 반환.
+ *
+ * Codex 4차 P1: electron-builder의 `win.target: "portable"`는 실행 시 process.execPath가
+ * %TEMP%/<랜덤UUID>/BFLOW.exe (압축 풀린 임시 폴더)을 가리킴. 원래 launcher path
+ * (사용자가 클릭한 G드라이브의 BFLOW.exe)는 `PORTABLE_EXECUTABLE_FILE` 환경변수에 있음.
+ * 이 변수는 portable 모드 + 부트스트랩 시점에만 set됨 — 그 외(win-unpacked 실행 등)는 undefined.
+ *
+ * 따라서 Drive 감지는 PORTABLE_EXECUTABLE_FILE 우선, 없으면 process.execPath fallback.
+ */
+export function getLaunchExePath(): string {
+  return process.env.PORTABLE_EXECUTABLE_FILE || process.execPath;
+}
+
+/**
  * 현재 실행 파일이 Google Drive 경로 하위에 있는지 추정.
  *
  * Codex 2차 P0: 이전엔 `guessGoogleDriveRoots()`로 받은 모든 drive root와 startsWith
- * 비교했는데, 1차 수정에서 A~Z 전체 scan으로 바뀌면서 일반 디스크(C:\, D:\) root 도
- * 후보에 포함 → 로컬 설치된 정상 PC에서도 항상 true 반환 → 무한 self-installer 루프.
- *
- * 새 휴리스틱: process.execPath에 Drive 마운트 마커("공유 드라이브" 등)가 포함됐는지
- * `includes`로 검사. drive letter 무관하게 정확히 Drive 경로만 매칭.
+ * 비교 → 일반 디스크(C:, D:)도 매치되어 무한 self-installer 루프. 마커 폴더 휴리스틱으로 수정.
+ * Codex 4차 P1: process.execPath만 검사 → portable 모드에서 Temp 경로만 보고 Drive 감지 실패.
+ * getLaunchExePath()로 진짜 launcher 경로 사용.
  */
 export function isRunningFromGoogleDrive(): boolean {
-  const exe = process.execPath.toLowerCase();
+  const exe = getLaunchExePath().toLowerCase();
   return DRIVE_MOUNT_MARKERS.some(
     (marker) => exe.includes(`${path.sep}${marker}${path.sep}`.toLowerCase())
                 || exe.includes(`/${marker}/`.toLowerCase()),

--- a/electron/autoUpdate/paths.ts
+++ b/electron/autoUpdate/paths.ts
@@ -1,0 +1,108 @@
+/**
+ * v1.21.0 자동 업데이트 — 모든 경로 상수 + G드라이브 폴더 추정.
+ * 순수 함수만. fs 사이드 이펙트 X (existsSync 같은 lookup만 허용).
+ *
+ * spec §3 디렉토리 레이아웃:
+ *   %LOCALAPPDATA%\Bflow-BGonly\
+ *     ├ app\       ← 현재 사용 중 BFLOW (win-unpacked 통째로)
+ *     ├ pending\   ← 백그라운드로 받은 새 버전 (종료 시 swap 대기)
+ *     └ backup\    ← 이전 버전 1개 (긴급 롤백용)
+ */
+import { app } from 'electron';
+import { existsSync, statSync } from 'fs';
+import path from 'path';
+
+/** 로컬 본체 루트 — `%LOCALAPPDATA%\Bflow-BGonly\` */
+export function localRoot(): string {
+  // app.getPath('userData') = %APPDATA%\Bflow-BGonly (Roaming) — 사용자 데이터용.
+  // 우리는 LocalAppData를 별도로 사용 — sync 안 됨 + Roaming보다 디스크 빠름.
+  const localAppData = process.env.LOCALAPPDATA
+    || path.join(process.env.USERPROFILE || '', 'AppData', 'Local');
+  return path.join(localAppData, 'Bflow-BGonly');
+}
+
+export const APP_DIR_NAME = 'app';
+export const PENDING_DIR_NAME = 'pending';
+export const BACKUP_DIR_NAME = 'backup';
+export const READY_MARKER = '.ready';
+
+export function localAppDir(): string { return path.join(localRoot(), APP_DIR_NAME); }
+export function localPendingDir(): string { return path.join(localRoot(), PENDING_DIR_NAME); }
+export function localBackupDir(): string { return path.join(localRoot(), BACKUP_DIR_NAME); }
+export function localReadyMarker(): string { return path.join(localPendingDir(), READY_MARKER); }
+
+/** `app/BFLOW.exe` */
+export function localBflowExe(): string {
+  return path.join(localAppDir(), 'BFLOW.exe');
+}
+
+/**
+ * 현재 실행 파일이 G드라이브 경로 하위에 있는지 추정.
+ * 한글 경로 안전성 — path 모듈만 사용 (정규식 직접 비교 X).
+ */
+export function isRunningFromGoogleDrive(): boolean {
+  const exe = process.execPath;
+  const candidates = guessGoogleDriveRoots();
+  for (const root of candidates) {
+    if (exe.toLowerCase().startsWith(root.toLowerCase())) return true;
+  }
+  return false;
+}
+
+/**
+ * G드라이브 desktop 동기화 루트 후보. Drive desktop의 standard mount letter들 +
+ * 사용자 홈의 'Google Drive' 폴더(레거시). 존재하지 않는 후보는 자동 skip.
+ */
+export function guessGoogleDriveRoots(): string[] {
+  const candidates: string[] = [];
+  // Drive desktop의 가상 마운트 (보통 G:, 일부 사용자는 H: 또는 다른 letter)
+  for (const letter of ['G', 'H', 'I', 'J']) {
+    candidates.push(`${letter}:\\`);
+  }
+  // 레거시 데스크톱 sync 폴더
+  if (process.env.USERPROFILE) {
+    candidates.push(path.join(process.env.USERPROFILE, 'Google Drive'));
+    candidates.push(path.join(process.env.USERPROFILE, 'GoogleDrive'));
+  }
+  return candidates.filter((c) => {
+    try { return existsSync(c) && statSync(c).isDirectory(); } catch { return false; }
+  });
+}
+
+/**
+ * 우리 dist가 들어있는 G드라이브 경로 추정. 후보를 스캔해 manifest.json + win-unpacked가
+ * 같이 있는 폴더를 찾아 그 폴더 경로 반환. 없으면 null.
+ *
+ * Studio JBBJ 표준 경로 (DEVLOG/DEPLOYMENT.md §2): G:\공유 드라이브\JBBJ 자료실\한솔이의 두근두근 실험실\Bflow-BGonly\dist\
+ */
+export function findRemoteDistRoot(): string | null {
+  const SUFFIX = path.join('공유 드라이브', 'JBBJ 자료실', '한솔이의 두근두근 실험실', 'Bflow-BGonly', 'dist');
+  const drives = guessGoogleDriveRoots();
+  for (const drive of drives) {
+    const candidate = path.join(drive, SUFFIX);
+    if (existsSync(path.join(candidate, 'manifest.json'))
+        && existsSync(path.join(candidate, 'win-unpacked', 'BFLOW.exe'))) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+/** G드라이브 dist의 win-unpacked 경로 (없으면 null) */
+export function findRemoteWinUnpacked(): string | null {
+  const root = findRemoteDistRoot();
+  return root ? path.join(root, 'win-unpacked') : null;
+}
+
+/** G드라이브 manifest.json 경로 (없으면 null) */
+export function findRemoteManifest(): string | null {
+  const root = findRemoteDistRoot();
+  if (!root) return null;
+  const m = path.join(root, 'manifest.json');
+  return existsSync(m) ? m : null;
+}
+
+/** 현재 실행 중인 BFLOW의 자기 버전 (package.json) */
+export function getOwnVersion(): string {
+  return app.getVersion();
+}

--- a/electron/autoUpdate/paths.ts
+++ b/electron/autoUpdate/paths.ts
@@ -59,12 +59,19 @@ export function localPendingVerificationMarker(): string {
 }
 
 /**
- * Drive desktop 가상 마운트의 표준 마커 폴더 — Drive 마운트 root에는 항상 이 중 하나가 있음.
- *  - 한국어 로케일: "공유 드라이브", "내 드라이브"
- *  - 영어 로케일:   "Shared drives", "My Drive"
- * 일반 C:, D: 같은 디스크 root에는 이 폴더가 없으므로 Drive와 일반 디스크를 정확히 구분.
+ * Drive 가상 마운트 마커 폴더.
+ *  - Drive desktop 가상 마운트(한국어): "공유 드라이브", "내 드라이브"
+ *  - Drive desktop 가상 마운트(영어):   "Shared drives", "My Drive"
+ *  - Legacy desktop sync:               "Google Drive", "GoogleDrive"
+ *
+ * Codex 7차 P1: 이전엔 legacy ~\Google Drive 마커가 누락되어 legacy 사용자는 self-installer
+ * skip 됐음. legacy 마커도 추가.
  */
-const DRIVE_MOUNT_MARKERS = ['공유 드라이브', '내 드라이브', 'Shared drives', 'My Drive'];
+const DRIVE_MOUNT_MARKERS = [
+  '공유 드라이브', '내 드라이브',
+  'Shared drives', 'My Drive',
+  'Google Drive', 'GoogleDrive',
+];
 
 /**
  * 현재 실행 *진입점* 경로 — portable 빌드 / 일반 빌드 모두 정확히 반환.
@@ -143,9 +150,13 @@ export function guessGoogleDriveRoots(): string[] {
  */
 export function findRemoteDistRoot(): string | null {
   const COMMON_TAIL = path.join('JBBJ 자료실', '한솔이의 두근두근 실험실', 'Bflow-BGonly', 'dist');
+  // Drive desktop 가상 마운트는 root 안에 "공유 드라이브"/"Shared drives" prefix 있음.
+  // Legacy ~\Google Drive root는 sync root 자체이므로 prefix 없이 COMMON_TAIL만 추가.
+  // Codex 7차 P1: 이전엔 legacy root에도 prefix prepend하던 문제 — null prefix 폴백 추가.
   const SUFFIXES = [
     path.join('공유 드라이브', COMMON_TAIL),
     path.join('Shared drives', COMMON_TAIL),
+    COMMON_TAIL, // legacy: prefix 없음
   ];
   const drives = guessGoogleDriveRoots();
   for (const drive of drives) {

--- a/electron/autoUpdate/paths.ts
+++ b/electron/autoUpdate/paths.ts
@@ -37,43 +37,64 @@ export function localBflowExe(): string {
 }
 
 /**
- * 현재 실행 파일이 G드라이브 경로 하위에 있는지 추정.
- * 한글 경로 안전성 — path 모듈만 사용 (정규식 직접 비교 X).
+ * Drive desktop 가상 마운트의 표준 마커 폴더 — Drive 마운트 root에는 항상 이 중 하나가 있음.
+ *  - 한국어 로케일: "공유 드라이브", "내 드라이브"
+ *  - 영어 로케일:   "Shared drives", "My Drive"
+ * 일반 C:, D: 같은 디스크 root에는 이 폴더가 없으므로 Drive와 일반 디스크를 정확히 구분.
+ */
+const DRIVE_MOUNT_MARKERS = ['공유 드라이브', '내 드라이브', 'Shared drives', 'My Drive'];
+
+/**
+ * 현재 실행 파일이 Google Drive 경로 하위에 있는지 추정.
+ *
+ * Codex 2차 P0: 이전엔 `guessGoogleDriveRoots()`로 받은 모든 drive root와 startsWith
+ * 비교했는데, 1차 수정에서 A~Z 전체 scan으로 바뀌면서 일반 디스크(C:\, D:\) root 도
+ * 후보에 포함 → 로컬 설치된 정상 PC에서도 항상 true 반환 → 무한 self-installer 루프.
+ *
+ * 새 휴리스틱: process.execPath에 Drive 마운트 마커("공유 드라이브" 등)가 포함됐는지
+ * `includes`로 검사. drive letter 무관하게 정확히 Drive 경로만 매칭.
  */
 export function isRunningFromGoogleDrive(): boolean {
-  const exe = process.execPath;
-  const candidates = guessGoogleDriveRoots();
-  for (const root of candidates) {
-    if (exe.toLowerCase().startsWith(root.toLowerCase())) return true;
-  }
-  return false;
+  const exe = process.execPath.toLowerCase();
+  return DRIVE_MOUNT_MARKERS.some(
+    (marker) => exe.includes(`${path.sep}${marker}${path.sep}`.toLowerCase())
+                || exe.includes(`/${marker}/`.toLowerCase()),
+  );
 }
 
 /**
  * G드라이브 desktop 동기화 루트 후보. Drive desktop은 사용자 환경에 따라 다른 drive
- * letter (다른 네트워크 드라이브가 G:~J:를 점유하면 Drive가 K: 이상에 마운트되기도)에
- * 마운트될 수 있어 모든 letter (A~Z)를 스캔. existsSync + statSync는 ms 수준이라
- * 26회 호출은 비용 무시 가능.
+ * letter에 마운트될 수 있어 A~Z 전체를 스캔하되, **Drive 마운트 마커 폴더가 있는 root
+ * 만** 통과시켜 일반 디스크는 제외.
  *
- * 추가로 레거시 desktop sync 폴더 (~\Google Drive)도 후보에 포함.
- *
- * Codex 1차 P2: 이전엔 G~J 4개만 체크해 다른 letter 마운트 환경에서 install 감지/
- * remote update discovery 모두 실패하던 문제 수정.
+ * 레거시 desktop sync 폴더(~\Google Drive)도 후보에 포함 — 거기는 폴더 자체가 마커.
  */
 export function guessGoogleDriveRoots(): string[] {
   const candidates: string[] = [];
-  // A~Z 전체 스캔 — Drive desktop이 어떤 letter에 마운트됐든 감지
-  for (let i = 65; i <= 90; i++) { // 'A'.charCodeAt(0) = 65, 'Z' = 90
-    candidates.push(`${String.fromCharCode(i)}:\\`);
+  // A~Z 전체 스캔, 단 Drive 마운트 마커 폴더가 있는 root만
+  for (let i = 65; i <= 90; i++) { // 'A' ~ 'Z'
+    const root = `${String.fromCharCode(i)}:\\`;
+    try {
+      if (!existsSync(root) || !statSync(root).isDirectory()) continue;
+    } catch { continue; }
+    const isDriveMount = DRIVE_MOUNT_MARKERS.some((marker) => {
+      try { return existsSync(path.join(root, marker)); } catch { return false; }
+    });
+    if (isDriveMount) candidates.push(root);
   }
-  // 레거시 데스크톱 sync 폴더
+  // 레거시 데스크톱 sync 폴더 (별도 마커 검사 X — 폴더 자체가 sync 루트)
   if (process.env.USERPROFILE) {
-    candidates.push(path.join(process.env.USERPROFILE, 'Google Drive'));
-    candidates.push(path.join(process.env.USERPROFILE, 'GoogleDrive'));
+    const legacyCandidates = [
+      path.join(process.env.USERPROFILE, 'Google Drive'),
+      path.join(process.env.USERPROFILE, 'GoogleDrive'),
+    ];
+    for (const c of legacyCandidates) {
+      try {
+        if (existsSync(c) && statSync(c).isDirectory()) candidates.push(c);
+      } catch { /* ignore */ }
+    }
   }
-  return candidates.filter((c) => {
-    try { return existsSync(c) && statSync(c).isDirectory(); } catch { return false; }
-  });
+  return candidates;
 }
 
 /**

--- a/electron/autoUpdate/paths.ts
+++ b/electron/autoUpdate/paths.ts
@@ -101,16 +101,26 @@ export function guessGoogleDriveRoots(): string[] {
  * 우리 dist가 들어있는 G드라이브 경로 추정. 후보를 스캔해 manifest.json + win-unpacked가
  * 같이 있는 폴더를 찾아 그 폴더 경로 반환. 없으면 null.
  *
- * Studio JBBJ 표준 경로 (DEVLOG/DEPLOYMENT.md §2): G:\공유 드라이브\JBBJ 자료실\한솔이의 두근두근 실험실\Bflow-BGonly\dist\
+ * Studio JBBJ 표준 경로 (DEVLOG/DEPLOYMENT.md §2):
+ *   G:\공유 드라이브\JBBJ 자료실\한솔이의 두근두근 실험실\Bflow-BGonly\dist\
+ *
+ * Codex 3차 P1: 영어 OS의 Drive desktop은 "Shared drives" 폴더로 노출되므로 두 prefix
+ * 모두 시도해야 한국어/영어 사용자 모두 자동 업데이트 동작.
  */
 export function findRemoteDistRoot(): string | null {
-  const SUFFIX = path.join('공유 드라이브', 'JBBJ 자료실', '한솔이의 두근두근 실험실', 'Bflow-BGonly', 'dist');
+  const COMMON_TAIL = path.join('JBBJ 자료실', '한솔이의 두근두근 실험실', 'Bflow-BGonly', 'dist');
+  const SUFFIXES = [
+    path.join('공유 드라이브', COMMON_TAIL),
+    path.join('Shared drives', COMMON_TAIL),
+  ];
   const drives = guessGoogleDriveRoots();
   for (const drive of drives) {
-    const candidate = path.join(drive, SUFFIX);
-    if (existsSync(path.join(candidate, 'manifest.json'))
-        && existsSync(path.join(candidate, 'win-unpacked', 'BFLOW.exe'))) {
-      return candidate;
+    for (const suffix of SUFFIXES) {
+      const candidate = path.join(drive, suffix);
+      if (existsSync(path.join(candidate, 'manifest.json'))
+          && existsSync(path.join(candidate, 'win-unpacked', 'BFLOW.exe'))) {
+        return candidate;
+      }
     }
   }
   return null;

--- a/electron/autoUpdate/paths.ts
+++ b/electron/autoUpdate/paths.ts
@@ -50,14 +50,21 @@ export function isRunningFromGoogleDrive(): boolean {
 }
 
 /**
- * G드라이브 desktop 동기화 루트 후보. Drive desktop의 standard mount letter들 +
- * 사용자 홈의 'Google Drive' 폴더(레거시). 존재하지 않는 후보는 자동 skip.
+ * G드라이브 desktop 동기화 루트 후보. Drive desktop은 사용자 환경에 따라 다른 drive
+ * letter (다른 네트워크 드라이브가 G:~J:를 점유하면 Drive가 K: 이상에 마운트되기도)에
+ * 마운트될 수 있어 모든 letter (A~Z)를 스캔. existsSync + statSync는 ms 수준이라
+ * 26회 호출은 비용 무시 가능.
+ *
+ * 추가로 레거시 desktop sync 폴더 (~\Google Drive)도 후보에 포함.
+ *
+ * Codex 1차 P2: 이전엔 G~J 4개만 체크해 다른 letter 마운트 환경에서 install 감지/
+ * remote update discovery 모두 실패하던 문제 수정.
  */
 export function guessGoogleDriveRoots(): string[] {
   const candidates: string[] = [];
-  // Drive desktop의 가상 마운트 (보통 G:, 일부 사용자는 H: 또는 다른 letter)
-  for (const letter of ['G', 'H', 'I', 'J']) {
-    candidates.push(`${letter}:\\`);
+  // A~Z 전체 스캔 — Drive desktop이 어떤 letter에 마운트됐든 감지
+  for (let i = 65; i <= 90; i++) { // 'A'.charCodeAt(0) = 65, 'Z' = 90
+    candidates.push(`${String.fromCharCode(i)}:\\`);
   }
   // 레거시 데스크톱 sync 폴더
   if (process.env.USERPROFILE) {

--- a/electron/autoUpdate/paths.ts
+++ b/electron/autoUpdate/paths.ts
@@ -37,6 +37,16 @@ export function localBflowExe(): string {
 }
 
 /**
+ * 설치 완료 마커 — install()이 *완전히* 성공했을 때만 작성.
+ * Codex 5차 P1: 이전엔 BFLOW.exe 존재만으로 "이미 설치됨" 판단 → mid-copy 실패한
+ * partial install이 무한 startup failure trap이 되던 문제. 이 마커가 있어야 진짜
+ * 설치 완료로 간주.
+ */
+export function localInstalledMarker(): string {
+  return path.join(localAppDir(), '.installed');
+}
+
+/**
  * Drive desktop 가상 마운트의 표준 마커 폴더 — Drive 마운트 root에는 항상 이 중 하나가 있음.
  *  - 한국어 로케일: "공유 드라이브", "내 드라이브"
  *  - 영어 로케일:   "Shared drives", "My Drive"

--- a/electron/autoUpdate/swapper.ts
+++ b/electron/autoUpdate/swapper.ts
@@ -1,0 +1,80 @@
+/**
+ * v1.21.0 자동 업데이트 — before-quit hook에서 호출.
+ * pending/.ready 가 있으면 app/ → backup/, pending/ → app/ 으로 swap.
+ *
+ * 락 안전성:
+ *   app/ 내부 BFLOW.exe는 *현재 실행 중*이라 락 걸려있다고 생각하기 쉽지만,
+ *   Windows의 directory rename은 자식 파일의 락과 무관하게 디렉토리 자체가 비어있지
+ *   않으면 atomic rename. before-quit hook은 *renderer가 종료된 후 메인 프로세스 종료
+ *   직전*에 발화하므로 BFLOW.exe 파일 자체는 여전히 실행 중이지만, 디렉토리 rename은
+ *   가능 (Windows는 실행 중 exe의 부모 디렉토리 rename 허용).
+ *
+ *   그래도 일부 시나리오에서 락이 걸릴 수 있으므로(드물게 antivirus 등) 실패 시 graceful
+ *   처리: app/ → backup 시도가 실패하면 그대로 두고 swap 안 함. 다음 종료 시 재시도.
+ *
+ * spec §4.2 step 6, §6 "swap 실패 / 새 버전 깨짐" 처리.
+ */
+import { promises as fsp, existsSync, renameSync } from 'fs';
+import path from 'path';
+import {
+  localAppDir, localPendingDir, localBackupDir, localReadyMarker,
+} from './paths';
+
+export async function hasPending(): Promise<boolean> {
+  return existsSync(localReadyMarker());
+}
+
+export interface SwapResult {
+  ok: boolean;
+  reason?: string;
+}
+
+/**
+ * pending → app swap. before-quit hook에서 호출.
+ * 동기 rename 사용 — 짧고 결정론적이어야 함.
+ */
+export async function swapIfPending(): Promise<SwapResult> {
+  const ready = localReadyMarker();
+  if (!existsSync(ready)) return { ok: false, reason: 'no-pending' };
+
+  const app_ = localAppDir();
+  const pending_ = localPendingDir();
+  const backup_ = localBackupDir();
+
+  // 1. 이전 backup 정리 — 1개만 유지하니 통째로 지움 (실패해도 무시)
+  try {
+    if (existsSync(backup_)) {
+      await fsp.rm(backup_, { recursive: true, force: true });
+    }
+  } catch (err) {
+    console.warn('[swapper] 이전 backup 정리 실패 (무시):', err);
+  }
+
+  // 2. app/ → backup/
+  try {
+    if (existsSync(app_)) {
+      renameSync(app_, backup_);
+    }
+  } catch (err) {
+    return { ok: false, reason: `app→backup rename 실패: ${(err as Error).message}` };
+  }
+
+  // 3. pending/ → app/
+  try {
+    renameSync(pending_, app_);
+  } catch (err) {
+    // 복구 시도: backup → app으로 되돌림
+    try { renameSync(backup_, app_); } catch {
+      // 더 할 게 없음 — 사용자가 옛 바로가기로 self-installer 재진입
+    }
+    return { ok: false, reason: `pending→app rename 실패: ${(err as Error).message}` };
+  }
+
+  // 4. .ready 마커 정리 — pending 안에 있던 마커가 swap으로 app/.ready가 됨
+  try {
+    const stale = path.join(app_, '.ready');
+    if (existsSync(stale)) await fsp.unlink(stale);
+  } catch { /* 무시 */ }
+
+  return { ok: true };
+}

--- a/electron/autoUpdate/swapper.ts
+++ b/electron/autoUpdate/swapper.ts
@@ -18,7 +18,7 @@ import { promises as fsp, existsSync, renameSync } from 'fs';
 import path from 'path';
 import {
   localAppDir, localPendingDir, localBackupDir, localReadyMarker,
-  localInstalledMarker,
+  localInstalledMarker, localPendingVerificationMarker,
 } from './paths';
 
 export async function hasPending(): Promise<boolean> {
@@ -84,6 +84,16 @@ export async function swapIfPending(): Promise<SwapResult> {
     await fsp.writeFile(localInstalledMarker(), new Date().toISOString() + '\n', 'utf-8');
   } catch (err) {
     console.warn('[swapper] .installed 마커 작성 실패 (무시 — 다음 실행에서 재설치 트리거 가능):', err);
+  }
+
+  // 6. .pending-verification 마커 작성 — 새 빌드로 swap 직후이므로 *다음 실행*은 검증 모드.
+  //    healthCheck가 이 마커가 있을 때만 .start-attempt를 트래킹해 rollback 트리거.
+  //    그 외 일상 실행(평소 강제 종료·시스템 kill 등)은 검증 비활성으로 의도치 않은 롤백 X.
+  //    Codex 6차 P1.
+  try {
+    await fsp.writeFile(localPendingVerificationMarker(), new Date().toISOString() + '\n', 'utf-8');
+  } catch (err) {
+    console.warn('[swapper] .pending-verification 마커 작성 실패 (무시 — 자가 검증 비활성, 안전):', err);
   }
 
   return { ok: true };

--- a/electron/autoUpdate/swapper.ts
+++ b/electron/autoUpdate/swapper.ts
@@ -18,6 +18,7 @@ import { promises as fsp, existsSync, renameSync } from 'fs';
 import path from 'path';
 import {
   localAppDir, localPendingDir, localBackupDir, localReadyMarker,
+  localInstalledMarker,
 } from './paths';
 
 export async function hasPending(): Promise<boolean> {
@@ -75,6 +76,15 @@ export async function swapIfPending(): Promise<SwapResult> {
     const stale = path.join(app_, '.ready');
     if (existsSync(stale)) await fsp.unlink(stale);
   } catch { /* 무시 */ }
+
+  // 5. .installed 마커 작성 — swap된 새 app/도 정상 설치 상태로 표시.
+  //    이게 없으면 다음 실행 시 installer.ts가 partial install로 잘못 감지하고 G드라이브
+  //    click 시 정리·재설치 흐름 진입. 마커는 pending에서는 안 만들었으니 swap 후 명시 작성.
+  try {
+    await fsp.writeFile(localInstalledMarker(), new Date().toISOString() + '\n', 'utf-8');
+  } catch (err) {
+    console.warn('[swapper] .installed 마커 작성 실패 (무시 — 다음 실행에서 재설치 트리거 가능):', err);
+  }
 
   return { ok: true };
 }

--- a/electron/autoUpdate/swapper.ts
+++ b/electron/autoUpdate/swapper.ts
@@ -20,6 +20,30 @@ import {
   localAppDir, localPendingDir, localBackupDir, localReadyMarker,
   localInstalledMarker, localPendingVerificationMarker,
 } from './paths';
+import { copyDirMirror } from './copy';
+
+/**
+ * Codex 8차 P1: rename은 cross-device·AV race·partial file-lock 등에서 실패할 수 있어
+ * fallback으로 copy + 원본 삭제. swap의 핵심 안전성을 보장 — rename 실패 시에도
+ * app/ 디렉토리가 사라지지 않게.
+ */
+async function moveDirRobust(src: string, dst: string): Promise<void> {
+  try {
+    renameSync(src, dst);
+    return;
+  } catch (renameErr) {
+    // rename 실패 → copy fallback (느리지만 락에 robust)
+    try {
+      await copyDirMirror(src, dst);
+      await fsp.rm(src, { recursive: true, force: true });
+    } catch (copyErr) {
+      throw new Error(
+        `rename 및 copy 모두 실패 (rename: ${(renameErr as Error).message}, `
+        + `copy: ${(copyErr as Error).message})`,
+      );
+    }
+  }
+}
 
 export async function hasPending(): Promise<boolean> {
   return existsSync(localReadyMarker());
@@ -51,24 +75,39 @@ export async function swapIfPending(): Promise<SwapResult> {
     console.warn('[swapper] 이전 backup 정리 실패 (무시):', err);
   }
 
-  // 2. app/ → backup/
-  try {
-    if (existsSync(app_)) {
-      renameSync(app_, backup_);
+  // 2. app/ → backup/  (rename + copy fallback)
+  let movedToBackup = false;
+  if (existsSync(app_)) {
+    try {
+      await moveDirRobust(app_, backup_);
+      movedToBackup = true;
+    } catch (err) {
+      return { ok: false, reason: `app→backup 실패: ${(err as Error).message}` };
     }
-  } catch (err) {
-    return { ok: false, reason: `app→backup rename 실패: ${(err as Error).message}` };
   }
 
-  // 3. pending/ → app/
+  // 3. pending/ → app/  (rename + copy fallback)
   try {
-    renameSync(pending_, app_);
-  } catch (err) {
-    // 복구 시도: backup → app으로 되돌림
-    try { renameSync(backup_, app_); } catch {
-      // 더 할 게 없음 — 사용자가 옛 바로가기로 self-installer 재진입
+    await moveDirRobust(pending_, app_);
+  } catch (pendingErr) {
+    // Codex 8차 P1: pending→app 실패 시 backup→app 복구 시도. backup 복구도 robust하게.
+    if (movedToBackup) {
+      try {
+        await moveDirRobust(backup_, app_);
+        return { ok: false, reason: `pending→app 실패 — backup 복구 완료: ${(pendingErr as Error).message}` };
+      } catch (recoverErr) {
+        // 양쪽 모두 실패 — app/ 부재 가능성. 다음 실행은 옛 G드라이브 BFLOW.exe로 self-installer
+        // 재진입하면 자동 복구됨 (기존 partial install 정리 → mirror copy 새로 받음).
+        return {
+          ok: false,
+          reason:
+            `pending→app + backup→app 모두 실패. app/ 부재 가능성 — `
+            + `옛 G드라이브 BFLOW.exe 클릭으로 자동 복구 가능. `
+            + `pending: ${(pendingErr as Error).message}; backup recovery: ${(recoverErr as Error).message}`,
+        };
+      }
     }
-    return { ok: false, reason: `pending→app rename 실패: ${(err as Error).message}` };
+    return { ok: false, reason: `pending→app 실패 (backup 없어 복구 없음): ${(pendingErr as Error).message}` };
   }
 
   // 4. .ready 마커 정리 — pending 안에 있던 마커가 swap으로 app/.ready가 됨

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -18,6 +18,15 @@ import { uploadImage as driveUploadImage, setImageUploadUrl } from './drive-imag
 import { uploadImage as storageUploadImage, deleteImage as storageDeleteImage } from './storage';
 // v1.20.0: 사용자 폰트 IPC + bflow-font:// custom protocol
 import { registerFontProtocol, registerFontIpcHandlers } from './fontIpc';
+// v1.21.0: 자동 업데이트 시스템 (G드라이브 → 로컬 PC 본체로 swap)
+import {
+  runFirstInstallIfNeeded,
+  scheduleUpdateCheck,
+  hasPending,
+  swapIfPending,
+  checkLastStartAndRollback,
+  markStartSucceeded,
+} from './autoUpdate';
 import {
   initVacation,
   isVacationConnected,
@@ -633,6 +642,14 @@ function createWindow(): void {
       pendingDeepLink = null;
     }
     try { console.timeEnd('splash-to-main'); } catch {/* 이미 종료됨 */}
+
+    // ★ v1.21.0 자동 업데이트:
+    //   1) 정상 시작 표시 (자가 검증 마커 삭제)
+    //   2) 5초 후 백그라운드 업데이트 체크 (한 번만, 사용자 작업 영향 0)
+    markStartSucceeded().catch(() => { /* noop */ });
+    setTimeout(() => {
+      scheduleUpdateCheck().catch((err) => console.warn('[autoUpdate] 체크 실패:', err));
+    }, 5_000);
   });
 
   mainWindow.on('close', (e) => {
@@ -2735,14 +2752,31 @@ app.whenReady().then(async () => {
   // 두 번째 인스턴스면 초기화하지 않고 종료
   if (!gotTheLock) return;
 
+  // ★ v1.21.0 자동 업데이트:
+  //   G드라이브에서 직접 실행됐으면 self-installer로 로컬에 설치 후 새 위치에서 spawn.
+  //   이미 설치돼있는 경우는 즉시 로컬 spawn (옛 바로가기 폴백). 로컬 실행이면 통과.
+  const installResult = await runFirstInstallIfNeeded();
+  if (installResult.exited) return;
+
+  // ★ v1.21.0 자가 검증:
+  //   이전 시작이 메인 창까지 못 갔으면(.start-attempt 마커 잔존) backup → app 롤백.
+  //   여기서 작성한 새 마커는 mainWindow did-finish-load 시점에 markStartSucceeded()가 삭제.
+  await checkLastStartAndRollback();
+
+  // ★ v1.20.x perf (gifted-darwin-99908d 964241d 포트):
+  //   사용자에게 즉시 "켜졌다" 피드백을 주려면 스플래시를 가장 먼저 띄워야 함.
+  //   이전엔 cleanupImageCache의 동기 readdirSync + N×statSync가 사용자 데이터
+  //   디렉토리의 이미지 수에 비례해 첫 창 표시까지의 체감 지연을 만들었음.
+  createSplashWindow();
+  console.time('splash-to-main'); // 스플래시 노출 시점부터 메인 did-finish-load까지 측정
+
   // 메인 창 bounds 미리 로드 — createWindow 전에 캐시 완료되어 있어야 첫 창부터 저장 크기로 뜸
   await preloadMainWindowBounds();
 
   // 위젯 위치 캐시 로드 (Phase 0-6)
   loadWidgetPositions();
 
-  // 이미지 캐시 정리 (500MB 초과 시 Drive 백업된 파일 자동 삭제)
-  cleanupImageCache();
+  // ※ cleanupImageCache()는 시작 시점이 아니라 메인 창 로드 후 백그라운드로 미룸 (아래 setTimeout)
 
   // bflow-img:// 프로토콜 핸들러: userData/images/ 폴더에서 이미지 서빙
   // standard URL이므로 hostname은 소문자로 변환됨 → pathname에 파일명 보관
@@ -2785,11 +2819,18 @@ app.whenReady().then(async () => {
     return new Response('Drive image not found', { status: 404 });
   });
 
-  console.time('splash-to-main'); // 측정 시작
-
-  createSplashWindow(); // 1. 가장 먼저 스플래시
-  createTray();        // 먼저 트레이 준비 (실패해도 앱은 계속)
+  // (스플래시·console.time은 위 gotTheLock 체크 직후로 이동했음 — 시작 직후 즉시 노출 위해)
+  createTray();        // 트레이 준비 (실패해도 앱은 계속)
   createWindow();
+
+  // ★ v1.20.x perf (gifted-darwin-99908d 964241d 포트):
+  //   이미지 캐시 정리는 백그라운드로 — 시작 지연의 가장 큰 원인이었음.
+  //   `fs.readdirSync` + N×`fs.statSync` 가 동기로 돌아 사용자 데이터 디렉토리에
+  //   이미지가 많을수록 비례해서 느려짐. 메인 창 로드 후 5초 뒤 한 번 정리해도
+  //   캐시 한도(500MB)는 충분히 지킬 수 있다.
+  setTimeout(() => {
+    try { cleanupImageCache(); } catch (err) { console.warn('[ImageCache] cleanup 실패:', err); }
+  }, 5_000);
 
   // 메인 로드 30초 타임아웃 (좀비 방지).
   // Task 2.3의 did-finish-load 핸들러에서 clearTimeout + 해제 처리.
@@ -2888,33 +2929,52 @@ app.on('before-quit', (e) => {
   const sheetsPending = getPendingOpsCount();
   const vacPending = getVacPendingOpsCount();
   const totalPending = sheetsPending + vacPending;
+  // v1.21.0: 자동 업데이트 swap이 있으면 어떤 분기든 e.preventDefault + 비동기 chain 끝에 swap.
+  // 기존 fire-and-forget 분기도 swap 시점까지 대기 — race 위험 제거.
+  e.preventDefault();
+
+  // 메인 윈도우에 "저장 중" 알림 (pending 작업이 있는 경우만 의미 있음)
   if (totalPending > 0) {
-    e.preventDefault();
-
     console.log(`[종료] ${totalPending}개 작업 대기 중 (시트: ${sheetsPending}, 휴가: ${vacPending})... 완료 후 종료합니다.`);
-
-    // 메인 윈도우에 "저장 중" 알림
     if (mainWindow && !mainWindow.isDestroyed()) {
       mainWindow.webContents.send('app:saving-before-quit', totalPending);
     }
-
-    // Watch 정리 + 시트 15초 + 휴가 60초 대기 후 종료
-    const watchWithTimeout = Promise.race([watchCleanup, new Promise<void>((r) => setTimeout(r, 5000))]);
-    Promise.all([
-      watchWithTimeout,
-      waitForAllPendingOps(15000),
-      waitForVacPendingOps(60000),
-    ]).then(([, sheetsDone, vacDone]) => {
-      if (!sheetsDone || !vacDone) {
-        console.warn('[종료] 타임아웃 — 일부 작업이 완료되지 않았을 수 있습니다');
-      }
-      console.log('[종료] 저장 완료, 앱을 종료합니다');
-      app.quit();
-    });
-  } else {
-    // 대기 중 작업 없음: Watch 정리는 fire-and-forget (종료를 지연시키지 않음)
-    Promise.race([watchCleanup, new Promise<void>((r) => setTimeout(r, 2000))]).catch(() => {});
   }
+
+  const watchWithTimeout = Promise.race([
+    watchCleanup,
+    new Promise<void>((r) => setTimeout(r, totalPending > 0 ? 5000 : 2000)),
+  ]);
+
+  (async () => {
+    try {
+      if (totalPending > 0) {
+        const [, sheetsDone, vacDone] = await Promise.all([
+          watchWithTimeout,
+          waitForAllPendingOps(15000),
+          waitForVacPendingOps(60000),
+        ]);
+        if (!sheetsDone || !vacDone) {
+          console.warn('[종료] 타임아웃 — 일부 작업이 완료되지 않았을 수 있습니다');
+        } else {
+          console.log('[종료] 저장 완료, 앱을 종료합니다');
+        }
+      } else {
+        await watchWithTimeout.catch(() => { /* noop */ });
+      }
+
+      // ★ v1.21.0 자동 업데이트 swap (마지막 step)
+      if (await hasPending()) {
+        const result = await swapIfPending();
+        if (!result.ok) console.warn('[autoUpdate] swap 실패:', result.reason);
+        else console.log('[autoUpdate] swap 완료 — 다음 실행 = 새 버전');
+      }
+    } catch (err) {
+      console.warn('[종료] 정리/swap 예외:', err);
+    } finally {
+      app.exit(0);
+    }
+  })();
 });
 
 process.on('exit', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "dist-electron/main.js",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build && electron-builder",
-    "build:vite": "tsc && vite build",
+    "build": "tsc && vite build && electron-builder && node scripts/generate-manifest.js",
+    "build:vite": "tsc && vite build && node scripts/generate-manifest.js",
     "preview": "vite preview",
     "electron:dev": "vite build && electron .",
     "lint": "eslint src --ext ts,tsx"

--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+/**
+ * v1.21.0 자동 업데이트 — 빌드 후 dist/manifest.json 자동 생성.
+ * `npm run build` 마지막 step. 한솔 손 거치지 않음.
+ *
+ * 출력 형식 (spec §3): { "version": "1.21.0", "buildAt": "ISO8601" }
+ */
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf-8'));
+
+const distDir = path.join(root, 'dist');
+if (!fs.existsSync(distDir)) {
+  console.error('[generate-manifest] dist/ 가 없음. vite build 먼저 실행하세요.');
+  process.exit(1);
+}
+
+const manifest = {
+  version: pkg.version,
+  buildAt: new Date().toISOString(),
+};
+
+const out = path.join(distDir, 'manifest.json');
+fs.writeFileSync(out, JSON.stringify(manifest, null, 2) + '\n');
+console.log(`[generate-manifest] ${out} 생성 — v${manifest.version} @ ${manifest.buildAt}`);

--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -17,11 +17,42 @@ if (!fs.existsSync(distDir)) {
   process.exit(1);
 }
 
+/**
+ * Codex 9차 P1: win-unpacked의 fileCount + totalBytes 기록.
+ * checker가 G드라이브 sync 완전성 검증 (원격 manifest와 실제 파일 트리 비교) +
+ * mirror copy 사후 검증 (로컬 pending이 원격과 일치하는지) 두 단계로 사용.
+ * partial sync/copy 상태에서 .ready 마커가 잘못 만들어져 broken app swap되는 사고 방지.
+ */
+const winUnpacked = path.join(distDir, 'win-unpacked');
+let fileCount = 0;
+let totalBytes = 0;
+function walk(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full);
+    } else if (entry.isFile()) {
+      fileCount++;
+      totalBytes += fs.statSync(full).size;
+    }
+  }
+}
+if (fs.existsSync(winUnpacked)) {
+  walk(winUnpacked);
+} else {
+  console.warn('[generate-manifest] dist/win-unpacked 없음 — fileCount/totalBytes 0으로 기록');
+}
+
 const manifest = {
   version: pkg.version,
   buildAt: new Date().toISOString(),
+  fileCount,
+  totalBytes,
 };
 
 const out = path.join(distDir, 'manifest.json');
 fs.writeFileSync(out, JSON.stringify(manifest, null, 2) + '\n');
-console.log(`[generate-manifest] ${out} 생성 — v${manifest.version} @ ${manifest.buildAt}`);
+console.log(
+  `[generate-manifest] ${out} 생성 — v${manifest.version} @ ${manifest.buildAt} `
+  + `(${fileCount} files, ${(totalBytes / 1024 / 1024).toFixed(1)}MB)`,
+);

--- a/src/components/widgets/OverallProgressWidget.tsx
+++ b/src/components/widgets/OverallProgressWidget.tsx
@@ -69,8 +69,6 @@ const RANDOM_MESSAGES: MotivMessage[] = [
   { text: '응후응후', author: '이혜민' },
   { text: 'る..', author: 'ちいかわ' },
   { text: '저는 서울에 사는 초등학생을 보면 너무 화나요', author: '이명훈' },
-  { text: '저 인스타 지울 수 있습니다', author: '강지융' },
-  { text: '근데 인스타에 연락처가 있어서 못지워요', author: '강지융' },
   { text: '네 ㅋㅋ 찌찌 ㅋㅋ', author: '원동우' },
   { text: '너 지웅이 좋아해?', author: '류이레' },
   { text: '우리 언젠가 분명히 잡혀갈거야.....', author: '정영준' },


### PR DESCRIPTION
## 📝 업데이트 로그 (비개발자용)

**문제**: G드라이브에서 직접 BFLOW.exe를 실행하면 매 실행마다 Windows Defender가 처음 보는 파일처럼 풀 스캔 → 13~17초 cold start. 일부 사용자는 동적 import 청크가 임시 폴더에서 fetch 실패해서 앱이 깨짐 (`[Promise 오류] Failed to fetch dynamically imported module ... lastSeenTracker-MtZSySJz.js`).

**해결**: 사용자 PC에 BFLOW 본체를 한 번 복사해두고 *로컬에서 실행*. 새 빌드는 G드라이브에서 *백그라운드로 받아 swap*. 측정값 (한솔 PC, 2026-05-01):

| 실행 환경 | 1차 | 2차 (재실행) |
|---|---|---|
| G드라이브 직접 | 17.3초 | 14.6초 (캐시 거의 없음) |
| 로컬 디스크 | 14.7초 | **1.6초** ⚡ |

### 사용자 시나리오

**한솔이 새 빌드 push 후**
1. G드라이브 동기화 (지금 그대로)
2. 팀원이 평소처럼 바탕화면 바로가기 더블클릭 → **1~2초 즉시 실행** (현재 버전)
3. 백그라운드: 새 빌드 자동 감지 → `pending\` 으로 변경분만 다운로드 (사용자는 모름)
4. 사용자 종료 → 종료 시 자동 swap (조용히)
5. 다음 실행 = **1~2초 새 버전** ✨

**신규 팀원 또는 옛 바로가기 사용자 첫 클릭**
1. G드라이브 BFLOW.exe 더블클릭
2. dialog "B flow 를 PC에 설치합니다 (한 번만, ~5초)" → 설치 클릭
3. 5~30초 후 새 위치에서 실행 + 바탕화면/시작메뉴 바로가기 자동 생성
4. (옵션) Defender 제외 등록 dialog → "허용" → UAC → 새 빌드 직후 첫 실행도 빠름
5. 다음부터 바탕화면 바로가기 사용

**컴퓨터 껐다 켜고 앱 시작 (업데이트 없음)**
- 1~2초 즉시 실행 ✅

---

## 🧱 기술 변경 요약

### 신규 모듈 (`electron/autoUpdate/`)

| 파일 | 책임 |
|---|---|
| `paths.ts` | 모든 경로 상수 + G드라이브 dist 폴더 추정 (Studio JBBJ 표준 suffix). |
| `manifest.ts` | `manifest.json` 안전 read + semver 비교. partial sync 안전. |
| `copy.ts` | 디렉토리 mirror — size+mtime 비교로 변경분만, orphan 자동 제거. Node fs API 직접. |
| `installer.ts` | 첫 실행 self-installer + 옛 바로가기 폴백. 바탕화면/시작메뉴 바로가기 + Defender 옵션. |
| `checker.ts` | 메인 창 로드 후 5초 백그라운드 체크 + pending 다운로드 + `.ready` 마커. |
| `swapper.ts` | before-quit hook에서 `app/` ↔ `pending/` swap. 실패 시 backup 복구. |
| `healthCheck.ts` | `.start-attempt` 마커로 시작 실패 감지 → backup 자동 롤백 + 손상 빌드 보존. |
| `index.ts` | main.ts가 import하는 단일 진입점. |

### 빌드 산출물

| 변경 | |
|---|---|
| `scripts/generate-manifest.js` (신규) | `npm run build` 마지막 step. `dist/manifest.json = { version, buildAt }` 자동 생성. |
| `package.json` build/build:vite | 끝에 `&& node scripts/generate-manifest.js` 추가. |

### 사용자 PC 디렉토리 레이아웃 (신규)

```
%LOCALAPPDATA%\Bflow-BGonly\
├── app\              ← 현재 사용 중 BFLOW (win-unpacked 통째로)
├── pending\          ← 백그라운드 다운로드 (종료 시 swap 대기)
├── backup\           ← 이전 버전 1개 (긴급 롤백용)
└── .start-attempt    ← 자가 검증 마커 (정상 시작 시 자동 삭제)

%APPDATA%\Bflow-BGonly\   ← 사용자 데이터 (변경 없음)
```

### main.ts 통합 (3 지점)

1. **`app.whenReady` 진입 직후** — `runFirstInstallIfNeeded`로 G드라이브/로컬 분기. 이전 시작 실패 자동 롤백 (`checkLastStartAndRollback`).
2. **`mainWindow did-finish-load`** — `markStartSucceeded` + 5초 후 `scheduleUpdateCheck` 백그라운드 호출.
3. **`before-quit`** — 항상 `e.preventDefault` + 기존 정리(gcal/sheets/vac) → 마지막에 swap → `app.exit(0)`. 기존 fire-and-forget watchCleanup의 race도 함께 제거.

### 이전 perf 변경 (gifted-darwin-99908d 964241d 포트, 같이 머지)

- `electron/main.ts` — `createSplashWindow()`를 가장 먼저 호출 (즉시 사용자 피드백) + `cleanupImageCache()`를 메인 창 로드 후 5초 백그라운드로 미룸.
  - 이전엔 `cleanupImageCache`의 동기 `readdirSync` + N×`statSync`가 사용자 데이터 디렉토리 이미지 수에 비례해 시작 차단.
- `src/components/widgets/OverallProgressWidget.tsx` — RANDOM_MESSAGES 명언 2개 제거 (한솔 요청).

### 새 NPM 의존성

**0 (zero)** — Node 빌트인 + Electron API만 사용. 외부 의존성 추가 없음.

---

## 🛡 7가지 안전장치 (한솔님 "정말 안전한가?" 답변)

| # | 케이스 | 처리 |
|---|---|---|
| 1 | G드라이브 폴더 못 찾음 (Drive 안 켰거나 경로 다름) | `console.log` 만, 자기 버전 그대로 실행. 사용자 알림 X. |
| 2 | manifest.json 못 읽음 (sync 진행 중, 깨짐) | fallback 자기 버전. JSON.parse throw 안 하고 null 반환. |
| 3 | 다운로드 중 네트워크/Drive sync 끊김 | `.ready` 마커 안 만들어짐 → swap 안 함, 다음 cycle 재시도. partial 파일은 다음 mirror copy에서 정정. |
| 4 | swap 실패 (락) | `app/` → `backup/` 단계 실패 시 그대로 두고 종료. `pending/` → `app/` 단계 실패 시 backup → app 자동 복구. 다음 종료 시 재시도. |
| 5 | **새 버전 깨짐 (앱 시작 실패)** | `.start-attempt` 마커가 잔존하면 자동 감지 → `backup/` → `app/` 으로 자동 롤백 + 손상된 빌드는 `.corrupt-<ts>/` 로 보존 (진단용). |
| 6 | Defender 제외 거부 | 정상 진행. 새 빌드 직후 첫 실행만 약간 느림 (~10초), 이후 정상 (1~2초). |
| 7 | 권한 부족 (LocalAppData 쓰기 불가) | 명확한 dialog 에러 메시지, 폴백 X (`%LOCALAPPDATA%`는 사실상 모든 사용자가 쓰기 가능). |

추가 — **사용자 데이터 안전**: `%APPDATA%\Bflow-BGonly\` (Roaming, 사용자 설정)은 새 시스템과 분리 — 변경 없음. 본체 swap은 LocalAppData에서만.

---

## 🛠 개발 난항

### 1. spec/멘탈 모델 정렬 (가장 중요)
한솔님이 마지막 확인 시 "최신버전 감지, 업데이트 중.." 인식 → spec §2 결정사항(UX 패턴 A: 조용히, 다음 재시작 시 적용)과 다름. 두 패턴(시작 시점 swap vs 종료 시점 swap)을 명확히 비교 후 옵션 X(spec 그대로)로 한솔 재확인.

### 2. v1.20.0 의존성 누락
새 worktree에서 첫 vite build 시 `Rollup failed to resolve import "opentype.js"`. main worktree에 v1.20.0 머지 후 `npm install`을 안 한 상태였음. main에서 `npm install` 1회 → junction 통해 새 worktree도 자동 사용 가능.

### 3. before-quit hook 통합 시 race 위험
기존 `before-quit`는 pending 작업 없을 때 `Promise.race(watchCleanup)` fire-and-forget. swap을 그 옆에 추가하면 process가 swap 끝나기 전 종료될 수 있음. 모든 분기를 `e.preventDefault` + 비동기 chain + `app.exit(0)`로 평탄화. 기존 race 위험도 함께 제거.

### 4. Windows directory rename 락 안전성
`app/` 안에 현재 실행 중인 BFLOW.exe가 있는데 디렉토리 rename이 가능한지 확인. Windows는 실행 중 exe의 *파일* 이동은 막지만 *부모 디렉토리* rename은 허용 — atomic하게 디렉토리 그대로 이동. drop-in 안전 검증.

### 5. PowerShell elevated UAC 호출 (Defender 등록)
`Start-Process powershell -Verb RunAs`로 UAC 자동. 부모 BFLOW가 종료돼도 detached로 PowerShell 살아남도록 `spawn(... { detached: true, stdio: 'ignore' }).unref()`. single quote escape (`''`) PowerShell 표준 따름.

---

## ✅ 테스트 가이드 (한솔 PC에서 빌드 직후 — G드라이브 동기화 *전* 검증)

### 시나리오 A: 첫 설치
- [ ] `dist/BFLOW.exe` (portable) 더블클릭 → "B flow 를 PC에 설치합니다 (한 번만, ~5초)" dialog 등장
- [ ] "설치" 클릭 → 5~30초 후 새 위치에서 BFLOW 실행 (스플래시 → 메인 창 1~2초)
- [ ] `%LOCALAPPDATA%\Bflow-BGonly\app\BFLOW.exe` 존재 확인 (탐색기로)
- [ ] 바탕화면에 "B flow.lnk" 생성 확인
- [ ] 시작 메뉴에 "B flow.lnk" 생성 확인
- [ ] Defender 제외 dialog 등장 → "허용" 클릭 → UAC → PowerShell 백그라운드 실행 (Get-MpPreference로 확인)

### 시나리오 B: 일상 사용
- [ ] 바탕화면 "B flow" 더블클릭 → 1~2초 시작 (Defender 캐시)
- [ ] 알림 패널의 🐢 시작 시간 분석 측정값 확인 (1~2초)
- [ ] 메인 창 정상 동작 (씬·위젯·메모 등)

### 시나리오 C: 옛 바로가기 폴백
- [ ] 이미 설치된 후 `dist/BFLOW.exe` 다시 더블클릭
- [ ] dialog 없이 즉시 종료 후 로컬 BFLOW 실행 (사고 X)

### 시나리오 D: 백그라운드 업데이트 (2 cycle)
- [ ] G드라이브에 v1.21.0 robocopy
- [ ] 팀원 1명에게 옛 바로가기 클릭 부탁 → 첫 설치 → 새 바로가기 사용
- [ ] 한솔이 코드 변경 + v1.21.1 빌드 + G드라이브 robocopy
- [ ] 팀원이 BFLOW 켠 상태에서 5초 뒤 console 또는 알림 패널에 "새 버전 감지" 표시
- [ ] `%LOCALAPPDATA%\Bflow-BGonly\pending\.ready` 존재 확인
- [ ] BFLOW 종료 → swap 진행 → app.exit
- [ ] 다시 켜면 v1.21.1 ✨
- [ ] `backup\` 폴더에 v1.21.0 존재 확인

### 시나리오 E: G드라이브 sync 끊김
- [ ] G드라이브 partial 상태 (manifest.json은 있는데 일부 파일 없음)
- [ ] 백그라운드 다운로드 중 mirror copy 일부 실패 → console.warn만
- [ ] `pending/.ready` 안 만들어짐
- [ ] 종료 → swap 안 됨 → 다음 실행 = 자기 버전 그대로

### 시나리오 F: 새 버전 깨짐 (롤백)
- [ ] pending에 일부러 corrupt BFLOW.exe 넣고 swap → 다음 실행 메인 창 못 띄움
- [ ] 다음 실행 (3번째) 시 `.start-attempt` 마커 감지 → backup → app 롤백 → corrupt 빌드는 `.corrupt-<ts>` 로 보존

### 시나리오 G: Defender 제외 거부
- [ ] 첫 설치 시 Defender dialog "나중에" 클릭 → 정상 진행
- [ ] 새 빌드 직후 첫 실행 약 10초 (Defender 풀 스캔) → 이후 1~2초

---

## ⚠️ 머지 후 한솔님 명시 시에만 진행 (메모리 규칙)

- **G드라이브 robocopy** — `robocopy <local dist> <G드라이브 dist> /MIR /R:1 /W:1`
- **슬랙 공지** — 새 시스템 사용법 안내 (옛 바로가기 폴백 동작도 안내해서 안심시키기)
- **워크트리 정리** — 옛 `gifted-darwin-99908d` worktree 제거

---

## 진단 코드 처리 (별도 PR)

spec §10대로, 자동 업데이트로 1~2초 검증 후 한솔님 명시 시 진단 코드(현재 `electron/main.ts`의 `__t_*` 변수, `preload.ts`의 `onStartupPerf`, `types/index.ts`, `App.tsx`의 useEffect) 별도 commit으로 제거.

> 참고: 현재 우리 main에는 진단 코드가 없음 (`gifted-darwin-99908d`에 있던 거고 main에 머지 안 됨). 자동 업데이트 검증은 console log로 충분하니 진단 코드 포트 X.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
