### PR TITLE
[v1.22.1] 자동업데이트 토스트 알림 — 상용 앱 패턴

### DIFF
--- a/electron/autoUpdate/checker.ts
+++ b/electron/autoUpdate/checker.ts
@@ -24,6 +24,11 @@ import { copyDirMirror } from './copy';
  *
  * v1.22.1: 다운로드 + .ready 마커 작성이 완료되면 onReady 콜백 호출. main.ts가
  * 이를 받아 renderer에 'update:ready' IPC 송신 → 토스트 띄움.
+ *
+ * Codex 1차 P2: pending이 이미 ready인 케이스에서 *현재 fetch한 manifest version*을
+ * 토스트로 알리면 misleading — pending에 들어있는 실제 build version과 다를 수 있음
+ * (옛 다운로드 + 그 사이 새 manifest push 시나리오). 실제 pending payload의 version을
+ * 읽어 알려준다.
  */
 export async function scheduleUpdateCheck(onReady?: (version: string) => void): Promise<void> {
   try {
@@ -47,10 +52,28 @@ export async function scheduleUpdateCheck(onReady?: (version: string) => void): 
     const downloaded = await downloadToPending(remote);
     if (downloaded) {
       console.log(`[autoUpdate] 다운로드 완료. 다음 종료 시 swap.`);
-      onReady?.(remote.version);
+      // pending이 이미 ready였을 수도 있으므로 실제 pending payload version 우선.
+      const pendingVer = await readPendingVersion();
+      onReady?.(pendingVer ?? remote.version);
     }
   } catch (err) {
     console.warn('[autoUpdate] 체크 실패:', err);
+  }
+}
+
+/**
+ * pending 폴더 안의 실제 빌드 version 읽기 — `pending/resources/app/package.json`.
+ * pending이 옛 fetch 결과라면 fresh manifest와 version이 다를 수 있어, 토스트 표시는
+ * 이 함수 결과를 우선 사용해야 swap 후 실제 적용될 version과 일치.
+ */
+async function readPendingVersion(): Promise<string | null> {
+  try {
+    const pkgPath = path.join(localPendingDir(), 'resources', 'app', 'package.json');
+    const content = await fsp.readFile(pkgPath, 'utf-8');
+    const parsed = JSON.parse(content);
+    return typeof parsed?.version === 'string' ? parsed.version : null;
+  } catch {
+    return null;
   }
 }
 

--- a/electron/autoUpdate/checker.ts
+++ b/electron/autoUpdate/checker.ts
@@ -18,11 +18,14 @@ import { readManifest, compareVersions, countFilesAndBytes, type Manifest } from
 import { copyDirMirror } from './copy';
 
 /**
- * 백그라운드 체크 — 한 번만 실행. 실패는 console.warn만 (사용자 알림 X — UX 패턴 A).
+ * 백그라운드 체크 — 한 번만 실행. 실패는 console.warn만.
  *
  * 호출자: main.ts의 mainWindow.webContents.once('did-finish-load') → setTimeout 5초 후.
+ *
+ * v1.22.1: 다운로드 + .ready 마커 작성이 완료되면 onReady 콜백 호출. main.ts가
+ * 이를 받아 renderer에 'update:ready' IPC 송신 → 토스트 띄움.
  */
-export async function scheduleUpdateCheck(): Promise<void> {
+export async function scheduleUpdateCheck(onReady?: (version: string) => void): Promise<void> {
   try {
     const remoteManifestPath = findRemoteManifest();
     if (!remoteManifestPath) {
@@ -41,22 +44,26 @@ export async function scheduleUpdateCheck(): Promise<void> {
       return;
     }
     console.log(`[autoUpdate] 새 버전 감지: ${own} → ${remote.version}. 백그라운드 다운로드 시작.`);
-    await downloadToPending(remote);
-    console.log(`[autoUpdate] 다운로드 완료. 다음 종료 시 swap.`);
+    const downloaded = await downloadToPending(remote);
+    if (downloaded) {
+      console.log(`[autoUpdate] 다운로드 완료. 다음 종료 시 swap.`);
+      onReady?.(remote.version);
+    }
   } catch (err) {
     console.warn('[autoUpdate] 체크 실패:', err);
   }
 }
 
-async function downloadToPending(remoteManifest: Manifest): Promise<void> {
+async function downloadToPending(remoteManifest: Manifest): Promise<boolean> {
   const remoteWinUnpacked = findRemoteWinUnpacked();
   if (!remoteWinUnpacked) throw new Error('원격 win-unpacked 없음');
 
   // pending이 .ready 상태(이전 다운로드 완료)인 경우는 그대로 둠 — swap만 기다림.
+  // v1.22.1: 이미 ready여도 토스트는 띄워야 함(이전 세션에서 사용자가 못 봤을 수 있음).
   const ready = localReadyMarker();
   if (existsSync(ready)) {
     console.log('[autoUpdate] pending이 이미 ready 상태 — 추가 다운로드 skip');
-    return;
+    return true;
   }
 
   // Codex 9차 P1: 원격 sync 완전성 사전 검증.
@@ -74,13 +81,13 @@ async function downloadToPending(remoteManifest: Manifest): Promise<void> {
         + `${expected.totalBytes}B, 실제: ${remoteActual.fileCount}files/${remoteActual.totalBytes}B). `
         + `다음 체크 cycle에서 재시도.`,
       );
-      return; // .ready 작성 X
+      return false; // .ready 작성 X
     }
   }
   // 호환 폴백 — 옛 manifest(fileCount 없음)는 핵심 파일 (BFLOW.exe) 존재만 검증
   if (!expected && !existsSync(path.join(remoteWinUnpacked, 'BFLOW.exe'))) {
     console.log('[autoUpdate] G드라이브 win-unpacked에 BFLOW.exe 없음 — sync 미완료, 다음 cycle 재시도');
-    return;
+    return false;
   }
 
   const pending = localPendingDir();
@@ -98,10 +105,11 @@ async function downloadToPending(remoteManifest: Manifest): Promise<void> {
         + `${localActual.totalBytes}B) ≠ manifest(${expected.fileCount}files/`
         + `${expected.totalBytes}B). .ready 작성 skip — 다음 cycle 재시도.`,
       );
-      return; // .ready 작성 X
+      return false; // .ready 작성 X
     }
   }
 
   // .ready 마커 — swapper가 이걸 보고 swap 실행
   await fsp.writeFile(ready, new Date().toISOString(), 'utf-8');
+  return true;
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -725,7 +725,14 @@ function migrateLegacyUsersFileIfNeeded(): void {
 // app.relaunch()는 다음 프로세스 spawn을 예약, app.quit()이 before-quit hook을
 // 트리거 → 그 안에서 swapIfPending이 pending → app 폴더 rename. 종료 후 Electron이
 // 같은 process.execPath(이제 새 BFLOW.exe를 가리킴)로 spawn → 새 버전 자동 시작.
+//
+// Codex 1차 P2: app.relaunch()는 매 호출마다 spawn을 큐잉 → 사용자가 토스트 버튼을
+// 빠르게 두 번 누르거나 invoke가 race로 중복 호출되면 종료 후 multiple instance가
+// spawn됨. one-shot guard로 한 종료 사이클당 한 번만 relaunch 예약.
+let updateRelaunchScheduled = false;
 ipcMain.handle('update:apply-now', () => {
+  if (updateRelaunchScheduled) return;
+  updateRelaunchScheduled = true;
   app.relaunch();
   app.quit();
 });

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -648,7 +648,13 @@ function createWindow(): void {
     //   2) 5초 후 백그라운드 업데이트 체크 (한 번만, 사용자 작업 영향 0)
     markStartSucceeded().catch(() => { /* noop */ });
     setTimeout(() => {
-      scheduleUpdateCheck().catch((err) => console.warn('[autoUpdate] 체크 실패:', err));
+      scheduleUpdateCheck((version) => {
+        // v1.22.1: 다운로드 + .ready 마커 작성 완료 → renderer에 토스트 띄우기 신호.
+        // 사용자가 "지금 재시작" 클릭 시 update:apply-now → swap + relaunch.
+        if (mainWindow && !mainWindow.isDestroyed()) {
+          mainWindow.webContents.send('update:ready', version);
+        }
+      }).catch((err) => console.warn('[autoUpdate] 체크 실패:', err));
     }, 5_000);
   });
 
@@ -714,6 +720,15 @@ function migrateLegacyUsersFileIfNeeded(): void {
     console.warn('[users] 레거시 users.dat 마이그레이션 실패:', err);
   }
 }
+
+// v1.22.1: 자동 업데이트 토스트 — 사용자가 "지금 재시작" 클릭 시 호출.
+// app.relaunch()는 다음 프로세스 spawn을 예약, app.quit()이 before-quit hook을
+// 트리거 → 그 안에서 swapIfPending이 pending → app 폴더 rename. 종료 후 Electron이
+// 같은 process.execPath(이제 새 BFLOW.exe를 가리킴)로 spawn → 새 버전 자동 시작.
+ipcMain.handle('update:apply-now', () => {
+  app.relaunch();
+  app.quit();
+});
 
 ipcMain.handle('users:read', () => {
   migrateLegacyUsersFileIfNeeded();

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -56,6 +56,15 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return () => { ipcRenderer.removeListener('app:saving-before-quit', handler); };
   },
 
+  // v1.22.1: 자동 업데이트 알림 — 백그라운드 fetch 완료 시 토스트 띄우기
+  onUpdateReady: (callback: (version: string) => void) => {
+    const handler = (_event: unknown, version: string) => callback(version);
+    ipcRenderer.on('update:ready', handler);
+    return () => { ipcRenderer.removeListener('update:ready', handler); };
+  },
+  // 사용자가 토스트의 "지금 재시작" 클릭 시 — main이 swap 후 자동 재실행
+  applyUpdateNow: () => ipcRenderer.invoke('update:apply-now') as Promise<void>,
+
   // 네이티브 알림 (OS 데스크톱 알림)
   showNativeNotification: (title: string, body: string) =>
     ipcRenderer.invoke('notification:show-native', title, body),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -109,6 +109,23 @@ export default function App() {
     return () => { cleanup?.(); };
   }, []);
 
+  // v1.22.1: 자동 업데이트 다운로드 완료 알림 → "지금 재시작" 버튼 토스트.
+  // 사용자가 클릭 시 main이 app.relaunch + app.quit → before-quit hook의 swap 진행 →
+  // Electron이 새 BFLOW.exe로 자동 재시작 (1~2초 깜빡임).
+  useEffect(() => {
+    const cleanup = window.electronAPI?.onUpdateReady?.((version) => {
+      sonnerToast.success(`새 버전 v${version} 사용 가능`, {
+        description: '지금 재시작하면 즉시 적용됩니다',
+        duration: Infinity,  // 사용자가 직접 닫을 때까지
+        action: {
+          label: '지금 재시작',
+          onClick: () => { window.electronAPI?.applyUpdateNow?.(); },
+        },
+      });
+    });
+    return () => { cleanup?.(); };
+  }, []);
+
   // currentUser 변경 시 메인 프로세스에 동기화 (활동 기록 자동 user_id/user_name 사용)
   useEffect(() => {
     window.electronAPI?.authSetCurrentUser?.(

--- a/src/mocks/devElectronAPI.ts
+++ b/src/mocks/devElectronAPI.ts
@@ -61,6 +61,8 @@ export function installDevElectronAPI(): void {
     onSheetChanged: noop,
     onRetryNotify: noop,
     onSavingBeforeQuit: noop,
+    onUpdateReady: noop,
+    applyUpdateNow: async () => {},
 
     showNativeNotification: async (title: string, body: string) => {
       console.log(`[DEV 알림] ${title}: ${body}`);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -433,6 +433,9 @@ export interface ElectronAPI {
   onSheetChanged: (callback: (delta?: SheetDelta) => void) => () => void;
   onRetryNotify?: (callback: (message: string) => void) => () => void;
   onSavingBeforeQuit?: (callback: (pendingCount: number) => void) => () => void;
+  // v1.22.1: 자동 업데이트 알림
+  onUpdateReady?: (callback: (version: string) => void) => () => void;
+  applyUpdateNow?: () => Promise<void>;
   // 네이티브 알림
   showNativeNotification?: (title: string, body: string) => Promise<void>;
   // 이미지 파일 저장/삭제 (하이브리드 이미지 스토리지)


### PR DESCRIPTION
## 배경

v1.22.0까지: 백그라운드 fetch 완료 → 사용자가 BFLOW 종료 → 다시 켜야 새 버전 적용. 핫픽스 시나리오에 답답함.

상용 앱(Discord, Slack, VSCode)처럼 토스트 → 한 클릭 재시작.

## 흐름

```
BFLOW 사용 중
  ↓ 5초 후
백그라운드 fetch
  ↓ .ready 마커 작성
checker.ts onReady 콜백 → main.ts → renderer
  ↓
🎉 새 버전 v1.22.1 사용 가능
   [지금 재시작]  토스트 (sonner)
  ↓ 클릭
applyUpdateNow IPC
  ↓
app.relaunch() + app.quit()
  ↓
before-quit hook → swapIfPending (pending → app rename)
  ↓ exit
Electron이 새 BFLOW.exe로 자동 spawn
  ↓ 1~2초
새 버전 시작
```

## 변경

| 파일 | 변경 |
|---|---|
| `checker.ts` | `downloadToPending` boolean 반환. `.ready` 작성 성공 시에만 onReady 콜백 |
| `main.ts` | scheduleUpdateCheck에 콜백 전달 → `update:ready` IPC 송신. `update:apply-now` handler 추가 |
| `preload.ts` | onUpdateReady + applyUpdateNow contextBridge 노출 |
| `App.tsx` | useEffect로 onUpdateReady 등록 + sonner 토스트 |
| `types/index.ts` | electronAPI 타입 확장 |
| `mocks/devElectronAPI.ts` | dev mock 추가 |

## 검증 시나리오

이 PR 자체가 v1.22.0 자동업데이트의 검증 역할:
- 한솔 PC = NSIS v1.22.0 설치 상태
- 이 PR 머지 → G드라이브에 v1.22.1 배포
- 한솔 PC가 백그라운드에서 manifest 비교 → v1.22.1 fetch
- 토스트 떠야 함 (이게 검증 포인트 1)
- "지금 재시작" 클릭 → 1~2초 만에 v1.22.1 → 토스트 사라지고 정상 동작 (검증 포인트 2)
- NSIS Uninstall.exe도 보존 검증 (검증 포인트 3)

## 검증

- `tsc --noEmit` ✅
- `vite build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)