### PR TITLE
[v1.22.0] NSIS 단일 인스톨러 도입 — 첫 설치 매우 느림 fix

### DIFF
--- a/electron/autoUpdate/installer.ts
+++ b/electron/autoUpdate/installer.ts
@@ -26,14 +26,46 @@ export interface InstallResult {
 }
 
 /**
+ * NSIS 설치 PC 감지 — `%LOCALAPPDATA%\Programs\BFLOW\Uninstall BFLOW.exe` 존재 여부.
+ * v1.22.0+ 부터 NSIS가 첫 설치를 담당하므로 NSIS 흔적이 있으면 self-installer 흐름은
+ * 무관 — 사용자가 잘못된 경로(G드라이브 win-unpacked)를 클릭한 상황으로 안내만.
+ */
+function isNsisInstalled(): boolean {
+  const localAppData = process.env.LOCALAPPDATA
+    || path.join(process.env.USERPROFILE || '', 'AppData', 'Local');
+  return existsSync(path.join(localAppData, 'Programs', 'BFLOW', 'Uninstall BFLOW.exe'));
+}
+
+/**
  * main.ts의 app.whenReady 진입 직후 한 번 호출.
- * - G드라이브에서 실행됐고 로컬 본체 없으면 → 첫 설치 (dialog → 복사 → spawn).
- * - G드라이브에서 실행됐고 로컬 본체 있으면 → 즉시 로컬 spawn (옛 바로가기 폴백).
  * - 로컬에서 실행됐으면 → 그냥 정상 진행 (return { exited: false }).
+ * - G드라이브에서 실행됐고 NSIS로 이미 설치돼 있으면 → 안내 dialog + 종료
+ *   (사용자가 잘못된 경로를 클릭한 경우. v1.22.0+ NSIS Setup이 정식 첫 설치).
+ * - G드라이브에서 실행됐고 v1.21.x self-installer로 설치돼 있으면 → 즉시 로컬 spawn (옛 바로가기 폴백).
+ * - G드라이브에서 실행됐고 미설치 + NSIS 없음 → 옛 self-installer 첫 설치 흐름 (호환).
+ *   (정상 경로는 BFLOW-Setup.exe 클릭이지만 사용자가 win-unpacked\BFLOW.exe를 클릭한
+ *    edge case 호환 — 매우 느리지만 동작은 함.)
  */
 export async function runFirstInstallIfNeeded(): Promise<InstallResult> {
   if (!isRunningFromGoogleDrive()) {
     return { exited: false };
+  }
+
+  // v1.22.0: NSIS 설치 PC면 안내 dialog만 띄우고 종료. 자동업데이트는 데스크톱 바로가기로
+  // 시작된 BFLOW가 백그라운드에서 처리하므로 G드라이브 직접 실행 자체가 불필요.
+  if (isNsisInstalled()) {
+    await dialog.showMessageBox({
+      type: 'warning',
+      title: 'B flow — 잘못된 실행 경로',
+      message: '데스크톱의 "B flow" 바로가기를 사용해주세요',
+      detail:
+        'G드라이브에서 직접 실행하면 매우 느립니다.\n\n'
+        + '이미 PC에 설치되어 있으니 바탕화면 또는 시작 메뉴의 "B flow" 바로가기를 사용하세요.\n\n'
+        + '(자동 업데이트는 백그라운드에서 처리되므로 G드라이브 직접 실행은 불필요합니다.)',
+      buttons: ['확인'],
+    });
+    app.exit(0);
+    return { exited: true };
   }
 
   const localExe = localBflowExe();

--- a/electron/autoUpdate/installer.ts
+++ b/electron/autoUpdate/installer.ts
@@ -26,14 +26,21 @@ export interface InstallResult {
 }
 
 /**
- * NSIS 설치 PC 감지 — `%LOCALAPPDATA%\Programs\BFLOW\Uninstall BFLOW.exe` 존재 여부.
+ * NSIS 설치 PC 감지 — electron-builder의 oneClick + perMachine: false 기본 install dir은
+ * `%LOCALAPPDATA%\Programs\${name}\` (package.json의 `name` 필드, 소문자 'bflow'). 그 안에
+ * `Uninstall ${productName}.exe` ('BFLOW' 대문자)가 NSIS uninstaller 파일명.
+ *
  * v1.22.0+ 부터 NSIS가 첫 설치를 담당하므로 NSIS 흔적이 있으면 self-installer 흐름은
  * 무관 — 사용자가 잘못된 경로(G드라이브 win-unpacked)를 클릭한 상황으로 안내만.
+ *
+ * Codex 1차 P1: 이전엔 'Programs/BFLOW/' (대문자) 검사 → electron-builder는 'name' 필드를
+ * 폴더명으로 쓰므로 실제 install dir은 'Programs/bflow/' (소문자). 검사 miss → NSIS 설치
+ * PC가 G드라이브 win-unpacked 클릭 시 안내 dialog 없이 옛 self-installer 흐름 진입.
  */
 function isNsisInstalled(): boolean {
   const localAppData = process.env.LOCALAPPDATA
     || path.join(process.env.USERPROFILE || '', 'AppData', 'Local');
-  return existsSync(path.join(localAppData, 'Programs', 'BFLOW', 'Uninstall BFLOW.exe'));
+  return existsSync(path.join(localAppData, 'Programs', 'bflow', 'Uninstall BFLOW.exe'));
 }
 
 /**

--- a/electron/autoUpdate/paths.ts
+++ b/electron/autoUpdate/paths.ts
@@ -2,34 +2,67 @@
  * v1.21.0 자동 업데이트 — 모든 경로 상수 + G드라이브 폴더 추정.
  * 순수 함수만. fs 사이드 이펙트 X (existsSync 같은 lookup만 허용).
  *
- * spec §3 디렉토리 레이아웃:
- *   %LOCALAPPDATA%\Bflow-BGonly\
- *     ├ app\       ← 현재 사용 중 BFLOW (win-unpacked 통째로)
- *     ├ pending\   ← 백그라운드로 받은 새 버전 (종료 시 swap 대기)
- *     └ backup\    ← 이전 버전 1개 (긴급 롤백용)
+ * v1.22.0: NSIS 설치 도입 → process.execPath 기준 동적 경로로 전환. NSIS 설치
+ * (`%LOCALAPPDATA%\Programs\BFLOW\`)와 기존 v1.21.x self-installer 설치
+ * (`%LOCALAPPDATA%\Bflow-BGonly\app\`) 모두 자동 인식.
+ *
+ * 디렉토리 레이아웃 (실행 위치에 따라 자동):
+ *   NSIS 설치:
+ *     %LOCALAPPDATA%\Programs\BFLOW\          ← localAppDir (실행 중)
+ *     %LOCALAPPDATA%\Programs\BFLOW-pending\  ← localPendingDir
+ *     %LOCALAPPDATA%\Programs\BFLOW-backup\   ← localBackupDir
+ *     %LOCALAPPDATA%\Bflow-BGonly\            ← localRoot (마커 전용)
+ *
+ *   v1.21.x self-installer 설치:
+ *     %LOCALAPPDATA%\Bflow-BGonly\app\         ← localAppDir
+ *     %LOCALAPPDATA%\Bflow-BGonly\app-pending\ ← localPendingDir
+ *     %LOCALAPPDATA%\Bflow-BGonly\app-backup\  ← localBackupDir
+ *     %LOCALAPPDATA%\Bflow-BGonly\            ← localRoot
+ *
+ * (개발 모드: process.execPath = electron.exe → 안전한 fallback 경로 사용)
  */
 import { app } from 'electron';
 import { existsSync, statSync } from 'fs';
 import path from 'path';
 
-/** 로컬 본체 루트 — `%LOCALAPPDATA%\Bflow-BGonly\` */
+/**
+ * 마커 파일들이 들어가는 root — 항상 `%LOCALAPPDATA%\Bflow-BGonly\`.
+ * 설치 위치(NSIS vs self-installer)와 무관하게 일관되게 마커를 한 곳에 모으기 위해 고정.
+ */
 export function localRoot(): string {
-  // app.getPath('userData') = %APPDATA%\Bflow-BGonly (Roaming) — 사용자 데이터용.
-  // 우리는 LocalAppData를 별도로 사용 — sync 안 됨 + Roaming보다 디스크 빠름.
   const localAppData = process.env.LOCALAPPDATA
     || path.join(process.env.USERPROFILE || '', 'AppData', 'Local');
   return path.join(localAppData, 'Bflow-BGonly');
 }
 
+/**
+ * 현재 실행 중인 BFLOW.exe의 폴더 — swap 대상.
+ * - NSIS 설치: `%LOCALAPPDATA%\Programs\BFLOW\`
+ * - v1.21.x self-installer: `%LOCALAPPDATA%\Bflow-BGonly\app\`
+ * - 개발 모드(process.execPath = electron.exe): 호환을 위해 v1.21.x 기본 경로 fallback
+ * - G드라이브 직접 실행: G드라이브 폴더 자체를 swap target으로 잡으면 안 되므로
+ *   v1.21.x self-installer 기본 경로 fallback (옛 호환성). swap은 그 dir을 대상으로
+ *   하고, BFLOW.exe는 G드라이브에서 실행 중이라 swap 시 영향 없음.
+ */
+export function localAppDir(): string {
+  if (!app.isPackaged) {
+    return path.join(localRoot(), 'app');  // dev fallback
+  }
+  if (isRunningFromGoogleDrive()) {
+    return path.join(localRoot(), 'app');  // G드라이브 직접 실행 — fallback
+  }
+  return path.dirname(process.execPath);
+}
+
+/** swap 대상 폴더의 형제 — pending/backup도 같은 부모 아래 형제로 둬서 atomic rename 가능. */
+export function localPendingDir(): string { return localAppDir() + '-pending'; }
+export function localBackupDir(): string { return localAppDir() + '-backup'; }
+export function localReadyMarker(): string { return path.join(localPendingDir(), '.ready'); }
+
 export const APP_DIR_NAME = 'app';
 export const PENDING_DIR_NAME = 'pending';
 export const BACKUP_DIR_NAME = 'backup';
 export const READY_MARKER = '.ready';
-
-export function localAppDir(): string { return path.join(localRoot(), APP_DIR_NAME); }
-export function localPendingDir(): string { return path.join(localRoot(), PENDING_DIR_NAME); }
-export function localBackupDir(): string { return path.join(localRoot(), BACKUP_DIR_NAME); }
-export function localReadyMarker(): string { return path.join(localPendingDir(), READY_MARKER); }
 
 /** `app/BFLOW.exe` */
 export function localBflowExe(): string {

--- a/electron/autoUpdate/swapper.ts
+++ b/electron/autoUpdate/swapper.ts
@@ -75,6 +75,21 @@ export async function swapIfPending(): Promise<SwapResult> {
     console.warn('[swapper] 이전 backup 정리 실패 (무시):', err);
   }
 
+  // v1.22.0: NSIS Uninstall.exe 보존. NSIS 인스톨러로 설치된 경우 install dir에
+  // `Uninstall BFLOW.exe`가 있고, 그게 없으면 Windows "프로그램 추가/제거"의 BFLOW
+  // 항목이 깨짐. swap = pending → app dir rename이라 새 app dir엔 Uninstall이 없음.
+  // swap 직전에 pending으로 copy해 swap 후에도 보존.
+  const uninstallName = 'Uninstall BFLOW.exe';
+  const oldUninstall = path.join(app_, uninstallName);
+  const newUninstall = path.join(pending_, uninstallName);
+  if (existsSync(oldUninstall) && !existsSync(newUninstall)) {
+    try {
+      await fsp.copyFile(oldUninstall, newUninstall);
+    } catch (err) {
+      console.warn('[swapper] NSIS Uninstall.exe 보존 실패 (무시 — 자동업데이트 자체엔 무영향):', err);
+    }
+  }
+
   // 2. app/ → backup/  (rename + copy fallback)
   let movedToBackup = false;
   if (existsSync(app_)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.21.3",
+  "version": "1.22.0",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {
@@ -61,7 +61,22 @@
       "package.json"
     ],
     "win": {
-      "target": "dir"
+      "target": [
+        "nsis",
+        "dir"
+      ]
+    },
+    "nsis": {
+      "oneClick": true,
+      "perMachine": false,
+      "allowToChangeInstallationDirectory": false,
+      "createDesktopShortcut": true,
+      "createStartMenuShortcut": true,
+      "shortcutName": "B flow",
+      "menuCategory": false,
+      "deleteAppDataOnUninstall": false,
+      "runAfterFinish": true,
+      "artifactName": "BFLOW-Setup.${ext}"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
## 배경

v1.21.x는 G드라이브 `win-unpacked\BFLOW.exe` 클릭 시 7,000여 파일을 Drive Desktop이 lazy fetch하느라 다른 PC에서 매우 느림. 한솔 PC는 어떻게든 install 완료(.installed + app/BFLOW.exe 정상)됐지만 다른 팀원 PC는 사실상 사용 불가 수준 — 진행은 되지만 매우 천천히 fetch.

## Fix

NSIS 단일 인스톨러로 첫 설치 fetch 비용을 7,000파일 → 1파일로 압축.

### 변경

| 파일 | 변경 |
|---|---|
| `package.json` | `win.target: ["nsis", "dir"]` + NSIS 옵션 (oneClick, perMachine: false, 바로가기 자동 생성) |
| `paths.ts` | `process.execPath` 기준 동적 경로 — NSIS(`%LOCALAPPDATA%\Programs\BFLOW\`) + v1.21.x(`%LOCALAPPDATA%\Bflow-BGonly\app\`) 모두 자동 인식 |
| `swapper.ts` | NSIS `Uninstall BFLOW.exe`를 swap 직전 pending에 copy → "프로그램 추가/제거" 항목 보존 |
| `installer.ts` | NSIS 흔적 감지(Uninstall.exe). NSIS 설치 PC가 G드라이브 직접 실행 시 안내 dialog로 종료 |

### G드라이브 배포 구조

```
dist/
 ├── BFLOW-Setup.exe       ← 첫 설치용 (사용자 클릭)
 ├── win-unpacked/         ← 자동업데이트 fetch 원본
 └── manifest.json
```

### 호환성

| 시나리오 | 결과 |
|---|---|
| 새 팀원 PC | `BFLOW-Setup.exe` 클릭 → NSIS 자동 설치 (Drive fetch 200MB 한 번) |
| 한솔 PC (v1.21.x) | 자동업데이트 swap으로 v1.22.0 받음. process.execPath 기준이라 옛 경로 그대로 동작 |
| NSIS 설치 PC가 잘못해서 G드라이브 win-unpacked 클릭 | 안내 dialog → 종료 (느린 실행 회피) |
| v1.21.x PC가 G드라이브 win-unpacked 클릭 | 옛 self-heal 흐름으로 relaunch (호환) |

## 산출물 (로컬 빌드 검증)

- `BFLOW-Setup.exe` 200MB
- `win-unpacked/BFLOW.exe` 188MB
- `manifest.json` v1.22.0 / 7,071 files / 687MB

## 다음 PR

v1.22.1 — 토스트 자동업데이트 알림 ("새 버전 사용 가능 / 지금 재시작" 버튼)

## 검증

- `tsc --noEmit` ✅
- `vite build` + `electron-builder` (NSIS) ✅
- `node scripts/generate-manifest.js` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)