### PR TITLE
[v1.21.3] 이미 설치된 PC 자동 바로가기 self-heal

### DIFF
--- a/electron/autoUpdate/installer.ts
+++ b/electron/autoUpdate/installer.ts
@@ -16,6 +16,7 @@ import {
   localPendingDir,
   localBflowExe,
   localInstalledMarker,
+  localSelfHealFailedMarker,
 } from './paths';
 import { copyDirMirror } from './copy';
 
@@ -44,6 +45,11 @@ export async function runFirstInstallIfNeeded(): Promise<InstallResult> {
   const partialInstall = existsSync(localExe) && !existsSync(installedMarker);
 
   if (fullyInstalled) {
+    // v1.21.3 self-heal: desktop/startMenu 바로가기 둘 다 부재 시 보충 시도.
+    // v1.21.1 install이 shell.writeShortcutLink silent fail로 바로가기 없이
+    // 끝난 PC를 위한 안전망 — v1.21.2 PowerShell COM 폴백을 활용해 보충.
+    // 실패해도 relaunch는 막지 않음 (.shortcut-self-heal-failed 마커로 재시도 억제).
+    await ensureShortcutsExist();
     // spec §4.4: 옛 바로가기 폴백. 로컬 본체로 spawn하고 자기는 종료.
     relaunchAndExit(localExe);
     return { exited: true };
@@ -125,6 +131,34 @@ async function install(): Promise<void> {
   const desktopOk = await createDesktopShortcut();
   const startMenuOk = await createStartMenuShortcut();
   if (!desktopOk && !startMenuOk) {
+    await notifyShortcutFailure();
+  }
+}
+
+/**
+ * v1.21.3 self-heal — fullyInstalled 분기에서 호출. desktop OR startMenu .lnk 중
+ * 하나라도 있으면 noop. 둘 다 부재 시 보충 시도하되, 이전에 실패한 적 있으면
+ * (.shortcut-self-heal-failed 마커) skip해 매 실행 dialog spam 방지.
+ */
+async function ensureShortcutsExist(): Promise<void> {
+  const desktopLnk = path.join(process.env.USERPROFILE || '', 'Desktop', 'B flow.lnk');
+  const startMenuLnk = path.join(
+    process.env.APPDATA || '',
+    'Microsoft', 'Windows', 'Start Menu', 'Programs', 'B flow.lnk',
+  );
+  if (existsSync(desktopLnk) || existsSync(startMenuLnk)) return;
+
+  const failedMarker = localSelfHealFailedMarker();
+  if (existsSync(failedMarker)) return;
+
+  const desktopOk = await createDesktopShortcut();
+  const startMenuOk = await createStartMenuShortcut();
+  if (!desktopOk && !startMenuOk) {
+    try {
+      await fsp.writeFile(failedMarker, new Date().toISOString() + '\n', 'utf-8');
+    } catch (err) {
+      console.warn('[installer] self-heal failed marker 작성 실패 (무시):', err);
+    }
     await notifyShortcutFailure();
   }
 }

--- a/electron/autoUpdate/paths.ts
+++ b/electron/autoUpdate/paths.ts
@@ -47,6 +47,18 @@ export function localInstalledMarker(): string {
 }
 
 /**
+ * Self-heal 시도 실패 마커 (v1.21.3). fullyInstalled 분기에서 desktop/startMenu 바로가기가
+ * 모두 부재해 self-heal을 시도했으나 둘 다 실패한 경우 작성. 다음 실행부터 self-heal을
+ * skip해 매 실행마다 동일 dialog 띄우는 annoyance 방지.
+ *
+ * 사용자가 수동으로 .lnk를 만들면 ensureShortcutsExist의 existsSync 검사가 즉시 noop이
+ * 되므로 마커가 남아있어도 영향 없음.
+ */
+export function localSelfHealFailedMarker(): string {
+  return path.join(localRoot(), '.shortcut-self-heal-failed');
+}
+
+/**
  * Swap 직후 첫 실행 검증 마커 — swapper가 swap 완료 후 작성, healthCheck가 해당 실행이
  * 정상 메인 창 도달하면 삭제.
  *

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.21.2",
+  "version": "1.21.3",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
## 배경

v1.21.1로 설치된 PC들은 install 시 `shell.writeShortcutLink`가 silent fail해 데스크톱 바로가기 없이 끝남. v1.21.2의 PowerShell COM 폴백은 `install()` 함수 안에서만 호출되므로, 이미 `.installed` 마커가 있는 PC는 fullyInstalled 분기로 빠져 영영 보충되지 않음. 이런 PC는 매번 G드라이브 `BFLOW.exe`를 클릭하면 매번 ~14초+ Defender 검사를 거치는 상태.

(한솔 PC가 정확히 이 케이스 — 이번 세션에서 PowerShell COM으로 수동 검증 후 v1.21.2 PR 머지)

## Fix

`fullyInstalled` 분기에 `ensureShortcutsExist()` 추가:

1. desktop **OR** startMenu .lnk 하나라도 있음 → noop
2. 둘 다 부재 + `.shortcut-self-heal-failed` 마커 없음 → `createShortcut` 시도 (v1.21.2 1차 Electron API → 2차 PowerShell COM 폴백 활용)
3. 시도 실패 → 마커 작성 + 안내 dialog 한 번. 다음 실행부터 self-heal 자체 skip
4. 사용자가 수동으로 .lnk 만들면 existsSync 검사가 noop → 마커 영향 없음

## 시나리오

| PC | 결과 |
|---|---|
| 한솔 PC (이미 수동 .lnk 있음) | self-heal noop, 정상 진행 |
| v1.21.1 설치 + .lnk 없음 + 새로 G드라이브 BFLOW.exe 클릭 | self-heal로 자동 보충 |
| v1.21.2 새 install | install() 흐름에서 이미 보충됨 |

## 검증

- `tsc --noEmit` ✅
- `vite build` ✅
- 단위 검증: existsSync 분기 수동 트레이스

🤖 Generated with [Claude Code](https://claude.com/claude-code)