### PR TITLE
[v1.22.5] 자동업데이트 체크 즉시 실행 — 토스트 더 빠르게

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -645,17 +645,17 @@ function createWindow(): void {
 
     // ★ v1.21.0 자동 업데이트:
     //   1) 정상 시작 표시 (자가 검증 마커 삭제)
-    //   2) 5초 후 백그라운드 업데이트 체크 (한 번만, 사용자 작업 영향 0)
+    //   2) v1.22.5: 5s → 즉시 (한솔: "토스트가 좀 늦게 떠"). manifest 비교는 G드라이브
+    //      manifest.json (수백 byte) read 한 번이라 매우 가벼움. fetch는 어차피 비동기
+    //      백그라운드 진행이라 메인 창 사용성에 영향 X.
     markStartSucceeded().catch(() => { /* noop */ });
-    setTimeout(() => {
-      scheduleUpdateCheck((version) => {
-        // v1.22.1: 다운로드 + .ready 마커 작성 완료 → renderer에 토스트 띄우기 신호.
-        // 사용자가 "지금 재시작" 클릭 시 update:apply-now → swap + relaunch.
-        if (mainWindow && !mainWindow.isDestroyed()) {
-          mainWindow.webContents.send('update:ready', version);
-        }
-      }).catch((err) => console.warn('[autoUpdate] 체크 실패:', err));
-    }, 5_000);
+    scheduleUpdateCheck((version) => {
+      // v1.22.1: 다운로드 + .ready 마커 작성 완료 → renderer에 토스트 띄우기 신호.
+      // 사용자가 "지금 재시작" 클릭 시 update:apply-now → swap + relaunch.
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send('update:ready', version);
+      }
+    }).catch((err) => console.warn('[autoUpdate] 체크 실패:', err));
   });
 
   mainWindow.on('close', (e) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.22.4",
+  "version": "1.22.5",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
## 배경

한솔 보고: "토스트가 좀 늦게 떠".

기존: did-finish-load 후 setTimeout 5s → scheduleUpdateCheck. 5초 delay + Drive Desktop manifest fetch + win-unpacked diff fetch 합치면 토스트까지 시간이 큼.

## Fix

`setTimeout(5_000)` 제거 → did-finish-load 직후 **즉시** scheduleUpdateCheck 호출.

- manifest.json은 수백 byte read 한 번 → 매우 가벼움
- fetch는 어차피 비동기 백그라운드 → 메인 창 사용성 영향 X
- 5초 delay는 시작 안정성 우선의 보수적 값일 뿐 필수 아님

## 부수 효과 — helper swap 검증

이번 PR push 자체가 v1.22.4 helper swap의 **첫 진짜 검증**:
- 한솔 PC가 v1.22.4 → v1.22.5 swap을 helper로 거침
- in-process swap이 EBUSY로 실패하던 문제(swap.log로 확인)가 helper로 회피됐는지 확인

기대 흐름:
1. 한솔 PC v1.22.4 BFLOW가 시작 직후 manifest 비교 → v1.22.5 발견 → fetch
2. 토스트 "v1.22.5 사용 가능" → "지금 재시작" 클릭
3. before-quit hook → spawnSwapHelper detached → BFLOW 종료
4. helper가 BFLOW process 죽기 wait → swap (file lock 없음) → 새 BFLOW spawn
5. v1.22.5 BFLOW 자동 시작

## 검증

- `tsc --noEmit` ✅
- `vite build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)