### PR TITLE
[v1.21.1] portable target 제거 — dist 깔끔 + 잘못 클릭할 진입점 X

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -24,6 +24,12 @@
       "runtimeExecutable": "python",
       "runtimeArgs": ["-m", "http.server", "5558"],
       "port": 5558
+    },
+    {
+      "name": "font-mockup",
+      "runtimeExecutable": "python",
+      "runtimeArgs": ["-m", "http.server", "5559"],
+      "port": 5559
     }
   ]
 }

--- a/docs/superpowers/mockups/font-feature-mockup.html
+++ b/docs/superpowers/mockups/font-feature-mockup.html
@@ -1,0 +1,815 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>B flow · 글꼴 변경 기능 — 디자인 목업</title>
+
+  <!-- Pretendard (한국 IT 사실상 표준) -->
+  <link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css">
+
+  <!-- Spoqa Han Sans Neo -->
+  <link rel="stylesheet" href="https://spoqa.github.io/spoqa-han-sans/css/SpoqaHanSansNeo.css">
+
+  <!-- Google Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Sans+KR:wght@400;500;600;700&family=IBM+Plex+Sans+KR:wght@400;500;600;700&family=Nanum+Gothic:wght@400;700;800&family=Gowun+Dodum&family=Noto+Serif+KR:wght@400;500;600;700&display=swap">
+
+  <style>
+    :root {
+      --bg-primary: #0F1117;
+      --bg-card: #1A1D27;
+      --bg-card-2: #20232E;
+      --bg-border: #2D3041;
+      --text-primary: #E8E8EE;
+      --text-secondary: #8B8DA3;
+      --text-tertiary: #5C5F73;
+      --accent: #6C5CE7;
+      --accent-sub: #A29BFE;
+      --color-lo: #74B9FF;
+      --color-done: #A29BFE;
+      --color-review: #FDCB6E;
+      --color-png: #00B894;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body {
+      background: var(--bg-primary);
+      color: var(--text-primary);
+      min-height: 100vh;
+    }
+    body {
+      font-family: 'Pretendard', system-ui, sans-serif;
+      padding: 32px 32px 64px;
+      max-width: 1400px;
+      margin: 0 auto;
+      font-size: 14px;
+      line-height: 1.5;
+    }
+
+    /* ── 헤더 ───────────────────────────── */
+    header h1 {
+      font-size: 24px;
+      font-weight: 700;
+      margin-bottom: 6px;
+      letter-spacing: -0.01em;
+    }
+    header .lead {
+      color: var(--text-secondary);
+      font-size: 13px;
+      margin-bottom: 28px;
+    }
+    header .lead b { color: var(--accent-sub); font-weight: 600; }
+
+    /* ── 섹션 헤더 ───────────────────────── */
+    .section {
+      margin-top: 36px;
+      padding-top: 24px;
+      border-top: 1px solid var(--bg-border);
+    }
+    .section:first-of-type { border-top: none; padding-top: 0; margin-top: 0; }
+    .section-num {
+      display: inline-block;
+      font-size: 11px;
+      color: var(--accent);
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      margin-bottom: 6px;
+    }
+    .section-title {
+      font-size: 18px;
+      font-weight: 700;
+      margin-bottom: 4px;
+      letter-spacing: -0.01em;
+    }
+    .section-desc {
+      color: var(--text-secondary);
+      font-size: 13px;
+      margin-bottom: 20px;
+    }
+
+    /* ── 글꼴 비교 그리드 ──────────────── */
+    .font-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(290px, 1fr));
+      gap: 14px;
+    }
+    .font-card {
+      background: var(--bg-card);
+      border: 1px solid var(--bg-border);
+      border-radius: 12px;
+      padding: 18px;
+      transition: border-color .15s, transform .15s;
+      cursor: pointer;
+      position: relative;
+    }
+    .font-card:hover { border-color: var(--accent); transform: translateY(-1px); }
+    .font-card.is-recommended {
+      border-color: var(--accent);
+      box-shadow: 0 0 0 1px var(--accent), 0 4px 16px rgba(108,92,231,0.18);
+    }
+    .font-card.is-recommended::before {
+      content: '★ 기본값 추천';
+      position: absolute;
+      top: -10px;
+      right: 14px;
+      background: var(--accent);
+      color: white;
+      font-size: 10px;
+      font-weight: 600;
+      padding: 3px 9px;
+      border-radius: 8px;
+      letter-spacing: 0.02em;
+    }
+
+    /* 카드 라벨은 항상 Pretendard로 통일 (식별용) */
+    .font-meta {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      margin-bottom: 14px;
+      padding-bottom: 12px;
+      border-bottom: 1px dashed var(--bg-border);
+      font-family: 'Pretendard', system-ui, sans-serif;
+    }
+    .font-name { font-size: 13px; font-weight: 600; }
+    .font-tag {
+      font-size: 10px;
+      color: var(--text-secondary);
+      padding: 2px 8px;
+      background: var(--bg-primary);
+      border-radius: 6px;
+    }
+
+    /* === 실제 글꼴이 적용되는 미리보기 영역 === */
+    .preview-title { font-size: 18px; font-weight: 700; margin-bottom: 4px; letter-spacing: -0.01em; }
+    .preview-subtitle { font-size: 13px; color: var(--accent-sub); margin-bottom: 10px; font-weight: 500; }
+    .preview-body { font-size: 13px; line-height: 1.55; margin-bottom: 12px; }
+    .preview-numbers {
+      display: flex;
+      gap: 14px;
+      margin-bottom: 10px;
+      font-variant-numeric: tabular-nums;
+    }
+    .preview-number { font-size: 17px; font-weight: 600; color: var(--color-png); }
+    .preview-caption { font-size: 11px; color: var(--text-secondary); }
+    .preview-eng { font-size: 11px; color: var(--text-tertiary); margin-top: 4px; }
+
+    /* 폰트 클래스 */
+    .font-pretendard .preview-title, .font-pretendard .preview-subtitle, .font-pretendard .preview-body, .font-pretendard .preview-number, .font-pretendard .preview-caption, .font-pretendard .preview-eng { font-family: 'Pretendard', system-ui, sans-serif; }
+    .font-inter .preview-title, .font-inter .preview-subtitle, .font-inter .preview-body, .font-inter .preview-number, .font-inter .preview-caption, .font-inter .preview-eng { font-family: 'Inter', 'Pretendard', system-ui, sans-serif; }
+    .font-noto-sans .preview-title, .font-noto-sans .preview-subtitle, .font-noto-sans .preview-body, .font-noto-sans .preview-number, .font-noto-sans .preview-caption, .font-noto-sans .preview-eng { font-family: 'Noto Sans KR', system-ui, sans-serif; }
+    .font-ibm .preview-title, .font-ibm .preview-subtitle, .font-ibm .preview-body, .font-ibm .preview-number, .font-ibm .preview-caption, .font-ibm .preview-eng { font-family: 'IBM Plex Sans KR', system-ui, sans-serif; }
+    .font-spoqa .preview-title, .font-spoqa .preview-subtitle, .font-spoqa .preview-body, .font-spoqa .preview-number, .font-spoqa .preview-caption, .font-spoqa .preview-eng { font-family: 'Spoqa Han Sans Neo', system-ui, sans-serif; }
+    .font-nanum .preview-title, .font-nanum .preview-subtitle, .font-nanum .preview-body, .font-nanum .preview-number, .font-nanum .preview-caption, .font-nanum .preview-eng { font-family: 'Nanum Gothic', system-ui, sans-serif; }
+    .font-gowun .preview-title, .font-gowun .preview-subtitle, .font-gowun .preview-body, .font-gowun .preview-number, .font-gowun .preview-caption, .font-gowun .preview-eng { font-family: 'Gowun Dodum', system-ui, sans-serif; }
+    .font-noto-serif .preview-title, .font-noto-serif .preview-subtitle, .font-noto-serif .preview-body, .font-noto-serif .preview-number, .font-noto-serif .preview-caption, .font-noto-serif .preview-eng { font-family: 'Noto Serif KR', serif; }
+    .font-system .preview-title, .font-system .preview-subtitle, .font-system .preview-body, .font-system .preview-number, .font-system .preview-caption, .font-system .preview-eng { font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+
+    /* ── 설정 화면 목업 ──────────────────── */
+    .settings-mock {
+      background: var(--bg-card);
+      border: 1px solid var(--bg-border);
+      border-radius: 14px;
+      padding: 24px;
+      max-width: 720px;
+    }
+    .settings-section-title {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 14px;
+      font-weight: 600;
+      margin-bottom: 14px;
+    }
+    .settings-section-title .icon {
+      width: 18px; height: 18px;
+      display: inline-flex; align-items: center; justify-content: center;
+      color: var(--accent);
+      flex-shrink: 0;
+    }
+    .settings-section-title .icon svg { width: 18px; height: 18px; stroke-width: 2; }
+    .new-badge {
+      font-size: 9px;
+      background: var(--accent);
+      color: white;
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-weight: 600;
+      margin-left: 4px;
+      letter-spacing: 0.04em;
+    }
+    .settings-block {
+      padding-bottom: 18px;
+      margin-bottom: 18px;
+      border-bottom: 1px solid var(--bg-border);
+    }
+    .settings-block:last-child { border-bottom: none; margin-bottom: 0; padding-bottom: 0; }
+    .settings-row { display: flex; align-items: center; gap: 12px; margin-bottom: 8px; }
+    .settings-label {
+      font-size: 11px;
+      color: var(--text-secondary);
+      width: 80px;
+      flex-shrink: 0;
+    }
+    .chip-group { display: flex; gap: 6px; flex-wrap: wrap; }
+    .chip {
+      padding: 6px 12px;
+      background: var(--bg-primary);
+      border: 1px solid var(--bg-border);
+      border-radius: 8px;
+      font-size: 12px;
+      cursor: pointer;
+      transition: all .15s;
+      color: var(--text-secondary);
+    }
+    .chip:hover { border-color: var(--accent); color: var(--text-primary); }
+    .chip.active {
+      background: rgba(108,92,231,.15);
+      border-color: var(--accent);
+      color: var(--accent);
+    }
+
+    /* 사용자 추가 글꼴 칩 (삭제 버튼 포함) */
+    .chip-with-delete {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 8px 6px 12px;
+      background: var(--bg-primary);
+      border: 1px solid var(--bg-border);
+      border-radius: 8px;
+      font-size: 12px;
+      color: var(--text-secondary);
+      transition: all .15s;
+    }
+    .chip-with-delete:hover { border-color: var(--accent); color: var(--text-primary); }
+    .chip-delete {
+      width: 18px; height: 18px;
+      display: inline-flex; align-items: center; justify-content: center;
+      background: transparent; border: none;
+      border-radius: 4px;
+      color: var(--text-tertiary);
+      cursor: pointer;
+      font-size: 14px;
+      line-height: 1;
+      transition: all .15s;
+      padding: 0;
+    }
+    .chip-delete:hover { background: rgba(255, 100, 100, .15); color: #ff8888; }
+
+    /* + 글꼴 추가 버튼 */
+    .chip-add {
+      padding: 6px 12px;
+      background: transparent;
+      border: 1px dashed var(--bg-border);
+      border-radius: 8px;
+      font-size: 12px;
+      cursor: pointer;
+      transition: all .15s;
+      color: var(--accent-sub);
+      font-family: inherit;
+    }
+    .chip-add:hover {
+      border-color: var(--accent);
+      border-style: solid;
+      background: rgba(108,92,231,.08);
+      color: var(--accent);
+    }
+
+    .seg-group {
+      display: flex; gap: 2px; padding: 4px;
+      background: var(--bg-primary); border-radius: 9px; width: fit-content;
+    }
+    .seg {
+      padding: 6px 12px; font-size: 12px; cursor: pointer;
+      border-radius: 6px; color: var(--text-secondary);
+      transition: all .15s;
+    }
+    .seg:hover { color: var(--text-primary); }
+    .seg.active { background: var(--bg-card); color: var(--text-primary); box-shadow: 0 1px 2px rgba(0,0,0,.2); }
+
+    .slider-wrap {
+      flex: 1; display: flex; align-items: center; gap: 12px;
+      max-width: 360px;
+    }
+    .slider-wrap input[type=range] {
+      flex: 1;
+      accent-color: var(--accent);
+    }
+    .slider-value {
+      font-size: 11px;
+      font-variant-numeric: tabular-nums;
+      color: var(--accent);
+      min-width: 36px;
+      text-align: right;
+    }
+
+    .toggle {
+      width: 38px; height: 22px;
+      background: var(--bg-border); border-radius: 11px;
+      position: relative; cursor: pointer;
+      transition: background .15s;
+      flex-shrink: 0;
+    }
+    .toggle::after {
+      content: ''; width: 18px; height: 18px;
+      background: white; border-radius: 50%;
+      position: absolute; top: 2px; left: 2px;
+      transition: left .15s;
+    }
+    .toggle.on { background: var(--accent); }
+    .toggle.on::after { left: 18px; }
+
+    /* ── 비교 (전/후) ──────────────────── */
+    .compare { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+    .compare-cell {
+      background: var(--bg-card);
+      border: 1px solid var(--bg-border);
+      border-radius: 12px;
+      padding: 20px;
+    }
+    .compare-cell h3 {
+      font-size: 11px;
+      color: var(--text-secondary);
+      margin-bottom: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      font-weight: 600;
+    }
+    .compare-cell .label-on { color: var(--accent); }
+    .compare-cell .label-off { color: var(--text-secondary); }
+
+    .preview-tight { line-height: 1.25; letter-spacing: -0.025em; font-size: 13px; }
+    .preview-normal { line-height: 1.55; letter-spacing: 0; font-size: 13px; }
+    .preview-loose { line-height: 1.95; letter-spacing: 0.05em; font-size: 13px; }
+    .gap-y-10 { margin-bottom: 10px; }
+
+    .num-stack { display: flex; flex-direction: column; gap: 4px; }
+    .num-stack .num { font-size: 16px; font-weight: 600; }
+    .num-default { font-variant-numeric: normal; }
+    .num-tabular { font-variant-numeric: tabular-nums; }
+
+    .footnote { color: var(--text-tertiary); font-size: 10px; margin-top: 10px; line-height: 1.5; }
+    .label-pill { display: inline-block; font-size: 10px; padding: 2px 8px; border-radius: 6px; margin-bottom: 8px; font-weight: 500; letter-spacing: 0.02em; }
+    .pill-before { background: rgba(139,141,163,.18); color: var(--text-secondary); }
+    .pill-after { background: rgba(108,92,231,.18); color: var(--accent-sub); }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>B flow · 글꼴 변경 기능 — 디자인 목업</h1>
+    <p class="lead">
+      한솔님 결정 기반 — <b>① 한 글꼴로 앱 전체 통일</b> · <b>② 줄간격·자간 조절</b> · <b>③ 숫자 정렬 옵션</b>.
+      섹션 1에서 마음에 드는 글꼴 분위기를 봐주시고, 섹션 2/3에서 실제 설정 화면과 적용 효과를 확인해주세요.
+    </p>
+  </header>
+
+  <!-- ════════════════════════════════════════ -->
+  <!-- 섹션 1: 글꼴 후보 9종 -->
+  <!-- ════════════════════════════════════════ -->
+  <section class="section">
+    <div class="section-num">SECTION 1 — 글꼴 후보</div>
+    <h2 class="section-title">9가지 글꼴 — 같은 위젯 콘텐츠를 9가지 글꼴로 한눈에 비교</h2>
+    <p class="section-desc">실제 우리 앱의 위젯 콘텐츠(제목·부제·본문·숫자·캡션)를 각 글꼴로 그려봤어요. 글꼴 이름은 안 외우셔도 돼요. <b>분위기 느낌</b>으로만 골라주세요.</p>
+
+    <div class="font-grid">
+      <!-- 1. Pretendard (추천) -->
+      <div class="font-card font-pretendard is-recommended">
+        <div class="font-meta">
+          <span class="font-name">Pretendard</span>
+          <span class="font-tag">모던 · 표준</span>
+        </div>
+        <div class="preview-title">전체 진행률</div>
+        <div class="preview-subtitle">EP01 · 마감 D-3</div>
+        <div class="preview-body">오늘 작업할 씬이 12개 남아있어요.</div>
+        <div class="preview-numbers">
+          <span class="preview-number">23.4%</span>
+          <span class="preview-number">8.7%</span>
+          <span class="preview-number">100%</span>
+        </div>
+        <div class="preview-caption">마지막 업데이트 14:32</div>
+        <div class="preview-eng">Studio JBBJ · BG Dashboard</div>
+      </div>
+
+      <!-- 2. Inter (영문 우선) -->
+      <div class="font-card font-inter">
+        <div class="font-meta">
+          <span class="font-name">Inter</span>
+          <span class="font-tag">영문 우선 · 모던</span>
+        </div>
+        <div class="preview-title">전체 진행률</div>
+        <div class="preview-subtitle">EP01 · 마감 D-3</div>
+        <div class="preview-body">오늘 작업할 씬이 12개 남아있어요.</div>
+        <div class="preview-numbers">
+          <span class="preview-number">23.4%</span>
+          <span class="preview-number">8.7%</span>
+          <span class="preview-number">100%</span>
+        </div>
+        <div class="preview-caption">마지막 업데이트 14:32</div>
+        <div class="preview-eng">Studio JBBJ · BG Dashboard</div>
+      </div>
+
+      <!-- 3. Noto Sans KR -->
+      <div class="font-card font-noto-sans">
+        <div class="font-meta">
+          <span class="font-name">Noto Sans KR</span>
+          <span class="font-tag">모던 · 부드러움</span>
+        </div>
+        <div class="preview-title">전체 진행률</div>
+        <div class="preview-subtitle">EP01 · 마감 D-3</div>
+        <div class="preview-body">오늘 작업할 씬이 12개 남아있어요.</div>
+        <div class="preview-numbers">
+          <span class="preview-number">23.4%</span>
+          <span class="preview-number">8.7%</span>
+          <span class="preview-number">100%</span>
+        </div>
+        <div class="preview-caption">마지막 업데이트 14:32</div>
+        <div class="preview-eng">Studio JBBJ · BG Dashboard</div>
+      </div>
+
+      <!-- 4. IBM Plex Sans KR -->
+      <div class="font-card font-ibm">
+        <div class="font-meta">
+          <span class="font-name">IBM Plex Sans KR</span>
+          <span class="font-tag">선명 · 진중</span>
+        </div>
+        <div class="preview-title">전체 진행률</div>
+        <div class="preview-subtitle">EP01 · 마감 D-3</div>
+        <div class="preview-body">오늘 작업할 씬이 12개 남아있어요.</div>
+        <div class="preview-numbers">
+          <span class="preview-number">23.4%</span>
+          <span class="preview-number">8.7%</span>
+          <span class="preview-number">100%</span>
+        </div>
+        <div class="preview-caption">마지막 업데이트 14:32</div>
+        <div class="preview-eng">Studio JBBJ · BG Dashboard</div>
+      </div>
+
+      <!-- 5. Spoqa Han Sans Neo -->
+      <div class="font-card font-spoqa">
+        <div class="font-meta">
+          <span class="font-name">Spoqa Han Sans Neo</span>
+          <span class="font-tag">선명 · 신뢰감</span>
+        </div>
+        <div class="preview-title">전체 진행률</div>
+        <div class="preview-subtitle">EP01 · 마감 D-3</div>
+        <div class="preview-body">오늘 작업할 씬이 12개 남아있어요.</div>
+        <div class="preview-numbers">
+          <span class="preview-number">23.4%</span>
+          <span class="preview-number">8.7%</span>
+          <span class="preview-number">100%</span>
+        </div>
+        <div class="preview-caption">마지막 업데이트 14:32</div>
+        <div class="preview-eng">Studio JBBJ · BG Dashboard</div>
+      </div>
+
+      <!-- 6. Nanum Gothic -->
+      <div class="font-card font-nanum">
+        <div class="font-meta">
+          <span class="font-name">나눔고딕</span>
+          <span class="font-tag">친숙 · 전통</span>
+        </div>
+        <div class="preview-title">전체 진행률</div>
+        <div class="preview-subtitle">EP01 · 마감 D-3</div>
+        <div class="preview-body">오늘 작업할 씬이 12개 남아있어요.</div>
+        <div class="preview-numbers">
+          <span class="preview-number">23.4%</span>
+          <span class="preview-number">8.7%</span>
+          <span class="preview-number">100%</span>
+        </div>
+        <div class="preview-caption">마지막 업데이트 14:32</div>
+        <div class="preview-eng">Studio JBBJ · BG Dashboard</div>
+      </div>
+
+      <!-- 7. Gowun Dodum -->
+      <div class="font-card font-gowun">
+        <div class="font-meta">
+          <span class="font-name">고운 도담</span>
+          <span class="font-tag">따뜻 · 부드러움</span>
+        </div>
+        <div class="preview-title">전체 진행률</div>
+        <div class="preview-subtitle">EP01 · 마감 D-3</div>
+        <div class="preview-body">오늘 작업할 씬이 12개 남아있어요.</div>
+        <div class="preview-numbers">
+          <span class="preview-number">23.4%</span>
+          <span class="preview-number">8.7%</span>
+          <span class="preview-number">100%</span>
+        </div>
+        <div class="preview-caption">마지막 업데이트 14:32</div>
+        <div class="preview-eng">Studio JBBJ · BG Dashboard</div>
+      </div>
+
+      <!-- 8. Noto Serif KR -->
+      <div class="font-card font-noto-serif">
+        <div class="font-meta">
+          <span class="font-name">본명조 (Noto Serif KR)</span>
+          <span class="font-tag">감성 · 정통</span>
+        </div>
+        <div class="preview-title">전체 진행률</div>
+        <div class="preview-subtitle">EP01 · 마감 D-3</div>
+        <div class="preview-body">오늘 작업할 씬이 12개 남아있어요.</div>
+        <div class="preview-numbers">
+          <span class="preview-number">23.4%</span>
+          <span class="preview-number">8.7%</span>
+          <span class="preview-number">100%</span>
+        </div>
+        <div class="preview-caption">마지막 업데이트 14:32</div>
+        <div class="preview-eng">Studio JBBJ · BG Dashboard</div>
+      </div>
+
+      <!-- 9. System Default (현재 상태) -->
+      <div class="font-card font-system">
+        <div class="font-meta">
+          <span class="font-name">시스템 기본 (현재)</span>
+          <span class="font-tag">OS 기본</span>
+        </div>
+        <div class="preview-title">전체 진행률</div>
+        <div class="preview-subtitle">EP01 · 마감 D-3</div>
+        <div class="preview-body">오늘 작업할 씬이 12개 남아있어요.</div>
+        <div class="preview-numbers">
+          <span class="preview-number">23.4%</span>
+          <span class="preview-number">8.7%</span>
+          <span class="preview-number">100%</span>
+        </div>
+        <div class="preview-caption">마지막 업데이트 14:32</div>
+        <div class="preview-eng">Studio JBBJ · BG Dashboard</div>
+      </div>
+    </div>
+
+    <p class="footnote">
+      카드 위에 마우스 올리면 강조됩니다 (실제 앱에선 클릭 → 적용). 윈도우에선 '시스템 기본'이 곧 '맑은 고딕(또는 Segoe UI)' 인데 자세히 보면 한자 호환을 위해 약간 어긋나는 게 보일 거예요.
+    </p>
+  </section>
+
+
+  <!-- ════════════════════════════════════════ -->
+  <!-- 섹션 2: 새 글꼴 탭 UI -->
+  <!-- ════════════════════════════════════════ -->
+  <section class="section">
+    <div class="section-num">SECTION 2 — 설정 화면</div>
+    <h2 class="section-title">새 [글꼴] 탭 UI 목업</h2>
+    <p class="section-desc">기존 ‘글꼴 크기 / 글자 색상’ 두 섹션 위에 <b>글꼴 (서체)</b>이 추가되고, 아래에 <b>간격</b> 조절과 <b>숫자 정렬</b> 토글이 새로 들어갑니다. 디자인은 기존 패턴과 통일.</p>
+
+    <div class="settings-mock">
+      <!-- 글꼴 (NEW) -->
+      <div class="settings-block">
+        <div class="settings-section-title">
+          <span class="icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="m3 15 4-8 4 8"/><path d="M4 13h6"/><circle cx="18" cy="12" r="3"/><path d="M21 9v6"/></svg></span>
+          글꼴 (서체)
+          <span class="new-badge">NEW</span>
+        </div>
+
+        <!-- 기본 글꼴 그룹 -->
+        <div class="settings-row" style="align-items: flex-start;">
+          <span class="settings-label" style="padding-top: 6px;">기본 글꼴</span>
+          <div class="chip-group">
+            <span class="chip active">Pretendard</span>
+            <span class="chip">Inter</span>
+            <span class="chip">Noto Sans KR</span>
+            <span class="chip">IBM Plex Sans KR</span>
+            <span class="chip">Spoqa Han Sans Neo</span>
+            <span class="chip">나눔고딕</span>
+            <span class="chip">고운 도담</span>
+            <span class="chip">본명조</span>
+            <span class="chip">시스템 기본</span>
+          </div>
+        </div>
+
+        <!-- 내 글꼴 그룹 (NEW) -->
+        <div class="settings-row" style="align-items: flex-start; margin-top: 10px;">
+          <span class="settings-label" style="padding-top: 6px;">내 글꼴</span>
+          <div class="chip-group">
+            <!-- 추가된 글꼴 예시 -->
+            <span class="chip-with-delete">
+              <span>산돌네오2</span>
+              <button class="chip-delete" title="삭제">×</button>
+            </span>
+            <span class="chip-with-delete">
+              <span>JBBJ 자체 폰트</span>
+              <button class="chip-delete" title="삭제">×</button>
+            </span>
+            <!-- + 추가 버튼 -->
+            <button class="chip chip-add" title="OTF/TTF/WOFF 파일 추가">＋ 글꼴 추가</button>
+          </div>
+        </div>
+        <p class="footnote" style="margin-top: 8px; display: flex; align-items: flex-start; gap: 6px;">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:13px;height:13px;color:#FDCB6E;flex-shrink:0;margin-top:1px;"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><path d="M12 9v4"/><path d="M12 17h.01"/></svg>
+          <span>추가하시는 글꼴의 라이선스는 본인이 확인해주세요. · 추가된 글꼴은 한솔님 PC에만 저장됩니다 (다른 팀원에게는 안 보임).</span>
+        </p>
+      </div>
+
+      <!-- 글꼴 크기 (기존) -->
+      <div class="settings-block">
+        <div class="settings-section-title">
+          <span class="icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 7 4 4 20 4 20 7"/><line x1="9" x2="15" y1="20" y2="20"/><line x1="12" x2="12" y1="4" y2="20"/></svg></span>
+          글꼴 크기
+          <span style="font-size: 10px; color: var(--text-tertiary); margin-left: 4px; font-weight: 400;">(기존)</span>
+        </div>
+        <div class="settings-row">
+          <span class="settings-label">빠른 조절</span>
+          <div class="seg-group">
+            <span class="seg">아주 작게</span>
+            <span class="seg">작게</span>
+            <span class="seg active">보통</span>
+            <span class="seg">크게</span>
+            <span class="seg">아주 크게</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- 글자 색상 (기존) -->
+      <div class="settings-block">
+        <div class="settings-section-title">
+          <span class="icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="13.5" cy="6.5" r=".5" fill="currentColor"/><circle cx="17.5" cy="10.5" r=".5" fill="currentColor"/><circle cx="8.5" cy="7.5" r=".5" fill="currentColor"/><circle cx="6.5" cy="12.5" r=".5" fill="currentColor"/><path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z"/></svg></span>
+          글자 색상
+          <span style="font-size: 10px; color: var(--text-tertiary); margin-left: 4px; font-weight: 400;">(기존)</span>
+        </div>
+        <div class="settings-row">
+          <span class="settings-label">프리셋</span>
+          <div class="chip-group">
+            <span class="chip active">테마 기본</span>
+            <span class="chip">고대비</span>
+            <span class="chip">부드러움</span>
+            <span class="chip">단색</span>
+            <span class="chip">사용자 지정</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- 간격 (NEW) -->
+      <div class="settings-block">
+        <div class="settings-section-title">
+          <span class="icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect width="10" height="6" x="7" y="9" rx="2"/><path d="M22 20H2"/><path d="M22 4H2"/></svg></span>
+          간격
+          <span class="new-badge">NEW</span>
+        </div>
+        <div class="settings-row">
+          <span class="settings-label">줄간격</span>
+          <div class="slider-wrap">
+            <input type="range" min="1.2" max="2.0" step="0.05" value="1.55">
+            <span class="slider-value">1.55</span>
+          </div>
+        </div>
+        <div class="settings-row">
+          <span class="settings-label">자간</span>
+          <div class="slider-wrap">
+            <input type="range" min="-0.05" max="0.1" step="0.005" value="0">
+            <span class="slider-value">0.00</span>
+          </div>
+        </div>
+        <p class="footnote">기본값 1.55 / 0 — 슬라이더 옆에 ‘기본값 복원’ 버튼 (다른 섹션과 동일 패턴)</p>
+      </div>
+
+      <!-- 숫자 정렬 — 토글 제거, 항상 ON으로 자동 적용 (한솔님 결정) -->
+    </div>
+    <p class="footnote" style="margin-top: 12px; max-width: 720px;">
+      ※ 숫자 자릿수 고정(<code style="color: var(--accent-sub); font-size: 10px;">tabular-nums</code>)은 별도 설정 없이 <b style="color: var(--accent-sub);">기본 적용</b>됩니다 — 위젯·표 어디서나 숫자가 일자로 정렬됩니다.
+    </p>
+  </section>
+
+
+  <!-- ════════════════════════════════════════ -->
+  <!-- 섹션 3: 효과 비교 -->
+  <!-- ════════════════════════════════════════ -->
+  <section class="section">
+    <div class="section-num">SECTION 3 — 효과 비교</div>
+    <h2 class="section-title">간격·숫자 옵션이 실제로 뭘 바꾸나</h2>
+    <p class="section-desc">왼쪽이 ‘기본/적용 안 함’, 오른쪽이 ‘적용 후’입니다.</p>
+
+    <div class="compare">
+      <!-- 줄간격·자간 -->
+      <div class="compare-cell">
+        <h3>① 줄간격·자간</h3>
+
+        <span class="label-pill pill-before">BEFORE — 줄간격 1.25, 자간 -0.025em</span>
+        <p class="preview-tight">우리 BG 작업의 진척 상황을 한눈에 확인하세요. 오늘 처리할 씬이 12개, 검수 대기 4개, 완료 8개 있습니다. 마감일 D-3까지 남은 작업량을 분배해드립니다.</p>
+
+        <div style="height: 18px"></div>
+
+        <span class="label-pill pill-after">AFTER — 줄간격 1.95, 자간 +0.05em</span>
+        <p class="preview-loose">우리 BG 작업의 진척 상황을 한눈에 확인하세요. 오늘 처리할 씬이 12개, 검수 대기 4개, 완료 8개 있습니다. 마감일 D-3까지 남은 작업량을 분배해드립니다.</p>
+
+        <p class="footnote">긴 메모·댓글·씬 설명 영역에서 가독성 직접 ↑. 한솔님 1순위 동기 ‘가독성’에 가장 큰 효과.</p>
+      </div>
+
+      <!-- 숫자 정렬 -->
+      <div class="compare-cell">
+        <h3>② 숫자 정렬 (Tabular)</h3>
+
+        <span class="label-pill pill-before">BEFORE — 자릿수 폭 들쑥날쑥</span>
+        <div class="num-stack num-default">
+          <span class="num">23.4%</span>
+          <span class="num">8.7%</span>
+          <span class="num">100.0%</span>
+          <span class="num">5.2%</span>
+          <span class="num">76.8%</span>
+        </div>
+
+        <div style="height: 18px"></div>
+
+        <span class="label-pill pill-after">AFTER — 자릿수 일정, 일자로 정렬</span>
+        <div class="num-stack num-tabular">
+          <span class="num">23.4%</span>
+          <span class="num">8.7%</span>
+          <span class="num">100.0%</span>
+          <span class="num">5.2%</span>
+          <span class="num">76.8%</span>
+        </div>
+
+        <p class="footnote">진행률·시간·EP번호 등 우리 앱의 위젯 숫자가 표 형태로 깔끔하게 정렬됩니다.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ════════════════════════════════════════ -->
+  <!-- 섹션 4: 글꼴 변경시 앱이 어떻게 보이는지 (작은 위젯 시연) -->
+  <!-- ════════════════════════════════════════ -->
+  <section class="section">
+    <div class="section-num">SECTION 4 — 실제 위젯 적용 예시</div>
+    <h2 class="section-title">진짜 위젯 위에 글꼴 적용했을 때</h2>
+    <p class="section-desc">우리 앱의 ‘에피소드 요약 위젯’을 모방한 미니 카드. 같은 위젯이 글꼴 3종에 따라 어떻게 달라지는지.</p>
+
+    <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px;">
+      <!-- Mini widget 1: Pretendard -->
+      <div class="font-card font-pretendard" style="cursor: default;">
+        <div class="font-meta">
+          <span class="font-name">Pretendard</span>
+          <span class="font-tag">현재 추천</span>
+        </div>
+        <div style="display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 12px;">
+          <div>
+            <div class="preview-title">EP02</div>
+            <div class="preview-caption">씬 24개 · 마감 5월 8일</div>
+          </div>
+          <div style="font-variant-numeric: tabular-nums; text-align: right;">
+            <div class="preview-number" style="font-size: 22px;">87.5%</div>
+            <div class="preview-caption">진행률</div>
+          </div>
+        </div>
+        <div style="display: flex; gap: 8px; font-size: 11px;">
+          <span style="color: var(--color-lo);">LO 18</span>
+          <span style="color: var(--color-done);">완료 14</span>
+          <span style="color: var(--color-review);">검수 3</span>
+          <span style="color: var(--color-png);">PNG 9</span>
+        </div>
+      </div>
+
+      <!-- Mini widget 2: IBM Plex -->
+      <div class="font-card font-ibm" style="cursor: default;">
+        <div class="font-meta">
+          <span class="font-name">IBM Plex Sans KR</span>
+          <span class="font-tag">진중</span>
+        </div>
+        <div style="display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 12px;">
+          <div>
+            <div class="preview-title">EP02</div>
+            <div class="preview-caption">씬 24개 · 마감 5월 8일</div>
+          </div>
+          <div style="font-variant-numeric: tabular-nums; text-align: right;">
+            <div class="preview-number" style="font-size: 22px;">87.5%</div>
+            <div class="preview-caption">진행률</div>
+          </div>
+        </div>
+        <div style="display: flex; gap: 8px; font-size: 11px;">
+          <span style="color: var(--color-lo);">LO 18</span>
+          <span style="color: var(--color-done);">완료 14</span>
+          <span style="color: var(--color-review);">검수 3</span>
+          <span style="color: var(--color-png);">PNG 9</span>
+        </div>
+      </div>
+
+      <!-- Mini widget 3: Gowun Dodum -->
+      <div class="font-card font-gowun" style="cursor: default;">
+        <div class="font-meta">
+          <span class="font-name">고운 도담</span>
+          <span class="font-tag">부드러움</span>
+        </div>
+        <div style="display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 12px;">
+          <div>
+            <div class="preview-title">EP02</div>
+            <div class="preview-caption">씬 24개 · 마감 5월 8일</div>
+          </div>
+          <div style="font-variant-numeric: tabular-nums; text-align: right;">
+            <div class="preview-number" style="font-size: 22px;">87.5%</div>
+            <div class="preview-caption">진행률</div>
+          </div>
+        </div>
+        <div style="display: flex; gap: 8px; font-size: 11px;">
+          <span style="color: var(--color-lo);">LO 18</span>
+          <span style="color: var(--color-done);">완료 14</span>
+          <span style="color: var(--color-review);">검수 3</span>
+          <span style="color: var(--color-png);">PNG 9</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <footer style="margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--bg-border); color: var(--text-tertiary); font-size: 11px; display: flex; align-items: center; gap: 8px;">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:13px;height:13px;flex-shrink:0;"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>
+    <span>목업 — 실제 앱이 아니라 디자인 미리보기. 한솔님이 좋아하시는 글꼴 / 빼고 싶은 글꼴 / 추가 원하는 분위기를 말씀해주세요.</span>
+  </footer>
+</body>
+</html>

--- a/docs/superpowers/plans/2026-05-06-font-system.md
+++ b/docs/superpowers/plans/2026-05-06-font-system.md
@@ -1,0 +1,950 @@
+# 글꼴 시스템 구현 계획 (v1.20.0)
+
+> **For agentic workers:** REQUIRED: Use superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** B flow에 사용자가 글꼴(서체)을 자유롭게 선택·추가할 수 있는 시스템 구축. 큐레이션 9종 + OTF/TTF 직접 추가(드래그앤드롭 포함) + 줄간격·자간 조절 + 숫자 자릿수 자동 정렬.
+
+**Architecture:** CSS 변수(`--font-family`, `--text-line-height`, `--text-letter-spacing`)를 `applyFontFamily/applySpacing` 헬퍼로 갱신 → 즉시 DOM 반영. 사용자 폰트는 메인 프로세스가 `%APPDATA%/Bflow-BGonly/fonts/`로 복사 + opentype.js로 한글 검증, 렌더러는 `bflow-font://` custom protocol로 로드. Settings preferences.json에 `fontFamily / lineHeight / letterSpacing / customFonts[]` 추가.
+
+**Tech Stack:** React 18 + TypeScript + Tailwind + Electron 33 + lucide-react (아이콘) + @fontsource (폰트 패키지) + opentype.js (메타 파싱) + uuid (커스텀 ID).
+
+**Spec reference:** [`docs/superpowers/specs/2026-05-06-font-system-design.md`](../specs/2026-05-06-font-system-design.md)
+
+---
+
+## File Structure
+
+### 신규 파일
+- `src/components/settings/FontFamilySection.tsx` — 글꼴(서체) 선택 UI + 사용자 추가/삭제/DnD
+- `src/components/settings/SpacingSection.tsx` — 줄간격·자간 슬라이더
+- `electron/fontIpc.ts` — IPC 핸들러 + custom protocol 등록 헬퍼
+
+### 변경 파일
+- `src/utils/typography.ts` — `FONT_FAMILIES`, `applyFontFamily`, `applySpacing`, `applyPreferencesToDOM` 확장
+- `src/services/settingsService.ts` — `UserPreferences` + `CustomFont` 타입 확장
+- `src/index.css` — `--font-family / --text-line-height / --text-letter-spacing` CSS 변수 + `tabular-nums` 적용
+- `src/main.tsx` 또는 `src/App.tsx` — 시작 시 `applyPreferencesToDOM` 호출에 폰트 필드 포함
+- `src/views/SettingsView.tsx` 또는 그에 준하는 위치 — `font` 탭에 신규 섹션 추가
+- `electron/main.ts` — IPC 핸들러 등록 + custom protocol 등록 호출
+- `electron/preload.ts` — `fontAdd / fontAddByPath / fontDelete / fontList` 노출
+- `package.json` — 의존성 9개 추가
+
+---
+
+## Chunk 1: 의존성 설치 + 타입/CSS 기반 작업
+
+### Task 1.1: NPM 의존성 설치
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: 폰트 패키지 + 헬퍼 설치 (한 번에)**
+
+```bash
+npm install pretendard @fontsource/inter @fontsource/noto-sans-kr @fontsource/ibm-plex-sans-kr @fontsource/nanum-gothic @fontsource/gowun-dodum @fontsource/noto-serif-kr spoqa-han-sans opentype.js uuid
+npm install --save-dev @types/uuid
+```
+
+- [ ] **Step 2: 타입 체크**
+
+```bash
+npx tsc --noEmit
+```
+Expected: PASS (의존성만 설치, 코드 변경 X)
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore(font): 글꼴 시스템 의존성 설치"
+```
+
+---
+
+### Task 1.2: typography.ts에 FontFamily / Spacing 타입 + 헬퍼 추가
+
+**Files:**
+- Modify: `src/utils/typography.ts`
+
+- [ ] **Step 1: 타입 정의 추가** (파일 끝에)
+
+```typescript
+// ─── 글꼴 서체 (Font Family) ──────────────────
+
+export interface CustomFont {
+  id: string;                   // `custom:${uuid}`
+  name: string;                 // 폰트 메타 이름
+  filename: string;             // 디스크 저장된 실제 파일명
+  format: 'otf' | 'ttf' | 'woff' | 'woff2';
+  hasKorean: boolean;
+  addedAt: string;              // ISO
+}
+
+export interface FontFamilyMeta {
+  id: string;
+  label: string;
+  cssStack: string;
+  group: 'modern' | 'soft' | 'serious' | 'character' | 'system';
+}
+
+export const FONT_FAMILIES: FontFamilyMeta[] = [
+  { id: 'pretendard',    label: 'Pretendard',         cssStack: `'Pretendard Variable', Pretendard, system-ui, sans-serif`, group: 'modern' },
+  { id: 'inter',         label: 'Inter',              cssStack: `Inter, 'Pretendard Variable', Pretendard, system-ui, sans-serif`, group: 'modern' },
+  { id: 'noto-sans-kr',  label: 'Noto Sans KR',       cssStack: `'Noto Sans KR', system-ui, sans-serif`, group: 'modern' },
+  { id: 'ibm-plex-kr',   label: 'IBM Plex Sans KR',   cssStack: `'IBM Plex Sans KR', system-ui, sans-serif`, group: 'serious' },
+  { id: 'spoqa',         label: 'Spoqa Han Sans Neo', cssStack: `'Spoqa Han Sans Neo', system-ui, sans-serif`, group: 'serious' },
+  { id: 'nanum-gothic',  label: '나눔고딕',           cssStack: `'Nanum Gothic', system-ui, sans-serif`, group: 'soft' },
+  { id: 'gowun-dodum',   label: '고운 도담',          cssStack: `'Gowun Dodum', system-ui, sans-serif`, group: 'soft' },
+  { id: 'noto-serif-kr', label: '본명조',             cssStack: `'Noto Serif KR', serif`, group: 'character' },
+  { id: 'system',        label: '시스템 기본',        cssStack: `system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif`, group: 'system' },
+];
+
+export const DEFAULT_FONT_FAMILY = 'pretendard';
+const FALLBACK_STACK = `'Pretendard Variable', Pretendard, system-ui, sans-serif`;
+
+// ─── Spacing (줄간격·자간) ─────────────────────
+
+export const DEFAULT_LINE_HEIGHT = 1.55;
+export const DEFAULT_LETTER_SPACING = 0;
+export const LINE_HEIGHT_MIN = 1.2;
+export const LINE_HEIGHT_MAX = 2.0;
+export const LINE_HEIGHT_STEP = 0.05;
+export const LETTER_SPACING_MIN = -0.05;
+export const LETTER_SPACING_MAX = 0.10;
+export const LETTER_SPACING_STEP = 0.005;
+
+// ─── DOM 적용 ────────────────────────────────
+
+export function applyFontFamily(familyId: string, customFonts: CustomFont[] = []): void {
+  const root = document.documentElement;
+  let stack = FALLBACK_STACK;
+  if (familyId.startsWith('custom:')) {
+    const cf = customFonts.find((f) => f.id === familyId);
+    if (cf) {
+      injectCustomFontFace(cf);
+      stack = `'${cf.name}', ${FALLBACK_STACK}`;
+    }
+  } else {
+    const meta = FONT_FAMILIES.find((f) => f.id === familyId);
+    if (meta) stack = meta.cssStack;
+  }
+  root.style.setProperty('--font-family', stack);
+}
+
+export function applySpacing(lineHeight: number, letterSpacing: number): void {
+  const root = document.documentElement;
+  root.style.setProperty('--text-line-height', String(lineHeight));
+  root.style.setProperty('--text-letter-spacing', `${letterSpacing}em`);
+}
+
+function injectCustomFontFace(font: CustomFont): void {
+  if (document.querySelector(`style[data-font-id="${font.id}"]`)) return;
+  const formatHint = { otf: 'opentype', ttf: 'truetype', woff: 'woff', woff2: 'woff2' }[font.format];
+  const url = `bflow-font://${encodeURIComponent(font.filename)}`;
+  const style = document.createElement('style');
+  style.setAttribute('data-font-id', font.id);
+  style.textContent = `@font-face { font-family: '${font.name}'; src: url('${url}') format('${formatHint}'); font-display: swap; }`;
+  document.head.appendChild(style);
+}
+
+export function ensureCustomFontsLoaded(customFonts: CustomFont[]): void {
+  customFonts.forEach(injectCustomFontFace);
+}
+```
+
+- [ ] **Step 2: applyPreferencesToDOM 확장** (기존 함수 시그니처에 새 필드 추가)
+
+기존 함수의 prefs 타입에 다음 필드 추가:
+```typescript
+fontFamily?: string;
+lineHeight?: number;
+letterSpacing?: number;
+customFonts?: CustomFont[];
+```
+
+함수 본문 끝에 추가:
+```typescript
+ensureCustomFontsLoaded(prefs.customFonts ?? []);
+applyFontFamily(prefs.fontFamily ?? DEFAULT_FONT_FAMILY, prefs.customFonts ?? []);
+applySpacing(
+  prefs.lineHeight ?? DEFAULT_LINE_HEIGHT,
+  prefs.letterSpacing ?? DEFAULT_LETTER_SPACING,
+);
+```
+
+- [ ] **Step 3: 타입 체크**
+
+```bash
+npx tsc --noEmit
+```
+Expected: PASS
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/utils/typography.ts
+git commit -m "feat(font): typography에 FontFamily/Spacing 타입 + 헬퍼 추가"
+```
+
+---
+
+### Task 1.3: UserPreferences 타입 확장
+
+**Files:**
+- Modify: `src/services/settingsService.ts` (또는 UserPreferences 정의 위치)
+
+- [ ] **Step 1: 위치 확인**
+
+```bash
+grep -rn "interface UserPreferences" src/
+```
+
+- [ ] **Step 2: UserPreferences interface에 신규 필드 추가**
+
+```typescript
+import type { CustomFont } from '@/utils/typography';
+
+export interface UserPreferences {
+  // ... 기존
+  fontFamily?: string;
+  lineHeight?: number;
+  letterSpacing?: number;
+  customFonts?: CustomFont[];
+}
+```
+
+- [ ] **Step 3: 타입 체크 + 커밋**
+
+```bash
+npx tsc --noEmit
+git add src/services/settingsService.ts
+git commit -m "feat(font): UserPreferences에 fontFamily/spacing/customFonts 필드 추가"
+```
+
+---
+
+### Task 1.4: index.css에 CSS 변수 + 폰트 import + tabular-nums
+
+**Files:**
+- Modify: `src/index.css`
+- Modify: `src/main.tsx` (폰트 import 위치에 따라)
+
+- [ ] **Step 1: 폰트 CSS import** (`src/main.tsx` 최상단 또는 `src/index.css` 시작 부분)
+
+```typescript
+// src/main.tsx 상단
+import 'pretendard/dist/web/static/pretendard.css';
+import '@fontsource/inter/400.css';
+import '@fontsource/inter/500.css';
+import '@fontsource/inter/600.css';
+import '@fontsource/inter/700.css';
+import '@fontsource/noto-sans-kr/400.css';
+import '@fontsource/noto-sans-kr/500.css';
+import '@fontsource/noto-sans-kr/700.css';
+import '@fontsource/ibm-plex-sans-kr/400.css';
+import '@fontsource/ibm-plex-sans-kr/500.css';
+import '@fontsource/ibm-plex-sans-kr/700.css';
+import '@fontsource/nanum-gothic/400.css';
+import '@fontsource/nanum-gothic/700.css';
+import '@fontsource/gowun-dodum/400.css';
+import '@fontsource/noto-serif-kr/400.css';
+import '@fontsource/noto-serif-kr/500.css';
+import '@fontsource/noto-serif-kr/700.css';
+import 'spoqa-han-sans/css/SpoqaHanSansNeo.css';
+```
+
+- [ ] **Step 2: index.css에 CSS 변수 추가** (기존 `:root` 블록 안에)
+
+```css
+:root {
+  /* ... 기존 변수들 */
+
+  /* 글꼴 시스템 (v1.20.0) */
+  --font-family: 'Pretendard Variable', Pretendard, system-ui, sans-serif;
+  --text-line-height: 1.55;
+  --text-letter-spacing: 0em;
+}
+
+/* @layer base 안에 추가 */
+@layer base {
+  html, body {
+    font-family: var(--font-family);
+    line-height: var(--text-line-height);
+    letter-spacing: var(--text-letter-spacing);
+  }
+}
+
+/* tabular-nums 글로벌 — 숫자 영역에 자동 적용 */
+[data-numeric],
+.tabular,
+.font-mono {
+  font-variant-numeric: tabular-nums;
+}
+```
+
+- [ ] **Step 3: 빌드 + 시각 확인**
+
+```bash
+npm run build:vite
+```
+Expected: PASS, dist 폴더 정상 생성
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/main.tsx src/index.css
+git commit -m "feat(font): 폰트 패키지 import + CSS 변수 + tabular-nums 글로벌"
+```
+
+---
+
+## Chunk 2: 메인 프로세스 IPC + Custom Protocol
+
+### Task 2.1: electron/fontIpc.ts 신규 작성
+
+**Files:**
+- Create: `electron/fontIpc.ts`
+
+- [ ] **Step 1: 파일 생성** — 전체 코드:
+
+```typescript
+import { app, dialog, ipcMain, protocol, net } from 'electron';
+import { promises as fsp, existsSync, mkdirSync } from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { v4 as uuidv4 } from 'uuid';
+import opentype from 'opentype.js';
+import type { CustomFont } from '../src/utils/typography';
+
+const FONT_DIR = path.join(app.getPath('userData'), 'fonts');
+const KOREAN_SAMPLE = ['가', '나', '다', '한', '글', '안', '녕', '스', '튜', '디', '오'];
+const SUPPORTED_EXT = ['.otf', '.ttf', '.woff', '.woff2'] as const;
+
+export function ensureFontDir(): void {
+  if (!existsSync(FONT_DIR)) mkdirSync(FONT_DIR, { recursive: true });
+}
+
+/** Electron app:ready 이전에 호출 필요 */
+export function registerFontProtocolPriv(): void {
+  protocol.registerSchemesAsPrivileged([
+    { scheme: 'bflow-font', privileges: { secure: true, standard: true, supportFetchAPI: true, stream: true } },
+  ]);
+}
+
+/** Electron app:ready 이후 호출 */
+export function registerFontProtocol(): void {
+  ensureFontDir();
+  protocol.handle('bflow-font', (request) => {
+    const url = new URL(request.url);
+    const filename = decodeURIComponent(url.hostname + url.pathname);
+    const safe = path.basename(filename); // path traversal 방지
+    const filePath = path.join(FONT_DIR, safe);
+    if (!filePath.startsWith(FONT_DIR)) {
+      return new Response('forbidden', { status: 403 });
+    }
+    return net.fetch(pathToFileURL(filePath).toString());
+  });
+}
+
+async function addFontFromPath(srcPath: string): Promise<CustomFont | { error: string }> {
+  const ext = path.extname(srcPath).toLowerCase() as typeof SUPPORTED_EXT[number];
+  if (!SUPPORTED_EXT.includes(ext)) {
+    return { error: `지원하지 않는 형식: ${ext}` };
+  }
+  let font: opentype.Font;
+  try {
+    font = await opentype.load(srcPath);
+  } catch (e) {
+    return { error: `폰트 파일 파싱 실패: ${(e as Error).message}` };
+  }
+  const name = font.names.fontFamily?.en || font.names.fullName?.en || path.basename(srcPath, ext);
+  const hasKorean = KOREAN_SAMPLE.every((c) => {
+    const g = font.charToGlyph(c);
+    return !!g && g.unicode === c.charCodeAt(0);
+  });
+  const id = `custom:${uuidv4()}`;
+  const filename = `${id.replace(/[^a-z0-9-]/gi, '_')}${ext}`;
+  await fsp.copyFile(srcPath, path.join(FONT_DIR, filename));
+  return {
+    id,
+    name,
+    filename,
+    format: ext.slice(1) as CustomFont['format'],
+    hasKorean,
+    addedAt: new Date().toISOString(),
+  };
+}
+
+export function registerFontIpcHandlers(): void {
+  ipcMain.handle('font:add', async () => {
+    const result = await dialog.showOpenDialog({
+      properties: ['openFile', 'multiSelections'],
+      filters: [{ name: 'Font Files', extensions: ['otf', 'ttf', 'woff', 'woff2'] }],
+      title: '글꼴 파일 선택',
+    });
+    if (result.canceled) return [];
+    return Promise.all(result.filePaths.map(addFontFromPath));
+  });
+
+  ipcMain.handle('font:add-by-path', async (_e, filePaths: string[]) => {
+    return Promise.all(filePaths.map(addFontFromPath));
+  });
+
+  ipcMain.handle('font:delete', async (_e, font: CustomFont) => {
+    try {
+      await fsp.unlink(path.join(FONT_DIR, font.filename));
+      return { ok: true };
+    } catch (e) {
+      return { ok: false, error: (e as Error).message };
+    }
+  });
+}
+```
+
+- [ ] **Step 2: 타입 체크**
+
+```bash
+npx tsc --noEmit
+```
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add electron/fontIpc.ts
+git commit -m "feat(font): 사용자 폰트 IPC + bflow-font:// custom protocol"
+```
+
+---
+
+### Task 2.2: electron/main.ts에 IPC + 프로토콜 통합
+
+**Files:**
+- Modify: `electron/main.ts`
+
+- [ ] **Step 1: import 추가**
+
+```typescript
+import { registerFontProtocolPriv, registerFontProtocol, registerFontIpcHandlers } from './fontIpc';
+```
+
+- [ ] **Step 2: app.whenReady() 호출 전에**
+
+```typescript
+registerFontProtocolPriv();
+```
+※ `registerSchemesAsPrivileged`는 ready 이전에 호출되어야 함.
+
+- [ ] **Step 3: app.whenReady() 콜백 안에**
+
+```typescript
+registerFontProtocol();
+registerFontIpcHandlers();
+```
+
+- [ ] **Step 4: 빌드 + Electron 실행 검증**
+
+```bash
+npm run build:vite
+```
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add electron/main.ts
+git commit -m "feat(font): main.ts에 IPC/프로토콜 등록"
+```
+
+---
+
+### Task 2.3: preload.ts에 API 노출
+
+**Files:**
+- Modify: `electron/preload.ts`
+
+- [ ] **Step 1: contextBridge에 추가**
+
+```typescript
+contextBridge.exposeInMainWorld('electronAPI', {
+  // ... 기존
+  fontAdd: () => ipcRenderer.invoke('font:add'),
+  fontAddByPath: (paths: string[]) => ipcRenderer.invoke('font:add-by-path', paths),
+  fontDelete: (font: any) => ipcRenderer.invoke('font:delete', font),
+});
+```
+
+- [ ] **Step 2: src/types에서 electronAPI 타입에 동일 메서드 추가** (있는 경우)
+
+```bash
+grep -rn "interface ElectronAPI" src/types/
+```
+해당 위치에 추가.
+
+- [ ] **Step 3: 타입 체크 + 커밋**
+
+```bash
+npx tsc --noEmit
+git add electron/preload.ts src/types/
+git commit -m "feat(font): preload에 fontAdd/Delete API 노출"
+```
+
+---
+
+## Chunk 3: 렌더러 컴포넌트
+
+### Task 3.1: FontFamilySection 신규 작성
+
+**Files:**
+- Create: `src/components/settings/FontFamilySection.tsx`
+
+- [ ] **Step 1: 컴포넌트 작성** (목업 구조 그대로 React 컴포넌트화)
+
+```tsx
+import { useState, useCallback } from 'react';
+import { CaseSensitive, Plus, Trash2, AlertTriangle, Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+import { cn } from '@/utils/cn';
+import { SettingsSection } from './SettingsSection';
+import {
+  FONT_FAMILIES,
+  DEFAULT_FONT_FAMILY,
+  applyFontFamily,
+  type CustomFont,
+} from '@/utils/typography';
+import { loadPreferences, savePreferences } from '@/services/settingsService';
+
+interface Props {
+  fontFamily: string;
+  customFonts: CustomFont[];
+  onChange: (familyId: string, customFonts: CustomFont[]) => void;
+}
+
+export function FontFamilySection({ fontFamily, customFonts, onChange }: Props) {
+  const [busy, setBusy] = useState(false);
+  const [dragging, setDragging] = useState(false);
+
+  const persistAndApply = useCallback(async (familyId: string, nextCustomFonts: CustomFont[]) => {
+    applyFontFamily(familyId, nextCustomFonts);
+    onChange(familyId, nextCustomFonts);
+    const prev = (await loadPreferences()) ?? {};
+    await savePreferences({ ...prev, fontFamily: familyId, customFonts: nextCustomFonts });
+    window.electronAPI?.preferencesBroadcastChange?.({ fontFamily: familyId, customFonts: nextCustomFonts });
+  }, [onChange]);
+
+  const handleSelect = useCallback((id: string) => {
+    persistAndApply(id, customFonts);
+  }, [customFonts, persistAndApply]);
+
+  const handleAddViaButton = useCallback(async () => {
+    setBusy(true);
+    try {
+      const results = await window.electronAPI!.fontAdd();
+      processAddResults(results);
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const handleDrop = useCallback(async (e: React.DragEvent) => {
+    e.preventDefault();
+    setDragging(false);
+    const paths = [...e.dataTransfer.files].map((f: any) => f.path).filter(Boolean);
+    if (paths.length === 0) return;
+    setBusy(true);
+    try {
+      const results = await window.electronAPI!.fontAddByPath(paths);
+      processAddResults(results);
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const processAddResults = useCallback((results: any[]) => {
+    const added: CustomFont[] = [];
+    for (const r of results) {
+      if (!r) continue;
+      if ('error' in r) {
+        toast.error(`폰트 추가 실패: ${r.error}`);
+      } else {
+        added.push(r as CustomFont);
+        if (!(r as CustomFont).hasKorean) {
+          toast.warning(`"${(r as CustomFont).name}"은(는) 한글 글리프가 없어 영문/숫자만 표시됩니다.`);
+        }
+      }
+    }
+    if (added.length > 0) {
+      const next = [...customFonts, ...added];
+      persistAndApply(fontFamily, next);
+      toast.success(`${added.length}개 폰트 추가됨`);
+    }
+  }, [customFonts, fontFamily, persistAndApply]);
+
+  const handleDelete = useCallback(async (font: CustomFont) => {
+    if (!confirm(`"${font.name}" 글꼴을 삭제하시겠습니까?`)) return;
+    await window.electronAPI!.fontDelete(font);
+    const next = customFonts.filter((f) => f.id !== font.id);
+    const fallbackId = fontFamily === font.id ? DEFAULT_FONT_FAMILY : fontFamily;
+    persistAndApply(fallbackId, next);
+  }, [customFonts, fontFamily, persistAndApply]);
+
+  return (
+    <SettingsSection
+      icon={<CaseSensitive size={18} className="text-accent" />}
+      title="글꼴 (서체)"
+    >
+      <div
+        onDragEnter={(e) => { e.preventDefault(); setDragging(true); }}
+        onDragOver={(e) => { e.preventDefault(); }}
+        onDragLeave={() => setDragging(false)}
+        onDrop={handleDrop}
+        className={cn(
+          'transition-all rounded-lg',
+          dragging && 'ring-2 ring-accent ring-offset-2 ring-offset-bg-card bg-accent/5',
+        )}
+      >
+        <p className="text-xs text-text-secondary mb-2">기본 글꼴</p>
+        <div className="flex gap-1.5 flex-wrap mb-4">
+          {FONT_FAMILIES.map((meta) => (
+            <button
+              key={meta.id}
+              onClick={() => handleSelect(meta.id)}
+              className={cn(
+                'px-3 py-1.5 rounded-md text-xs font-medium border transition-all cursor-pointer',
+                fontFamily === meta.id
+                  ? 'bg-accent/15 border-accent text-accent'
+                  : 'border-bg-border text-text-primary hover:bg-bg-border/30',
+              )}
+              style={{ fontFamily: meta.cssStack }}
+            >
+              {meta.label}
+            </button>
+          ))}
+        </div>
+
+        {customFonts.length > 0 && (
+          <>
+            <p className="text-xs text-text-secondary mb-2">내 글꼴</p>
+            <div className="flex gap-1.5 flex-wrap mb-3">
+              {customFonts.map((font) => {
+                const active = fontFamily === font.id;
+                return (
+                  <span
+                    key={font.id}
+                    className={cn(
+                      'inline-flex items-center gap-1 pl-3 pr-1 py-0.5 rounded-md text-xs font-medium border transition-all',
+                      active ? 'bg-accent/15 border-accent text-accent' : 'border-bg-border text-text-primary',
+                    )}
+                  >
+                    <button
+                      onClick={() => handleSelect(font.id)}
+                      className="cursor-pointer"
+                      style={{ fontFamily: `'${font.name}', system-ui, sans-serif` }}
+                    >
+                      {font.name}
+                    </button>
+                    <button
+                      onClick={() => handleDelete(font)}
+                      className="w-5 h-5 inline-flex items-center justify-center rounded text-text-tertiary hover:bg-red-500/15 hover:text-red-400 cursor-pointer"
+                      title="삭제"
+                    >
+                      <Trash2 size={11} />
+                    </button>
+                  </span>
+                );
+              })}
+            </div>
+          </>
+        )}
+
+        <button
+          onClick={handleAddViaButton}
+          disabled={busy}
+          className={cn(
+            'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium border border-dashed transition-all cursor-pointer',
+            'border-bg-border text-accent-sub hover:border-accent hover:bg-accent/8 hover:border-solid',
+            busy && 'opacity-50 cursor-wait',
+          )}
+        >
+          {busy ? <Loader2 size={12} className="animate-spin" /> : <Plus size={12} />}
+          글꼴 추가
+        </button>
+
+        <p className="mt-3 text-[10px] text-text-secondary/60 flex items-start gap-1.5">
+          <AlertTriangle size={11} className="text-amber-400 shrink-0 mt-0.5" />
+          <span>추가하시는 글꼴의 라이선스는 본인이 확인해주세요. 추가된 글꼴은 본인 PC에만 저장됩니다 (다른 팀원에게는 안 보임).</span>
+        </p>
+      </div>
+    </SettingsSection>
+  );
+}
+```
+
+- [ ] **Step 2: 타입 체크**
+
+```bash
+npx tsc --noEmit
+```
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/components/settings/FontFamilySection.tsx
+git commit -m "feat(font): FontFamilySection 컴포넌트 (선택+추가+DnD+삭제)"
+```
+
+---
+
+### Task 3.2: SpacingSection 신규 작성
+
+**Files:**
+- Create: `src/components/settings/SpacingSection.tsx`
+
+- [ ] **Step 1: 컴포넌트 작성**
+
+```tsx
+import { useCallback } from 'react';
+import { AlignVerticalSpaceAround, RotateCcw } from 'lucide-react';
+import { cn } from '@/utils/cn';
+import { SettingsSection } from './SettingsSection';
+import {
+  applySpacing,
+  DEFAULT_LINE_HEIGHT, DEFAULT_LETTER_SPACING,
+  LINE_HEIGHT_MIN, LINE_HEIGHT_MAX, LINE_HEIGHT_STEP,
+  LETTER_SPACING_MIN, LETTER_SPACING_MAX, LETTER_SPACING_STEP,
+} from '@/utils/typography';
+import { loadPreferences, savePreferences } from '@/services/settingsService';
+
+interface Props {
+  lineHeight: number;
+  letterSpacing: number;
+  onChange: (lineHeight: number, letterSpacing: number) => void;
+}
+
+export function SpacingSection({ lineHeight, letterSpacing, onChange }: Props) {
+  const persist = useCallback(async (lh: number, ls: number) => {
+    applySpacing(lh, ls);
+    onChange(lh, ls);
+    const prev = (await loadPreferences()) ?? {};
+    await savePreferences({ ...prev, lineHeight: lh, letterSpacing: ls });
+    window.electronAPI?.preferencesBroadcastChange?.({ lineHeight: lh, letterSpacing: ls });
+  }, [onChange]);
+
+  const handleReset = useCallback(() => {
+    persist(DEFAULT_LINE_HEIGHT, DEFAULT_LETTER_SPACING);
+  }, [persist]);
+
+  const isCustom = lineHeight !== DEFAULT_LINE_HEIGHT || letterSpacing !== DEFAULT_LETTER_SPACING;
+
+  return (
+    <SettingsSection
+      icon={<AlignVerticalSpaceAround size={18} className="text-accent" />}
+      title="간격"
+      action={
+        isCustom && (
+          <button
+            onClick={handleReset}
+            className="flex items-center gap-1 px-2 py-1 rounded-md text-[11px] text-text-secondary hover:text-text-primary hover:bg-bg-border/30 cursor-pointer"
+          >
+            <RotateCcw size={12} />
+            기본값 복원
+          </button>
+        )
+      }
+    >
+      <div className="space-y-3">
+        <div className="flex items-center gap-3">
+          <span className="w-16 shrink-0 text-xs font-medium">줄간격</span>
+          <input
+            type="range"
+            min={LINE_HEIGHT_MIN} max={LINE_HEIGHT_MAX} step={LINE_HEIGHT_STEP}
+            value={lineHeight}
+            onChange={(e) => persist(parseFloat(e.target.value), letterSpacing)}
+            className="flex-1 h-1.5 cursor-pointer"
+          />
+          <span className={cn(
+            'w-12 text-right text-xs font-mono tabular-nums',
+            lineHeight === DEFAULT_LINE_HEIGHT ? 'text-text-secondary/50' : 'text-accent',
+          )}>
+            {lineHeight.toFixed(2)}
+          </span>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <span className="w-16 shrink-0 text-xs font-medium">자간</span>
+          <input
+            type="range"
+            min={LETTER_SPACING_MIN} max={LETTER_SPACING_MAX} step={LETTER_SPACING_STEP}
+            value={letterSpacing}
+            onChange={(e) => persist(lineHeight, parseFloat(e.target.value))}
+            className="flex-1 h-1.5 cursor-pointer"
+          />
+          <span className={cn(
+            'w-12 text-right text-xs font-mono tabular-nums',
+            letterSpacing === DEFAULT_LETTER_SPACING ? 'text-text-secondary/50' : 'text-accent',
+          )}>
+            {letterSpacing.toFixed(3)}
+          </span>
+        </div>
+      </div>
+    </SettingsSection>
+  );
+}
+```
+
+- [ ] **Step 2: 타입 체크 + 커밋**
+
+```bash
+npx tsc --noEmit
+git add src/components/settings/SpacingSection.tsx
+git commit -m "feat(font): SpacingSection 컴포넌트 (줄간격/자간 슬라이더)"
+```
+
+---
+
+## Chunk 4: 통합 + 검증
+
+### Task 4.1: SettingsView에 신규 섹션 통합
+
+**Files:**
+- Modify: `src/views/SettingsView.tsx` (또는 활성 탭 분기 위치)
+
+- [ ] **Step 1: 위치 확인**
+
+```bash
+grep -rn "FontSizeSection" src/
+```
+
+- [ ] **Step 2: import 추가**
+
+```typescript
+import { FontFamilySection } from '@/components/settings/FontFamilySection';
+import { SpacingSection } from '@/components/settings/SpacingSection';
+```
+
+- [ ] **Step 3: font 탭 분기 안에 통합**
+
+```tsx
+{activeTab === 'font' && (
+  <>
+    <FontFamilySection
+      fontFamily={fontFamily}
+      customFonts={customFonts}
+      onChange={(id, customs) => { setFontFamily(id); setCustomFonts(customs); }}
+    />
+    <FontSizeSection {...기존 props} />
+    <FontColorSection />
+    <SpacingSection
+      lineHeight={lineHeight}
+      letterSpacing={letterSpacing}
+      onChange={(lh, ls) => { setLineHeight(lh); setLetterSpacing(ls); }}
+    />
+  </>
+)}
+```
+
+- [ ] **Step 4: 상태 관리** — useAppStore (Zustand) 또는 SettingsView 로컬 state로 fontFamily/customFonts/lineHeight/letterSpacing 초기 로드. 기존 패턴(themeId 등)을 그대로 따라간다.
+
+- [ ] **Step 5: 타입 체크 + 빌드 + 커밋**
+
+```bash
+npx tsc --noEmit
+npm run build:vite
+git add src/views/SettingsView.tsx src/stores/useAppStore.ts
+git commit -m "feat(font): 글꼴 탭에 FontFamilySection/SpacingSection 통합"
+```
+
+---
+
+### Task 4.2: App.tsx 시작 흐름에 폰트 적용
+
+**Files:**
+- Modify: `src/App.tsx`
+
+- [ ] **Step 1: 시작 시 preferences hydrate 위치 확인**
+
+```bash
+grep -n "applyPreferencesToDOM\|loadPreferences" src/App.tsx src/main.tsx
+```
+
+- [ ] **Step 2: applyPreferencesToDOM 호출이 이미 있다면, 신규 필드도 자동 적용됨** (Task 1.2에서 확장 완료). 없다면 hydrate 직후 호출 추가.
+
+- [ ] **Step 3: 다른 창(플로팅 위젯) preferencesBroadcastChange 수신 핸들러도 같은 헬퍼 사용** — 검증.
+
+- [ ] **Step 4: 빌드 + 커밋**
+
+```bash
+npm run build:vite
+git add src/App.tsx
+git commit -m "feat(font): App 시작 시 글꼴 prefs 자동 적용"
+```
+
+---
+
+### Task 4.3: 빌드 + 수동 검증
+
+- [ ] **Step 1: 풀 빌드**
+
+```bash
+npm run build:vite
+```
+Expected: PASS
+
+- [ ] **Step 2: Electron 실행 + 수동 체크리스트**
+
+```bash
+npm run electron:dev
+```
+
+체크:
+- [ ] 첫 실행 시 Pretendard 자동 적용
+- [ ] 9개 기본 글꼴 칩 클릭 시 즉시 적용
+- [ ] 다른 창(플로팅 위젯)도 같이 변경
+- [ ] 줄간격 슬라이더 동작 (메모/댓글 영역에 변화 보임)
+- [ ] 자간 슬라이더 동작
+- [ ] "기본값 복원" 동작
+- [ ] `+ 글꼴 추가` 클릭 → 탐색기 열림 → OTF 선택 → 칩 등장 → 클릭 시 적용
+- [ ] 드래그앤드롭 → 동일하게 추가
+- [ ] 한글 미지원 폰트 (예: Inter.otf) → 토스트 경고
+- [ ] 휴지통 → 삭제 + 적용 중이던 폰트라면 Pretendard로 폴백
+- [ ] 앱 재시작 → 마지막 선택 폰트 유지
+- [ ] 위젯 숫자가 자릿수 일자로 정렬 (대시보드 % 확인)
+
+- [ ] **Step 3: 발견된 버그 수정 후 커밋** (있는 경우만)
+
+---
+
+### Task 4.4: 버전 bump + PR
+
+- [ ] **Step 1: package.json version → 1.20.0**
+
+- [ ] **Step 2: 최종 커밋**
+
+```bash
+git add package.json
+git commit -m "chore(release): v1.20.0 — 글꼴 시스템"
+```
+
+- [ ] **Step 3: 푸시 + PR 생성** (pr-creator 스킬 활용)
+
+```bash
+git push -u origin claude/crazy-goldberg-b4d4eb
+```
+PR 본문 — 비개발자 이해 가능한 업데이트 로그 + 상세 기술 설명 + 테스트 가이드 (한솔님 기존 PR 패턴 그대로).
+
+---
+
+## 완료 기준
+
+- ✅ 9개 기본 글꼴 즉시 적용
+- ✅ 사용자 OTF/TTF/WOFF/WOFF2 추가 (탐색기 + DnD)
+- ✅ 한글 글리프 자동 검증 + 경고 토스트
+- ✅ 줄간격·자간 슬라이더 즉시 반영
+- ✅ 위젯 숫자 자릿수 자동 정렬
+- ✅ 다른 창 동기화
+- ✅ 앱 재시작 시 설정 유지
+- ✅ tsc --noEmit + vite build 통과
+- ✅ Pretendard 기본값 자동 적용
+- ✅ PR 생성
+
+---
+
+*Plan 끝. 실행은 위에서 아래로 순차 진행. 각 task 종료 후 커밋. 빌드 깨지면 즉시 fix.*

--- a/docs/superpowers/specs/2026-05-06-font-system-design.md
+++ b/docs/superpowers/specs/2026-05-06-font-system-design.md
@@ -1,0 +1,504 @@
+# 글꼴 시스템 — 설계 문서
+
+> **작성일**: 2026-05-06
+> **대상 버전**: v1.20.0
+> **상태**: 설계 확정, 구현 준비
+> **mockup**: [`docs/superpowers/mockups/font-feature-mockup.html`](../mockups/font-feature-mockup.html)
+> **선행**: v1.19.x (리비전 보드 리뉴얼 후 안정화 완료)
+
+---
+
+## 1. 배경과 목표
+
+### 현재 상태
+
+- `index.html`의 body에 `font-family: system-ui, sans-serif` 한 줄만 설정 — 윈도우에서는 사실상 맑은 고딕/Segoe UI가 강제됨
+- 설정 → "글꼴" 탭 = `FontSizeSection` + `FontColorSection` (5단계 크기 프리셋 + 카테고리별 색상 프리셋)
+- **사용자가 글꼴(서체) 자체는 바꿀 수 없음** — 이게 이번 작업의 출발점
+
+### 동기 (한솔님 인터뷰 결과)
+
+1. **가독성** — 현재 OS 기본 글꼴이 눈에 잘 안 들어옴 (특히 숫자 ·작은 텍스트)
+2. **분위기/감성** — OS 기본 느낌이 사무적, 더 부드럽거나 진중한 느낌 원함
+3. **팀원별 취향** — Studio JBBJ 멤버 ~20명 각자 좋아하는 글꼴이 다름 → 개인별 선택권 필요
+
+### 목표
+
+- 앱 전체에 한 번에 적용되는 **글꼴(서체) 선택 기능**
+- 큐레이션 **9종 번들 배포** + **사용자 직접 추가**(OTF/TTF/WOFF/WOFF2) 가능
+- 가독성 보조: **줄간격·자간** 슬라이더
+- 대시보드 숫자 자동 정렬 (`tabular-nums` 글로벌 적용, 사용자 옵션 없음)
+- 개인별 저장 (`preferences.json` 확장, Supabase 미사용)
+
+### 비목표 (이번 범위 밖)
+
+- 카테고리별(제목/본문)로 다른 글꼴 적용 — 한솔님이 "한 방 통일" 선택
+- "느낌 묶음" 프리셋 — 한솔님이 후보에서 제외
+- 굵기(weight) 슬라이더 — 한솔님이 후보에서 제외
+- 공유 폴더 자동 스캔 — 한솔님이 옵션 3(개인별만) 선택
+
+---
+
+## 2. 핵심 사용자 흐름
+
+### 시나리오 A — 큐레이션 글꼴 선택 (가장 흔한 흐름)
+
+1. 사용자가 ⚙️ 설정 → "글꼴" 탭 진입
+2. 새 "글꼴 (서체)" 섹션의 **기본 글꼴** 9개 칩 중 하나 클릭 (예: `Noto Sans KR`)
+3. 즉시 앱 전체 글꼴 변경 (낙관적 적용 — DOM CSS 변수 즉시 갱신)
+4. `preferences.json`에 저장 + `electronAPI.preferencesBroadcastChange`로 다른 창(플로팅 위젯) 동기화
+
+### 시나리오 B — 자기 PC 글꼴 추가 (+ 버튼)
+
+1. **내 글꼴** 그룹의 `＋ 글꼴 추가` 버튼 클릭
+2. Electron `dialog.showOpenDialog` 호출 → 윈도우 탐색기 팝업 (필터: `*.otf,*.ttf,*.woff,*.woff2`, multi-select OK)
+3. 사용자가 "산돌네오2.otf" 선택 → "열기"
+4. 메인 프로세스가 파일을 `%APPDATA%/Bflow-BGonly/fonts/<uuid>.otf`로 복사
+5. opentype.js로 메타데이터 파싱 → 폰트 이름 추출 + 한글 글리프 검증
+6. preferences.json의 `customFonts[]`에 메타데이터 추가
+7. "내 글꼴" 그룹에 칩으로 등장 → 사용자 클릭하면 시나리오 A의 3~4단계
+8. 한글 미지원 폰트일 경우 토스트 경고 (`영문/숫자만 표시됩니다`)
+
+### 시나리오 C — 드래그 앤 드롭 추가
+
+1. 사용자가 G드라이브 폴더(또는 어디든)에서 OTF 파일을 드래그
+2. 설정 화면 위에 마우스가 올라오면 **드롭존 강조** (점선 보더 + 액센트 색 배경)
+3. 떨굼 → 메인 프로세스에 파일 경로 전달 (`font:add-by-path` IPC) → 시나리오 B의 4~7단계
+
+### 시나리오 D — 가독성 조절 (줄간격·자간)
+
+1. "간격" 섹션의 줄간격 슬라이더 조작 (1.2 ~ 2.0)
+2. 즉시 미리보기 + DOM 변수 적용 (`--text-line-height`)
+3. preferences.json에 저장
+4. 자간(letter-spacing) 슬라이더도 동일 흐름
+5. "기본값 복원" 버튼 클릭 시 1.55 / 0 으로 복귀
+
+### 시나리오 E — 사용자 폰트 삭제
+
+1. "내 글꼴" 그룹의 폰트 칩 우측 휴지통(×) 클릭
+2. 확인 다이얼로그 ("삭제하시겠습니까?")
+3. 파일 삭제 + preferences.customFonts에서 제거
+4. 만약 현재 적용 중이던 폰트라면 → 자동으로 기본값(Pretendard)으로 폴백
+
+---
+
+## 3. UI 변경 요약
+
+### 3-1. "글꼴" 탭 섹션 구성 (변경 후)
+
+| 순서 | 섹션 | 상태 | 헤더 아이콘 (lucide) |
+|------|------|------|----------------------|
+| 1 | 글꼴 (서체) | **NEW** | `CaseSensitive` |
+| 2 | 글꼴 크기 | 기존 | `Type` |
+| 3 | 글자 색상 | 기존 | `Palette` |
+| 4 | 간격 | **NEW** | `AlignVerticalSpaceAround` |
+
+### 3-2. 글꼴 (서체) 섹션 — 신규
+
+**기본 글꼴** 그룹 (9종 칩):
+- Pretendard ★ (기본값)
+- Inter
+- Noto Sans KR
+- IBM Plex Sans KR
+- Spoqa Han Sans Neo
+- 나눔고딕
+- 고운 도담
+- 본명조 (Noto Serif KR)
+- 시스템 기본
+
+**내 글꼴** 그룹:
+- 추가된 폰트 칩 (휴지통 × 아이콘 포함)
+- `＋ 글꼴 추가` 버튼 (점선 보더 → 호버 시 액센트 강조)
+- 드롭존 (섹션 전체)
+
+**라이선스 안내 footnote** (AlertTriangle 아이콘 + 호박색):
+> "추가하시는 글꼴의 라이선스는 본인이 확인해주세요. 추가된 글꼴은 본인 PC에만 저장됩니다."
+
+### 3-3. 글꼴 크기 / 글자 색상 (기존)
+
+기능 변경 없음. 단:
+- 헤더 아이콘만 통일 (`Type`, `Palette`)
+
+### 3-4. 간격 섹션 — 신규
+
+| 항목 | 범위 | step | 기본값 |
+|------|------|------|--------|
+| 줄간격 | 1.2 ~ 2.0 | 0.05 | 1.55 |
+| 자간 | -0.05 ~ 0.10 em | 0.005 | 0 |
+
+"기본값 복원" 버튼 (다른 섹션과 동일 패턴).
+
+### 3-5. 숫자 정렬 — 사용자 옵션 없음 (기본 적용)
+
+`font-variant-numeric: tabular-nums`를 글로벌 CSS에 적용:
+- body 단위 적용 시 한글 글자 폭 영향 가능성 → **숫자 영역에만 선택적 적용** (위젯 숫자, 표, 진행률, 시간 표시 등)
+- 적용 대상: 위젯 차트 라벨, AssigneeCardsWidget 카드, EpisodeSummaryWidget 셀, OverallProgressWidget % 표시 등
+- 구현 방식: Tailwind utility (`tabular-nums` 클래스) + 글로벌 CSS rule (`.tabular, [data-numeric], .num-stack`) 혼합
+
+---
+
+## 4. 데이터 모델 변경
+
+### 4-1. `UserPreferences` 타입 확장
+
+`src/services/settingsService.ts` (또는 그에 준하는 위치):
+
+```typescript
+export interface UserPreferences {
+  // ... 기존 필드 (themeId, fontScale, fontCategoryScales, fontCategoryColors, ...)
+
+  // 신규 (이번 작업)
+  fontFamily?: string;          // 'pretendard' | 'inter' | 'noto-sans-kr' | ... | 'system' | `custom:${uuid}`
+  lineHeight?: number;          // 1.2 ~ 2.0, 기본 1.55
+  letterSpacing?: number;       // -0.05 ~ 0.10 em, 기본 0
+  customFonts?: CustomFont[];   // 사용자 추가 폰트 메타데이터
+}
+
+export interface CustomFont {
+  id: string;                   // `custom:${uuid}`
+  name: string;                 // '산돌네오2' (opentype 메타에서 추출)
+  filename: string;             // 디스크에 저장된 실제 파일명 (uuid 기반)
+  format: 'otf' | 'ttf' | 'woff' | 'woff2';
+  hasKorean: boolean;           // 한글 글리프 존재 여부
+  addedAt: string;              // ISO 날짜
+}
+```
+
+### 4-2. `typography.ts` 확장
+
+```typescript
+// 신규
+export type FontFamilyId = string; // 자유 문자열 (커스텀 ID 포함)
+
+export const FONT_FAMILIES: Array<{
+  id: FontFamilyId;
+  label: string;
+  cssStack: string;             // CSS font-family stack (fallback 포함)
+  group: 'modern' | 'soft' | 'serious' | 'character' | 'system';
+}> = [
+  { id: 'pretendard',      label: 'Pretendard',         cssStack: `'Pretendard Variable', Pretendard, system-ui, sans-serif`, group: 'modern' },
+  { id: 'inter',           label: 'Inter',              cssStack: `Inter, 'Pretendard Variable', Pretendard, system-ui, sans-serif`, group: 'modern' },
+  { id: 'noto-sans-kr',    label: 'Noto Sans KR',       cssStack: `'Noto Sans KR', system-ui, sans-serif`, group: 'modern' },
+  { id: 'ibm-plex-kr',     label: 'IBM Plex Sans KR',   cssStack: `'IBM Plex Sans KR', system-ui, sans-serif`, group: 'serious' },
+  { id: 'spoqa',           label: 'Spoqa Han Sans Neo', cssStack: `'Spoqa Han Sans Neo', system-ui, sans-serif`, group: 'serious' },
+  { id: 'nanum-gothic',    label: '나눔고딕',           cssStack: `'Nanum Gothic', system-ui, sans-serif`, group: 'soft' },
+  { id: 'gowun-dodum',     label: '고운 도담',          cssStack: `'Gowun Dodum', system-ui, sans-serif`, group: 'soft' },
+  { id: 'noto-serif-kr',   label: '본명조',             cssStack: `'Noto Serif KR', serif`, group: 'character' },
+  { id: 'system',          label: '시스템 기본',        cssStack: `system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif`, group: 'system' },
+];
+
+export const DEFAULT_FONT_FAMILY: FontFamilyId = 'pretendard';
+export const DEFAULT_LINE_HEIGHT = 1.55;
+export const DEFAULT_LETTER_SPACING = 0;
+
+export const LINE_HEIGHT_MIN = 1.2;
+export const LINE_HEIGHT_MAX = 2.0;
+export const LINE_HEIGHT_STEP = 0.05;
+
+export const LETTER_SPACING_MIN = -0.05;
+export const LETTER_SPACING_MAX = 0.10;
+export const LETTER_SPACING_STEP = 0.005;
+
+export function applyFontFamily(
+  familyId: FontFamilyId,
+  customFonts: CustomFont[] = [],
+): void {
+  const root = document.documentElement;
+  let stack: string;
+  if (familyId.startsWith('custom:')) {
+    const cf = customFonts.find((f) => f.id === familyId);
+    stack = cf
+      ? `'${cf.name}', system-ui, sans-serif`
+      : DEFAULT_CSS_STACK;
+  } else {
+    const meta = FONT_FAMILIES.find((f) => f.id === familyId);
+    stack = meta?.cssStack ?? DEFAULT_CSS_STACK;
+  }
+  root.style.setProperty('--font-family', stack);
+}
+
+export function applySpacing(lineHeight: number, letterSpacing: number): void {
+  const root = document.documentElement;
+  root.style.setProperty('--text-line-height', String(lineHeight));
+  root.style.setProperty('--text-letter-spacing', `${letterSpacing}em`);
+}
+```
+
+`applyPreferencesToDOM` 확장:
+
+```typescript
+export function applyPreferencesToDOM(prefs: {
+  // ... 기존
+  fontFamily?: string;
+  lineHeight?: number;
+  letterSpacing?: number;
+  customFonts?: CustomFont[];
+}): void {
+  // ... 기존 (size + color)
+  applyFontFamily(prefs.fontFamily ?? DEFAULT_FONT_FAMILY, prefs.customFonts ?? []);
+  applySpacing(
+    prefs.lineHeight ?? DEFAULT_LINE_HEIGHT,
+    prefs.letterSpacing ?? DEFAULT_LETTER_SPACING,
+  );
+}
+```
+
+### 4-3. CSS 변수 (index.css)
+
+```css
+:root {
+  --font-family: 'Pretendard Variable', Pretendard, system-ui, sans-serif;
+  --text-line-height: 1.55;
+  --text-letter-spacing: 0em;
+}
+
+html, body {
+  font-family: var(--font-family);
+  line-height: var(--text-line-height);
+  letter-spacing: var(--text-letter-spacing);
+}
+
+/* 사용자 추가 폰트는 동적으로 @font-face 주입됨 (loadCustomFonts) */
+
+/* 위젯 숫자 영역에 자동 tabular-nums */
+[data-numeric],
+.num-stack,
+.tabular,
+.widget-card .number,
+.episode-summary-cell,
+.assignee-card .count,
+.progress-percentage {
+  font-variant-numeric: tabular-nums;
+}
+```
+
+---
+
+## 5. IPC 구조 (사용자 폰트 추가)
+
+CLAUDE.md 규칙 — "렌더러에서 직접 fs/dialog 호출 금지, IPC → 메인 → fs". 다음 핸들러 추가:
+
+### 5-1. 메인 프로세스 (electron/main.ts 또는 그에 준하는 위치)
+
+```typescript
+// 사용자 폰트 디렉토리
+const userFontsDir = path.join(app.getPath('userData'), 'fonts');
+fs.mkdirSync(userFontsDir, { recursive: true });
+
+// 1. 파일 선택 다이얼로그 + 추가
+ipcMain.handle('font:add', async (event) => {
+  const result = await dialog.showOpenDialog({
+    properties: ['openFile', 'multiSelections'],
+    filters: [{ name: 'Font Files', extensions: ['otf', 'ttf', 'woff', 'woff2'] }],
+    title: '글꼴 파일 선택',
+  });
+  if (result.canceled || result.filePaths.length === 0) return [];
+  return Promise.all(result.filePaths.map(addFontFromPath));
+});
+
+// 2. 드래그앤드롭에서 호출
+ipcMain.handle('font:add-by-path', async (event, filePath: string) => {
+  return addFontFromPath(filePath);
+});
+
+// 3. 삭제
+ipcMain.handle('font:delete', async (event, fontId: string) => {
+  // ... preferences에서 찾아 파일 삭제
+});
+
+// 핵심 로직
+async function addFontFromPath(srcPath: string): Promise<CustomFont | { error: string }> {
+  // - 형식 검증 (확장자)
+  // - opentype.js 파싱 → 폰트 이름 추출
+  // - 한글 글리프 검사 (가나다 같은 음절 코드 확인)
+  // - UUID 생성 → %APPDATA%/Bflow-BGonly/fonts/<uuid>.<ext> 로 복사
+  // - CustomFont 메타 반환
+}
+```
+
+### 5-2. preload.ts에 노출
+
+```typescript
+contextBridge.exposeInMainWorld('electronAPI', {
+  // ... 기존
+  fontAdd: () => ipcRenderer.invoke('font:add'),
+  fontAddByPath: (path: string) => ipcRenderer.invoke('font:add-by-path', path),
+  fontDelete: (fontId: string) => ipcRenderer.invoke('font:delete', fontId),
+});
+```
+
+### 5-3. 렌더러에서 폰트 동적 로드
+
+`applyFontFamily` 호출 시 사용자 폰트는 `@font-face` 동적 주입:
+
+```typescript
+function injectCustomFontFace(font: CustomFont): void {
+  // 이미 있으면 skip
+  if (document.querySelector(`style[data-font-id="${font.id}"]`)) return;
+
+  const url = `bflow-font://${font.filename}`; // custom protocol (electron main에 등록)
+  const formatHint = { otf: 'opentype', ttf: 'truetype', woff: 'woff', woff2: 'woff2' }[font.format];
+
+  const style = document.createElement('style');
+  style.setAttribute('data-font-id', font.id);
+  style.textContent = `
+    @font-face {
+      font-family: '${font.name}';
+      src: url('${url}') format('${formatHint}');
+      font-display: swap;
+    }
+  `;
+  document.head.appendChild(style);
+}
+```
+
+`bflow-font://` custom protocol을 메인 프로세스에 등록하여 `userFontsDir` 안의 파일만 안전하게 로드.
+
+---
+
+## 6. 한글 글리프 검증
+
+opentype.js로 폰트 파싱 후 다음 한글 음절을 샘플링하여 모두 글리프가 있는지 확인:
+
+```typescript
+const KOREAN_SAMPLE_CHARS = ['가', '나', '다', '한', '글', '안', '녕', '스', '튜', '디', '오'];
+
+function hasKoreanSupport(font: opentype.Font): boolean {
+  return KOREAN_SAMPLE_CHARS.every((c) => {
+    const glyph = font.charToGlyph(c);
+    return glyph && glyph.unicode === c.charCodeAt(0); // .notdef 글리프 아님
+  });
+}
+```
+
+한글 미지원 시 폰트는 추가하되 토스트로 안내:
+> ⚠️ "산돌신영" 폰트는 한글 글리프가 없어 영문/숫자만 표시됩니다.
+
+---
+
+## 7. 컴포넌트 구조
+
+### 7-1. FontFamilySection (신규)
+
+```
+src/components/settings/FontFamilySection.tsx
+```
+
+Props: `{ fontFamily, customFonts, onChange, onCustomFontAdd, onCustomFontDelete }` (또는 useAppStore 직접 접근)
+
+내부 구조:
+- 헤더 (아이콘 CaseSensitive + 라벨 + NEW 배지)
+- 기본 글꼴 칩 그룹 (FONT_FAMILIES의 'system' 외 8개 + 시스템 기본)
+- 내 글꼴 칩 그룹 (customFonts.map → 칩 + 휴지통)
+- + 글꼴 추가 버튼 (점선 보더)
+- 드롭존 (섹션 전체에 dragover 이벤트)
+- 라이선스 footnote
+
+### 7-2. SpacingSection (신규)
+
+```
+src/components/settings/SpacingSection.tsx
+```
+
+내부 구조:
+- 헤더 (AlignVerticalSpaceAround + NEW)
+- 줄간격 슬라이더 (FontSizeSection의 카테고리 슬라이더와 동일 패턴)
+- 자간 슬라이더 (동일)
+- "기본값 복원" 버튼
+
+### 7-3. 통합 — Settings 화면
+
+기존 `src/views/SettingsView.tsx` (또는 그에 준하는 위치)의 'font' 탭 분기에서 다음 4개 컴포넌트를 순서대로 렌더:
+
+```tsx
+{activeTab === 'font' && (
+  <>
+    <FontFamilySection />      {/* 신규 */}
+    <FontSizeSection {...} />  {/* 기존 */}
+    <FontColorSection />       {/* 기존 */}
+    <SpacingSection />         {/* 신규 */}
+  </>
+)}
+```
+
+---
+
+## 8. 영향 범위
+
+### 신규 파일
+- `src/components/settings/FontFamilySection.tsx`
+- `src/components/settings/SpacingSection.tsx`
+- `electron/fontIpc.ts` (또는 main.ts 안에 inline)
+
+### 변경 파일
+- `src/utils/typography.ts` — FontFamily 타입, FONT_FAMILIES, applyFontFamily, applySpacing, applyPreferencesToDOM 확장
+- `src/services/settingsService.ts` — UserPreferences 확장
+- `src/index.css` — CSS 변수 + 폰트 import + tabular-nums 글로벌
+- `src/main.tsx` 또는 `src/App.tsx` — 시작 시 preferences 적용 흐름에 fontFamily/spacing 추가
+- `electron/main.ts` — IPC 핸들러 + custom protocol 등록
+- `electron/preload.ts` — fontAdd/fontDelete 노출
+- `src/views/SettingsView.tsx` (또는 SettingsTab) — font 탭에 신규 섹션 통합
+- `package.json` — 의존성 추가
+- `tailwind.config.js` (필요시) — `tabular-nums` 유틸 활성화
+
+### 추가 NPM 패키지
+- `pretendard` (Pretendard 폰트)
+- `@fontsource/inter`
+- `@fontsource/noto-sans-kr`
+- `@fontsource/ibm-plex-sans-kr`
+- `@fontsource/nanum-gothic`
+- `@fontsource/gowun-dodum`
+- `@fontsource/noto-serif-kr`
+- `spoqa-han-sans` (Spoqa Han Sans Neo, npm 패키지 존재)
+- `opentype.js` (한글 검증 + 폰트 메타 파싱)
+- `uuid` (커스텀 폰트 ID)
+
+대략 추가 번들 크기: 한국어 폰트는 큰 편이라 (Noto Sans KR ~10MB) `font-display: swap` + variable font 사용으로 최적화. 실제 다운로드 크기는 첫 사용 시점에만 영향.
+
+### 영향 받는 영역
+- 앱 전체 텍스트 (글꼴 변경)
+- 위젯 숫자 영역 (tabular-nums 자동 적용)
+- 메모, 댓글, 씬 모달 등 (간격 설정 적용)
+
+### 영향 안 받는 영역
+- Supabase 통신 — 글꼴 설정은 개인 설정이라 Supabase 안 거침 (CLAUDE.md "Supabase 단일 경로" 규칙 위반 X — 새 분기 추가 X, preferences.json 기존 경로 그대로)
+- 데이터 무결성 — 시각적 변경만, 데이터 형식 영향 X
+- 기존 색상/크기 설정 — 그대로 작동
+
+### 호환성
+- 기존 사용자: `preferences.json`에 `fontFamily` 없으면 기본값 'pretendard'
+- 기존 색상/크기 설정 그대로 유지 — 별도 마이그레이션 X
+- 첫 실행 후 사용자가 글꼴 직접 바꾸지 않으면 = OS 기본 → Pretendard로 자동 전환됨 (체감 변화 있음)
+
+---
+
+## 9. 검증 / 테스트 전략
+
+### 자동
+- TypeScript: `npm run tsc -- --noEmit` (CLAUDE.md 빌드 검증 규칙)
+- 빌드: `npm run build`
+
+### 수동 (구현 후 직접 확인 필요)
+- 9개 기본 글꼴 모두 클릭 → 즉시 적용 확인
+- 줄간격 슬라이더 0.05 단위로 부드럽게 작동
+- 자간 슬라이더 동일
+- + 버튼 → 다이얼로그 → 폰트 추가 → 칩으로 등장 → 클릭하면 적용
+- 드래그앤드롭 → 동일하게 추가
+- 한글 미지원 폰트 (예: Roboto.ttf) → 토스트 경고
+- 휴지통 클릭 → 삭제 + 적용 중이던 폰트라면 Pretendard로 폴백
+- 다른 창(플로팅 위젯) 동기화 — 메인 창에서 글꼴 바꾸면 플로팅도 같이 변경
+- 앱 재시작 후 마지막 선택 글꼴 유지
+
+---
+
+## 10. 미래 확장 (옵션, 이번 범위 X)
+
+- **카테고리별 다른 글꼴** — 제목은 본명조, 본문은 Pretendard 같은 식
+- **"느낌 묶음" 프리셋** — 글꼴+크기+색을 한 번에 적용 (정보형/감성형/독서모드)
+- **G드라이브 공유 폴더 자동 스캔** — 팀 전체가 같은 글꼴 보기
+- **굵기(weight) 슬라이더** — 같은 글꼴이라도 얇게/굵게
+- **숫자 정렬 사용자 토글** — 만약 tabular-nums가 한글 폭에 영향을 주는 경우 옵션화
+
+---
+
+*디자인 doc 끝. 구현은 writing-plans → executing-plans 흐름으로 단계적 진행.*

--- a/electron/fontIpc.ts
+++ b/electron/fontIpc.ts
@@ -16,6 +16,11 @@ import { pathToFileURL } from 'url';
 import { v4 as uuidv4 } from 'uuid';
 // opentype.js는 default export가 없어 namespace import 사용
 import * as opentype from 'opentype.js';
+// WOFF2는 Brotli 압축 → opentype.js가 직접 파싱 못 함. wawoff2가 WASM으로 TTF로 디컴프레션해줌.
+// (Codex 2차 P2 — 광고는 woff2 지원이지만 디컴프레션 누락으로 항상 실패하던 문제 수정)
+// CJS 패키지 + 타입 정의 없음 → require로 로드.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const wawoff2: { decompress(buf: Buffer | Uint8Array): Promise<Uint8Array> } = require('wawoff2');
 
 interface CustomFont {
   id: string;
@@ -90,7 +95,20 @@ async function addFontFromPath(srcPath: string): Promise<CustomFont | { error: s
 
   let font: opentype.Font;
   try {
-    font = await opentype.load(srcPath);
+    if (ext === '.woff2') {
+      // wawoff2.decompress: WOFF2(Brotli) → TTF Uint8Array. 그 후 opentype.parse로 메타 추출.
+      const buf = await fsp.readFile(srcPath);
+      const ttfBytes = await wawoff2.decompress(buf);
+      // opentype.parse는 ArrayBuffer를 받음 — Uint8Array의 underlying buffer를 정확한 슬라이스로.
+      const ab = ttfBytes.buffer.slice(
+        ttfBytes.byteOffset,
+        ttfBytes.byteOffset + ttfBytes.byteLength,
+      ) as ArrayBuffer;
+      font = opentype.parse(ab);
+    } else {
+      // OTF/TTF/WOFF는 opentype.js가 직접 처리
+      font = await opentype.load(srcPath);
+    }
   } catch (e) {
     return { error: `폰트 파일 파싱 실패: ${(e as Error).message}` };
   }

--- a/electron/fontIpc.ts
+++ b/electron/fontIpc.ts
@@ -13,7 +13,9 @@ import { app, dialog, ipcMain, protocol, net } from 'electron';
 import { promises as fsp, existsSync, mkdirSync } from 'fs';
 import path from 'path';
 import { pathToFileURL } from 'url';
-import { v4 as uuidv4 } from 'uuid';
+// Codex 7차 P1: uuid@14는 ESM-only → CJS Electron main 번들에서 require 시 ERR_REQUIRE_ESM
+// production 빌드 시 fontIpc 로드 시점에 main 프로세스 크래시 가능. Node 빌트인 randomUUID로 전환.
+import { randomUUID } from 'crypto';
 // opentype.js는 default export가 없어 namespace import 사용
 import * as opentype from 'opentype.js';
 // WOFF2는 Brotli 압축 → opentype.js가 직접 파싱 못 함. wawoff2가 WASM으로 TTF로 디컴프레션해줌.
@@ -151,7 +153,7 @@ async function addFontFromPath(srcPath: string): Promise<CustomFont | { error: s
     hasKorean = false; // 검증 실패 시 보수적으로 false → 사용자에게 영문/숫자만 경고
   }
 
-  const id = `custom:${uuidv4()}`;
+  const id = `custom:${randomUUID()}`;
   const safeId = id.replace(/[^a-z0-9-]/gi, '_');
   const filename = `${safeId}${ext}`;
   const dir = fontDir();

--- a/electron/fontIpc.ts
+++ b/electron/fontIpc.ts
@@ -86,6 +86,12 @@ export function registerFontProtocol(): void {
 /**
  * 단일 폰트 파일을 fontDir에 복사하고 메타데이터 추출.
  * 실패 시 { error: ... } 반환 (throw 안 함 — 다중 추가 시 일부 성공/실패 허용).
+ *
+ * v1.20.x: 한솔님 보고 — `font.names` undefined로 TypeError 발생하던 문제 수정.
+ *   - `opentype.load` 대신 `fsp.readFile + opentype.parse`로 통일 (load는 nodejs 경로 인코딩 이슈 사례 있음)
+ *   - font/font.names null guard
+ *   - charToGlyph 호출도 try/catch로 보호 → names/cmap 누락된 비표준 폰트도 graceful 처리
+ *   - 메타 누락 시 파일명 fallback + hasKorean=false 보수적 가정
  */
 async function addFontFromPath(srcPath: string): Promise<CustomFont | { error: string }> {
   const ext = path.extname(srcPath).toLowerCase();
@@ -93,37 +99,57 @@ async function addFontFromPath(srcPath: string): Promise<CustomFont | { error: s
     return { error: `지원하지 않는 형식: ${ext || '(확장자 없음)'}` };
   }
 
-  let font: opentype.Font;
+  // 모든 형식을 fsp.readFile → ArrayBuffer → opentype.parse 한 흐름으로 통일.
+  let arrayBuf: ArrayBuffer;
   try {
+    const buf = await fsp.readFile(srcPath);
     if (ext === '.woff2') {
-      // wawoff2.decompress: WOFF2(Brotli) → TTF Uint8Array. 그 후 opentype.parse로 메타 추출.
-      const buf = await fsp.readFile(srcPath);
+      // wawoff2.decompress: WOFF2(Brotli) → TTF Uint8Array
       const ttfBytes = await wawoff2.decompress(buf);
-      // opentype.parse는 ArrayBuffer를 받음 — Uint8Array의 underlying buffer를 정확한 슬라이스로.
-      const ab = ttfBytes.buffer.slice(
+      arrayBuf = ttfBytes.buffer.slice(
         ttfBytes.byteOffset,
         ttfBytes.byteOffset + ttfBytes.byteLength,
       ) as ArrayBuffer;
-      font = opentype.parse(ab);
     } else {
-      // OTF/TTF/WOFF는 opentype.js가 직접 처리
-      font = await opentype.load(srcPath);
+      arrayBuf = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
     }
+  } catch (e) {
+    return { error: `폰트 파일 읽기 실패: ${(e as Error).message}` };
+  }
+
+  let font: opentype.Font | null = null;
+  try {
+    font = opentype.parse(arrayBuf);
   } catch (e) {
     return { error: `폰트 파일 파싱 실패: ${(e as Error).message}` };
   }
+  if (!font) {
+    return { error: '폰트 파일을 읽을 수 없습니다 (parse 결과 비정상).' };
+  }
 
+  // names가 undefined / 비어있을 수 있는 비표준 폰트 graceful 처리
+  const namesObj = (font.names ?? {}) as {
+    fontFamily?: { en?: string };
+    fullName?: { en?: string };
+    preferredFamily?: { en?: string };
+  };
+  const fallbackName = path.basename(srcPath, ext);
   const name =
-    font.names.fontFamily?.en
-    || font.names.fullName?.en
-    || font.names.preferredFamily?.en
-    || path.basename(srcPath, ext);
+    namesObj.fontFamily?.en
+    || namesObj.fullName?.en
+    || namesObj.preferredFamily?.en
+    || fallbackName;
 
-  const hasKorean = KOREAN_SAMPLE.every((c) => {
-    const g = font.charToGlyph(c);
-    // .notdef 글리프(인덱스 0)이면 미지원
-    return g && g.index !== 0;
-  });
+  // charToGlyph 호출도 보호 — cmap 테이블 누락된 폰트는 throw 함
+  let hasKorean = false;
+  try {
+    hasKorean = KOREAN_SAMPLE.every((c) => {
+      const g = font!.charToGlyph(c);
+      return !!g && g.index !== 0;
+    });
+  } catch {
+    hasKorean = false; // 검증 실패 시 보수적으로 false → 사용자에게 영문/숫자만 경고
+  }
 
   const id = `custom:${uuidv4()}`;
   const safeId = id.replace(/[^a-z0-9-]/gi, '_');

--- a/electron/fontIpc.ts
+++ b/electron/fontIpc.ts
@@ -156,7 +156,13 @@ async function addFontFromPath(srcPath: string): Promise<CustomFont | { error: s
   const filename = `${safeId}${ext}`;
   const dir = fontDir();
   ensureFontDir();
-  await fsp.copyFile(srcPath, path.join(dir, filename));
+  // Codex 5차 P2: copyFile이 try/catch 밖이면 한 파일 실패 시 Promise.all 전체 배치가 reject됨.
+  // 이 함수는 { error } 반환으로 partial success를 허용하기로 설계됐으니 copyFile도 보호.
+  try {
+    await fsp.copyFile(srcPath, path.join(dir, filename));
+  } catch (e) {
+    return { error: `폰트 파일 복사 실패: ${(e as Error).message}` };
+  }
 
   return {
     id,

--- a/electron/fontIpc.ts
+++ b/electron/fontIpc.ts
@@ -1,0 +1,163 @@
+/**
+ * v1.20.0: 사용자 폰트 IPC + custom protocol
+ *
+ * - `font:add` — dialog로 OTF/TTF/WOFF/WOFF2 선택 → %APPDATA%/<app>/fonts/ 복사
+ * - `font:add-by-path` — 드래그앤드롭에서 호출 (filePaths 배열)
+ * - `font:delete` — 파일 삭제
+ * - `bflow-font://<filename>` — 렌더러가 @font-face src로 사용할 custom protocol
+ *
+ * 한글 글리프 검증: opentype.js로 'KOREAN_SAMPLE' 음절을 모두 매핑할 수 있는지 확인.
+ * Path traversal 방지: filename은 path.basename으로만 사용, FONT_DIR 밖은 차단.
+ */
+import { app, dialog, ipcMain, protocol, net } from 'electron';
+import { promises as fsp, existsSync, mkdirSync } from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { v4 as uuidv4 } from 'uuid';
+// opentype.js는 default export가 없어 namespace import 사용
+import * as opentype from 'opentype.js';
+
+interface CustomFont {
+  id: string;
+  name: string;
+  filename: string;
+  format: 'otf' | 'ttf' | 'woff' | 'woff2';
+  hasKorean: boolean;
+  addedAt: string;
+}
+
+const KOREAN_SAMPLE = ['가', '나', '다', '한', '글', '안', '녕', '스', '튜', '디', '오'];
+const SUPPORTED_EXT = ['.otf', '.ttf', '.woff', '.woff2'] as const;
+
+function fontDir(): string {
+  return path.join(app.getPath('userData'), 'fonts');
+}
+
+function ensureFontDir(): void {
+  const dir = fontDir();
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+/**
+ * Electron app:ready 이전에 호출 필수. main.ts의 protocol.registerSchemesAsPrivileged 배열에
+ * 통합되어야 하는데, 이미 main.ts에서 bflow-img/drive-img를 등록하고 있어 그 옆에 추가.
+ * 이 함수는 단독 호출용 (다른 진입점용).
+ */
+export function registerFontProtocolPrivileged(): void {
+  protocol.registerSchemesAsPrivileged([
+    {
+      scheme: 'bflow-font',
+      privileges: { secure: true, standard: true, supportFetchAPI: true, stream: true },
+    },
+  ]);
+}
+
+/** Electron app:ready 이후 호출. */
+export function registerFontProtocol(): void {
+  ensureFontDir();
+  const dir = fontDir();
+  protocol.handle('bflow-font', async (request) => {
+    try {
+      const url = new URL(request.url);
+      // bflow-font://<filename> — hostname에 파일명, pathname은 보통 빈 문자열 or '/'
+      const raw = decodeURIComponent(url.hostname + url.pathname).replace(/\/+$/, '');
+      const safe = path.basename(raw); // path traversal 방지
+      const filePath = path.join(dir, safe);
+      // 추가 안전 체크: 정규화된 경로가 fontDir 안에 있는지
+      const resolved = path.resolve(filePath);
+      if (!resolved.startsWith(path.resolve(dir))) {
+        return new Response('forbidden', { status: 403 });
+      }
+      if (!existsSync(resolved)) {
+        return new Response('not-found', { status: 404 });
+      }
+      return net.fetch(pathToFileURL(resolved).toString());
+    } catch (e) {
+      return new Response('error: ' + (e as Error).message, { status: 500 });
+    }
+  });
+}
+
+/**
+ * 단일 폰트 파일을 fontDir에 복사하고 메타데이터 추출.
+ * 실패 시 { error: ... } 반환 (throw 안 함 — 다중 추가 시 일부 성공/실패 허용).
+ */
+async function addFontFromPath(srcPath: string): Promise<CustomFont | { error: string }> {
+  const ext = path.extname(srcPath).toLowerCase();
+  if (!(SUPPORTED_EXT as readonly string[]).includes(ext)) {
+    return { error: `지원하지 않는 형식: ${ext || '(확장자 없음)'}` };
+  }
+
+  let font: opentype.Font;
+  try {
+    font = await opentype.load(srcPath);
+  } catch (e) {
+    return { error: `폰트 파일 파싱 실패: ${(e as Error).message}` };
+  }
+
+  const name =
+    font.names.fontFamily?.en
+    || font.names.fullName?.en
+    || font.names.preferredFamily?.en
+    || path.basename(srcPath, ext);
+
+  const hasKorean = KOREAN_SAMPLE.every((c) => {
+    const g = font.charToGlyph(c);
+    // .notdef 글리프(인덱스 0)이면 미지원
+    return g && g.index !== 0;
+  });
+
+  const id = `custom:${uuidv4()}`;
+  const safeId = id.replace(/[^a-z0-9-]/gi, '_');
+  const filename = `${safeId}${ext}`;
+  const dir = fontDir();
+  ensureFontDir();
+  await fsp.copyFile(srcPath, path.join(dir, filename));
+
+  return {
+    id,
+    name,
+    filename,
+    format: ext.slice(1) as CustomFont['format'],
+    hasKorean,
+    addedAt: new Date().toISOString(),
+  };
+}
+
+export function registerFontIpcHandlers(): void {
+  // 1. 파일 선택 다이얼로그 → 추가
+  ipcMain.handle('font:add', async () => {
+    const result = await dialog.showOpenDialog({
+      properties: ['openFile', 'multiSelections'],
+      filters: [{ name: 'Font Files', extensions: ['otf', 'ttf', 'woff', 'woff2'] }],
+      title: '글꼴 파일 선택',
+    });
+    if (result.canceled || result.filePaths.length === 0) return [];
+    return Promise.all(result.filePaths.map(addFontFromPath));
+  });
+
+  // 2. 드래그앤드롭에서 호출 (filePaths 배열)
+  ipcMain.handle('font:add-by-path', async (_e, filePaths: string[]) => {
+    if (!Array.isArray(filePaths) || filePaths.length === 0) return [];
+    return Promise.all(filePaths.map(addFontFromPath));
+  });
+
+  // 3. 삭제 — { id, filename } 받음
+  ipcMain.handle('font:delete', async (_e, font: { id: string; filename: string }) => {
+    try {
+      const dir = fontDir();
+      const safe = path.basename(font.filename);
+      const filePath = path.join(dir, safe);
+      const resolved = path.resolve(filePath);
+      if (!resolved.startsWith(path.resolve(dir))) {
+        return { ok: false, error: 'forbidden path' };
+      }
+      if (existsSync(resolved)) {
+        await fsp.unlink(resolved);
+      }
+      return { ok: true };
+    } catch (e) {
+      return { ok: false, error: (e as Error).message };
+    }
+  });
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -16,6 +16,8 @@ import {
 } from './sheets';
 import { uploadImage as driveUploadImage, setImageUploadUrl } from './drive-image';
 import { uploadImage as storageUploadImage, deleteImage as storageDeleteImage } from './storage';
+// v1.20.0: 사용자 폰트 IPC + bflow-font:// custom protocol
+import { registerFontProtocol, registerFontIpcHandlers } from './fontIpc';
 import {
   initVacation,
   isVacationConnected,
@@ -40,7 +42,7 @@ app.commandLine.appendSwitch('js-flags', '--nolazy');
 app.commandLine.appendSwitch('enable-gpu-rasterization');
 app.commandLine.appendSwitch('disable-renderer-backgrounding');
 
-// ─── 이미지 커스텀 프로토콜 등록 (app.ready 전에 호출 필수) ──
+// ─── 이미지 + 폰트 커스텀 프로토콜 등록 (app.ready 전에 호출 필수) ──
 protocol.registerSchemesAsPrivileged([
   {
     scheme: 'bflow-img',
@@ -49,6 +51,11 @@ protocol.registerSchemesAsPrivileged([
   {
     scheme: 'drive-img',
     privileges: { standard: true, secure: true, supportFetchAPI: true },
+  },
+  // v1.20.0: 사용자 폰트
+  {
+    scheme: 'bflow-font',
+    privileges: { secure: true, standard: true, supportFetchAPI: true, stream: true },
   },
 ]);
 
@@ -2745,6 +2752,10 @@ app.whenReady().then(async () => {
     const fullPath = path.join(getDataPath(), 'images', fileName);
     return net.fetch(pathToFileURL(fullPath).toString());
   });
+
+  // v1.20.0: bflow-font:// 프로토콜 + IPC 핸들러 (사용자 폰트 추가/삭제/로드)
+  registerFontProtocol();
+  registerFontIpcHandlers();
 
   // drive-img:// 프로토콜 핸들러: Google Drive 이미지 프록시
   // uc?export=view URL은 Electron 렌더러에서 403 차단됨 → 메인 프로세스에서 대신 fetch

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from 'electron';
+import { contextBridge, ipcRenderer, webUtils } from 'electron';
 import type { BulkStageUpdate, BulkFieldUpdate, BulkUpdateResult } from './supabase';
 
 contextBridge.exposeInMainWorld('electronAPI', {
@@ -26,6 +26,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   fontAdd: () => ipcRenderer.invoke('font:add'),
   fontAddByPath: (filePaths: string[]) => ipcRenderer.invoke('font:add-by-path', filePaths),
   fontDelete: (font: { id: string; filename: string }) => ipcRenderer.invoke('font:delete', font),
+  // v1.20.0: 드래그앤드롭에서 File → 절대 경로 (Electron 32+에선 File.path 제거 → webUtils 사용 필수)
+  fontGetPathForFile: (file: File) => webUtils.getPathForFile(file),
 
   // 실시간 동기화: 다른 창이 데이터를 변경했을 때 델타 알림
   onDataChanged: (callback: (delta?: unknown) => void) => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -22,6 +22,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
   writeSettings: (fileName: string, data: unknown) =>
     ipcRenderer.invoke('settings:write', fileName, data),
 
+  // v1.20.0: 사용자 폰트 (OTF/TTF/WOFF/WOFF2 추가/삭제)
+  fontAdd: () => ipcRenderer.invoke('font:add'),
+  fontAddByPath: (filePaths: string[]) => ipcRenderer.invoke('font:add-by-path', filePaths),
+  fontDelete: (font: { id: string; filename: string }) => ipcRenderer.invoke('font:delete', font),
+
   // 실시간 동기화: 다른 창이 데이터를 변경했을 때 델타 알림
   onDataChanged: (callback: (delta?: unknown) => void) => {
     const handler = (_event: unknown, delta?: unknown) => callback(delta);

--- a/index.html
+++ b/index.html
@@ -5,7 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>B flow</title>
   </head>
-  <body style="margin:0; background: rgb(var(--color-bg-primary)); color: rgb(var(--color-text-primary)); font-family:system-ui,sans-serif;">
+  <!-- v1.20.x: font-family를 inline에서 제거 — index.css의 var(--font-family)가 즉시 반영되도록.
+       이전엔 inline style의 specificity가 높아 글꼴 칩 클릭 시 즉시 업데이트 안 되던 버그(한솔님 보고). -->
+  <body style="margin:0; background: rgb(var(--color-bg-primary)); color: rgb(var(--color-text-primary));">
     <div id="root">
       <!-- React 마운트 전 로딩 표시 — 마운트 성공 시 React가 교체함 -->
       <div style="display:flex; align-items:center; justify-content:center; height:100vh; flex-direction:column; gap:12px;">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bflow",
-  "version": "1.19.7",
+  "version": "1.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bflow",
-      "version": "1.19.7",
+      "version": "1.20.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@fontsource/gowun-dodum": "^5.2.8",
@@ -39,6 +39,7 @@
         "spoqa-han-sans": "^3.3.0",
         "tiptap-markdown": "^0.8.10",
         "uuid": "^14.0.0",
+        "wawoff2": "^2.0.1",
         "zustand": "^4.5.2"
       },
       "devDependencies": {
@@ -8127,6 +8128,19 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
+    },
+    "node_modules/wawoff2": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/wawoff2/-/wawoff2-2.0.1.tgz",
+      "integrity": "sha512-r0CEmvpH63r4T15ebFqeOjGqU4+EgTx4I510NtK35EMciSdcTxCw3Byy3JnBonz7iyIFZ0AbVo0bbFpEVuhCYA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "woff2_compress.js": "bin/woff2_compress.js",
+        "woff2_decompress.js": "bin/woff2_decompress.js"
+      }
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "sonner": "^2.0.7",
         "spoqa-han-sans": "^3.3.0",
         "tiptap-markdown": "^0.8.10",
-        "uuid": "^14.0.0",
         "wawoff2": "^2.0.1",
         "zustand": "^4.5.2"
       },
@@ -8011,19 +8010,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
     },
     "node_modules/verror": {
       "version": "1.10.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,20 @@
 {
   "name": "bflow",
-  "version": "1.18.1",
+  "version": "1.19.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bflow",
-      "version": "1.18.1",
+      "version": "1.19.7",
       "license": "UNLICENSED",
       "dependencies": {
+        "@fontsource/gowun-dodum": "^5.2.8",
+        "@fontsource/ibm-plex-sans-kr": "^5.2.8",
+        "@fontsource/inter": "^5.2.8",
+        "@fontsource/nanum-gothic": "^5.2.7",
+        "@fontsource/noto-sans-kr": "^5.2.9",
+        "@fontsource/noto-serif-kr": "^5.2.9",
         "@liveblocks/client": "^3.14.1",
         "@liveblocks/react": "^3.14.1",
         "@supabase/supabase-js": "^2.99.1",
@@ -24,11 +30,15 @@
         "framer-motion": "^10.18.0",
         "googleapis": "^171.4.0",
         "lucide-react": "^0.303.0",
+        "opentype.js": "^1.3.5",
+        "pretendard": "^1.3.9",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-grid-layout": "^1.4.4",
         "sonner": "^2.0.7",
+        "spoqa-han-sans": "^3.3.0",
         "tiptap-markdown": "^0.8.10",
+        "uuid": "^14.0.0",
         "zustand": "^4.5.2"
       },
       "devDependencies": {
@@ -1039,6 +1049,60 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@fontsource/gowun-dodum": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/gowun-dodum/-/gowun-dodum-5.2.8.tgz",
+      "integrity": "sha512-DZBZxz80w/IE8PMDtz0atDsTsXKsn6TfWcZDW0KTCdZoXWZr66/R9IWaB5Ym7OFWyDUJKzoBhHQTmgahRUKN/Q==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/ibm-plex-sans-kr": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-sans-kr/-/ibm-plex-sans-kr-5.2.8.tgz",
+      "integrity": "sha512-U16zCX5J3s8H6OVm7apRZnLU493VFbkh/kf8ZaSeb53XJQJKfDqgZODqta2TG2MwZC7043xihL7OwErTuEtjBQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/nanum-gothic": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/nanum-gothic/-/nanum-gothic-5.2.7.tgz",
+      "integrity": "sha512-pJB8vp5c3XLN/pBNvlinivGBxZZkSBS4DpuGht3rOmdmOvvzNf4HUyaIINHRfZmsoCse+QXWGXamNf9JRdMLeg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/noto-sans-kr": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@fontsource/noto-sans-kr/-/noto-sans-kr-5.2.9.tgz",
+      "integrity": "sha512-pbF8F0rUzKkDmnk/KYGAbxjgW4TrIHdFKnV6OQ+kUC9ELCn5utrAURcEgMqq3J9SRX+FvjOz+aBCmfcC8/r7cw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/noto-serif-kr": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@fontsource/noto-serif-kr/-/noto-serif-kr-5.2.9.tgz",
+      "integrity": "sha512-DqWJwPt1yduqF/XRD7S1QrJPoLw3qFxtGgp8sZMB2Tb+mahDXkVm3zD/G+MvF0fIxqSWrnl/iyHotKkfFosepw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -6103,6 +6167,15 @@
         "wrappy": "1"
       }
     },
+    "node_modules/opentype.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/opentype.js/-/opentype.js-1.3.5.tgz",
+      "integrity": "sha512-thKDiELidAApOvXlncrpwDZKJCa9fXLEKM4+FoEWI+qTLDeNb+h7EkN+8a7KQODsB1GZ+Exz9KknkoPrEdXZDw==",
+      "license": "MIT",
+      "bin": {
+        "ot": "bin/ot"
+      }
+    },
     "node_modules/orderedmap": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
@@ -6401,6 +6474,12 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pretendard": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/pretendard/-/pretendard-1.3.9.tgz",
+      "integrity": "sha512-PaQAADyLY5v4kYFwkpSJHbSSYIkiriY/1xXw75TKoZ9UQQqeU+tvP05yTdZAWibiIYoo8ZKtRv8PM7w0IaywSw==",
+      "license": "OFL-1.1"
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
@@ -7340,6 +7419,12 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/spoqa-han-sans": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/spoqa-han-sans/-/spoqa-han-sans-3.3.0.tgz",
+      "integrity": "sha512-uEetiueUQdfc8MW+JN0Dj9aN3oONctICzBljqbd+a7XXeQV0+Cg3bKFJVtSyIgjQkpG8F7csAVX86ZUEzTt+Iw==",
+      "license": "SEE LICENSE IN LICENSE"
+    },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
@@ -7925,6 +8010,19 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
     },
     "node_modules/verror": {
       "version": "1.10.1",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "spoqa-han-sans": "^3.3.0",
     "tiptap-markdown": "^0.8.10",
     "uuid": "^14.0.0",
+    "wawoff2": "^2.0.1",
     "zustand": "^4.5.2"
   },
   "build": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "sonner": "^2.0.7",
     "spoqa-han-sans": "^3.3.0",
     "tiptap-markdown": "^0.8.10",
-    "uuid": "^14.0.0",
     "wawoff2": "^2.0.1",
     "zustand": "^4.5.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.19.7",
+  "version": "1.20.0",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {
@@ -15,6 +15,12 @@
   "license": "UNLICENSED",
   "private": true,
   "dependencies": {
+    "@fontsource/gowun-dodum": "^5.2.8",
+    "@fontsource/ibm-plex-sans-kr": "^5.2.8",
+    "@fontsource/inter": "^5.2.8",
+    "@fontsource/nanum-gothic": "^5.2.7",
+    "@fontsource/noto-sans-kr": "^5.2.9",
+    "@fontsource/noto-serif-kr": "^5.2.9",
     "@liveblocks/client": "^3.14.1",
     "@liveblocks/react": "^3.14.1",
     "@supabase/supabase-js": "^2.99.1",
@@ -30,11 +36,15 @@
     "framer-motion": "^10.18.0",
     "googleapis": "^171.4.0",
     "lucide-react": "^0.303.0",
+    "opentype.js": "^1.3.5",
+    "pretendard": "^1.3.9",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-grid-layout": "^1.4.4",
     "sonner": "^2.0.7",
+    "spoqa-han-sans": "^3.3.0",
     "tiptap-markdown": "^0.8.10",
+    "uuid": "^14.0.0",
     "zustand": "^4.5.2"
   },
   "build": {

--- a/src/components/settings/FontFamilySection.tsx
+++ b/src/components/settings/FontFamilySection.tsx
@@ -6,7 +6,7 @@
  * - 추가 방법: '+ 글꼴 추가' 버튼 (탐색기) 또는 드래그앤드롭
  * - 한글 미지원 폰트는 추가하되 토스트 경고
  */
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { CaseSensitive, Plus, Trash2, AlertTriangle, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { cn } from '@/utils/cn';
@@ -28,6 +28,11 @@ export function FontFamilySection() {
   const [dragging, setDragging] = useState(false);
   const [hasLoaded, setHasLoaded] = useState(false);
 
+  // Codex 8차 P2: family 칩 빠른 연타 시 concurrent load→save가 out-of-order로 끝나 stale 값이
+  // last write가 되던 race. SpacingSection 패턴과 동일하게 디바운스 + last-write-wins.
+  const familySaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingFamilyRef = useRef<string | null>(null);
+
   // 저장된 설정 로드
   useEffect(() => {
     let cancelled = false;
@@ -42,23 +47,83 @@ export function FontFamilySection() {
     return () => { cancelled = true; };
   }, []);
 
-  // 변경 후 저장 + 적용 + 다른 창 동기화 (낙관적 업데이트 패턴)
-  const persistAndApply = useCallback(async (familyId: string, nextCustomFonts: CustomFont[]) => {
+  // Unmount 시 pending family 저장 즉시 flush
+  useEffect(() => {
+    return () => {
+      if (familySaveTimerRef.current) {
+        clearTimeout(familySaveTimerRef.current);
+        const pending = pendingFamilyRef.current;
+        if (pending) {
+          (async () => {
+            try {
+              const prev = (await loadPreferences()) ?? {};
+              const merged = { ...prev, fontFamily: pending };
+              await savePreferences(merged);
+              window.electronAPI?.preferencesBroadcastChange?.(merged);
+            } catch (err) {
+              console.error('[글꼴] flush 실패:', err);
+            }
+          })();
+        }
+      }
+    };
+  }, []);
+
+  /**
+   * Codex 8차 P1: family 변경 시 customFonts를 component-local state(mount 시 한 번 로드)에서
+   * 그대로 disk에 덮어쓰면, 다른 창이 추가/삭제한 폰트가 영구 erase됨.
+   * 해결: family-only 변경은 disk latest customFonts를 우선하고, family 필드만 갱신.
+   */
+  const persistFamilyOnly = useCallback((familyId: string, nextCustomFonts: CustomFont[]) => {
+    // UI 즉시 적용 (낙관적)
+    applyFontFamily(familyId, nextCustomFonts);
+    setFontFamily(familyId);
+    // 저장은 디바운스 — last-write-wins. 디바운스 동안 다른 창 변경이 들어오면
+    // 어차피 disk latest를 read하므로 안전.
+    pendingFamilyRef.current = familyId;
+    if (familySaveTimerRef.current) clearTimeout(familySaveTimerRef.current);
+    familySaveTimerRef.current = setTimeout(async () => {
+      const target = pendingFamilyRef.current;
+      pendingFamilyRef.current = null;
+      familySaveTimerRef.current = null;
+      if (target == null) return;
+      try {
+        const prev = (await loadPreferences()) ?? {};
+        // ★ customFonts는 disk latest 사용 — local state 덮어쓰지 않음
+        const merged = { ...prev, fontFamily: target };
+        await savePreferences(merged);
+        window.electronAPI?.preferencesBroadcastChange?.(merged);
+      } catch (err) {
+        console.error('[글꼴] family 저장 실패:', err);
+      }
+    }, 150);
+  }, []);
+
+  /**
+   * + 글꼴 추가 / 삭제처럼 customFonts 자체를 변경하는 흐름 — 즉시 저장.
+   * 사용자 explicit action이라 race 거의 없음(busy 플래그 + confirm dialog로 보호).
+   */
+  const persistFontsList = useCallback(async (familyId: string, nextCustomFonts: CustomFont[]) => {
     applyFontFamily(familyId, nextCustomFonts);
     setFontFamily(familyId);
     setCustomFonts(nextCustomFonts);
     try {
       const prev = (await loadPreferences()) ?? {};
-      await savePreferences({ ...prev, fontFamily: familyId, customFonts: nextCustomFonts });
-      window.electronAPI?.preferencesBroadcastChange?.({ fontFamily: familyId, customFonts: nextCustomFonts });
+      const merged = { ...prev, fontFamily: familyId, customFonts: nextCustomFonts };
+      await savePreferences(merged);
+      window.electronAPI?.preferencesBroadcastChange?.(merged);
     } catch (err) {
-      console.error('[글꼴] 설정 저장 실패:', err);
+      console.error('[글꼴] customFonts 저장 실패:', err);
     }
   }, []);
 
+  // 호환성: 기존 add/delete 경로의 이름 유지 (의미 = customFonts 포함 저장)
+  const persistAndApply = persistFontsList;
+
   const handleSelect = useCallback((id: string) => {
-    persistAndApply(id, customFonts);
-  }, [customFonts, persistAndApply]);
+    // family만 변경 — customFonts는 disk latest 보존
+    persistFamilyOnly(id, customFonts);
+  }, [customFonts, persistFamilyOnly]);
 
   // 폰트 추가 결과 처리 (Add 버튼/DnD 공통)
   const processAddResults = useCallback((

--- a/src/components/settings/FontFamilySection.tsx
+++ b/src/components/settings/FontFamilySection.tsx
@@ -1,0 +1,255 @@
+/**
+ * v1.20.0: 글꼴(서체) 선택 + 사용자 폰트 추가/삭제 + 드래그앤드롭
+ *
+ * - 기본 글꼴: 큐레이션 9종 (FONT_FAMILIES)
+ * - 내 글꼴: 사용자가 추가한 OTF/TTF/WOFF/WOFF2 (preferences.customFonts)
+ * - 추가 방법: '+ 글꼴 추가' 버튼 (탐색기) 또는 드래그앤드롭
+ * - 한글 미지원 폰트는 추가하되 토스트 경고
+ */
+import { useState, useCallback, useEffect } from 'react';
+import { CaseSensitive, Plus, Trash2, AlertTriangle, Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+import { cn } from '@/utils/cn';
+import { SettingsSection } from './SettingsSection';
+import {
+  FONT_FAMILIES,
+  DEFAULT_FONT_FAMILY,
+  applyFontFamily,
+  ensureCustomFontsLoaded,
+  type CustomFont,
+} from '@/utils/typography';
+import { loadPreferences, savePreferences } from '@/services/settingsService';
+
+export function FontFamilySection() {
+  const [fontFamily, setFontFamily] = useState<string>(DEFAULT_FONT_FAMILY);
+  const [customFonts, setCustomFonts] = useState<CustomFont[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [dragging, setDragging] = useState(false);
+  const [hasLoaded, setHasLoaded] = useState(false);
+
+  // 저장된 설정 로드
+  useEffect(() => {
+    let cancelled = false;
+    loadPreferences().then((prefs) => {
+      if (cancelled) return;
+      const customs = (prefs?.customFonts ?? []) as CustomFont[];
+      ensureCustomFontsLoaded(customs);
+      setCustomFonts(customs);
+      setFontFamily(prefs?.fontFamily ?? DEFAULT_FONT_FAMILY);
+      setHasLoaded(true);
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  // 변경 후 저장 + 적용 + 다른 창 동기화 (낙관적 업데이트 패턴)
+  const persistAndApply = useCallback(async (familyId: string, nextCustomFonts: CustomFont[]) => {
+    applyFontFamily(familyId, nextCustomFonts);
+    setFontFamily(familyId);
+    setCustomFonts(nextCustomFonts);
+    try {
+      const prev = (await loadPreferences()) ?? {};
+      await savePreferences({ ...prev, fontFamily: familyId, customFonts: nextCustomFonts });
+      window.electronAPI?.preferencesBroadcastChange?.({ fontFamily: familyId, customFonts: nextCustomFonts });
+    } catch (err) {
+      console.error('[글꼴] 설정 저장 실패:', err);
+    }
+  }, []);
+
+  const handleSelect = useCallback((id: string) => {
+    persistAndApply(id, customFonts);
+  }, [customFonts, persistAndApply]);
+
+  // 폰트 추가 결과 처리 (Add 버튼/DnD 공통)
+  const processAddResults = useCallback((
+    results: Array<CustomFont | { error: string }>,
+  ): CustomFont[] => {
+    const added: CustomFont[] = [];
+    for (const r of results) {
+      if (!r) continue;
+      if ('error' in r) {
+        toast.error(`폰트 추가 실패: ${r.error}`);
+      } else {
+        added.push(r);
+        if (!r.hasKorean) {
+          toast.warning(`"${r.name}" 글꼴은 한글 글리프가 없어 영문/숫자만 표시됩니다.`);
+        }
+      }
+    }
+    if (added.length > 0) {
+      toast.success(`${added.length}개 폰트 추가됨`);
+    }
+    return added;
+  }, []);
+
+  const handleAddViaButton = useCallback(async () => {
+    if (!window.electronAPI?.fontAdd) {
+      toast.error('Electron API를 사용할 수 없습니다.');
+      return;
+    }
+    setBusy(true);
+    try {
+      const results = await window.electronAPI.fontAdd();
+      const added = processAddResults(results);
+      if (added.length > 0) {
+        const next = [...customFonts, ...added];
+        ensureCustomFontsLoaded(added); // 새로 추가된 것만 inject
+        await persistAndApply(fontFamily, next);
+      }
+    } finally {
+      setBusy(false);
+    }
+  }, [customFonts, fontFamily, persistAndApply, processAddResults]);
+
+  const handleDrop = useCallback(async (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragging(false);
+    if (!window.electronAPI?.fontAddByPath) {
+      toast.error('Electron API를 사용할 수 없습니다.');
+      return;
+    }
+    // Electron의 File 객체는 .path 속성을 노출 (브라우저 표준엔 없음)
+    const paths = Array.from(e.dataTransfer.files)
+      .map((f) => (f as unknown as { path: string }).path)
+      .filter(Boolean);
+    if (paths.length === 0) {
+      toast.error('드롭된 파일에서 경로를 읽을 수 없습니다.');
+      return;
+    }
+    setBusy(true);
+    try {
+      const results = await window.electronAPI.fontAddByPath(paths);
+      const added = processAddResults(results);
+      if (added.length > 0) {
+        const next = [...customFonts, ...added];
+        ensureCustomFontsLoaded(added);
+        await persistAndApply(fontFamily, next);
+      }
+    } finally {
+      setBusy(false);
+    }
+  }, [customFonts, fontFamily, persistAndApply, processAddResults]);
+
+  const handleDelete = useCallback(async (font: CustomFont) => {
+    if (!confirm(`"${font.name}" 글꼴을 삭제하시겠습니까?`)) return;
+    if (!window.electronAPI?.fontDelete) return;
+    await window.electronAPI.fontDelete({ id: font.id, filename: font.filename });
+    const next = customFonts.filter((f) => f.id !== font.id);
+    // 삭제 중이던 폰트가 현재 적용 중이면 → DEFAULT_FONT_FAMILY로 폴백
+    const fallbackId = fontFamily === font.id ? DEFAULT_FONT_FAMILY : fontFamily;
+    // <head>에서 @font-face 제거
+    document.querySelector(`style[data-font-id="${font.id}"]`)?.remove();
+    await persistAndApply(fallbackId, next);
+  }, [customFonts, fontFamily, persistAndApply]);
+
+  if (!hasLoaded) return null;
+
+  return (
+    <SettingsSection
+      icon={<CaseSensitive size={18} className="text-accent" />}
+      title="글꼴 (서체)"
+    >
+      <div
+        onDragEnter={(e) => { e.preventDefault(); e.stopPropagation(); setDragging(true); }}
+        onDragOver={(e) => { e.preventDefault(); e.stopPropagation(); }}
+        onDragLeave={(e) => {
+          // currentTarget을 떠나는 경우만 (자식 간 이동은 무시)
+          if (e.currentTarget.contains(e.relatedTarget as Node)) return;
+          setDragging(false);
+        }}
+        onDrop={handleDrop}
+        className={cn(
+          'transition-all rounded-lg -mx-2 px-2 py-2',
+          dragging && 'ring-2 ring-accent ring-offset-2 ring-offset-bg-card bg-accent/8',
+        )}
+      >
+        {/* 기본 글꼴 그룹 */}
+        <p className="text-xs text-text-secondary mb-2">기본 글꼴</p>
+        <div className="flex gap-1.5 flex-wrap mb-4">
+          {FONT_FAMILIES.map((meta) => {
+            const active = fontFamily === meta.id;
+            return (
+              <button
+                key={meta.id}
+                onClick={() => handleSelect(meta.id)}
+                className={cn(
+                  'px-3 py-1.5 rounded-md text-xs font-medium border transition-all cursor-pointer',
+                  active
+                    ? 'bg-accent/15 border-accent text-accent'
+                    : 'border-bg-border text-text-primary hover:bg-bg-border/30',
+                )}
+                style={{ fontFamily: meta.cssStack }}
+              >
+                {meta.label}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* 내 글꼴 그룹 */}
+        {customFonts.length > 0 && (
+          <>
+            <p className="text-xs text-text-secondary mb-2">내 글꼴</p>
+            <div className="flex gap-1.5 flex-wrap mb-3">
+              {customFonts.map((font) => {
+                const active = fontFamily === font.id;
+                return (
+                  <span
+                    key={font.id}
+                    className={cn(
+                      'inline-flex items-center gap-0.5 pl-3 pr-1 py-0.5 rounded-md text-xs font-medium border transition-all',
+                      active
+                        ? 'bg-accent/15 border-accent text-accent'
+                        : 'border-bg-border text-text-primary hover:bg-bg-border/30',
+                    )}
+                  >
+                    <button
+                      onClick={() => handleSelect(font.id)}
+                      className="cursor-pointer py-1 pr-1"
+                      style={{ fontFamily: `'${font.name}', system-ui, sans-serif` }}
+                      title={font.hasKorean ? font.name : `${font.name} (영문/숫자만 지원)`}
+                    >
+                      {font.name}
+                      {!font.hasKorean && <span className="ml-1 text-[9px] opacity-60">EN</span>}
+                    </button>
+                    <button
+                      onClick={() => handleDelete(font)}
+                      className="w-5 h-5 inline-flex items-center justify-center rounded text-text-secondary/60 hover:bg-red-500/15 hover:text-red-400 cursor-pointer transition-colors"
+                      title="삭제"
+                      aria-label={`${font.name} 삭제`}
+                    >
+                      <Trash2 size={11} />
+                    </button>
+                  </span>
+                );
+              })}
+            </div>
+          </>
+        )}
+
+        {/* + 글꼴 추가 버튼 */}
+        <button
+          onClick={handleAddViaButton}
+          disabled={busy}
+          className={cn(
+            'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium border border-dashed transition-all',
+            busy
+              ? 'opacity-50 cursor-wait border-bg-border text-text-secondary'
+              : 'border-bg-border text-accent-sub cursor-pointer hover:border-accent hover:bg-accent/8 hover:border-solid',
+          )}
+        >
+          {busy ? <Loader2 size={12} className="animate-spin" /> : <Plus size={12} />}
+          글꼴 추가
+        </button>
+
+        {/* 라이선스 안내 */}
+        <p className="mt-3 text-[10px] text-text-secondary/60 flex items-start gap-1.5 leading-relaxed">
+          <AlertTriangle size={11} className="text-amber-400 shrink-0 mt-0.5" />
+          <span>
+            추가하시는 글꼴의 라이선스는 본인이 확인해주세요. 추가된 글꼴은 본인 PC에만 저장됩니다 (다른 팀원에게는 안 보임). 드래그 앤 드롭으로도 추가할 수 있습니다.
+          </span>
+        </p>
+      </div>
+    </SettingsSection>
+  );
+}

--- a/src/components/settings/FontFamilySection.tsx
+++ b/src/components/settings/FontFamilySection.tsx
@@ -16,6 +16,7 @@ import {
   DEFAULT_FONT_FAMILY,
   applyFontFamily,
   ensureCustomFontsLoaded,
+  escapeFontFamilyName,
   type CustomFont,
 } from '@/utils/typography';
 import { loadPreferences, savePreferences } from '@/services/settingsService';
@@ -104,13 +105,13 @@ export function FontFamilySection() {
     e.preventDefault();
     e.stopPropagation();
     setDragging(false);
-    if (!window.electronAPI?.fontAddByPath) {
+    if (!window.electronAPI?.fontAddByPath || !window.electronAPI?.fontGetPathForFile) {
       toast.error('Electron API를 사용할 수 없습니다.');
       return;
     }
-    // Electron의 File 객체는 .path 속성을 노출 (브라우저 표준엔 없음)
+    // Electron 32+에선 File.path가 제거됨 → webUtils.getPathForFile 사용 (preload 경유)
     const paths = Array.from(e.dataTransfer.files)
-      .map((f) => (f as unknown as { path: string }).path)
+      .map((f) => window.electronAPI!.fontGetPathForFile(f))
       .filter(Boolean);
     if (paths.length === 0) {
       toast.error('드롭된 파일에서 경로를 읽을 수 없습니다.');
@@ -206,7 +207,7 @@ export function FontFamilySection() {
                     <button
                       onClick={() => handleSelect(font.id)}
                       className="cursor-pointer py-1 pr-1"
-                      style={{ fontFamily: `'${font.name}', system-ui, sans-serif` }}
+                      style={{ fontFamily: `'${escapeFontFamilyName(font.name)}', system-ui, sans-serif` }}
                       title={font.hasKorean ? font.name : `${font.name} (영문/숫자만 지원)`}
                     >
                       {font.name}

--- a/src/components/settings/FontFamilySection.tsx
+++ b/src/components/settings/FontFamilySection.tsx
@@ -134,7 +134,13 @@ export function FontFamilySection() {
   const handleDelete = useCallback(async (font: CustomFont) => {
     if (!confirm(`"${font.name}" 글꼴을 삭제하시겠습니까?`)) return;
     if (!window.electronAPI?.fontDelete) return;
-    await window.electronAPI.fontDelete({ id: font.id, filename: font.filename });
+    // Codex 6차 P2: IPC 결과 무시하고 항상 제거하면 파일 잠금/권한 실패 시 orphan 파일 발생.
+    // 성공 시에만 로컬 state/preferences에서 제거하고, 실패 시 토스트로 안내 + 재시도 가능.
+    const result = await window.electronAPI.fontDelete({ id: font.id, filename: font.filename });
+    if (!result?.ok) {
+      toast.error(`"${font.name}" 삭제 실패: ${result?.error ?? '알 수 없는 오류'} — 다시 시도해주세요.`);
+      return;
+    }
     const next = customFonts.filter((f) => f.id !== font.id);
     // 삭제 중이던 폰트가 현재 적용 중이면 → DEFAULT_FONT_FAMILY로 폴백
     const fallbackId = fontFamily === font.id ? DEFAULT_FONT_FAMILY : fontFamily;

--- a/src/components/settings/SpacingSection.tsx
+++ b/src/components/settings/SpacingSection.tsx
@@ -6,7 +6,7 @@
  * - "기본값 복원" 버튼 (다른 섹션과 일관)
  * - 즉시 적용 + savePreferences + 다른 창 동기화
  */
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { AlignVerticalSpaceAround, RotateCcw } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import { SettingsSection } from './SettingsSection';
@@ -22,6 +22,10 @@ import { loadPreferences, savePreferences } from '@/services/settingsService';
 export function SpacingSection() {
   const [lineHeight, setLineHeight] = useState<number>(DEFAULT_LINE_HEIGHT);
   const [letterSpacing, setLetterSpacing] = useState<number>(DEFAULT_LETTER_SPACING);
+  // Codex 1차 P2: 슬라이더 빠른 드래그 시 read-modify-write race로 stale 값이 디스크에 영구 저장될 수 있음.
+  // 해결: 저장만 디바운스(200ms) + 마지막 값을 ref로 잡아 정확히 한 번만 발화 → last-write-wins 보장.
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingValuesRef = useRef<{ lh: number; ls: number } | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -33,17 +37,44 @@ export function SpacingSection() {
     return () => { cancelled = true; };
   }, []);
 
-  const persist = useCallback(async (lh: number, ls: number) => {
+  // Unmount 시 pending 저장 즉시 flush — 슬라이더 조작 직후 탭 이동해도 손실 X
+  useEffect(() => {
+    return () => {
+      if (saveTimerRef.current) {
+        clearTimeout(saveTimerRef.current);
+        const pending = pendingValuesRef.current;
+        if (pending) {
+          // 비동기지만 fire-and-forget — unmount 시점이라 await 불필요
+          loadPreferences().then((prev) => {
+            savePreferences({ ...(prev ?? {}), lineHeight: pending.lh, letterSpacing: pending.ls });
+            window.electronAPI?.preferencesBroadcastChange?.({ lineHeight: pending.lh, letterSpacing: pending.ls });
+          }).catch((err) => console.error('[간격] flush 실패:', err));
+        }
+      }
+    };
+  }, []);
+
+  const persist = useCallback((lh: number, ls: number) => {
+    // 즉시 적용 (UI 반응성)
     applySpacing(lh, ls);
     setLineHeight(lh);
     setLetterSpacing(ls);
-    try {
-      const prev = (await loadPreferences()) ?? {};
-      await savePreferences({ ...prev, lineHeight: lh, letterSpacing: ls });
-      window.electronAPI?.preferencesBroadcastChange?.({ lineHeight: lh, letterSpacing: ls });
-    } catch (err) {
-      console.error('[간격] 설정 저장 실패:', err);
-    }
+    // 저장은 디바운스 — 마지막 값만 디스크에 (last-write-wins)
+    pendingValuesRef.current = { lh, ls };
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = setTimeout(async () => {
+      const target = pendingValuesRef.current;
+      pendingValuesRef.current = null;
+      saveTimerRef.current = null;
+      if (!target) return;
+      try {
+        const prev = (await loadPreferences()) ?? {};
+        await savePreferences({ ...prev, lineHeight: target.lh, letterSpacing: target.ls });
+        window.electronAPI?.preferencesBroadcastChange?.({ lineHeight: target.lh, letterSpacing: target.ls });
+      } catch (err) {
+        console.error('[간격] 설정 저장 실패:', err);
+      }
+    }, 200);
   }, []);
 
   const handleReset = useCallback(() => {

--- a/src/components/settings/SpacingSection.tsx
+++ b/src/components/settings/SpacingSection.tsx
@@ -1,0 +1,122 @@
+/**
+ * v1.20.0: 줄간격·자간 슬라이더
+ *
+ * - 줄간격: 1.2 ~ 2.0 (step 0.05), 기본 1.55
+ * - 자간: -0.05 ~ 0.10 em (step 0.005), 기본 0
+ * - "기본값 복원" 버튼 (다른 섹션과 일관)
+ * - 즉시 적용 + savePreferences + 다른 창 동기화
+ */
+import { useState, useCallback, useEffect } from 'react';
+import { AlignVerticalSpaceAround, RotateCcw } from 'lucide-react';
+import { cn } from '@/utils/cn';
+import { SettingsSection } from './SettingsSection';
+import {
+  applySpacing,
+  DEFAULT_LINE_HEIGHT,
+  DEFAULT_LETTER_SPACING,
+  LINE_HEIGHT_MIN, LINE_HEIGHT_MAX, LINE_HEIGHT_STEP,
+  LETTER_SPACING_MIN, LETTER_SPACING_MAX, LETTER_SPACING_STEP,
+} from '@/utils/typography';
+import { loadPreferences, savePreferences } from '@/services/settingsService';
+
+export function SpacingSection() {
+  const [lineHeight, setLineHeight] = useState<number>(DEFAULT_LINE_HEIGHT);
+  const [letterSpacing, setLetterSpacing] = useState<number>(DEFAULT_LETTER_SPACING);
+
+  useEffect(() => {
+    let cancelled = false;
+    loadPreferences().then((prefs) => {
+      if (cancelled) return;
+      setLineHeight(prefs?.lineHeight ?? DEFAULT_LINE_HEIGHT);
+      setLetterSpacing(prefs?.letterSpacing ?? DEFAULT_LETTER_SPACING);
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  const persist = useCallback(async (lh: number, ls: number) => {
+    applySpacing(lh, ls);
+    setLineHeight(lh);
+    setLetterSpacing(ls);
+    try {
+      const prev = (await loadPreferences()) ?? {};
+      await savePreferences({ ...prev, lineHeight: lh, letterSpacing: ls });
+      window.electronAPI?.preferencesBroadcastChange?.({ lineHeight: lh, letterSpacing: ls });
+    } catch (err) {
+      console.error('[간격] 설정 저장 실패:', err);
+    }
+  }, []);
+
+  const handleReset = useCallback(() => {
+    persist(DEFAULT_LINE_HEIGHT, DEFAULT_LETTER_SPACING);
+  }, [persist]);
+
+  const isCustom =
+    lineHeight !== DEFAULT_LINE_HEIGHT
+    || letterSpacing !== DEFAULT_LETTER_SPACING;
+
+  return (
+    <SettingsSection
+      icon={<AlignVerticalSpaceAround size={18} className="text-accent" />}
+      title="간격"
+      action={
+        isCustom ? (
+          <button
+            onClick={handleReset}
+            className="flex items-center gap-1 px-2 py-1 rounded-md text-[11px] text-text-secondary hover:text-text-primary hover:bg-bg-border/30 transition-colors cursor-pointer"
+          >
+            <RotateCcw size={12} />
+            기본값 복원
+          </button>
+        ) : null
+      }
+    >
+      <div className="space-y-4">
+        {/* 줄간격 */}
+        <div className="flex items-center gap-3">
+          <div className="w-16 shrink-0">
+            <span className="text-xs font-medium text-text-primary">줄간격</span>
+            <p className="text-[10px] text-text-secondary/50">위·아래 여백</p>
+          </div>
+          <input
+            type="range"
+            min={LINE_HEIGHT_MIN} max={LINE_HEIGHT_MAX} step={LINE_HEIGHT_STEP}
+            value={lineHeight}
+            onChange={(e) => persist(parseFloat(e.target.value), letterSpacing)}
+            className="flex-1 h-1.5 cursor-pointer"
+          />
+          <span className={cn(
+            'w-12 text-right text-xs font-mono tabular-nums',
+            lineHeight === DEFAULT_LINE_HEIGHT ? 'text-text-secondary/50' : 'text-accent',
+          )}>
+            {lineHeight.toFixed(2)}
+          </span>
+        </div>
+
+        {/* 자간 */}
+        <div className="flex items-center gap-3">
+          <div className="w-16 shrink-0">
+            <span className="text-xs font-medium text-text-primary">자간</span>
+            <p className="text-[10px] text-text-secondary/50">글자 사이</p>
+          </div>
+          <input
+            type="range"
+            min={LETTER_SPACING_MIN} max={LETTER_SPACING_MAX} step={LETTER_SPACING_STEP}
+            value={letterSpacing}
+            onChange={(e) => persist(lineHeight, parseFloat(e.target.value))}
+            className="flex-1 h-1.5 cursor-pointer"
+          />
+          <span className={cn(
+            'w-12 text-right text-xs font-mono tabular-nums',
+            letterSpacing === DEFAULT_LETTER_SPACING ? 'text-text-secondary/50' : 'text-accent',
+          )}>
+            {letterSpacing >= 0 ? '+' : ''}{letterSpacing.toFixed(3)}
+          </span>
+        </div>
+
+        <p className="text-[10px] text-text-secondary/40 mt-1">
+          긴 메모·댓글·씬 설명 영역에서 가독성 효과가 가장 큽니다.
+        </p>
+      </div>
+    </SettingsSection>
+  );
+}

--- a/src/components/settings/SpacingSection.tsx
+++ b/src/components/settings/SpacingSection.tsx
@@ -44,11 +44,17 @@ export function SpacingSection() {
         clearTimeout(saveTimerRef.current);
         const pending = pendingValuesRef.current;
         if (pending) {
-          // 비동기지만 fire-and-forget — unmount 시점이라 await 불필요
-          loadPreferences().then((prev) => {
-            savePreferences({ ...(prev ?? {}), lineHeight: pending.lh, letterSpacing: pending.ls });
-            window.electronAPI?.preferencesBroadcastChange?.({ lineHeight: pending.lh, letterSpacing: pending.ls });
-          }).catch((err) => console.error('[간격] flush 실패:', err));
+          // Codex 5차 P2: save 완료 전에 broadcast하면 다른 창이 stale 값을 읽을 수 있음
+          // → await 흐름으로 변경. async IIFE로 fire-and-forget but 내부 순서는 보장.
+          (async () => {
+            try {
+              const prev = (await loadPreferences()) ?? {};
+              await savePreferences({ ...prev, lineHeight: pending.lh, letterSpacing: pending.ls });
+              window.electronAPI?.preferencesBroadcastChange?.({ lineHeight: pending.lh, letterSpacing: pending.ls });
+            } catch (err) {
+              console.error('[간격] flush 실패:', err);
+            }
+          })();
         }
       }
     };

--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,30 @@
   --text-body-scale: 1;
   --text-caption-scale: 1;
   --text-micro-scale: 1;
+
+  /* v1.20.0: 글꼴 시스템 */
+  --font-family: 'Pretendard Variable', Pretendard, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --text-line-height: 1.55;
+  --text-letter-spacing: 0em;
+}
+
+/* v1.20.0: 글꼴 family / 줄간격 / 자간 — applyFontFamily/applySpacing이 CSS 변수 갱신 */
+@layer base {
+  html, body {
+    font-family: var(--font-family);
+    line-height: var(--text-line-height);
+    letter-spacing: var(--text-letter-spacing);
+  }
+}
+
+/* v1.20.0: 숫자 자릿수 고정 — 사용자 옵션 없이 항상 적용
+   대상: 위젯·표·진행률·시간·날짜 등 숫자 영역.
+   한글에는 영향 없음 (font-variant-numeric은 숫자 글리프에만 작용). */
+[data-numeric],
+.tabular,
+.font-mono,
+.tabular-nums {
+  font-variant-numeric: tabular-nums;
 }
 
 /* 타이포그래피 스케일 오버라이드: Tailwind 기본 클래스를 CSS 변수로 스케일링 */

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,28 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import { WidgetPopup } from './views/WidgetPopup';
+
+// v1.20.0: 글꼴 시스템 — 큐레이션 9종 중 8종 (시스템 기본은 OS 글꼴, import 불필요)
+// Pretendard Variable: 가변 폰트 1개 파일 → 모든 weight 자동 처리, 가장 효율적
+import 'pretendard/dist/web/variable/pretendardvariable.css';
+import '@fontsource/inter/400.css';
+import '@fontsource/inter/500.css';
+import '@fontsource/inter/600.css';
+import '@fontsource/inter/700.css';
+import '@fontsource/noto-sans-kr/400.css';
+import '@fontsource/noto-sans-kr/500.css';
+import '@fontsource/noto-sans-kr/700.css';
+import '@fontsource/ibm-plex-sans-kr/400.css';
+import '@fontsource/ibm-plex-sans-kr/500.css';
+import '@fontsource/ibm-plex-sans-kr/700.css';
+import '@fontsource/nanum-gothic/400.css';
+import '@fontsource/nanum-gothic/700.css';
+import '@fontsource/gowun-dodum/400.css';
+import '@fontsource/noto-serif-kr/400.css';
+import '@fontsource/noto-serif-kr/500.css';
+import '@fontsource/noto-serif-kr/700.css';
+import 'spoqa-han-sans/css/SpoqaHanSansNeo.css';
+
 import './index.css';
 import './styles/path-link.css';
 import './styles/activity-widget.css';

--- a/src/mocks/devElectronAPI.ts
+++ b/src/mocks/devElectronAPI.ts
@@ -43,6 +43,7 @@ export function installDevElectronAPI(): void {
       return [];
     },
     fontDelete: async () => ({ ok: true }),
+    fontGetPathForFile: () => '',
 
     usersRead: async () => ({
       users: MOCK_USERS.map(u => ({

--- a/src/mocks/devElectronAPI.ts
+++ b/src/mocks/devElectronAPI.ts
@@ -33,6 +33,17 @@ export function installDevElectronAPI(): void {
   const mockAPI: ElectronAPI = {
     getDataPath: async () => '/dev/mock-data',
 
+    // v1.20.0: 사용자 폰트 — 개발 환경에선 stub (Electron dialog/fs 사용 불가)
+    fontAdd: async () => {
+      console.warn('[devMock] fontAdd: Electron 환경에서만 작동');
+      return [];
+    },
+    fontAddByPath: async () => {
+      console.warn('[devMock] fontAddByPath: Electron 환경에서만 작동');
+      return [];
+    },
+    fontDelete: async () => ({ ok: true }),
+
     usersRead: async () => ({
       users: MOCK_USERS.map(u => ({
         id: u.id, name: u.name, slackId: u.slackId,

--- a/src/services/settingsService.ts
+++ b/src/services/settingsService.ts
@@ -91,6 +91,20 @@ export interface UserPreferences {
   };
   fontColorPreset?: 'theme' | 'high-contrast' | 'soft' | 'mono' | 'custom';
 
+  // v1.20.0: 글꼴 시스템
+  /** 'pretendard' | 'inter' | ... | 'system' | `custom:${uuid}` */
+  fontFamily?: string;
+  lineHeight?: number;
+  letterSpacing?: number;
+  customFonts?: Array<{
+    id: string;
+    name: string;
+    filename: string;
+    format: 'otf' | 'ttf' | 'woff' | 'woff2';
+    hasKorean: boolean;
+    addedAt: string;
+  }>;
+
   // Phase 8-3: 플렉서스 애니메이션
   plexus?: {
     loginEnabled?: boolean;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -665,6 +665,8 @@ export interface ElectronAPI {
     | { error: string }
   >>;
   fontDelete: (font: { id: string; filename: string }) => Promise<{ ok: boolean; error?: string }>;
+  /** 드래그앤드롭에서 File 객체 → 절대 경로 (Electron 32+ webUtils.getPathForFile) */
+  fontGetPathForFile: (file: File) => string;
 
   // ─── Google Calendar ──────────────────────────────
   gcalIsAuthenticated: () => Promise<boolean>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -655,6 +655,17 @@ export interface ElectronAPI {
   onVacationFailed: (cb: (payload: unknown) => void) => () => void;
   onVacationPendingChanged: (cb: (payload: unknown) => void) => () => void;
 
+  // ─── 사용자 폰트 (v1.20.0) ──────────────────────
+  fontAdd: () => Promise<Array<
+    | { id: string; name: string; filename: string; format: 'otf' | 'ttf' | 'woff' | 'woff2'; hasKorean: boolean; addedAt: string }
+    | { error: string }
+  >>;
+  fontAddByPath: (filePaths: string[]) => Promise<Array<
+    | { id: string; name: string; filename: string; format: 'otf' | 'ttf' | 'woff' | 'woff2'; hasKorean: boolean; addedAt: string }
+    | { error: string }
+  >>;
+  fontDelete: (font: { id: string; filename: string }) => Promise<{ ok: boolean; error?: string }>;
+
   // ─── Google Calendar ──────────────────────────────
   gcalIsAuthenticated: () => Promise<boolean>;
   gcalStartAuth: () => Promise<void>;

--- a/src/utils/typography.ts
+++ b/src/utils/typography.ts
@@ -272,12 +272,16 @@ export const LETTER_SPACING_STEP = 0.005;
 // ─── DOM 적용 헬퍼 ──────────────────────────────────
 
 /**
- * CSS `font-family` 값에 안전하게 끼워 넣을 수 있도록 single quote/backslash를 escape.
- * 예: `Kid's Sans` → `Kid\\'s Sans` → `'Kid\\'s Sans'` 가 유효한 CSS 값이 됨.
- * Codex 1차 P2: applyFontFamily / injectCustomFontFace / 렌더러 inline style 양쪽이 같은 규칙을 따라야 함.
+ * CSS `font-family` 값에 안전하게 끼워 넣을 수 있도록 sanitize + escape.
+ * - Codex 1차 P2: applyFontFamily / injectCustomFontFace / 렌더러 inline style 양쪽이 같은 규칙을 따라야 함.
+ * - Codex 6차 P3: CSS string은 raw newline/control char를 가질 수 없음 → 공백으로 정규화 후 backslash/quote escape.
+ *   예: `Kid's\nSans` → `Kid's Sans` → `Kid\\'s Sans` → `'Kid\\'s Sans'` 가 유효한 CSS 값.
  */
 export function escapeFontFamilyName(name: string): string {
-  return name.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+  // 1. 제어 문자(newline/CR/tab/form-feed/vertical-tab/NUL~US/DEL) → 공백 → trim
+  const sanitized = name.replace(/[ -]+/g, ' ').replace(/\s+/g, ' ').trim();
+  // 2. backslash + single quote escape
+  return sanitized.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
 }
 
 export function applyFontFamily(familyId: string, customFonts: CustomFont[] = []): void {

--- a/src/utils/typography.ts
+++ b/src/utils/typography.ts
@@ -192,6 +192,11 @@ export function applyPreferencesToDOM(prefs: {
   fontScale?: string;
   fontCategoryScales?: Partial<FontCategoryScales>;
   fontCategoryColors?: FontCategoryColors;
+  // v1.20.0: 글꼴 시스템
+  fontFamily?: string;
+  lineHeight?: number;
+  letterSpacing?: number;
+  customFonts?: CustomFont[];
 }): void {
   const scale: FontScale = isFontScale(prefs.fontScale) ? prefs.fontScale : DEFAULT_FONT_SCALE;
   applyFontSettings({
@@ -204,4 +209,107 @@ export function applyPreferencesToDOM(prefs: {
     },
   });
   applyTextColors(prefs.fontCategoryColors ?? {});
+
+  // v1.20.0: 글꼴 / 간격
+  ensureCustomFontsLoaded(prefs.customFonts ?? []);
+  applyFontFamily(prefs.fontFamily ?? DEFAULT_FONT_FAMILY, prefs.customFonts ?? []);
+  applySpacing(
+    prefs.lineHeight ?? DEFAULT_LINE_HEIGHT,
+    prefs.letterSpacing ?? DEFAULT_LETTER_SPACING,
+  );
+}
+
+// ─── v1.20.0: 글꼴 서체 (Font Family) ───────────────
+
+export interface CustomFont {
+  /** `custom:${uuid}` 형식 — preferences.fontFamily에 직접 저장됨 */
+  id: string;
+  /** opentype.js로 추출한 메타 이름 (사용자에게 표시) */
+  name: string;
+  /** 디스크에 저장된 실제 파일명 (uuid.확장자) */
+  filename: string;
+  format: 'otf' | 'ttf' | 'woff' | 'woff2';
+  /** 한글 글리프 존재 여부 — false면 토스트 경고 */
+  hasKorean: boolean;
+  addedAt: string; // ISO 8601
+}
+
+export interface FontFamilyMeta {
+  id: string;
+  label: string;
+  /** CSS font-family stack (fallback 포함) */
+  cssStack: string;
+  group: 'modern' | 'soft' | 'serious' | 'character' | 'system';
+}
+
+const FALLBACK_STACK = `'Pretendard Variable', Pretendard, system-ui, sans-serif`;
+
+export const FONT_FAMILIES: FontFamilyMeta[] = [
+  { id: 'pretendard',    label: 'Pretendard',         cssStack: `'Pretendard Variable', Pretendard, system-ui, sans-serif`, group: 'modern' },
+  { id: 'inter',         label: 'Inter',              cssStack: `Inter, 'Pretendard Variable', Pretendard, system-ui, sans-serif`, group: 'modern' },
+  { id: 'noto-sans-kr',  label: 'Noto Sans KR',       cssStack: `'Noto Sans KR', system-ui, sans-serif`, group: 'modern' },
+  { id: 'ibm-plex-kr',   label: 'IBM Plex Sans KR',   cssStack: `'IBM Plex Sans KR', system-ui, sans-serif`, group: 'serious' },
+  { id: 'spoqa',         label: 'Spoqa Han Sans Neo', cssStack: `'Spoqa Han Sans Neo', system-ui, sans-serif`, group: 'serious' },
+  { id: 'nanum-gothic',  label: '나눔고딕',           cssStack: `'Nanum Gothic', system-ui, sans-serif`, group: 'soft' },
+  { id: 'gowun-dodum',   label: '고운 도담',          cssStack: `'Gowun Dodum', system-ui, sans-serif`, group: 'soft' },
+  { id: 'noto-serif-kr', label: '본명조',             cssStack: `'Noto Serif KR', serif`, group: 'character' },
+  { id: 'system',        label: '시스템 기본',        cssStack: `system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif`, group: 'system' },
+];
+
+export const DEFAULT_FONT_FAMILY = 'pretendard';
+
+// ─── 간격 (Line Height / Letter Spacing) ─────────────
+
+export const DEFAULT_LINE_HEIGHT = 1.55;
+export const DEFAULT_LETTER_SPACING = 0;
+export const LINE_HEIGHT_MIN = 1.2;
+export const LINE_HEIGHT_MAX = 2.0;
+export const LINE_HEIGHT_STEP = 0.05;
+export const LETTER_SPACING_MIN = -0.05;
+export const LETTER_SPACING_MAX = 0.10;
+export const LETTER_SPACING_STEP = 0.005;
+
+// ─── DOM 적용 헬퍼 ──────────────────────────────────
+
+export function applyFontFamily(familyId: string, customFonts: CustomFont[] = []): void {
+  const root = document.documentElement;
+  let stack = FALLBACK_STACK;
+
+  if (familyId.startsWith('custom:')) {
+    const cf = customFonts.find((f) => f.id === familyId);
+    if (cf) {
+      injectCustomFontFace(cf);
+      stack = `'${cf.name}', ${FALLBACK_STACK}`;
+    }
+    // 못 찾으면 폴백 → DEFAULT_FONT_FAMILY와 동일 효과
+  } else {
+    const meta = FONT_FAMILIES.find((f) => f.id === familyId);
+    if (meta) stack = meta.cssStack;
+  }
+
+  root.style.setProperty('--font-family', stack);
+}
+
+export function applySpacing(lineHeight: number, letterSpacing: number): void {
+  const root = document.documentElement;
+  root.style.setProperty('--text-line-height', String(lineHeight));
+  root.style.setProperty('--text-letter-spacing', `${letterSpacing}em`);
+}
+
+/** 사용자 폰트의 @font-face를 동적으로 <head>에 주입. 같은 id가 이미 있으면 skip. */
+function injectCustomFontFace(font: CustomFont): void {
+  if (document.querySelector(`style[data-font-id="${font.id}"]`)) return;
+  const formatHint: Record<CustomFont['format'], string> = {
+    otf: 'opentype', ttf: 'truetype', woff: 'woff', woff2: 'woff2',
+  };
+  const url = `bflow-font://${encodeURIComponent(font.filename)}`;
+  const style = document.createElement('style');
+  style.setAttribute('data-font-id', font.id);
+  style.textContent = `@font-face { font-family: '${font.name.replace(/'/g, "\\'")}'; src: url('${url}') format('${formatHint[font.format]}'); font-display: swap; }`;
+  document.head.appendChild(style);
+}
+
+/** 모든 사용자 폰트의 @font-face를 미리 주입 — 앱 시작 시 호출. */
+export function ensureCustomFontsLoaded(customFonts: CustomFont[]): void {
+  customFonts.forEach(injectCustomFontFace);
 }

--- a/src/utils/typography.ts
+++ b/src/utils/typography.ts
@@ -271,6 +271,15 @@ export const LETTER_SPACING_STEP = 0.005;
 
 // ─── DOM 적용 헬퍼 ──────────────────────────────────
 
+/**
+ * CSS `font-family` 값에 안전하게 끼워 넣을 수 있도록 single quote/backslash를 escape.
+ * 예: `Kid's Sans` → `Kid\\'s Sans` → `'Kid\\'s Sans'` 가 유효한 CSS 값이 됨.
+ * Codex 1차 P2: applyFontFamily / injectCustomFontFace / 렌더러 inline style 양쪽이 같은 규칙을 따라야 함.
+ */
+export function escapeFontFamilyName(name: string): string {
+  return name.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
 export function applyFontFamily(familyId: string, customFonts: CustomFont[] = []): void {
   const root = document.documentElement;
   let stack = FALLBACK_STACK;
@@ -279,7 +288,7 @@ export function applyFontFamily(familyId: string, customFonts: CustomFont[] = []
     const cf = customFonts.find((f) => f.id === familyId);
     if (cf) {
       injectCustomFontFace(cf);
-      stack = `'${cf.name}', ${FALLBACK_STACK}`;
+      stack = `'${escapeFontFamilyName(cf.name)}', ${FALLBACK_STACK}`;
     }
     // 못 찾으면 폴백 → DEFAULT_FONT_FAMILY와 동일 효과
   } else {
@@ -305,7 +314,7 @@ function injectCustomFontFace(font: CustomFont): void {
   const url = `bflow-font://${encodeURIComponent(font.filename)}`;
   const style = document.createElement('style');
   style.setAttribute('data-font-id', font.id);
-  style.textContent = `@font-face { font-family: '${font.name.replace(/'/g, "\\'")}'; src: url('${url}') format('${formatHint[font.format]}'); font-display: swap; }`;
+  style.textContent = `@font-face { font-family: '${escapeFontFamilyName(font.name)}'; src: url('${url}') format('${formatHint[font.format]}'); font-display: swap; }`;
   document.head.appendChild(style);
 }
 

--- a/src/views/ScenesView.tsx
+++ b/src/views/ScenesView.tsx
@@ -779,6 +779,15 @@ function SceneCard({ scene, sceneIndex, celebrating, department, isHighlighted, 
               <span className="text-[10px] font-bold leading-none">{revisionCount}</span>
             </span>
           )}
+          {/* v1.20.x: 분리(BG/ACT 단독) 카드 뷰에도 씬 길이 변경 라벨 표시 — UnifiedSceneCard와 동일 패턴 */}
+          {scene.lengthChange && (
+            <span
+              className={`length-symbol ${scene.lengthChange === 'LD' ? 'up' : 'down'}`}
+              title={scene.lengthChange === 'LD' ? 'LD · Long Duration (길이 늘어남)' : 'SD · Short Duration (길이 줄어듦)'}
+            >
+              <LengthIcon kind={scene.lengthChange} />
+            </span>
+          )}
           <span className="bg-bg-primary/80 border border-bg-border/45 text-text-primary px-2.5 py-1 rounded-full text-[12px] font-semibold tabular-nums">
             {pct}%
           </span>

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -2,8 +2,11 @@ import { lazy, Suspense, useState, useEffect } from 'react';
 import { SettingsSidebar, type SettingsTabId } from '@/components/settings/SettingsSidebar';
 // 설정 섹션 lazy 로딩 — 활성 탭 진입 시에만 로드
 const ThemeSection = lazy(() => import('@/components/settings/ThemeSection').then(m => ({ default: m.ThemeSection })));
+// v1.20.0: 글꼴(서체) + 간격
+const FontFamilySection = lazy(() => import('@/components/settings/FontFamilySection').then(m => ({ default: m.FontFamilySection })));
 const FontSizeSection = lazy(() => import('@/components/settings/FontSizeSection').then(m => ({ default: m.FontSizeSection })));
 const FontColorSection = lazy(() => import('@/components/settings/FontColorSection').then(m => ({ default: m.FontColorSection })));
+const SpacingSection = lazy(() => import('@/components/settings/SpacingSection').then(m => ({ default: m.SpacingSection })));
 const SheetsSection = lazy(() => import('@/components/settings/SheetsSection').then(m => ({ default: m.SheetsSection })));
 const GuideSection = lazy(() => import('@/components/settings/GuideSection').then(m => ({ default: m.GuideSection })));
 const StartupSection = lazy(() => import('@/components/settings/StartupSection').then(m => ({ default: m.StartupSection })));
@@ -55,6 +58,8 @@ export function SettingsView() {
       case 'font':
         return (
           <div className="flex flex-col gap-6">
+            {/* v1.20.0: 글꼴(서체) — 큐레이션 9종 + 사용자 추가 */}
+            <FontFamilySection />
             <FontSizeSection
               fontScale={fontScale}
               categoryScales={categoryScales}
@@ -62,6 +67,8 @@ export function SettingsView() {
               onCategoryScalesChange={setCategoryScales}
             />
             <FontColorSection />
+            {/* v1.20.0: 간격 (줄간격 + 자간) */}
+            <SpacingSection />
           </div>
         );
       case 'sheets':


### PR DESCRIPTION
## 📝 업데이트 로그

### 무엇이 바뀌나
- G드라이브 `dist/` 루트의 **`BFLOW.exe` (portable, 466MB) 빌드 자체 안 만듦**.
- `dist/`에는 이제 `win-unpacked/` (사용자 본체) + `manifest.json` (자동 업데이트 metadata) + Vite renderer 산출물(redundant)만 남음.

### 한솔님·팀원 동작 변화 — **없음**
- 이미 모두 `win-unpacked\BFLOW.exe`를 가리키는 바로가기 사용 중. portable BFLOW.exe는 한 번도 정상 진입점이었던 적 없음.
- 자동 업데이트 시스템(v1.21.0)과 완전 호환 — `getLaunchExePath()`가 `PORTABLE_EXECUTABLE_FILE` 없으면 `process.execPath`로 폴백. win-unpacked exe로 진입해도 `isRunningFromGoogleDrive()` 정상 감지 → self-installer 진입 OK.

### 왜 제거했나
일부 사용자가 호기심에 portable BFLOW.exe 더블클릭하면:
1. **%TEMP%/<랜덤UUID>/에 466MB 압축 해제** (매번 다른 path)
2. **Windows Defender 매번 풀 스캔** (path 변동으로 cache 무력) → 17초+ cold start
3. **동적 import chunk fetch 실패 사례** — 한솔님 처음 보고하신 에러:  
   `Failed to fetch dynamically imported module: file:///C:/Users/dksfb/AppData/Local/Temp/3DB0Y0HgjX878YWhwUO1tqS0NeJ/resources/app/dist/assets/lastSeenTracker-MtZSySJz.js`  
   ← 정확히 이 시나리오의 path. portable이 임시 폴더에 풀 때 일부 청크가 락/AV/디스크 race로 누락.

→ portable 자체를 안 만들면 잘못 클릭할 진입점이 사라져 사고 원천 차단.

---

## 🧱 기술 변경 요약

```diff
// package.json
   "build": {
     ...
-    "win": {
-      "target": "portable"
-    },
-    "portable": {
-      "artifactName": "BFLOW.exe"
-    }
+    "win": {
+      "target": "dir"
+    }
   }
```

단 한 줄(블록)의 변경. 코드 0줄.

### 빌드 산출물 비교

| 파일 | v1.21.0 | v1.21.1 |
|---|---|---|
| `dist/BFLOW.exe` (portable) | 466MB | **없음** |
| `dist/win-unpacked/BFLOW.exe` (사용자 본체) | 188MB | 188MB |
| `dist/manifest.json` | ✅ | ✅ (fileCount/totalBytes 자동 업데이트) |
| 빌드 시간 | portable 압축 포함 (1~3분 길어짐) | 단축 |

### 자동 업데이트 시스템 호환성 검증

`electron/autoUpdate/paths.ts`의 `getLaunchExePath()`:
```ts
return process.env.PORTABLE_EXECUTABLE_FILE || process.execPath;
```
- portable 빌드: `PORTABLE_EXECUTABLE_FILE` set, `process.execPath`는 Temp/<UUID>/...
- dir 빌드 (이번 PR): `PORTABLE_EXECUTABLE_FILE` undefined, `process.execPath`는 실제 exe 경로 (G:\...\win-unpacked\BFLOW.exe)

둘 다 `\공유 드라이브\` path 마커로 정상 감지. self-installer 진입 동일.

---

## 🛠 개발 난항

### 1. spec과 한솔님 실제 워크플로우 미스매치 (이번 세션의 큰 학습)
이전 세션에서 작성한 spec doc(`docs/superpowers/specs/2026-05-01-auto-update-design.md`) §3에 "BFLOW.exe ← 변경 없음 (portable)"이라 명시. §4.3 self-installer 진입점도 portable BFLOW.exe로 가정.

그러나 한솔님 실제 패턴: 한솔님 + 모든 기존 팀원이 win-unpacked\BFLOW.exe만 사용. portable BFLOW.exe는 한 번도 사용 안 됨.

→ 이번 세션 시작 시 한솔님 첫 답변("portable.exe 빌드 제거")이 정확한 의도였는데, spec doc 따르면서 portable 유지로 결정해버린 게 잘못된 판단. 한솔님이 직접 지적하셔서 정정.

### 2. 변경의 안전성
이번 변경은 코드 0줄. 자동 업데이트 시스템(v1.21.0)이 이미 win-unpacked exe로 진입해도 정확히 같이 동작하도록 설계됨 (코덱스 4차 P1에서 `getLaunchExePath()`로 portable + dir 양쪽 호환 검증 끝). 그래서 이 PR은 "build 산출물에서 redundant + 사고 원인 한 가지 제거"의 최소 변경.

---

## ✅ 빌드 검증 (수동)

```bash
$ npm run build
# ... vite build (renderer + electron main + preload) + electron-builder dir target ...
$ ls dist/
assets  builder-debug.yml  index.html  manifest.json  splash  win-unpacked

$ ls dist/BFLOW.exe
ls: cannot access 'dist/BFLOW.exe': No such file or directory  ← 정확히 의도대로

$ cat dist/manifest.json
{
  "version": "1.21.1",
  "buildAt": "...",
  "fileCount": 18516,
  "totalBytes": 1043183107
}
```

---

## 🧪 테스트 시나리오 (한솔님 검증)

### 시나리오 1: 한솔님 일상 사용 (변화 없음)
- [ ] 바탕화면 "B flow" 더블클릭 → 1~2초 시작 (변화 X — 이미 win-unpacked exe 사용 중)

### 시나리오 2: G드라이브 BFLOW.exe(portable) 사라짐 확인
- [ ] G드라이브 동기화 후 `G:\...\dist\` 안에 `BFLOW.exe` 없음 (`win-unpacked\`, `manifest.json`만)

### 시나리오 3: 신규 팀원 첫 설치 (한솔님 만든 win-unpacked\BFLOW.exe 바로가기)
- [ ] 한솔님이 `G:\...\dist\win-unpacked\BFLOW.exe` 가리키는 바로가기 만들어 공유
- [ ] 팀원 클릭 → "B flow 를 PC에 설치합니다" dialog 정상 등장 (v1.21.0과 동일 self-installer 동작)

### 시나리오 4: 자동 업데이트 (v1.21.0 → v1.21.1 → v1.21.2)
- [ ] 사용자가 v1.21.0 BFLOW 켠 상태에서 한솔님이 v1.21.1 빌드 + robocopy
- [ ] 5초 후 백그라운드 다운로드 → pending\.ready 작성
- [ ] 종료 → swap → 다음 실행 v1.21.1

---

## ⚠️ 머지 후 한솔님 명시 시에만 진행 (메모리 규칙)

- **머지** — "머지해줘" 시
- **풀 빌드 + G드라이브 robocopy /MIR** — robocopy /MIR이 source에 없는 파일(이전 portable BFLOW.exe)을 자동 삭제하므로 G드라이브에서도 사라짐. 명시 시.
- **슬랙 공지** — 명시 시

🤖 Generated with [Claude Code](https://claude.com/claude-code)