### PR TITLE
[v1.22.4] swap을 detached PowerShell helper로 — EBUSY file lock 회피

### DIFF
--- a/electron/autoUpdate/helperSwap.ts
+++ b/electron/autoUpdate/helperSwap.ts
@@ -1,0 +1,167 @@
+/**
+ * v1.22.4 자동 업데이트 swap helper — detached PowerShell process로 BFLOW.exe 완전
+ * 종료 후 swap. file lock 회피.
+ *
+ * 배경: v1.22.3까지 swap을 main process before-quit hook 안에서 in-process 실행.
+ * Windows에서 실행 중인 .exe(또는 메모리 매핑된 .dll/.pak)가 들어있는 부모 디렉토리는
+ * EBUSY로 rename/rmdir 실패. v1.22.2 retry + copy fallback도 같은 EBUSY로 막힘.
+ *
+ * Fix: helper를 detached로 spawn → BFLOW.exe 모두 죽기까지 wait → 그 후 swap. main
+ * process가 종료된 시점엔 file handle release되어 lock 없음 → rename 정상 작동.
+ *
+ * 흐름:
+ *   1. main process가 spawnSwapHelper() 호출 → PowerShell helper detached spawn
+ *   2. main process 종료 (app.quit/exit)
+ *   3. helper가 부모 BFLOW pid + 모든 BFLOW process가 죽기까지 wait
+ *   4. helper가 directory swap (app→backup, pending→app)
+ *   5. helper가 .installed/.pending-verification 마커 작성, .swap-attempted 정리
+ *   6. (옵션) helper가 새 BFLOW.exe spawn
+ */
+import { spawn } from 'child_process';
+import {
+  localAppDir, localPendingDir, localBackupDir, localRoot, localBflowExe,
+} from './paths';
+
+export interface SwapHelperOptions {
+  /** swap 후 새 BFLOW.exe spawn 여부. true: apply-now(재시작), false: 사용자 종료(swap만). */
+  relaunch: boolean;
+}
+
+function escapePs(s: string): string {
+  // PowerShell single-quoted string 안에서 single quote는 ''로 escape.
+  return s.replace(/'/g, "''");
+}
+
+export function spawnSwapHelper(opts: SwapHelperOptions): void {
+  const appDir = escapePs(localAppDir());
+  const pendingDir = escapePs(localPendingDir());
+  const backupDir = escapePs(localBackupDir());
+  const root = escapePs(localRoot());
+  const bflowExe = escapePs(localBflowExe());
+  const myPid = process.pid;
+  const relaunchFlag = opts.relaunch ? '$true' : '$false';
+
+  // PowerShell script — multi-line. -EncodedCommand로 base64(UTF-16LE) 전달해 quoting 회피.
+  const psScript = `
+$ErrorActionPreference = 'Continue'
+$root = '${root}'
+$appDir = '${appDir}'
+$pendingDir = '${pendingDir}'
+$backupDir = '${backupDir}'
+$bflowExe = '${bflowExe}'
+
+function Write-SwapLog($msg) {
+  try {
+    if (-not (Test-Path $root)) { New-Item -ItemType Directory -Force -Path $root | Out-Null }
+    Add-Content -Path (Join-Path $root 'swap.log') -Value "$(Get-Date -Format 'o') [helper] $msg"
+  } catch {}
+}
+
+Write-SwapLog "waiting for parent pid=${myPid}"
+try {
+  $p = Get-Process -Id ${myPid} -ErrorAction SilentlyContinue
+  if ($p) { $p.WaitForExit(30000) | Out-Null }
+} catch {}
+
+# 다른 BFLOW 인스턴스도 모두 죽기 대기 (최대 15초)
+$deadline = (Get-Date).AddSeconds(15)
+while ((Get-Date) -lt $deadline) {
+  $alive = Get-Process -Name BFLOW -ErrorAction SilentlyContinue
+  if (-not $alive) { break }
+  Start-Sleep -Milliseconds 500
+}
+
+# 추가 안전 delay — Windows file handle release 타이밍 보정
+Start-Sleep -Milliseconds 1000
+Write-SwapLog "process all dead, swap start"
+
+# 1. 이전 backup 정리
+if (Test-Path $backupDir) {
+  Remove-Item -Path $backupDir -Recurse -Force -ErrorAction SilentlyContinue
+  Write-SwapLog "old backup cleaned"
+}
+
+# NSIS Uninstall.exe 보존 (swap 후에도 "프로그램 추가/제거" 항목 유지)
+$oldUninstall = Join-Path $appDir 'Uninstall BFLOW.exe'
+$newUninstall = Join-Path $pendingDir 'Uninstall BFLOW.exe'
+if ((Test-Path $oldUninstall) -and (-not (Test-Path $newUninstall))) {
+  try {
+    Copy-Item -Path $oldUninstall -Destination $newUninstall -ErrorAction Stop
+    Write-SwapLog "Uninstall.exe preserved"
+  } catch {
+    Write-SwapLog "Uninstall.exe 보존 실패 (무시): $($_.Exception.Message)"
+  }
+}
+
+# 2. app -> backup
+try {
+  if (Test-Path $appDir) {
+    Move-Item -Path $appDir -Destination $backupDir -Force -ErrorAction Stop
+    Write-SwapLog "step2 app->backup OK"
+  }
+} catch {
+  Write-SwapLog "step2 FAIL: $($_.Exception.Message)"
+  exit 1
+}
+
+# 3. pending -> app
+try {
+  Move-Item -Path $pendingDir -Destination $appDir -Force -ErrorAction Stop
+  Write-SwapLog "step3 pending->app OK"
+} catch {
+  Write-SwapLog "step3 FAIL: $($_.Exception.Message)"
+  # 복구 시도
+  try {
+    Move-Item -Path $backupDir -Destination $appDir -Force -ErrorAction Stop
+    Write-SwapLog "recover backup->app OK"
+  } catch {
+    Write-SwapLog "recover FAIL: $($_.Exception.Message) — app/ 부재 가능성"
+  }
+  exit 1
+}
+
+# 4. .ready 정리 (swap된 새 app 안에 .ready가 있을 수 있음)
+$stale = Join-Path $appDir '.ready'
+if (Test-Path $stale) { Remove-Item $stale -Force -ErrorAction SilentlyContinue }
+
+# 5. .installed 마커
+try {
+  Set-Content -Path (Join-Path $appDir '.installed') -Value (Get-Date -Format 'o') -Force -ErrorAction Stop
+} catch {
+  Write-SwapLog ".installed 마커 작성 실패 (무시): $($_.Exception.Message)"
+}
+
+# 6. .pending-verification 마커
+try {
+  Set-Content -Path (Join-Path $root '.pending-verification') -Value (Get-Date -Format 'o') -Force -ErrorAction Stop
+} catch {
+  Write-SwapLog ".pending-verification 작성 실패 (무시): $($_.Exception.Message)"
+}
+
+# 7. .swap-attempted 정리 (성공 → 다음 시작 시 dialog 안 띄움)
+$attempted = Join-Path $root '.swap-attempted'
+if (Test-Path $attempted) { Remove-Item $attempted -Force -ErrorAction SilentlyContinue }
+
+Write-SwapLog "swap OK"
+
+# 8. (옵션) 재시작
+if (${relaunchFlag}) {
+  try {
+    Start-Process -FilePath $bflowExe
+    Write-SwapLog "new BFLOW spawned"
+  } catch {
+    Write-SwapLog "spawn FAIL: $($_.Exception.Message)"
+  }
+}
+`;
+
+  const encoded = Buffer.from(psScript, 'utf16le').toString('base64');
+  spawn('powershell.exe', [
+    '-NoProfile', '-NonInteractive', '-WindowStyle', 'Hidden',
+    '-EncodedCommand', encoded,
+  ], {
+    detached: true,
+    stdio: 'ignore',
+    windowsHide: true,
+  }).unref();
+}

--- a/electron/autoUpdate/helperSwap.ts
+++ b/electron/autoUpdate/helperSwap.ts
@@ -156,12 +156,19 @@ if (${relaunchFlag}) {
 `;
 
   const encoded = Buffer.from(psScript, 'utf16le').toString('base64');
-  spawn('powershell.exe', [
+  // Codex 1차 P2: spawn 실패 시 ChildProcess가 'error' event emit. listener 없으면
+  // unhandled error로 quit flow 깨짐(constrained Windows, PATH 깨진 환경 등). listener
+  // 등록 후 unref — error는 console.warn으로만 swallow하여 main 종료를 막지 않음.
+  const child = spawn('powershell.exe', [
     '-NoProfile', '-NonInteractive', '-WindowStyle', 'Hidden',
     '-EncodedCommand', encoded,
   ], {
     detached: true,
     stdio: 'ignore',
     windowsHide: true,
-  }).unref();
+  });
+  child.once('error', (err) => {
+    console.warn('[helperSwap] PowerShell helper spawn 실패 (다음 시작 시 swap-attempted 마커로 dialog 안내):', err);
+  });
+  child.unref();
 }

--- a/electron/autoUpdate/helperSwap.ts
+++ b/electron/autoUpdate/helperSwap.ts
@@ -93,29 +93,54 @@ if ((Test-Path $oldUninstall) -and (-not (Test-Path $newUninstall))) {
   }
 }
 
-# 2. app -> backup
-try {
-  if (Test-Path $appDir) {
-    Move-Item -Path $appDir -Destination $backupDir -Force -ErrorAction Stop
-    Write-SwapLog "step2 app->backup OK"
+# Codex 2차 P1: rename + retry + copy fallback (이전 swapIfPending의 moveDirRobust 패턴
+# 복원). BFLOW 종료 후라 EBUSY 자체는 거의 없어야 하지만 AV 검사·Windows search indexer
+# 등 transient lock에 대비. retry → copy fallback 으로 safety net.
+function Move-DirRobust([string]$src, [string]$dst, [string]$stepName) {
+  $maxRetries = 3
+  for ($i = 0; $i -lt $maxRetries; $i++) {
+    try {
+      Move-Item -Path $src -Destination $dst -Force -ErrorAction Stop
+      Write-SwapLog "$stepName: rename try $($i+1) OK"
+      return $true
+    } catch {
+      Write-SwapLog "$stepName: rename try $($i+1) 실패 — $($_.Exception.Message)"
+      if ($i -lt ($maxRetries - 1)) { Start-Sleep -Milliseconds 500 }
+    }
   }
-} catch {
-  Write-SwapLog "step2 FAIL: $($_.Exception.Message)"
-  exit 1
+  # rename 모두 실패 → copy fallback (느리지만 락에 robust)
+  Write-SwapLog "$stepName: copy fallback 시작"
+  try {
+    Copy-Item -Path $src -Destination $dst -Recurse -Force -ErrorAction Stop
+    Remove-Item -Path $src -Recurse -Force -ErrorAction Stop
+    Write-SwapLog "$stepName: copy fallback OK"
+    return $true
+  } catch {
+    Write-SwapLog "$stepName: copy fallback 실패 — $($_.Exception.Message)"
+    return $false
+  }
+}
+
+# 2. app -> backup
+$movedToBackup = $false
+if (Test-Path $appDir) {
+  if (-not (Move-DirRobust $appDir $backupDir 'step2 app->backup')) {
+    Write-SwapLog "swap end: FAIL (step2)"
+    exit 1
+  }
+  $movedToBackup = $true
 }
 
 # 3. pending -> app
-try {
-  Move-Item -Path $pendingDir -Destination $appDir -Force -ErrorAction Stop
-  Write-SwapLog "step3 pending->app OK"
-} catch {
-  Write-SwapLog "step3 FAIL: $($_.Exception.Message)"
+if (-not (Move-DirRobust $pendingDir $appDir 'step3 pending->app')) {
+  Write-SwapLog "swap end: FAIL (step3)"
   # 복구 시도
-  try {
-    Move-Item -Path $backupDir -Destination $appDir -Force -ErrorAction Stop
-    Write-SwapLog "recover backup->app OK"
-  } catch {
-    Write-SwapLog "recover FAIL: $($_.Exception.Message) — app/ 부재 가능성"
+  if ($movedToBackup) {
+    if (Move-DirRobust $backupDir $appDir 'recover backup->app') {
+      Write-SwapLog "recover OK — 옛 버전 그대로 유지"
+    } else {
+      Write-SwapLog "recover FAIL — app/ 부재 가능성"
+    }
   }
   exit 1
 }

--- a/electron/autoUpdate/index.ts
+++ b/electron/autoUpdate/index.ts
@@ -7,5 +7,7 @@ export type { InstallResult } from './installer';
 export { scheduleUpdateCheck } from './checker';
 export { swapIfPending, hasPending } from './swapper';
 export type { SwapResult } from './swapper';
+export { spawnSwapHelper } from './helperSwap';
+export type { SwapHelperOptions } from './helperSwap';
 export { checkLastStartAndRollback, markStartSucceeded } from './healthCheck';
 export type { HealthResult } from './healthCheck';

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -23,7 +23,7 @@ import {
   runFirstInstallIfNeeded,
   scheduleUpdateCheck,
   hasPending,
-  swapIfPending,
+  spawnSwapHelper,
   checkLastStartAndRollback,
   markStartSucceeded,
 } from './autoUpdate';
@@ -722,18 +722,17 @@ function migrateLegacyUsersFileIfNeeded(): void {
 }
 
 // v1.22.1: 자동 업데이트 토스트 — 사용자가 "지금 재시작" 클릭 시 호출.
-// app.relaunch()는 다음 프로세스 spawn을 예약, app.quit()이 before-quit hook을
-// 트리거 → 그 안에서 swapIfPending이 pending → app 폴더 rename. 종료 후 Electron이
-// 같은 process.execPath(이제 새 BFLOW.exe를 가리킴)로 spawn → 새 버전 자동 시작.
 //
-// Codex 1차 P2: app.relaunch()는 매 호출마다 spawn을 큐잉 → 사용자가 토스트 버튼을
-// 빠르게 두 번 누르거나 invoke가 race로 중복 호출되면 종료 후 multiple instance가
-// spawn됨. one-shot guard로 한 종료 사이클당 한 번만 relaunch 예약.
+// v1.22.4: in-process swap이 file lock(EBUSY) 때문에 항상 실패 → detached PowerShell
+// helper로 위임. main.quit() → before-quit hook이 spawnSwapHelper 호출 → BFLOW 종료
+// 후 helper가 swap + 새 BFLOW spawn. updateRelaunchScheduled 플래그로 helper에게
+// "재시작 의도" 전달.
+//
+// Codex 1차 P2 (v1.22.1): one-shot guard. relaunch 예약은 한 종료 사이클당 한 번만.
 let updateRelaunchScheduled = false;
 ipcMain.handle('update:apply-now', () => {
   if (updateRelaunchScheduled) return;
   updateRelaunchScheduled = true;
-  app.relaunch();
   app.quit();
 });
 
@@ -3060,11 +3059,25 @@ app.on('before-quit', (e) => {
         await watchWithTimeout.catch(() => { /* noop */ });
       }
 
-      // ★ v1.21.0 자동 업데이트 swap (마지막 step)
+      // ★ v1.22.4 자동 업데이트 swap (마지막 step)
+      // in-process swap은 BFLOW.exe가 살아있는 상태라 EBUSY로 실패. detached PowerShell
+      // helper에게 위임 → main process 종료 후 helper가 BFLOW process 죽기 wait + swap +
+      // (옵션) 재시작. updateRelaunchScheduled 플래그가 helper에게 "사용자 의도가 재시작
+      // (apply-now 토스트)인지 / 단순 종료인지" 전달.
       if (await hasPending()) {
-        const result = await swapIfPending();
-        if (!result.ok) console.warn('[autoUpdate] swap 실패:', result.reason);
-        else console.log('[autoUpdate] swap 완료 — 다음 실행 = 새 버전');
+        try {
+          // swap 진입 마커 작성 — helper가 시작될 텐데 helper가 실패하더라도 다음 main
+          // 시작 시 dialog 트리거 조건(.ready + .swap-attempted)을 만족시켜 사용자에게 알림.
+          const path = await import('path');
+          const fsp = (await import('fs')).promises;
+          const { localRoot, localSwapAttemptedMarker } = await import('./autoUpdate/paths');
+          await fsp.mkdir(localRoot(), { recursive: true });
+          await fsp.writeFile(localSwapAttemptedMarker(), new Date().toISOString() + '\n', 'utf-8');
+        } catch (err) {
+          console.warn('[autoUpdate] .swap-attempted 마커 작성 실패 (무시):', err);
+        }
+        spawnSwapHelper({ relaunch: updateRelaunchScheduled });
+        console.log(`[autoUpdate] swap helper spawned (relaunch=${updateRelaunchScheduled})`);
       }
     } catch (err) {
       console.warn('[종료] 정리/swap 예외:', err);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.22.3",
+  "version": "1.22.4",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
## 배경

한솔 PC v1.22.2 → v1.22.3 swap이 EBUSY로 실패. v1.22.2의 swap.log로 정확한 원인 확정:

```
step2 app→backup: rename try 1 실패 — EBUSY: rename 'bflow' -> 'bflow-backup'
step2 app→backup: rename try 2 실패 — EBUSY
step2 app→backup: rename try 3 실패 — EBUSY
step2 app→backup: copy fallback 시작
step2 app→backup: copy fallback 실패 — EBUSY: rmdir 'bflow'
=== swap end: FAIL (app→backup)
```

**원인**: Windows에서 실행 중인 `.exe` (또는 메모리 매핑된 `.dll`/`.pak`) 가 들어있는 부모 디렉토리는 rename/rmdir 불가. before-quit hook 실행 시점엔 main process가 살아있어 항상 EBUSY. v1.22.2 retry/copy fallback도 같은 lock에 막힘.

(코드 코멘트는 "directory rename은 자식 lock과 무관"이라고 가정했지만 실제론 .exe 메모리 매핑이 부모 dir도 lock)

## Fix

swap을 main process 안에서 하지 않고 **detached PowerShell helper**로 위임.

```
main.quit() 호출
  ↓
before-quit hook → spawnSwapHelper(detached)
  ↓
main process exit
  ↓ (BFLOW.exe + 모든 child process 종료, file handle release)
  ↓
helper가 wait 끝나면 swap 진행 → file lock 없음 → Move-Item OK
  ↓
.installed/.pending-verification 마커 작성, .swap-attempted 정리
  ↓
(옵션) 새 BFLOW.exe spawn — apply-now 토스트 클릭 케이스
```

### 변경

| 파일 | 변경 |
|---|---|
| `electron/autoUpdate/helperSwap.ts` (NEW) | PowerShell helper 스크립트 spawn. Get-Process WaitForExit으로 부모 + 다른 BFLOW 인스턴스 종료 대기 → Move-Item swap → 마커 작성 → 옵션 재시작 |
| `electron/autoUpdate/index.ts` | `spawnSwapHelper` export |
| `electron/main.ts` | apply-now IPC: `app.relaunch+quit` → `app.quit`. before-quit hook의 `swapIfPending` → `spawnSwapHelper`. `updateRelaunchScheduled` 플래그가 helper에게 재시작 의도 전달 |

### Helper 안전성

- `-EncodedCommand`(base64 UTF-16LE) — quoting/escape 이슈 완전 회피
- `Get-Process -Id pid` + `WaitForExit(30s)` — 부모 종료 보장
- 다른 BFLOW 인스턴스도 max 15s wait
- 추가 1s safety delay (file handle release 타이밍)
- swap 실패 시 backup → app 복구
- Write-SwapLog로 모든 step swap.log 기록

## 검증

- `tsc --noEmit` ✅
- `vite build` ✅
- 한솔 PC 다음 swap 사이클(v1.22.3 → v1.22.4)에서 helper 작동 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)