### PR TITLE
[v1.22.9] swap.log rotation + helper swap 진짜 검증

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2773,6 +2773,29 @@ if (!gotTheLock) {
  *    영구 suppression. 사용자가 NSIS Setup 등으로 다른 version 설치 시 own 갱신 → marker
  *    version과 다르면 자동 정리되어 자동업데이트 재개.
  */
+/**
+ * v1.22.9 swap.log rotation — 진단 로그가 무한히 누적되지 않도록 1MB 초과 시 archive.
+ * swap.log → swap.log.old로 rename (1세대만 유지). best effort, 실패해도 startup 안 막음.
+ */
+async function rotateSwapLogIfNeeded(): Promise<void> {
+  try {
+    const path = await import('path');
+    const { promises: fsp, statSync, existsSync } = await import('fs');
+    const { localRoot } = await import('./autoUpdate/paths');
+    const logPath = path.join(localRoot(), 'swap.log');
+    if (!existsSync(logPath)) return;
+    const size = statSync(logPath).size;
+    const MAX = 1024 * 1024;  // 1MB
+    if (size <= MAX) return;
+    const archivePath = path.join(localRoot(), 'swap.log.old');
+    if (existsSync(archivePath)) await fsp.unlink(archivePath);
+    await fsp.rename(logPath, archivePath);
+    console.log(`[main] swap.log rotated (${size} bytes → swap.log.old)`);
+  } catch (err) {
+    console.warn('[main] swap.log rotation 실패 (무시):', err);
+  }
+}
+
 async function notifyAndCleanupOnSwapFailure(): Promise<void> {
   try {
     const path = await import('path');
@@ -2858,6 +2881,11 @@ app.whenReady().then(async () => {
   //   사용자에게 명시 안내(BFLOW-Setup.exe 권장 + swap.log 경로) + pending 정리.
   //   사용자가 NSIS Setup으로 해결하면 자연스럽게 끝, 그 전엔 자동 시도 중단.
   await notifyAndCleanupOnSwapFailure();
+
+  // ★ v1.22.9 swap.log rotation:
+  //   진단 로그가 swap 사이클마다 누적 — 1MB 초과 시 swap.log.old로 archive하고
+  //   새 swap.log 시작. 옛 archive는 1세대만 유지 (다음 rotation 시 덮어씀).
+  await rotateSwapLogIfNeeded();
 
   // ★ v1.20.x perf (gifted-darwin-99908d 964241d 포트):
   //   사용자에게 즉시 "켜졌다" 피드백을 주려면 스플래시를 가장 먼저 띄워야 함.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.22.8",
+  "version": "1.22.9",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
## Fix

swap.log rotation — 1MB 초과 시 swap.log.old로 archive (1세대만 유지). 진단 로그 무한 누적 방지.

## 검증 의의

이 PR이 push되면 한솔 PC v1.22.8(fix된 helper)이 v1.22.9 자동업데이트로 받게 됨 — `\$stepName:` 파싱 에러 fix 후 **helper swap 첫 실제 검증**.

기대 흐름:
1. v1.22.8 BFLOW가 manifest 비교 → v1.22.9 발견 → fetch
2. 토스트 → "지금 재시작" 클릭
3. before-quit hook → spawnSwapHelper detached + cmd wrapper
4. PowerShell 실행 (이번엔 파싱 에러 없음)
5. swap.log에 `[helper] [start] PowerShell helper alive` → 진짜 helper 작동 확인
6. helper가 swap 진행 → v1.22.9 BFLOW 자동 시작

## 검증

- `tsc --noEmit` ✅
- `vite build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)