### PR TITLE
[v1.24.3] 댓글 패널 ErrorBoundary 안전망 추가

### DIFF
--- a/DEVLOG/update-notes.json
+++ b/DEVLOG/update-notes.json
@@ -1,5 +1,21 @@
 [
   {
+    "version": "1.24.3",
+    "title": "댓글 패널 에러 안전망 추가",
+    "items": [
+      {
+        "category": "stability",
+        "summary": "댓글 패널이 일시적 오류로 멈춰도 다른 기능은 그대로",
+        "description": "댓글 영역에 에러 안전망(ErrorBoundary)을 둘러 vendor-ui 같은 외부 라이브러리 오류가 발생해도 모달의 다른 탭/이미지/리비전 기능은 영향받지 않습니다. 다시 시도 버튼으로 복구."
+      },
+      {
+        "category": "stability",
+        "summary": "댓글 오류 시 콘솔에 상세 진단 정보",
+        "description": "에러 발생 시 [CommentPanel ErrorBoundary] 로그로 component stack과 메시지가 콘솔에 찍혀 다음 hotfix를 빠르게 적용할 수 있습니다."
+      }
+    ]
+  },
+  {
     "version": "1.24.2",
     "title": "댓글 이미지 갤러리 통합 + 활동 클릭 디버깅",
     "items": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.24.2",
+  "version": "1.24.3",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/components/common/CommentPanelErrorBoundary.tsx
+++ b/src/components/common/CommentPanelErrorBoundary.tsx
@@ -1,0 +1,80 @@
+/**
+ * v1.24.3 — CommentPanel ErrorBoundary.
+ *
+ * 한솔 보고: vendor-ui chunk 에서 댓글 렌더링 중 React 에러 발생 (단편적 stack 만 받음).
+ * root cause 못 잡아도 *최소한 다른 기능을 막지 않게* fallback UI + 상세 에러 logging.
+ * 다음 발생 시 console.error 로 명확한 component stack + props 가 찍힘 → 추가 진단 가능.
+ */
+import { Component, type ReactNode, type ErrorInfo } from 'react';
+import { AlertTriangle, RefreshCw } from 'lucide-react';
+
+interface Props {
+  children: ReactNode;
+  /** 디버깅용 — 어느 댓글 패널이 죽었는지 식별 */
+  panelId?: string;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+  errorInfo: ErrorInfo | null;
+}
+
+export class CommentPanelErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, error: null, errorInfo: null };
+
+  static getDerivedStateFromError(error: Error): Partial<State> {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    // 명확한 진단을 위해 *전체* 스택 + component stack 콘솔에 출력
+    console.error('[CommentPanel ErrorBoundary] 댓글 렌더링 에러 캐치:', {
+      panelId: this.props.panelId,
+      message: error.message,
+      stack: error.stack,
+      componentStack: errorInfo.componentStack,
+    });
+    this.setState({ errorInfo });
+  }
+
+  handleReload = (): void => {
+    this.setState({ hasError: false, error: null, errorInfo: null });
+  };
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return (
+        <div className="flex-1 flex flex-col items-center justify-center text-center p-6 gap-3 bg-bg-card">
+          <AlertTriangle size={28} className="text-amber-400" />
+          <div className="text-sm font-semibold text-text-primary">댓글 패널을 불러오지 못했습니다</div>
+          <p className="text-[12px] text-text-secondary leading-relaxed max-w-[280px]">
+            일시적인 오류로 댓글 영역만 멈췄습니다. 모달의 다른 기능은 그대로 사용 가능합니다.
+            <br />
+            <span className="text-text-secondary/60 text-[11px]">
+              상세 정보는 콘솔 (Ctrl+Shift+I) 의 [CommentPanel ErrorBoundary] 로그를 확인해주세요.
+            </span>
+          </p>
+          <button
+            type="button"
+            onClick={this.handleReload}
+            className="mt-1 inline-flex items-center gap-1.5 px-3 py-1.5 text-[12px] rounded border border-accent/40 text-accent hover:bg-accent/10 cursor-pointer transition-colors"
+          >
+            <RefreshCw size={12} /> 다시 시도
+          </button>
+          {this.state.error && (
+            <details className="mt-2 text-left max-w-[280px]">
+              <summary className="text-[10.5px] text-text-secondary/60 cursor-pointer">
+                기술 정보
+              </summary>
+              <code className="block mt-1 text-[10px] text-text-secondary/70 break-all whitespace-pre-wrap">
+                {this.state.error.message}
+              </code>
+            </details>
+          )}
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/components/scenes/SceneDetailModal.tsx
+++ b/src/components/scenes/SceneDetailModal.tsx
@@ -25,6 +25,7 @@ import { PathLinkifiedText } from '@/components/common/PathLinkifiedText';
 import { resizeBlob, pasteImageFromClipboard } from '@/utils/imageUtils';
 import { ImageModal } from './ImageModal';
 import { CommentPanel } from './CommentPanel';
+import { CommentPanelErrorBoundary } from '@/components/common/CommentPanelErrorBoundary';
 import { RevisionPanel } from './RevisionPanel';
 import { getComments } from '@/services/commentService';
 import { useRevisionStore } from '@/stores/useRevisionStore';
@@ -1079,18 +1080,20 @@ export function SceneDetailModal({
             <div className="px-4 py-3 border-b border-bg-border shrink-0">
               <h3 className="text-sm font-medium text-text-primary">댓글 및 활동</h3>
             </div>
-            <CommentPanel
-              sceneKey={sceneKey}
-              secondarySceneKey={
-                counterpartSheetName && counterpartSceneNo != null
-                  ? `${counterpartSheetName}:${counterpartSceneNo}`
-                  : undefined
-              }
-              onCountChange={setCommentCount}
-              focusCommentId={focusCommentId}
-              // v1.24.0: 라이트박스 상단 라벨 — sheetName 에서 EP/파트 추출 + scene.sceneId.
-              sceneLabel={`${sheetName.replace(/_/g, ' ').replace(/^EP0?/, 'EP')}${scene.sceneId ? ` #${scene.sceneId}` : ''}`}
-            />
+            <CommentPanelErrorBoundary panelId="single">
+              <CommentPanel
+                sceneKey={sceneKey}
+                secondarySceneKey={
+                  counterpartSheetName && counterpartSceneNo != null
+                    ? `${counterpartSheetName}:${counterpartSceneNo}`
+                    : undefined
+                }
+                onCountChange={setCommentCount}
+                focusCommentId={focusCommentId}
+                // v1.24.0: 라이트박스 상단 라벨 — sheetName 에서 EP/파트 추출 + scene.sceneId.
+                sceneLabel={`${sheetName.replace(/_/g, ' ').replace(/^EP0?/, 'EP')}${scene.sceneId ? ` #${scene.sceneId}` : ''}`}
+              />
+            </CommentPanelErrorBoundary>
           </motion.div>
         </motion.div>
       </motion.div>

--- a/src/components/scenes/SceneDetailModal.tsx
+++ b/src/components/scenes/SceneDetailModal.tsx
@@ -1080,7 +1080,7 @@ export function SceneDetailModal({
             <div className="px-4 py-3 border-b border-bg-border shrink-0">
               <h3 className="text-sm font-medium text-text-primary">댓글 및 활동</h3>
             </div>
-            <CommentPanelErrorBoundary panelId="single">
+            <CommentPanelErrorBoundary panelId="single" key={sceneKey}>
               <CommentPanel
                 sceneKey={sceneKey}
                 secondarySceneKey={

--- a/src/components/scenes/UnifiedSceneDetailModal.tsx
+++ b/src/components/scenes/UnifiedSceneDetailModal.tsx
@@ -22,6 +22,7 @@ import { PathLinkifiedText } from '@/components/common/PathLinkifiedText';
 import { resizeBlob } from '@/utils/imageUtils';
 import { ImageModal } from './ImageModal';
 import { CommentPanel, type CommentInlineEvent } from './CommentPanel';
+import { CommentPanelErrorBoundary } from '@/components/common/CommentPanelErrorBoundary';
 import { RevisionPanel } from './RevisionPanel';
 import { SceneFilesTab } from './SceneFilesTab';
 import { SceneHistoryTab } from './SceneHistoryTab';
@@ -811,17 +812,19 @@ export function UnifiedSceneDetailModal({
                   )}
                 </h3>
               </div>
-              <CommentPanel
-                sceneKey={primaryCommentKey}
-                secondarySceneKey={secondaryCommentKey || undefined}
-                onCountChange={setCommentCount}
-                inlineEvents={inlineEvents}
-                focusCommentId={focusCommentId}
-                // v1.24.0: 댓글 이미지 라이트박스 상단 라벨용 — "EP01 / A컷 #03" 형태로 전달.
-                sceneLabel={[episodeLabel, partLabel, unifiedSceneId ? `#${unifiedSceneId}` : null]
-                  .filter(Boolean)
-                  .join(' / ')}
-              />
+              <CommentPanelErrorBoundary panelId="unified">
+                <CommentPanel
+                  sceneKey={primaryCommentKey}
+                  secondarySceneKey={secondaryCommentKey || undefined}
+                  onCountChange={setCommentCount}
+                  inlineEvents={inlineEvents}
+                  focusCommentId={focusCommentId}
+                  // v1.24.0: 댓글 이미지 라이트박스 상단 라벨용 — "EP01 / A컷 #03" 형태로 전달.
+                  sceneLabel={[episodeLabel, partLabel, unifiedSceneId ? `#${unifiedSceneId}` : null]
+                    .filter(Boolean)
+                    .join(' / ')}
+                />
+              </CommentPanelErrorBoundary>
             </motion.div>
           )}
         </motion.div>

--- a/src/components/scenes/UnifiedSceneDetailModal.tsx
+++ b/src/components/scenes/UnifiedSceneDetailModal.tsx
@@ -812,7 +812,7 @@ export function UnifiedSceneDetailModal({
                   )}
                 </h3>
               </div>
-              <CommentPanelErrorBoundary panelId="unified">
+              <CommentPanelErrorBoundary panelId="unified" key={primaryCommentKey}>
                 <CommentPanel
                   sceneKey={primaryCommentKey}
                   secondarySceneKey={secondaryCommentKey || undefined}


### PR DESCRIPTION
## 📋 업데이트 요약

한솔 보고: 댓글 영역에서 vendor-ui chunk 런타임 에러. 단편적 stack 만 받아 root cause 미확정. **최소한 다른 기능을 막지 않게 + 다음 발생 시 명확한 진단 정보** 확보.

- 🛡 **댓글 패널 ErrorBoundary 안전망** — vendor-ui 에러 발생 시 댓글 영역만 fallback UI 로 격리. 모달의 다른 탭/이미지/리비전은 정상 동작
- 🐛 **다음 발생 시 명확한 stack** — componentDidCatch 에 panelId + message + stack + componentStack 콘솔 출력 → 다음 hotfix 빠르게

## 🔧 상세

### CommentPanelErrorBoundary 신규
- `getDerivedStateFromError` → fallback UI 표시
- `componentDidCatch` → 콘솔 `[CommentPanel ErrorBoundary]` 그룹으로 panelId + message + stack + componentStack
- "다시 시도" 버튼으로 hasError reset → 재 렌더 시도
- "기술 정보" details 로 사용자가 메시지 직접 확인

### 적용 범위
- UnifiedSceneDetailModal: panelId="unified"
- SceneDetailModal: panelId="single"

### 데이터 무결성 검증 (참고)
supabase comments 테이블 직접 query — self-reference 0, orphan replies 0, bad-type 0, null/empty 0. **데이터 측 root cause 아님**. 코드 측 회귀.

## ✅ 검증
- typecheck / build:vite 통과

## 다음 단계 (사용자 깬 후)

ErrorBoundary 가 catch 했다면:
1. 모달 열기 → 댓글 패널이 fallback UI 로 표시됨 (다른 탭은 정상)
2. DevTools (Ctrl+Shift+I) 콘솔에서 `[CommentPanel ErrorBoundary]` 로그 확인
3. componentStack 의 *맨 위 component* 가 root cause 위치
4. 그 정보로 v1.24.4 hotfix

🤖 Generated with [Claude Code](https://claude.com/claude-code)