### PR TITLE
[v1.21.1] portable target 제거 + 빌드 size -34%

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bflow",
-  "version": "1.20.0",
+  "version": "1.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bflow",
-      "version": "1.20.0",
+      "version": "1.21.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@fontsource/gowun-dodum": "^5.2.8",
@@ -36,7 +36,6 @@
         "react-dom": "^18.3.1",
         "react-grid-layout": "^1.4.4",
         "sonner": "^2.0.7",
-        "spoqa-han-sans": "^3.3.0",
         "tiptap-markdown": "^0.8.10",
         "wawoff2": "^2.0.1",
         "zustand": "^4.5.2"
@@ -7418,12 +7417,6 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
-    },
-    "node_modules/spoqa-han-sans": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/spoqa-han-sans/-/spoqa-han-sans-3.3.0.tgz",
-      "integrity": "sha512-uEetiueUQdfc8MW+JN0Dj9aN3oONctICzBljqbd+a7XXeQV0+Cg3bKFJVtSyIgjQkpG8F7csAVX86ZUEzTt+Iw==",
-      "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/sprintf-js": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {
@@ -60,10 +60,7 @@
       "package.json"
     ],
     "win": {
-      "target": "portable"
-    },
-    "portable": {
-      "artifactName": "BFLOW.exe"
+      "target": "dir"
     }
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
       "dist-electron/**/*",
       "public/splash/**",
       "node_modules/**/*",
+      "!node_modules/@fontsource/**",
+      "!node_modules/pretendard/**",
       "package.json"
     ],
     "win": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "react-dom": "^18.3.1",
     "react-grid-layout": "^1.4.4",
     "sonner": "^2.0.7",
-    "spoqa-han-sans": "^3.3.0",
     "tiptap-markdown": "^0.8.10",
     "wawoff2": "^2.0.1",
     "zustand": "^4.5.2"

--- a/src/components/settings/FontFamilySection.tsx
+++ b/src/components/settings/FontFamilySection.tsx
@@ -102,8 +102,20 @@ export function FontFamilySection() {
   /**
    * + 글꼴 추가 / 삭제처럼 customFonts 자체를 변경하는 흐름 — 즉시 저장.
    * 사용자 explicit action이라 race 거의 없음(busy 플래그 + confirm dialog로 보호).
+   *
+   * 코덱스 PR #62 리뷰 P1: persistFamilyOnly가 디바운스 큐에 stale family 값을 넣어둔
+   * 상태에서 사용자가 빠르게 글꼴 추가/삭제하면, 디바운스 콜백이 immediate save 후에
+   * 실행되어 stale fontFamily(이미 삭제된 custom 폰트 ID 등)로 disk를 덮어쓸 수 있음.
+   * persistFontsList가 발화되면 pending family 디바운스를 즉시 cancel.
    */
   const persistFontsList = useCallback(async (familyId: string, nextCustomFonts: CustomFont[]) => {
+    // ★ 디바운스 cancel — pending family 콜백이 stale 값으로 overwrite하지 못하게.
+    if (familySaveTimerRef.current) {
+      clearTimeout(familySaveTimerRef.current);
+      familySaveTimerRef.current = null;
+    }
+    pendingFamilyRef.current = null;
+
     applyFontFamily(familyId, nextCustomFonts);
     setFontFamily(familyId);
     setCustomFonts(nextCustomFonts);

--- a/src/components/settings/FontFamilySection.tsx
+++ b/src/components/settings/FontFamilySection.tsx
@@ -39,6 +39,11 @@ export function FontFamilySection() {
   const customFontsRef = useRef<CustomFont[]>([]);
   useEffect(() => { customFontsRef.current = customFonts; }, [customFonts]);
 
+  // 코덱스 PR #62 3차 P2: handleDrop이 busy 체크 안 해서 concurrent run 가능 (drop 두 번
+  // 빠르게) → 각 호출이 stale baseline에서 diff 계산 → last save wins → 일부 폰트 silent
+  // drop. busyRef로 동기 lock 추가 (setBusy는 비동기라 useState만으론 race).
+  const busyRef = useRef(false);
+
   // 저장된 설정 로드
   useEffect(() => {
     let cancelled = false;
@@ -189,19 +194,22 @@ export function FontFamilySection() {
       toast.error('Electron API를 사용할 수 없습니다.');
       return;
     }
+    if (busyRef.current) return; // 동기 lock — concurrent run 차단 (3차 P2)
+    busyRef.current = true;
     setBusy(true);
     try {
       const results = await window.electronAPI.fontAdd();
       const added = processAddResults(results);
       if (added.length > 0) {
-        const next = [...customFonts, ...added];
+        const next = [...customFontsRef.current, ...added];
         ensureCustomFontsLoaded(added); // 새로 추가된 것만 inject
         await persistAndApply(fontFamily, next);
       }
     } finally {
+      busyRef.current = false;
       setBusy(false);
     }
-  }, [customFonts, fontFamily, persistAndApply, processAddResults]);
+  }, [fontFamily, persistAndApply, processAddResults]);
 
   const handleDrop = useCallback(async (e: React.DragEvent) => {
     e.preventDefault();
@@ -211,6 +219,7 @@ export function FontFamilySection() {
       toast.error('Electron API를 사용할 수 없습니다.');
       return;
     }
+    if (busyRef.current) return; // 동기 lock — drop concurrent run 차단 (3차 P2)
     // Electron 32+에선 File.path가 제거됨 → webUtils.getPathForFile 사용 (preload 경유)
     const paths = Array.from(e.dataTransfer.files)
       .map((f) => window.electronAPI!.fontGetPathForFile(f))
@@ -219,37 +228,47 @@ export function FontFamilySection() {
       toast.error('드롭된 파일에서 경로를 읽을 수 없습니다.');
       return;
     }
+    busyRef.current = true;
     setBusy(true);
     try {
       const results = await window.electronAPI.fontAddByPath(paths);
       const added = processAddResults(results);
       if (added.length > 0) {
-        const next = [...customFonts, ...added];
+        const next = [...customFontsRef.current, ...added];
         ensureCustomFontsLoaded(added);
         await persistAndApply(fontFamily, next);
       }
     } finally {
+      busyRef.current = false;
       setBusy(false);
     }
-  }, [customFonts, fontFamily, persistAndApply, processAddResults]);
+  }, [fontFamily, persistAndApply, processAddResults]);
 
   const handleDelete = useCallback(async (font: CustomFont) => {
+    if (busyRef.current) return; // 동기 lock — concurrent delete/add 차단 (3차 P2)
     if (!confirm(`"${font.name}" 글꼴을 삭제하시겠습니까?`)) return;
+    if (busyRef.current) return; // confirm 동안 다른 작업 시작 가능 → 재체크
     if (!window.electronAPI?.fontDelete) return;
-    // Codex 6차 P2: IPC 결과 무시하고 항상 제거하면 파일 잠금/권한 실패 시 orphan 파일 발생.
-    // 성공 시에만 로컬 state/preferences에서 제거하고, 실패 시 토스트로 안내 + 재시도 가능.
-    const result = await window.electronAPI.fontDelete({ id: font.id, filename: font.filename });
-    if (!result?.ok) {
-      toast.error(`"${font.name}" 삭제 실패: ${result?.error ?? '알 수 없는 오류'} — 다시 시도해주세요.`);
-      return;
+    busyRef.current = true;
+    setBusy(true);
+    try {
+      // Codex 6차 P2: IPC 결과 무시하고 항상 제거하면 파일 잠금/권한 실패 시 orphan 파일 발생.
+      const result = await window.electronAPI.fontDelete({ id: font.id, filename: font.filename });
+      if (!result?.ok) {
+        toast.error(`"${font.name}" 삭제 실패: ${result?.error ?? '알 수 없는 오류'} — 다시 시도해주세요.`);
+        return;
+      }
+      const next = customFontsRef.current.filter((f) => f.id !== font.id);
+      // 삭제 중이던 폰트가 현재 적용 중이면 → DEFAULT_FONT_FAMILY로 폴백
+      const fallbackId = fontFamily === font.id ? DEFAULT_FONT_FAMILY : fontFamily;
+      // <head>에서 @font-face 제거
+      document.querySelector(`style[data-font-id="${font.id}"]`)?.remove();
+      await persistAndApply(fallbackId, next);
+    } finally {
+      busyRef.current = false;
+      setBusy(false);
     }
-    const next = customFonts.filter((f) => f.id !== font.id);
-    // 삭제 중이던 폰트가 현재 적용 중이면 → DEFAULT_FONT_FAMILY로 폴백
-    const fallbackId = fontFamily === font.id ? DEFAULT_FONT_FAMILY : fontFamily;
-    // <head>에서 @font-face 제거
-    document.querySelector(`style[data-font-id="${font.id}"]`)?.remove();
-    await persistAndApply(fallbackId, next);
-  }, [customFonts, fontFamily, persistAndApply]);
+  }, [fontFamily, persistAndApply]);
 
   if (!hasLoaded) return null;
 

--- a/src/components/settings/FontFamilySection.tsx
+++ b/src/components/settings/FontFamilySection.tsx
@@ -33,6 +33,12 @@ export function FontFamilySection() {
   const familySaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingFamilyRef = useRef<string | null>(null);
 
+  // 코덱스 PR #62 2차 P2: customFonts의 latest baseline 추적 ref.
+  // persistFontsList가 호출 시점 closure가 아닌 ref를 통해 baseline을 읽어 nextCustomFonts와
+  // diff 계산 → disk customFonts에 add/remove만 적용 (multi-window 안전).
+  const customFontsRef = useRef<CustomFont[]>([]);
+  useEffect(() => { customFontsRef.current = customFonts; }, [customFonts]);
+
   // 저장된 설정 로드
   useEffect(() => {
     let cancelled = false;
@@ -101,29 +107,48 @@ export function FontFamilySection() {
 
   /**
    * + 글꼴 추가 / 삭제처럼 customFonts 자체를 변경하는 흐름 — 즉시 저장.
-   * 사용자 explicit action이라 race 거의 없음(busy 플래그 + confirm dialog로 보호).
    *
-   * 코덱스 PR #62 리뷰 P1: persistFamilyOnly가 디바운스 큐에 stale family 값을 넣어둔
-   * 상태에서 사용자가 빠르게 글꼴 추가/삭제하면, 디바운스 콜백이 immediate save 후에
-   * 실행되어 stale fontFamily(이미 삭제된 custom 폰트 ID 등)로 disk를 덮어쓸 수 있음.
-   * persistFontsList가 발화되면 pending family 디바운스를 즉시 cancel.
+   * 코덱스 PR #62 1차 P1: persistFamilyOnly 디바운스가 stale family로 overwrite 막기 위해
+   * 진입 시 timer cancel.
+   *
+   * 코덱스 PR #62 2차 P2: 이전엔 nextCustomFonts(component-local state)를 disk에 통째 overwrite
+   * → 다른 window가 추가/삭제한 customFonts가 영구 손실. 해결: customFontsRef(local baseline)와
+   * nextCustomFonts의 diff = 이번 호출의 add/remove 의도. disk customFonts에 그것만 적용.
+   * 다른 window의 변경분도 보존.
    */
   const persistFontsList = useCallback(async (familyId: string, nextCustomFonts: CustomFont[]) => {
-    // ★ 디바운스 cancel — pending family 콜백이 stale 값으로 overwrite하지 못하게.
+    // ★ family 디바운스 cancel — pending stale family 콜백 overwrite 방지 (1차 P1).
     if (familySaveTimerRef.current) {
       clearTimeout(familySaveTimerRef.current);
       familySaveTimerRef.current = null;
     }
     pendingFamilyRef.current = null;
 
+    // baseline (이번 컴포넌트가 직전에 안 disk 상태) — ref로 latest 추적
+    const baseline = customFontsRef.current;
+    const baselineIds = new Set(baseline.map((f) => f.id));
+    const nextIds = new Set(nextCustomFonts.map((f) => f.id));
+    // 이번 호출에서 추가된 폰트 (baseline에 없고 next에 있는 것)
+    const addedNow = nextCustomFonts.filter((f) => !baselineIds.has(f.id));
+    // 이번 호출에서 삭제된 폰트 ID (baseline에 있고 next에 없는 것)
+    const removedIdsNow = baseline.filter((f) => !nextIds.has(f.id)).map((f) => f.id);
+
     applyFontFamily(familyId, nextCustomFonts);
     setFontFamily(familyId);
     setCustomFonts(nextCustomFonts);
     try {
       const prev = (await loadPreferences()) ?? {};
-      const merged = { ...prev, fontFamily: familyId, customFonts: nextCustomFonts };
+      const diskFonts = ((prev.customFonts ?? []) as CustomFont[]);
+      // disk → 이번 호출의 add/remove 의도만 적용 (다른 window 변경분 보존)
+      const mergedFonts: CustomFont[] = [
+        ...diskFonts.filter((d) => !removedIdsNow.includes(d.id)),
+        ...addedNow.filter((a) => !diskFonts.some((d) => d.id === a.id)),
+      ];
+      const merged = { ...prev, fontFamily: familyId, customFonts: mergedFonts };
       await savePreferences(merged);
       window.electronAPI?.preferencesBroadcastChange?.(merged);
+      // local state도 disk merge 결과로 동기화 — 다른 window의 새 폰트도 보임
+      setCustomFonts(mergedFonts);
     } catch (err) {
       console.error('[글꼴] customFonts 저장 실패:', err);
     }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -49,8 +49,6 @@ import '@fontsource/noto-serif-kr/latin-400.css';
 import '@fontsource/noto-serif-kr/latin-500.css';
 import '@fontsource/noto-serif-kr/latin-700.css';
 
-import 'spoqa-han-sans/css/SpoqaHanSansNeo.css';
-
 import './index.css';
 import './styles/path-link.css';
 import './styles/activity-widget.css';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,24 +4,51 @@ import App from './App';
 import { WidgetPopup } from './views/WidgetPopup';
 
 // v1.20.0: 글꼴 시스템 — 큐레이션 9종 중 8종 (시스템 기본은 OS 글꼴, import 불필요)
-// Pretendard Variable: 가변 폰트 1개 파일 → 모든 weight 자동 처리, 가장 효율적
+//
+// 코덱스 PR #62 3차 P1: @fontsource의 weight별 .css는 *모든 subset*(한자 unified
+// ideographs, cyrillic, greek 등)을 포함시켜 빌드 size가 1GB로 폭증. Studio JBBJ
+// 사용자는 한국어+영어/숫자 위주이므로 `korean-<weight>.css` + `latin-<weight>.css`
+// subset만 명시 import → CJK 한자/cyrillic/greek 등 제외 → 빌드 size 70%+ 감소.
+//
+// Pretendard Variable: 가변 폰트 1개 파일 → 모든 weight 자동 처리.
 import 'pretendard/dist/web/variable/pretendardvariable.css';
-import '@fontsource/inter/400.css';
-import '@fontsource/inter/500.css';
-import '@fontsource/inter/600.css';
-import '@fontsource/inter/700.css';
-import '@fontsource/noto-sans-kr/400.css';
-import '@fontsource/noto-sans-kr/500.css';
-import '@fontsource/noto-sans-kr/700.css';
-import '@fontsource/ibm-plex-sans-kr/400.css';
-import '@fontsource/ibm-plex-sans-kr/500.css';
-import '@fontsource/ibm-plex-sans-kr/700.css';
-import '@fontsource/nanum-gothic/400.css';
-import '@fontsource/nanum-gothic/700.css';
-import '@fontsource/gowun-dodum/400.css';
-import '@fontsource/noto-serif-kr/400.css';
-import '@fontsource/noto-serif-kr/500.css';
-import '@fontsource/noto-serif-kr/700.css';
+
+// Inter — 영문 우선. latin subset만.
+import '@fontsource/inter/latin-400.css';
+import '@fontsource/inter/latin-500.css';
+import '@fontsource/inter/latin-600.css';
+import '@fontsource/inter/latin-700.css';
+
+// 한국어 폰트들 — korean + latin subset (한자/cyrillic/greek 등 제외).
+import '@fontsource/noto-sans-kr/korean-400.css';
+import '@fontsource/noto-sans-kr/korean-500.css';
+import '@fontsource/noto-sans-kr/korean-700.css';
+import '@fontsource/noto-sans-kr/latin-400.css';
+import '@fontsource/noto-sans-kr/latin-500.css';
+import '@fontsource/noto-sans-kr/latin-700.css';
+
+import '@fontsource/ibm-plex-sans-kr/korean-400.css';
+import '@fontsource/ibm-plex-sans-kr/korean-500.css';
+import '@fontsource/ibm-plex-sans-kr/korean-700.css';
+import '@fontsource/ibm-plex-sans-kr/latin-400.css';
+import '@fontsource/ibm-plex-sans-kr/latin-500.css';
+import '@fontsource/ibm-plex-sans-kr/latin-700.css';
+
+import '@fontsource/nanum-gothic/korean-400.css';
+import '@fontsource/nanum-gothic/korean-700.css';
+import '@fontsource/nanum-gothic/latin-400.css';
+import '@fontsource/nanum-gothic/latin-700.css';
+
+import '@fontsource/gowun-dodum/korean-400.css';
+import '@fontsource/gowun-dodum/latin-400.css';
+
+import '@fontsource/noto-serif-kr/korean-400.css';
+import '@fontsource/noto-serif-kr/korean-500.css';
+import '@fontsource/noto-serif-kr/korean-700.css';
+import '@fontsource/noto-serif-kr/latin-400.css';
+import '@fontsource/noto-serif-kr/latin-500.css';
+import '@fontsource/noto-serif-kr/latin-700.css';
+
 import 'spoqa-han-sans/css/SpoqaHanSansNeo.css';
 
 import './index.css';

--- a/src/utils/typography.ts
+++ b/src/utils/typography.ts
@@ -249,7 +249,10 @@ export const FONT_FAMILIES: FontFamilyMeta[] = [
   { id: 'inter',         label: 'Inter',              cssStack: `Inter, 'Pretendard Variable', Pretendard, system-ui, sans-serif`, group: 'modern' },
   { id: 'noto-sans-kr',  label: 'Noto Sans KR',       cssStack: `'Noto Sans KR', system-ui, sans-serif`, group: 'modern' },
   { id: 'ibm-plex-kr',   label: 'IBM Plex Sans KR',   cssStack: `'IBM Plex Sans KR', system-ui, sans-serif`, group: 'serious' },
-  { id: 'spoqa',         label: 'Spoqa Han Sans Neo', cssStack: `'Spoqa Han Sans Neo', system-ui, sans-serif`, group: 'serious' },
+  // Spoqa Han Sans Neo: 패키지가 모든 weight×모든 format(woff2/woff/ttf)을 한 덩어리로 묶어
+  // 빌드 size 30~50MB 차지. fontsource처럼 subset 분리 X → 큐레이션에서 제외 (한솔 결정,
+  // PR #62 4차 P2 대안). 옛 preferences에 'spoqa' 남아있으면 applyFontFamily가 FALLBACK_STACK
+  // (Pretendard)로 자동 폴백.
   { id: 'nanum-gothic',  label: '나눔고딕',           cssStack: `'Nanum Gothic', system-ui, sans-serif`, group: 'soft' },
   { id: 'gowun-dodum',   label: '고운 도담',          cssStack: `'Gowun Dodum', system-ui, sans-serif`, group: 'soft' },
   { id: 'noto-serif-kr', label: '본명조',             cssStack: `'Noto Serif KR', serif`, group: 'character' },


### PR DESCRIPTION
## 📝 핵심 변경

### portable target 제거 (PR 본질)
- `package.json`: `"win.target": "portable"` → `"dir"`. portable BFLOW.exe 빌드 자체 안 됨.
- 한솔님 워크플로우(win-unpacked\BFLOW.exe만 사용)와 정합. 잘못 클릭할 진입점 X.

### 빌드 size 대폭 감소 (코덱스 5차 P1 — 진짜 큰 발견)
- `package.json` `build.files`에 `"!node_modules/@fontsource/**"`, `"!node_modules/pretendard/**"` 추가.
- fontsource 패키지가 vite 산출물(dist/assets) + node_modules 통째 두 번 번들되던 redundant 제거.

### @fontsource subset 명시 (size + 깔끔)
- `main.tsx`: `@fontsource/<family>/400.css` → `@fontsource/<family>/korean-400.css` + `latin-400.css`.
- 한자 unified ideographs / cyrillic / greek 등 사용자가 안 보는 subset 제외.

### Spoqa 큐레이션 제외 (한솔 결정)
- Spoqa Han Sans Neo 패키지는 모든 weight × 모든 format(woff2/woff/ttf)을 한 덩어리로 번들 → fontsource처럼 subset 분리 X.
- 큐레이션 9종 → 8종. 사용자 preferences에 `'spoqa'` 잔존하면 Pretendard로 자동 폴백.

### 글꼴 시스템 race condition fix 4건 (코덱스 review)
- `FontFamilySection.tsx`:
  · 디바운스 race (1차 P1)
  · multi-window data loss (2차 P2)
  · busyRef 동기 lock — concurrent add/delete 차단 (3차 P2)
  · diff 기반 disk merge (다른 window 변경분 보존)

---

## 📊 빌드 size 비교 (v1.21.0 → v1.21.1)

| | files | bytes | win-unpacked |
|---|---|---|---|
| **v1.21.0** | 18,517 | 1,043 MB | 1,100 MB |
| **v1.21.1 (이 PR)** | **7,070** | **687 MB** | **671 MB** |
| **감소** | **-11,447 (-62%)** | **-356 MB (-34%)** | **-429 MB** |

추가로 `dist/BFLOW.exe` (portable 466 MB) **빌드 자체 사라짐**.

---

## 🛠 코덱스 review 6 라운드 누적

PR 생성 직후 코덱스 자동 review가 v1.20.0 글꼴 시스템 코드의 잠재 race condition들을 함께 잡음 → 같이 fix.

| 라운드 | 처리 |
|--------|------|
| 1차 | P1 디바운스 race |
| 2차 | P2 multi-window data loss |
| 3차 | P1 subset 명시 + P2 busyRef |
| 4차 | P2 Spoqa 큐레이션 제외 |
| **5차** | **P1 node_modules redundant** ⭐ -262 MB |
| 6차 | (false positive — 이미 처리된 race) |

---

## 🧪 테스트 가이드

### 시나리오 1: 빌드 + dist 검증
- [ ] `dist/BFLOW.exe` (portable) **없음** ← 정확히 의도대로
- [ ] `dist/win-unpacked/BFLOW.exe` 188 MB 정상
- [ ] `dist/manifest.json` v1.21.1 / fileCount 7070 / totalBytes ≈ 687 MB
- [ ] `dist/win-unpacked/resources/app/node_modules/@fontsource` **없음** (제외 정상 작동)

### 시나리오 2: 한솔님 일상 사용
- [ ] 바탕화면 "B flow" 더블클릭 → 1~2초 시작 (변화 X — 이미 win-unpacked exe 사용 중)

### 시나리오 3: 글꼴 변경 (Spoqa 사라짐 확인)
- [ ] 설정 → 글꼴 → 기본 글꼴 그룹에 **8개 칩** (Spoqa 빠짐)
- [ ] 옛 사용자가 Spoqa 적용 중이었어도 자동 Pretendard 폴백

### 시나리오 4: 자동 업데이트 시스템 호환성
- [ ] win-unpacked\BFLOW.exe로 진입해도 self-installer 정상 (v1.21.0 호환)

---

## ⚠️ 머지 후 한솔님 명시 시에만

- 머지 → "머지해" 시
- 풀 빌드 + G드라이브 robocopy /MIR (이전 portable BFLOW.exe 자동 삭제)
- 슬랙 공지

🤖 Generated with [Claude Code](https://claude.com/claude-code)