### PR TITLE
[v1.22.6] helper 진단 강화 + cmd.exe wrapper fallback + lock

### DIFF
--- a/electron/autoUpdate/helperSwap.ts
+++ b/electron/autoUpdate/helperSwap.ts
@@ -66,54 +66,69 @@ Write-SwapLog "[start] PowerShell helper alive — pid=$PID parent=${myPid}"
 
 # v1.22.6: helper 동시 실행 race 방지 (direct spawn + cmd wrapper 둘 다 발화 가능).
 #
-# Codex 2차 P1: atomic acquire — Test-Path + Out-File는 race 가능. [System.IO.File]::Open
-# 'CreateNew' + 'None' share는 OS-level atomic — file 존재 시 IOException throw.
-# Codex 3차 P2: PID + mtime 둘 다 검사 (단일 mtime 5분은 slow copy fallback에서 active
-# lock을 stale로 오인). PID 죽었으면 확실 stale (PID 재사용은 mtime으로 방어).
-# mtime 30분 fallback — slow AV 환경에서 swap이 분 단위 걸려도 안전 마진.
+# Codex 4차 P2: live PID + age check도 race 위험 (active helper의 slow copy가 mtime
+# 임계 초과 시 정리 → race). PID + 시작 timestamp(Ticks)로 정확 검증 — process가
+# StartTime까지 일치해야 active. PID 재사용 시 StartTime 다름 → stale 판정.
 $lockPath = Join-Path $root 'swap.lock'
 $lockHandle = $null
 
-# 1. stale lock 사전 정리: PID 죽음 (확실) 또는 mtime > 30분 (PID 재사용 방어)
+# 우리 PID의 StartTime을 lock에 기록할 준비
+try {
+  $myStartTicks = (Get-Process -Id $PID).StartTime.Ticks
+} catch {
+  $myStartTicks = 0
+}
+
+# 1. stale lock 사전 정리: PID 죽었거나 StartTime 불일치(PID 재사용)면 stale
 if (Test-Path $lockPath) {
-  $isStale = $false
+  $isStale = $true
   try {
     $oldContent = (Get-Content $lockPath -Raw -ErrorAction SilentlyContinue)
     if ($oldContent) { $oldContent = $oldContent.Trim() }
-    if ($oldContent -match '^\d+$') {
-      $oldPid = [int]$oldContent
+    # format: "PID|StartTimeTicks"
+    if ($oldContent -match '^(\d+)\|(\d+)$') {
+      $oldPid = [int]$Matches[1]
+      $oldStartTicks = [long]$Matches[2]
       $oldProc = Get-Process -Id $oldPid -ErrorAction SilentlyContinue
-      if (-not $oldProc) {
-        $isStale = $true
-        Write-SwapLog "stale lock (PID $oldPid dead) — cleared"
-      } else {
-        $age = (Get-Date) - (Get-Item $lockPath).LastWriteTime
-        if ($age.TotalMinutes -gt 30) {
-          $isStale = $true
-          Write-SwapLog "stale lock (PID $oldPid alive but age=$([int]$age.TotalMinutes)min > 30 — likely PID reuse) — cleared"
+      if ($oldProc) {
+        try {
+          if ($oldProc.StartTime.Ticks -eq $oldStartTicks) {
+            $isStale = $false  # 진짜 active
+            Write-SwapLog "active helper (PID $oldPid, start match) — exiting"
+          } else {
+            Write-SwapLog "stale lock (PID $oldPid reused — StartTime mismatch) — cleared"
+          }
+        } catch {
+          # StartTime 접근 실패 (권한 등) → 보수적으로 active로 간주
+          $isStale = $false
+          Write-SwapLog "PID $oldPid alive but StartTime unreadable — assuming active (exit)"
         }
+      } else {
+        Write-SwapLog "stale lock (PID $oldPid dead) — cleared"
       }
     } else {
-      $isStale = $true
-      Write-SwapLog "stale lock (invalid PID content) — cleared"
+      Write-SwapLog "stale lock (invalid format) — cleared"
     }
-  } catch {
-    $isStale = $true
+  } catch {}
+  if (-not $isStale) {
+    # active helper 진행 중 — 우리는 lock 안 잡고 종료. .ps1 self cleanup만.
+    if ($PSCommandPath) { try { Remove-Item -Path $PSCommandPath -Force -ErrorAction SilentlyContinue } catch {} }
+    exit 0
   }
-  if ($isStale) {
-    Remove-Item $lockPath -Force -ErrorAction SilentlyContinue
-  }
+  Remove-Item $lockPath -Force -ErrorAction SilentlyContinue
 }
 
-# 2. atomic acquire + PID 기록
+# 2. atomic acquire + PID|StartTime 기록
 try {
   $lockHandle = [System.IO.File]::Open($lockPath, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
-  $pidBytes = [System.Text.Encoding]::ASCII.GetBytes("$PID")
-  $lockHandle.Write($pidBytes, 0, $pidBytes.Length)
+  $payload = "$PID|$myStartTicks"
+  $payloadBytes = [System.Text.Encoding]::ASCII.GetBytes($payload)
+  $lockHandle.Write($payloadBytes, 0, $payloadBytes.Length)
   $lockHandle.Flush()
   Write-SwapLog "lock acquired by PID $PID (atomic CreateNew)"
 } catch [System.IO.IOException] {
   Write-SwapLog "another helper holding lock — exiting"
+  if ($PSCommandPath) { try { Remove-Item -Path $PSCommandPath -Force -ErrorAction SilentlyContinue } catch {} }
   exit 0
 } catch {
   Write-SwapLog "lock 획득 예외 (계속 진행): $($_.Exception.Message)"
@@ -190,6 +205,7 @@ if (Test-Path $appDir) {
     Write-SwapLog "swap end: FAIL (step2)"
     if ($lockHandle) { try { $lockHandle.Close() } catch {} }
     Remove-Item $lockPath -Force -ErrorAction SilentlyContinue
+    if ($PSCommandPath) { try { Remove-Item -Path $PSCommandPath -Force -ErrorAction SilentlyContinue } catch {} }
     exit 1
   }
   $movedToBackup = $true
@@ -249,6 +265,14 @@ if ($lockHandle) { try { $lockHandle.Close() } catch {} }
 if (Test-Path $lockPath) {
   Remove-Item $lockPath -Force -ErrorAction SilentlyContinue
   Write-SwapLog "lock released"
+}
+
+# 10. Codex 4차 P3: temp .ps1 self-cleanup. cmd wrapper가 helper를 -File 모드로 실행한
+# 케이스에서 %TEMP%\bflow-helper-{pid}-{ts}.ps1이 누적됨. PowerShell -File 모드는 시작
+# 시 file 내용 read 후 메모리 script로 보유 → file lock 안 잡으므로 자기 자신 삭제 가능.
+# (-EncodedCommand 모드는 $PSCommandPath null이라 Remove-Item noop)
+if ($PSCommandPath) {
+  try { Remove-Item -Path $PSCommandPath -Force -ErrorAction SilentlyContinue } catch {}
 }
 `;
 

--- a/electron/autoUpdate/helperSwap.ts
+++ b/electron/autoUpdate/helperSwap.ts
@@ -64,33 +64,35 @@ function Write-SwapLog($msg) {
 # 자체 실행이 실패한 것. 보이면 PowerShell은 시작됐고 다음 단계에서 fail.
 Write-SwapLog "[start] PowerShell helper alive — pid=$PID parent=${myPid}"
 
-# v1.22.6: helper 동시 실행 race 방지 — direct spawn + cmd wrapper 둘 다 발화 시 둘 다
-# PowerShell이 spawn되면 backup 정리 + step2 rename 등에서 충돌. 첫 번째 helper가 lock
-# file을 잡고 swap 진행, 두 번째는 즉시 종료.
+# v1.22.6: helper 동시 실행 race 방지 (direct spawn + cmd wrapper 둘 다 발화 가능).
 #
-# Codex 1차 P2: CreateNew는 file 존재만 검사. crash로 lock 남으면 영원히 블록. PID 기록
-# + stale lock 검사 (기존 PID가 살아있는지). 살아있으면 다른 helper 실행 중 → exit.
-# 죽었으면 stale → 갈아치움.
+# Codex 2차 P1: atomic acquire — Test-Path + Out-File는 race 가능. [System.IO.File]::Open
+# 'CreateNew' + 'None' share는 OS-level atomic — file 존재 시 IOException throw.
+# Codex 2차 P2: PID 재사용 회피 — process 검사 대신 file mtime 5분 timeout으로 stale
+# 검출. crash로 남은 lock은 mtime 오래되어 자동 정리됨.
 $lockPath = Join-Path $root 'swap.lock'
-try {
-  if (Test-Path $lockPath) {
-    $oldPid = (Get-Content $lockPath -Raw -ErrorAction SilentlyContinue).Trim()
-    if ($oldPid -match '^\d+$') {
-      $oldProc = Get-Process -Id ([int]$oldPid) -ErrorAction SilentlyContinue
-      if ($oldProc -and $oldProc.ProcessName -like 'powershell*') {
-        Write-SwapLog "another helper running (PID $oldPid alive, name=$($oldProc.ProcessName)) — exiting"
-        exit 0
-      }
-      Write-SwapLog "stale lock (PID $oldPid not alive or not ours) — clearing"
-    } else {
-      Write-SwapLog "lock file content invalid — clearing"
+$lockHandle = $null
+
+# 1. stale lock 사전 정리 (mtime 5분 초과)
+if (Test-Path $lockPath) {
+  try {
+    $age = (Get-Date) - (Get-Item $lockPath).LastWriteTime
+    if ($age.TotalMinutes -gt 5) {
+      Remove-Item $lockPath -Force -ErrorAction SilentlyContinue
+      Write-SwapLog "stale lock (age=$([int]$age.TotalMinutes)min) cleared"
     }
-    Remove-Item $lockPath -Force -ErrorAction SilentlyContinue
-  }
-  $PID | Out-File -FilePath $lockPath -NoNewline -Encoding ASCII
-  Write-SwapLog "lock acquired by PID $PID"
+  } catch {}
+}
+
+# 2. atomic acquire
+try {
+  $lockHandle = [System.IO.File]::Open($lockPath, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
+  Write-SwapLog "lock acquired by PID $PID (atomic CreateNew)"
+} catch [System.IO.IOException] {
+  Write-SwapLog "another helper holding lock — exiting"
+  exit 0
 } catch {
-  Write-SwapLog "lock acquisition 예외 (무시, 계속 진행): $($_.Exception.Message)"
+  Write-SwapLog "lock 획득 예외 (계속 진행): $($_.Exception.Message)"
 }
 
 Write-SwapLog "waiting for parent pid=${myPid}"
@@ -162,6 +164,7 @@ $movedToBackup = $false
 if (Test-Path $appDir) {
   if (-not (Move-DirRobust $appDir $backupDir 'step2 app->backup')) {
     Write-SwapLog "swap end: FAIL (step2)"
+    if ($lockHandle) { try { $lockHandle.Close() } catch {} }
     Remove-Item $lockPath -Force -ErrorAction SilentlyContinue
     exit 1
   }
@@ -217,7 +220,8 @@ if (${relaunchFlag}) {
   }
 }
 
-# 9. lock file 정리 (success path)
+# 9. lock file 정리 (success path) — handle close + file delete
+if ($lockHandle) { try { $lockHandle.Close() } catch {} }
 if (Test-Path $lockPath) {
   Remove-Item $lockPath -Force -ErrorAction SilentlyContinue
   Write-SwapLog "lock released"

--- a/electron/autoUpdate/helperSwap.ts
+++ b/electron/autoUpdate/helperSwap.ts
@@ -68,25 +68,49 @@ Write-SwapLog "[start] PowerShell helper alive — pid=$PID parent=${myPid}"
 #
 # Codex 2차 P1: atomic acquire — Test-Path + Out-File는 race 가능. [System.IO.File]::Open
 # 'CreateNew' + 'None' share는 OS-level atomic — file 존재 시 IOException throw.
-# Codex 2차 P2: PID 재사용 회피 — process 검사 대신 file mtime 5분 timeout으로 stale
-# 검출. crash로 남은 lock은 mtime 오래되어 자동 정리됨.
+# Codex 3차 P2: PID + mtime 둘 다 검사 (단일 mtime 5분은 slow copy fallback에서 active
+# lock을 stale로 오인). PID 죽었으면 확실 stale (PID 재사용은 mtime으로 방어).
+# mtime 30분 fallback — slow AV 환경에서 swap이 분 단위 걸려도 안전 마진.
 $lockPath = Join-Path $root 'swap.lock'
 $lockHandle = $null
 
-# 1. stale lock 사전 정리 (mtime 5분 초과)
+# 1. stale lock 사전 정리: PID 죽음 (확실) 또는 mtime > 30분 (PID 재사용 방어)
 if (Test-Path $lockPath) {
+  $isStale = $false
   try {
-    $age = (Get-Date) - (Get-Item $lockPath).LastWriteTime
-    if ($age.TotalMinutes -gt 5) {
-      Remove-Item $lockPath -Force -ErrorAction SilentlyContinue
-      Write-SwapLog "stale lock (age=$([int]$age.TotalMinutes)min) cleared"
+    $oldContent = (Get-Content $lockPath -Raw -ErrorAction SilentlyContinue)
+    if ($oldContent) { $oldContent = $oldContent.Trim() }
+    if ($oldContent -match '^\d+$') {
+      $oldPid = [int]$oldContent
+      $oldProc = Get-Process -Id $oldPid -ErrorAction SilentlyContinue
+      if (-not $oldProc) {
+        $isStale = $true
+        Write-SwapLog "stale lock (PID $oldPid dead) — cleared"
+      } else {
+        $age = (Get-Date) - (Get-Item $lockPath).LastWriteTime
+        if ($age.TotalMinutes -gt 30) {
+          $isStale = $true
+          Write-SwapLog "stale lock (PID $oldPid alive but age=$([int]$age.TotalMinutes)min > 30 — likely PID reuse) — cleared"
+        }
+      }
+    } else {
+      $isStale = $true
+      Write-SwapLog "stale lock (invalid PID content) — cleared"
     }
-  } catch {}
+  } catch {
+    $isStale = $true
+  }
+  if ($isStale) {
+    Remove-Item $lockPath -Force -ErrorAction SilentlyContinue
+  }
 }
 
-# 2. atomic acquire
+# 2. atomic acquire + PID 기록
 try {
   $lockHandle = [System.IO.File]::Open($lockPath, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
+  $pidBytes = [System.Text.Encoding]::ASCII.GetBytes("$PID")
+  $lockHandle.Write($pidBytes, 0, $pidBytes.Length)
+  $lockHandle.Flush()
   Write-SwapLog "lock acquired by PID $PID (atomic CreateNew)"
 } catch [System.IO.IOException] {
   Write-SwapLog "another helper holding lock — exiting"
@@ -294,10 +318,14 @@ if (Test-Path $lockPath) {
     writeFileSync(helperPs1, psScript, 'utf-8');
     earlyLog(`helper .ps1 written to ${helperPs1}`);
 
+    // Codex 2차 P1: -File 모드는 execution policy 영향. Restricted/AllSigned 환경에서
+    // 스크립트 실행 차단 → fallback 무력화. -ExecutionPolicy Bypass로 우회.
+    // (-EncodedCommand 모드는 in-memory script라 정책 영향 없음 — direct spawn은 OK)
     const cmdArgs = [
       '/c', 'start', '/B', '""',  // start /B = window 없이 background, "" = title
       'powershell.exe',
       '-NoProfile', '-NonInteractive', '-WindowStyle', 'Hidden',
+      '-ExecutionPolicy', 'Bypass',
       '-File', helperPs1,
     ];
     const cmdChild = spawn('cmd.exe', cmdArgs, {

--- a/electron/autoUpdate/helperSwap.ts
+++ b/electron/autoUpdate/helperSwap.ts
@@ -57,6 +57,23 @@ function Write-SwapLog($msg) {
   } catch {}
 }
 
+# v1.22.6: helper script 시작 시점 즉시 ping. 이 로그가 swap.log에 안 보이면 PowerShell
+# 자체 실행이 실패한 것. 보이면 PowerShell은 시작됐고 다음 단계에서 fail.
+Write-SwapLog "[start] PowerShell helper alive — pid=$PID parent=${myPid}"
+
+# v1.22.6: helper 동시 실행 race 방지 — direct spawn + cmd wrapper 둘 다 발화 시 둘 다
+# PowerShell이 spawn되면 backup 정리 + step2 rename 등에서 충돌. 첫 번째 helper가 lock
+# file을 잡고 swap 진행, 두 번째는 즉시 종료.
+$lockPath = Join-Path $root 'swap.lock'
+$lockHandle = $null
+try {
+  $lockHandle = [System.IO.File]::Open($lockPath, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
+  Write-SwapLog "lock acquired"
+} catch {
+  Write-SwapLog "another helper already running (lock held) — exiting"
+  exit 0
+}
+
 Write-SwapLog "waiting for parent pid=${myPid}"
 try {
   $p = Get-Process -Id ${myPid} -ErrorAction SilentlyContinue
@@ -126,6 +143,7 @@ $movedToBackup = $false
 if (Test-Path $appDir) {
   if (-not (Move-DirRobust $appDir $backupDir 'step2 app->backup')) {
     Write-SwapLog "swap end: FAIL (step2)"
+    if ($lockHandle) { try { $lockHandle.Close() } catch {}; Remove-Item $lockPath -Force -ErrorAction SilentlyContinue }
     exit 1
   }
   $movedToBackup = $true
@@ -142,6 +160,7 @@ if (-not (Move-DirRobust $pendingDir $appDir 'step3 pending->app')) {
       Write-SwapLog "recover FAIL — app/ 부재 가능성"
     }
   }
+  if ($lockHandle) { try { $lockHandle.Close() } catch {}; Remove-Item $lockPath -Force -ErrorAction SilentlyContinue }
   exit 1
 }
 
@@ -178,22 +197,92 @@ if (${relaunchFlag}) {
     Write-SwapLog "spawn FAIL: $($_.Exception.Message)"
   }
 }
+
+# 9. lock file 정리 — finally 블록처럼 동작. 모든 step에서 exit 1 한 경우엔 trap으로
+# 정리 못 하지만 PowerShell process가 종료되면 OS가 file handle release → 다음 helper가
+# CreateNew로 잡을 수 있음. 명시 정리는 success path 에서만.
+if ($lockHandle) {
+  try { $lockHandle.Close() } catch {}
+  if (Test-Path $lockPath) { Remove-Item $lockPath -Force -ErrorAction SilentlyContinue }
+  Write-SwapLog "lock released"
+}
 `;
 
   const encoded = Buffer.from(psScript, 'utf16le').toString('base64');
-  // Codex 1차 P2: spawn 실패 시 ChildProcess가 'error' event emit. listener 없으면
-  // unhandled error로 quit flow 깨짐(constrained Windows, PATH 깨진 환경 등). listener
-  // 등록 후 unref — error는 console.warn으로만 swallow하여 main 종료를 막지 않음.
-  const child = spawn('powershell.exe', [
+
+  // v1.22.6: spawn 자체가 실패하는 케이스 진단 + cmd.exe wrapper fallback.
+  //
+  // v1.22.4의 detached spawn이 한솔 PC에서 [helper] 로그를 단 한 번도 남기지 못함 →
+  // PowerShell 자체는 정상 동작 확인됐고 helper script도 정상이지만, Node child_process
+  // .spawn detached + windowsHide + stdio:'ignore' 조합이 어떤 이유로 실제 process를
+  // 띄우지 못하는 듯. 'spawn' event listener로 실제 spawn 여부 확인 + cmd /c start 패턴
+  // 으로 fallback.
+  const psArgs = [
     '-NoProfile', '-NonInteractive', '-WindowStyle', 'Hidden',
     '-EncodedCommand', encoded,
-  ], {
-    detached: true,
-    stdio: 'ignore',
-    windowsHide: true,
-  });
-  child.once('error', (err) => {
-    console.warn('[helperSwap] PowerShell helper spawn 실패 (다음 시작 시 swap-attempted 마커로 dialog 안내):', err);
-  });
-  child.unref();
+  ];
+
+  // 즉시 진단 — main process가 빠르게 종료되기 전에 swap.log에 spawn 시도 기록
+  const earlyLog = (msg: string) => {
+    try {
+      const fs = require('fs') as typeof import('fs');
+      const path = require('path') as typeof import('path');
+      const { localRoot } = require('./paths') as typeof import('./paths');
+      const root = localRoot();
+      if (!fs.existsSync(root)) fs.mkdirSync(root, { recursive: true });
+      fs.appendFileSync(
+        path.join(root, 'swap.log'),
+        `${new Date().toISOString()} [main] ${msg}\n`,
+        'utf-8',
+      );
+    } catch { /* best effort */ }
+  };
+
+  earlyLog(`spawnSwapHelper start — relaunch=${opts.relaunch}`);
+
+  // 1차 시도: 직접 powershell spawn (기존 방식)
+  let directOk = false;
+  try {
+    const child = spawn('powershell.exe', psArgs, {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+    child.once('spawn', () => {
+      earlyLog(`direct spawn OK — child pid=${child.pid}`);
+      directOk = true;
+    });
+    child.once('error', (err) => {
+      earlyLog(`direct spawn ERROR — ${err.message}`);
+    });
+    child.unref();
+  } catch (err) {
+    earlyLog(`direct spawn 예외 — ${(err as Error).message}`);
+  }
+
+  // 2차 fallback: cmd /c start /B powershell ... — Node spawn detached의 quirky 케이스
+  // (Windows에서 stdio:'ignore' + 빠른 main exit 시 자식 spawn 실패) 우회. cmd.exe가
+  // 중간 wrapper로 PowerShell을 띄움 → cmd 자체는 짧게 살고 PowerShell은 fully detached.
+  // 1차가 정상 작동하면 2차는 redundant이지만 안전망 — PowerShell 두 번 spawn돼도 helper
+  // script가 idempotent(.ready 검사 + .swap-attempted 마커)라 race로 깨지지 않음.
+  try {
+    const cmdArgs = [
+      '/c', 'start', '/B', '""',  // start /B = window 없이 background, "" = title
+      'powershell.exe', ...psArgs,
+    ];
+    const cmdChild = spawn('cmd.exe', cmdArgs, {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+    cmdChild.once('spawn', () => {
+      earlyLog(`cmd wrapper spawn OK — child pid=${cmdChild.pid}`);
+    });
+    cmdChild.once('error', (err) => {
+      earlyLog(`cmd wrapper spawn ERROR — ${err.message}`);
+    });
+    cmdChild.unref();
+  } catch (err) {
+    earlyLog(`cmd wrapper 예외 — ${(err as Error).message}`);
+  }
 }

--- a/electron/autoUpdate/helperSwap.ts
+++ b/electron/autoUpdate/helperSwap.ts
@@ -18,6 +18,9 @@
  *   6. (옵션) helper가 새 BFLOW.exe spawn
  */
 import { spawn } from 'child_process';
+import { writeFileSync, existsSync, mkdirSync } from 'fs';
+import path from 'path';
+import os from 'os';
 import {
   localAppDir, localPendingDir, localBackupDir, localRoot, localBflowExe,
 } from './paths';
@@ -64,14 +67,30 @@ Write-SwapLog "[start] PowerShell helper alive — pid=$PID parent=${myPid}"
 # v1.22.6: helper 동시 실행 race 방지 — direct spawn + cmd wrapper 둘 다 발화 시 둘 다
 # PowerShell이 spawn되면 backup 정리 + step2 rename 등에서 충돌. 첫 번째 helper가 lock
 # file을 잡고 swap 진행, 두 번째는 즉시 종료.
+#
+# Codex 1차 P2: CreateNew는 file 존재만 검사. crash로 lock 남으면 영원히 블록. PID 기록
+# + stale lock 검사 (기존 PID가 살아있는지). 살아있으면 다른 helper 실행 중 → exit.
+# 죽었으면 stale → 갈아치움.
 $lockPath = Join-Path $root 'swap.lock'
-$lockHandle = $null
 try {
-  $lockHandle = [System.IO.File]::Open($lockPath, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
-  Write-SwapLog "lock acquired"
+  if (Test-Path $lockPath) {
+    $oldPid = (Get-Content $lockPath -Raw -ErrorAction SilentlyContinue).Trim()
+    if ($oldPid -match '^\d+$') {
+      $oldProc = Get-Process -Id ([int]$oldPid) -ErrorAction SilentlyContinue
+      if ($oldProc -and $oldProc.ProcessName -like 'powershell*') {
+        Write-SwapLog "another helper running (PID $oldPid alive, name=$($oldProc.ProcessName)) — exiting"
+        exit 0
+      }
+      Write-SwapLog "stale lock (PID $oldPid not alive or not ours) — clearing"
+    } else {
+      Write-SwapLog "lock file content invalid — clearing"
+    }
+    Remove-Item $lockPath -Force -ErrorAction SilentlyContinue
+  }
+  $PID | Out-File -FilePath $lockPath -NoNewline -Encoding ASCII
+  Write-SwapLog "lock acquired by PID $PID"
 } catch {
-  Write-SwapLog "another helper already running (lock held) — exiting"
-  exit 0
+  Write-SwapLog "lock acquisition 예외 (무시, 계속 진행): $($_.Exception.Message)"
 }
 
 Write-SwapLog "waiting for parent pid=${myPid}"
@@ -143,7 +162,7 @@ $movedToBackup = $false
 if (Test-Path $appDir) {
   if (-not (Move-DirRobust $appDir $backupDir 'step2 app->backup')) {
     Write-SwapLog "swap end: FAIL (step2)"
-    if ($lockHandle) { try { $lockHandle.Close() } catch {}; Remove-Item $lockPath -Force -ErrorAction SilentlyContinue }
+    Remove-Item $lockPath -Force -ErrorAction SilentlyContinue
     exit 1
   }
   $movedToBackup = $true
@@ -198,12 +217,9 @@ if (${relaunchFlag}) {
   }
 }
 
-# 9. lock file 정리 — finally 블록처럼 동작. 모든 step에서 exit 1 한 경우엔 trap으로
-# 정리 못 하지만 PowerShell process가 종료되면 OS가 file handle release → 다음 helper가
-# CreateNew로 잡을 수 있음. 명시 정리는 success path 에서만.
-if ($lockHandle) {
-  try { $lockHandle.Close() } catch {}
-  if (Test-Path $lockPath) { Remove-Item $lockPath -Force -ErrorAction SilentlyContinue }
+# 9. lock file 정리 (success path)
+if (Test-Path $lockPath) {
+  Remove-Item $lockPath -Force -ErrorAction SilentlyContinue
   Write-SwapLog "lock released"
 }
 `;
@@ -263,12 +279,22 @@ if ($lockHandle) {
   // 2차 fallback: cmd /c start /B powershell ... — Node spawn detached의 quirky 케이스
   // (Windows에서 stdio:'ignore' + 빠른 main exit 시 자식 spawn 실패) 우회. cmd.exe가
   // 중간 wrapper로 PowerShell을 띄움 → cmd 자체는 짧게 살고 PowerShell은 fully detached.
-  // 1차가 정상 작동하면 2차는 redundant이지만 안전망 — PowerShell 두 번 spawn돼도 helper
-  // script가 idempotent(.ready 검사 + .swap-attempted 마커)라 race로 깨지지 않음.
+  // 1차가 정상 작동하면 2차는 redundant이지만 안전망 — helper script lock으로 race 방지.
+  //
+  // Codex 1차 P1: cmd.exe command line 길이 제한 8191자. helper script base64 (~15K)는
+  // EncodedCommand로 직접 넘기면 cmd 한계 초과 → cmd wrapper deterministic fail. 해결:
+  // helper script를 임시 .ps1 파일로 작성하고 cmd가 그 짧은 path만 인자로 받음.
   try {
+    const tempDir = os.tmpdir();
+    const helperPs1 = path.join(tempDir, `bflow-helper-${process.pid}-${Date.now()}.ps1`);
+    writeFileSync(helperPs1, psScript, 'utf-8');
+    earlyLog(`helper .ps1 written to ${helperPs1}`);
+
     const cmdArgs = [
       '/c', 'start', '/B', '""',  // start /B = window 없이 background, "" = title
-      'powershell.exe', ...psArgs,
+      'powershell.exe',
+      '-NoProfile', '-NonInteractive', '-WindowStyle', 'Hidden',
+      '-File', helperPs1,
     ];
     const cmdChild = spawn('cmd.exe', cmdArgs, {
       detached: true,
@@ -276,7 +302,7 @@ if ($lockHandle) {
       windowsHide: true,
     });
     cmdChild.once('spawn', () => {
-      earlyLog(`cmd wrapper spawn OK — child pid=${cmdChild.pid}`);
+      earlyLog(`cmd wrapper spawn OK — child pid=${cmdChild.pid}, helper file=${helperPs1}`);
     });
     cmdChild.once('error', (err) => {
       earlyLog(`cmd wrapper spawn ERROR — ${err.message}`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.22.5",
+  "version": "1.22.6",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
## 배경

한솔 PC v1.22.4 helper swap이 작동 안 함. swap.log에 `[helper]` 로그가 0건. 직접 시뮬레이션으로 PowerShell 자체 + detached spawn 자체는 정상 확인. 결국 Node `child_process.spawn(detached:true, stdio:'ignore', windowsHide:true)` 호출이 한솔 PC에서 PowerShell process를 못 띄우는 상황.

## Fix

### 진단 강화
- helper script 시작 즉시 `[start] PowerShell helper alive — pid=...` ping log → PowerShell 실행 검증
- main.ts spawn 호출 직후 `child.on('spawn')` / `'error'` event listener + sync swap.log 작성 → Node spawn 실제 발화 여부 추적
- swap.log에 `[main]` 라벨로 main process side 진단 기록

### cmd.exe wrapper fallback
1차 직접 spawn 실패 케이스 대비 `cmd /c start /B powershell.exe -EncodedCommand ...` 추가 spawn. cmd.exe가 중간 wrapper로 PowerShell을 띄움. Node detached의 quirky 케이스 회피.

### Race 방지 (lock 파일)
direct spawn + cmd wrapper 둘 다 발화 시 helper 두 개 동시 실행 race. helper script 시작 시 `swap.lock` 파일을 `CreateNew + FileShare.None`으로 잡음. 두 번째는 즉시 종료. 모든 exit path에서 lock cleanup.

## 검증 시나리오

이번 push 자체가 진단 — 한솔 PC v1.22.4 → v1.22.6 자동업데이트 cycle 시도 시 swap.log에:

| 로그 패턴 | 의미 |
|---|---|
| `[main] spawnSwapHelper start` | main.ts가 spawn 호출함 |
| `[main] direct spawn OK — child pid=N` | Node가 PowerShell 띄움 (정상) |
| `[main] direct spawn ERROR — ...` | Node spawn 실패 |
| `[main] cmd wrapper spawn OK — child pid=N` | cmd 경로 정상 |
| `[helper] [start] PowerShell helper alive` | PowerShell 실행됨 |
| `[helper] step2 OK` ... | swap 단계별 진행 |

어느 단계까지 도달하는지로 정확한 root cause 파악 가능.

## 검증

- `tsc --noEmit` ✅
- `vite build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)