### PR TITLE
[v1.22.3] swap 실패 시 사용자 안내 + 자동 재시도 중단

### DIFF
--- a/electron/autoUpdate/checker.ts
+++ b/electron/autoUpdate/checker.ts
@@ -12,6 +12,7 @@ import {
   findRemoteManifest,
   localPendingDir,
   localReadyMarker,
+  localSwapSuppressedMarker,
   getOwnVersion,
 } from './paths';
 import { readManifest, compareVersions, countFilesAndBytes, type Manifest } from './manifest';
@@ -32,6 +33,27 @@ import { copyDirMirror } from './copy';
  */
 export async function scheduleUpdateCheck(onReady?: (version: string) => void): Promise<void> {
   try {
+    const own = getOwnVersion();
+
+    // v1.22.3 P2 #2: suppression marker 검사. 직전에 swap 실패해서 사용자에게 안내한
+    // 상태면 자동 재시도 중단. own version과 marker version이 다르면(사용자가 NSIS Setup
+    // 등으로 갱신) marker 정리 후 자동업데이트 재개.
+    const suppressionMarker = localSwapSuppressedMarker();
+    if (existsSync(suppressionMarker)) {
+      try {
+        const recordedVersion = (await fsp.readFile(suppressionMarker, 'utf-8')).trim();
+        if (recordedVersion === own) {
+          console.log(`[autoUpdate] swap 실패 후 suppression 상태 (own=${own}) — fetch skip`);
+          return;
+        }
+        // own이 갱신됨 → marker 정리, 자동업데이트 재개
+        await fsp.unlink(suppressionMarker);
+        console.log(`[autoUpdate] suppression marker 정리 (recorded=${recordedVersion}, own=${own})`);
+      } catch (err) {
+        console.warn('[autoUpdate] suppression marker 처리 실패 (무시):', err);
+      }
+    }
+
     const remoteManifestPath = findRemoteManifest();
     if (!remoteManifestPath) {
       console.log('[autoUpdate] G드라이브 manifest 없음 — skip');
@@ -42,7 +64,6 @@ export async function scheduleUpdateCheck(onReady?: (version: string) => void): 
       console.log('[autoUpdate] G드라이브 manifest 읽기 실패 — skip');
       return;
     }
-    const own = getOwnVersion();
     const cmp = compareVersions(remote.version, own);
     if (cmp <= 0) {
       console.log(`[autoUpdate] 최신 (own=${own}, remote=${remote.version})`);

--- a/electron/autoUpdate/paths.ts
+++ b/electron/autoUpdate/paths.ts
@@ -92,6 +92,25 @@ export function localSelfHealFailedMarker(): string {
 }
 
 /**
+ * Swap 시도 마커 (v1.22.3) — swapper가 swap 진입 직후 작성, 정상 종료·복구 양쪽 모두에서
+ * 정리. .ready만으로는 swap 실제 시도 여부를 판별 못 함(crash·kill·OS restart 시 .ready가
+ * 다운로드 직후 남음 → false positive). 시작 시 .ready + .swap-attempted 둘 다 있을 때만
+ * 진짜 swap 실패로 간주.
+ */
+export function localSwapAttemptedMarker(): string {
+  return path.join(localRoot(), '.swap-attempted');
+}
+
+/**
+ * Swap 실패 알림 후 자동 재시도 영구 중단 마커 (v1.22.3) — content는 own version. 같은
+ * version에선 자동업데이트 cycle skip(checker가 검사)하고, 사용자가 NSIS Setup 등으로
+ * 다른 version 설치 시 own이 갱신 → marker version과 다르면 자동 정리(자동업데이트 재개).
+ */
+export function localSwapSuppressedMarker(): string {
+  return path.join(localRoot(), '.swap-suppressed');
+}
+
+/**
  * Swap 직후 첫 실행 검증 마커 — swapper가 swap 완료 후 작성, healthCheck가 해당 실행이
  * 정상 메인 창 도달하면 삭제.
  *

--- a/electron/autoUpdate/swapper.ts
+++ b/electron/autoUpdate/swapper.ts
@@ -14,7 +14,7 @@
  *
  * spec §4.2 step 6, §6 "swap 실패 / 새 버전 깨짐" 처리.
  */
-import { promises as fsp, existsSync, renameSync, appendFileSync } from 'fs';
+import { promises as fsp, existsSync, renameSync, appendFileSync, mkdirSync } from 'fs';
 import path from 'path';
 import {
   localRoot, localAppDir, localPendingDir, localBackupDir, localReadyMarker,
@@ -26,10 +26,17 @@ import { copyDirMirror } from './copy';
  * v1.22.2 swap 단계별 진단 로그 — `%LOCALAPPDATA%\Bflow-BGonly\swap.log`.
  * swap이 어디서 실패했는지 사용자 환경에서도 추적 가능하도록 파일에 기록.
  * sync write — swap은 짧고 결정론적이어야 하므로 비동기 큐잉 X.
+ *
+ * v1.22.3 P1: NSIS 첫 설치 PC는 self-installer install() 흐름을 거치지 않아
+ * `localRoot()` 디렉토리(`%LOCALAPPDATA%\Bflow-BGonly\`)가 미리 만들어져 있지 않을 수
+ * 있음. 부모 dir 보장 후 write — 이게 없으면 ENOENT로 silent fail하고 진짜 swap 실패도
+ * 추적 불가.
  */
 function logSwap(line: string): void {
   try {
-    const logPath = path.join(localRoot(), 'swap.log');
+    const root = localRoot();
+    if (!existsSync(root)) mkdirSync(root, { recursive: true });
+    const logPath = path.join(root, 'swap.log');
     appendFileSync(logPath, `${new Date().toISOString()} ${line}\n`, 'utf-8');
   } catch {
     /* 로깅 실패는 swap 자체를 막지 않음 — best effort */
@@ -110,7 +117,12 @@ export async function swapIfPending(): Promise<SwapResult> {
   // v1.22.3: swap 진입 시점에 .swap-attempted 마커 작성. crash/kill로 종료된 케이스에서
   // .ready만 검사하면 false positive(swap 실제 시도 없었는데 실패로 오인)가 발생.
   // 이 마커가 함께 남아있어야 진짜 swap 실패. 정상 종료/복구 시 정리.
+  //
+  // Codex 2차 P1: NSIS 첫 설치 PC는 self-installer install() 흐름을 거치지 않아
+  // localRoot() 디렉토리가 미리 만들어져 있지 않을 수 있음. write 전 mkdir 보장 —
+  // 이게 없으면 ENOENT로 silent fail하고 진짜 swap 실패 시 dialog 안 떠서 retry loop.
   try {
+    await fsp.mkdir(localRoot(), { recursive: true });
     await fsp.writeFile(attemptedMarker, new Date().toISOString() + '\n', 'utf-8');
   } catch (err) {
     logSwap(`  swap-attempted 마커 작성 실패 (무시) — ${(err as Error).message}`);

--- a/electron/autoUpdate/swapper.ts
+++ b/electron/autoUpdate/swapper.ts
@@ -18,7 +18,7 @@ import { promises as fsp, existsSync, renameSync, appendFileSync } from 'fs';
 import path from 'path';
 import {
   localRoot, localAppDir, localPendingDir, localBackupDir, localReadyMarker,
-  localInstalledMarker, localPendingVerificationMarker,
+  localInstalledMarker, localPendingVerificationMarker, localSwapAttemptedMarker,
 } from './paths';
 import { copyDirMirror } from './copy';
 
@@ -100,11 +100,21 @@ export async function swapIfPending(): Promise<SwapResult> {
   const app_ = localAppDir();
   const pending_ = localPendingDir();
   const backup_ = localBackupDir();
+  const attemptedMarker = localSwapAttemptedMarker();
 
   logSwap(`=== swap start ===`);
   logSwap(`  app=${app_}`);
   logSwap(`  pending=${pending_}`);
   logSwap(`  backup=${backup_}`);
+
+  // v1.22.3: swap 진입 시점에 .swap-attempted 마커 작성. crash/kill로 종료된 케이스에서
+  // .ready만 검사하면 false positive(swap 실제 시도 없었는데 실패로 오인)가 발생.
+  // 이 마커가 함께 남아있어야 진짜 swap 실패. 정상 종료/복구 시 정리.
+  try {
+    await fsp.writeFile(attemptedMarker, new Date().toISOString() + '\n', 'utf-8');
+  } catch (err) {
+    logSwap(`  swap-attempted 마커 작성 실패 (무시) — ${(err as Error).message}`);
+  }
 
   // 1. 이전 backup 정리 — 1개만 유지하니 통째로 지움 (실패해도 무시)
   try {
@@ -196,6 +206,13 @@ export async function swapIfPending(): Promise<SwapResult> {
   } catch (err) {
     console.warn('[swapper] .pending-verification 마커 작성 실패 (무시 — 자가 검증 비활성, 안전):', err);
   }
+
+  // v1.22.3: swap 끝까지 성공한 경우만 .swap-attempted 정리. 실패 경로(catastrophic 또는
+  // 부분 실패)는 마커 유지 → 다음 시작 시 main.ts notifyAndCleanupOnSwapFailure가 dialog로
+  // 안내. 부분 실패(backup 복구 성공)도 사용자 입장에선 "옛 버전 그대로"이므로 알림 필요.
+  try {
+    if (existsSync(attemptedMarker)) await fsp.unlink(attemptedMarker);
+  } catch { /* 무시 */ }
 
   logSwap(`=== swap end: OK ===`);
   return { ok: true };

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2808,14 +2808,22 @@ async function notifyAndCleanupOnSwapFailure(): Promise<void> {
     }
 
     // pending + .swap-attempted 정리. .ready는 pending 안에 있어서 같이 사라짐.
+    //
+    // Codex 2차 P2: pending 정리 실패(EBUSY/EPERM 등)에도 .swap-attempted를 정리하면 다음
+    // 시작 시 .ready만 남아 dialog 트리거 조건(.ready + .swap-attempted) 안 맞아 silent
+    // 무한 retry. pending 정리 성공 시에만 .swap-attempted 정리하여 다음에도 dialog 표시.
+    let pendingCleaned = false;
     try {
       await fsp.rm(localPendingDir(), { recursive: true, force: true });
+      pendingCleaned = !existsSync(localPendingDir());
     } catch (err) {
-      console.warn('[main] pending 정리 실패 (무시):', err);
+      console.warn('[main] pending 정리 실패 (무시 — .swap-attempted 유지하여 다음 시작 시 또 알림):', err);
     }
-    try {
-      await fsp.unlink(localSwapAttemptedMarker());
-    } catch { /* 무시 */ }
+    if (pendingCleaned) {
+      try {
+        await fsp.unlink(localSwapAttemptedMarker());
+      } catch { /* 무시 */ }
+    }
   } catch (err) {
     // 안내 자체에 문제가 있어도 부팅 막지 않음
     console.warn('[main] swap 실패 안내 처리 실패 (무시):', err);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2763,16 +2763,29 @@ if (!gotTheLock) {
 }
 
 /**
- * v1.22.3 — 시작 시 swap 실패 흔적(.ready 마커)이 남았는지 검사. 남았다면 직전 종료에서
- * 자동업데이트 swap이 실패한 것 → 사용자에게 1회 안내 dialog + pending 정리. 사용자가
- * BFLOW-Setup.exe로 해결하도록 유도하고, 그 전엔 자동 재시도 중단.
+ * v1.22.3 — 시작 시 swap 실패 흔적이 남았는지 검사 → 1회 안내 dialog + 자동 재시도 중단.
+ *
+ * Codex 1차 P2 fix:
+ * 1) .ready만으론 swap 실제 시도 여부 판별 불가(crash·kill로 종료 시점에도 .ready가 남음
+ *    → false positive로 정상 pending payload 삭제). swapper가 진입 시 `.swap-attempted`를
+ *    함께 작성/정상 종료 시 정리하므로, 둘 다 있어야 진짜 swap 실패로 간주.
+ * 2) pending 정리만으론 자동 재시도 못 막음(다음 세션에 checker가 또 fetch → .ready 다시
+ *    작성 → 종료 시 또 swap 시도). `.swap-suppressed` (content = own version) 마커로
+ *    영구 suppression. 사용자가 NSIS Setup 등으로 다른 version 설치 시 own 갱신 → marker
+ *    version과 다르면 자동 정리되어 자동업데이트 재개.
  */
 async function notifyAndCleanupOnSwapFailure(): Promise<void> {
   try {
     const path = await import('path');
     const { existsSync, promises: fsp } = await import('fs');
-    const { localReadyMarker, localPendingDir, localRoot } = await import('./autoUpdate/paths');
-    if (!existsSync(localReadyMarker())) return;
+    const {
+      localReadyMarker, localPendingDir, localRoot,
+      localSwapAttemptedMarker, localSwapSuppressedMarker,
+    } = await import('./autoUpdate/paths');
+
+    // P2 #1: .ready + .swap-attempted 둘 다 있어야 진짜 swap 실패. 둘 중 하나만 있으면
+    // crash/kill 등으로 unclean exit한 케이스 — 자동업데이트 cycle이 알아서 처리.
+    if (!existsSync(localReadyMarker()) || !existsSync(localSwapAttemptedMarker())) return;
 
     await dialog.showMessageBox({
       type: 'warning',
@@ -2785,12 +2798,24 @@ async function notifyAndCleanupOnSwapFailure(): Promise<void> {
       buttons: ['확인'],
     });
 
-    // pending 정리 — 자동 재시도 중단. 사용자가 NSIS Setup으로 해결하도록 유도.
+    // P2 #2: suppression marker 작성 — checker가 own version과 같으면 fetch skip → 자동
+    // 재시도 영구 중단. 사용자가 NSIS Setup으로 다른 version 설치하면 own 갱신 → marker
+    // version과 다르면 marker 자동 정리하여 자동업데이트 재개.
+    try {
+      await fsp.writeFile(localSwapSuppressedMarker(), app.getVersion(), 'utf-8');
+    } catch (err) {
+      console.warn('[main] suppression marker 작성 실패 (무시):', err);
+    }
+
+    // pending + .swap-attempted 정리. .ready는 pending 안에 있어서 같이 사라짐.
     try {
       await fsp.rm(localPendingDir(), { recursive: true, force: true });
     } catch (err) {
       console.warn('[main] pending 정리 실패 (무시):', err);
     }
+    try {
+      await fsp.unlink(localSwapAttemptedMarker());
+    } catch { /* 무시 */ }
   } catch (err) {
     // 안내 자체에 문제가 있어도 부팅 막지 않음
     console.warn('[main] swap 실패 안내 처리 실패 (무시):', err);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2762,6 +2762,41 @@ if (!gotTheLock) {
   watchDeepLinkFile();
 }
 
+/**
+ * v1.22.3 — 시작 시 swap 실패 흔적(.ready 마커)이 남았는지 검사. 남았다면 직전 종료에서
+ * 자동업데이트 swap이 실패한 것 → 사용자에게 1회 안내 dialog + pending 정리. 사용자가
+ * BFLOW-Setup.exe로 해결하도록 유도하고, 그 전엔 자동 재시도 중단.
+ */
+async function notifyAndCleanupOnSwapFailure(): Promise<void> {
+  try {
+    const path = await import('path');
+    const { existsSync, promises: fsp } = await import('fs');
+    const { localReadyMarker, localPendingDir, localRoot } = await import('./autoUpdate/paths');
+    if (!existsSync(localReadyMarker())) return;
+
+    await dialog.showMessageBox({
+      type: 'warning',
+      title: 'B flow — 자동 업데이트 적용 실패',
+      message: '이전에 받은 새 버전을 적용하지 못했습니다',
+      detail:
+        '백그라운드에서 받아둔 새 버전을 종료 시 적용하려 했지만 실패했습니다.\n\n'
+        + 'G드라이브 dist 폴더의 BFLOW-Setup.exe를 다시 실행하면 최신 버전으로 갱신됩니다.\n\n'
+        + '문제 진단 로그:\n' + path.join(localRoot(), 'swap.log'),
+      buttons: ['확인'],
+    });
+
+    // pending 정리 — 자동 재시도 중단. 사용자가 NSIS Setup으로 해결하도록 유도.
+    try {
+      await fsp.rm(localPendingDir(), { recursive: true, force: true });
+    } catch (err) {
+      console.warn('[main] pending 정리 실패 (무시):', err);
+    }
+  } catch (err) {
+    // 안내 자체에 문제가 있어도 부팅 막지 않음
+    console.warn('[main] swap 실패 안내 처리 실패 (무시):', err);
+  }
+}
+
 // macOS: open-url 이벤트
 app.on('open-url', (event, url) => {
   event.preventDefault();
@@ -2784,6 +2819,13 @@ app.whenReady().then(async () => {
   //   이전 시작이 메인 창까지 못 갔으면(.start-attempt 마커 잔존) backup → app 롤백.
   //   여기서 작성한 새 마커는 mainWindow did-finish-load 시점에 markStartSucceeded()가 삭제.
   await checkLastStartAndRollback();
+
+  // ★ v1.22.3 swap 실패 감지:
+  //   pending\.ready 마커가 시작 시점에 그대로 남아있으면 = 직전 종료 시 swap 시도가
+  //   실패했고 사용자는 옛 버전에 갇힌 상태. 매 시작마다 자동 재시도하기보다 한 번만
+  //   사용자에게 명시 안내(BFLOW-Setup.exe 권장 + swap.log 경로) + pending 정리.
+  //   사용자가 NSIS Setup으로 해결하면 자연스럽게 끝, 그 전엔 자동 시도 중단.
+  await notifyAndCleanupOnSwapFailure();
 
   // ★ v1.20.x perf (gifted-darwin-99908d 964241d 포트):
   //   사용자에게 즉시 "켜졌다" 피드백을 주려면 스플래시를 가장 먼저 띄워야 함.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.22.2",
+  "version": "1.22.3",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
## 배경

한솔 PC에서 v1.22.0 → v1.22.1 swap 실패 후 .ready 마커가 그대로 남았는데도 다음 시작 시 사용자에겐 알림이 없었음. 사용자는 매번 토스트 → 클릭 → swap 실패 → 옛 버전 그대로 사이클을 모르게 반복할 수 있는 구조.

## Fix

`main.ts`: `app.whenReady` 진입 시점에 `.ready` 마커 검사. 남아있으면 직전 종료에서 swap이 실패한 흔적 → 1회 안내 dialog (BFLOW-Setup.exe 재실행 권장 + swap.log 경로 명시) + `bflow-pending\` 정리. 자동 재시도 중단.

```
"이전에 받은 새 버전을 적용하지 못했습니다.
G드라이브 dist 폴더의 BFLOW-Setup.exe를 다시 실행하면 최신 버전으로 갱신됩니다.
문제 진단 로그: %LOCALAPPDATA%\Bflow-BGonly\swap.log"
```

## 시나리오

| 상황 | 동작 |
|---|---|
| swap 정상 → swap이 .ready 정리 → 시작 시 .ready 없음 | dialog X (정상) |
| swap 실패 → .ready 그대로 → 다음 시작 | **dialog 1회** + pending 정리 |
| 사용자가 BFLOW-Setup.exe로 갱신 | NSIS가 새로 설치, .ready 등 자동 정리 |

## 검증

- `tsc --noEmit` ✅
- `vite build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)