### PR TITLE
[v1.22.8] helper PowerShell 파싱 에러 fix — root cause 발견

### DIFF
--- a/electron/autoUpdate/helperSwap.ts
+++ b/electron/autoUpdate/helperSwap.ts
@@ -180,22 +180,22 @@ function Move-DirRobust([string]$src, [string]$dst, [string]$stepName) {
   for ($i = 0; $i -lt $maxRetries; $i++) {
     try {
       Move-Item -Path $src -Destination $dst -Force -ErrorAction Stop
-      Write-SwapLog "$stepName: rename try $($i+1) OK"
+      Write-SwapLog "${stepName}: rename try $($i+1) OK"
       return $true
     } catch {
-      Write-SwapLog "$stepName: rename try $($i+1) 실패 — $($_.Exception.Message)"
+      Write-SwapLog "${stepName}: rename try $($i+1) 실패 — $($_.Exception.Message)"
       if ($i -lt ($maxRetries - 1)) { Start-Sleep -Milliseconds 500 }
     }
   }
   # rename 모두 실패 → copy fallback (느리지만 락에 robust)
-  Write-SwapLog "$stepName: copy fallback 시작"
+  Write-SwapLog "${stepName}: copy fallback 시작"
   try {
     Copy-Item -Path $src -Destination $dst -Recurse -Force -ErrorAction Stop
     Remove-Item -Path $src -Recurse -Force -ErrorAction Stop
-    Write-SwapLog "$stepName: copy fallback OK"
+    Write-SwapLog "${stepName}: copy fallback OK"
     return $true
   } catch {
-    Write-SwapLog "$stepName: copy fallback 실패 — $($_.Exception.Message)"
+    Write-SwapLog "${stepName}: copy fallback 실패 — $($_.Exception.Message)"
     return $false
   }
 }
@@ -341,7 +341,10 @@ if ($PSCommandPath) {
   try {
     const tempDir = os.tmpdir();
     const helperPs1 = path.join(tempDir, `bflow-helper-${process.pid}-${Date.now()}.ps1`);
-    writeFileSync(helperPs1, psScript, 'utf-8');
+    // v1.22.8: UTF-8 BOM 추가. PowerShell 5.1 + 일부 환경에서 BOM 없는 UTF-8을 ANSI로
+    // 해석 → script 안의 한글이 깨져 syntax 에러. BOM(﻿)을 prepend하면 PowerShell이
+    // UTF-8로 명시 인식.
+    writeFileSync(helperPs1, '﻿' + psScript, 'utf-8');
     earlyLog(`helper .ps1 written to ${helperPs1}`);
 
     // Codex 2차 P1: -File 모드는 execution policy 영향. Restricted/AllSigned 환경에서

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.22.7",
+  "version": "1.22.8",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
## 진단

한솔 PC v1.22.6/.7 helper swap이 단 한 번도 작동 안 함. swap.log에 `[helper]` 0건. v1.22.6 진단 로깅(`[main] direct/cmd wrapper spawn`)도 안 남음. cmd 화면에 빨간색 에러 잠깐.

helper.ps1 잔존 파일을 직접 실행 → 정확한 에러 캐치:

```
Variable reference is not valid. ':' was not followed by a valid variable name character.
Consider using ${} to delimit the name.
At ... 133:22  Write-SwapLog "$stepName: rename try ..."
At ... 136:22  Write-SwapLog "$stepName: rename try ... 실패..."
At ... 141:18  Write-SwapLog "$stepName: copy fallback 시작"
At ... 145:20  Write-SwapLog "$stepName: copy fallback OK"
At ... 148:20  Write-SwapLog "$stepName: copy fallback 실패..."

Unexpected token '}' — ParserError
```

## Root cause

**1) `$varname:` 파싱 충돌**: PowerShell string interpolation에서 `$variable:` 패턴은 scope-qualified 변수(`$global:foo`, `$script:foo` 등)로 해석. 우리 `Write-SwapLog "$stepName: rename..."`도 `$stepName:`을 scope name으로 파싱 시도 → invalid → script 전체 syntax 에러 → PowerShell이 **시작도 못 함**. 그래서 swap.log에 [helper] 단 한 번도 못 적힘.

**2) UTF-8 BOM 누락**: `writeFileSync(path, psScript, 'utf-8')`는 BOM 없이 저장. 일부 PowerShell 환경에서 BOM 없는 UTF-8을 ANSI로 해석 → 한글 깨짐 → 추가 syntax 에러.

## Fix

- 5개 위치 모두 `"$stepName:"` → `"${stepName}:"` (Move-DirRobust 함수 안)
- `writeFileSync` 시 `'﻿' + psScript` (UTF-8 BOM prepend)

## 검증

- helper.ps1 직접 실행 시 syntax 에러 사라짐
- swap.log에 `[helper] [start] PowerShell helper alive` 로그 정상 작성 예상
- v1.22.7 → v1.22.8 자동업데이트 cycle에서 helper swap 진짜 작동

## tsc/build

- `tsc --noEmit` ✅
- `vite build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)