### PR TITLE
[v1.22.7] helper WaitForExit timeout 30s → 60s

### DIFF
--- a/electron/autoUpdate/helperSwap.ts
+++ b/electron/autoUpdate/helperSwap.ts
@@ -137,7 +137,9 @@ try {
 Write-SwapLog "waiting for parent pid=${myPid}"
 try {
   $p = Get-Process -Id ${myPid} -ErrorAction SilentlyContinue
-  if ($p) { $p.WaitForExit(30000) | Out-Null }
+  # v1.22.7: 30s → 60s. slow shutdown(supabase realtime cleanup, watchCleanup 등 비동기
+  # chain 수십 초 가능)에서 30s 부족 → helper가 EBUSY swap 진행. 60s 안전 마진.
+  if ($p) { $p.WaitForExit(60000) | Out-Null }
 } catch {}
 
 # 다른 BFLOW 인스턴스도 모두 죽기 대기 (최대 15초)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.22.6",
+  "version": "1.22.7",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
## 배경

한솔 PC v1.22.6의 helper swap을 검증하려면 parent BFLOW가 helper의 WaitForExit timeout 안에 죽어야 함. 현재 30s인데, BFLOW 종료 chain은 비동기 — Supabase Realtime cleanup + gcal stopAllWatches + waitForAllPendingOps + waitForVacPendingOps 등 수십 초 가능. 30s 부족 시 helper가 일찍 swap 시도 → EBUSY 위험.

## Fix

`$p.WaitForExit(30000)` → `$p.WaitForExit(60000)`.

helper script 한 줄 변경. 60s 안전 마진.

## 부수 효과 — helper swap 진짜 검증

이번 PR push로 한솔 PC가 v1.22.6 → v1.22.7 자동업데이트 cycle 거침. 토스트 → "지금 재시작" → 검증:
- swap.log에 `[main] direct/cmd wrapper spawn OK` → Node spawn 성공
- swap.log에 `[helper] [start] PowerShell helper alive` → PowerShell 실행 성공
- swap.log에 `[helper] step2/3 OK` → swap 진행 + 성공
- 화면에 v1.22.7 BFLOW 자동 시작

## 검증

- `tsc --noEmit` ✅
- `vite build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)