### PR TITLE
[v1.32.0] 씬 완료 UX와 전체 뷰 상호작용 개선

### DIFF
--- a/docs/mockups/2026-05-26-full-view-completion-options.html
+++ b/docs/mockups/2026-05-26-full-view-completion-options.html
@@ -1,0 +1,2850 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>B flow Full View Completion Actual Mockup</title>
+  <style>
+    :root {
+      --bg-primary: #0F1117;
+      --bg-card: #1A1D27;
+      --bg-panel: #151824;
+      --bg-border: #2D3041;
+      --text-primary: #E8E8EE;
+      --text-secondary: #8B8DA3;
+      --accent: #6C5CE7;
+      --accent-sub: #A29BFE;
+      --bg-color: #6C5CE7;
+      --act-color: #E17055;
+      --bg-lo: #C4BCFA;
+      --bg-done: #A599F5;
+      --bg-review: #8677EF;
+      --bg-png: #6C5CE7;
+      --act-lo: #F5BEB3;
+      --act-done: #EDA293;
+      --act-review: #E58A76;
+      --act-png: #E17055;
+      --phase-wait: #6E7388;
+      --phase-work: #74B9FF;
+      --phase-feedback: #FDCB6E;
+      --phase-done: #00B894;
+      --complete: #00B894;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background:
+        radial-gradient(circle at 18% 8%, rgba(108, 92, 231, .18), transparent 34%),
+        var(--bg-primary);
+      color: var(--text-primary);
+      font-family: Pretendard, Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      letter-spacing: 0;
+    }
+
+    button, input { font-family: inherit; }
+    button { cursor: pointer; }
+
+    .mock-shell {
+      width: min(1500px, calc(100vw - 28px));
+      min-height: calc(100vh - 28px);
+      margin: 14px auto;
+      display: grid;
+      grid-template-columns: 250px minmax(0, 1fr);
+      gap: 16px;
+    }
+
+    .tree {
+      border: 1px solid var(--bg-border);
+      border-radius: 12px;
+      background: rgba(26, 29, 39, .78);
+      padding: 12px;
+      min-height: 680px;
+    }
+
+    .tree-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 12px;
+    }
+
+    .tree-title {
+      font-size: 13px;
+      font-weight: 780;
+    }
+
+    .tree-btn {
+      width: 28px;
+      height: 28px;
+      border: 1px solid var(--bg-border);
+      border-radius: 8px;
+      background: rgba(15, 17, 23, .65);
+      color: var(--text-secondary);
+    }
+
+    .ep {
+      border-radius: 9px;
+      padding: 10px;
+      background: rgba(15, 17, 23, .42);
+      border: 1px solid rgba(45, 48, 65, .7);
+      margin-bottom: 8px;
+    }
+
+    .ep.active {
+      border-color: rgba(108, 92, 231, .55);
+      background: rgba(108, 92, 231, .12);
+    }
+
+    .ep-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      font-size: 12px;
+      font-weight: 720;
+    }
+
+    .part-list {
+      margin-top: 10px;
+      display: grid;
+      gap: 6px;
+    }
+
+    .part {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      min-height: 28px;
+      padding: 0 8px;
+      border-radius: 8px;
+      color: var(--text-secondary);
+      font-size: 12px;
+    }
+
+    .part.active {
+      color: white;
+      background: rgba(108, 92, 231, .22);
+    }
+
+    .content {
+      min-width: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+    }
+
+    .note-bar {
+      border: 1px solid rgba(108, 92, 231, .35);
+      border-radius: 10px;
+      background: rgba(108, 92, 231, .1);
+      padding: 10px 12px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      color: #D7D3FF;
+      font-size: 12px;
+      line-height: 1.45;
+    }
+
+    .option-tabs {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 4px;
+      border-radius: 8px;
+      background: rgba(15, 17, 23, .75);
+      border: 1px solid rgba(45, 48, 65, .8);
+      flex: 0 0 auto;
+    }
+
+    .option-tabs button,
+    .icon-tabs button {
+      border: 0;
+      border-radius: 6px;
+      background: transparent;
+      color: var(--text-secondary);
+      font-size: 12px;
+      font-weight: 720;
+      height: 29px;
+      padding: 0 10px;
+      transition: color .18s ease, background .18s ease;
+    }
+
+    .option-tabs button.active,
+    .icon-tabs button.active {
+      color: white;
+      background: rgba(108, 92, 231, .24);
+    }
+
+    .filter {
+      border: 1px solid var(--bg-border);
+      border-radius: 12px;
+      background: rgba(26, 29, 39, .9);
+      padding: 12px;
+      display: grid;
+      gap: 10px;
+    }
+
+    .filter-line {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .dept-tabs {
+      display: flex;
+      align-items: center;
+      gap: 2px;
+      padding: 2px;
+      border: 1px solid var(--bg-border);
+      border-radius: 9px;
+      background: var(--bg-primary);
+    }
+
+    .dept-tabs button {
+      border: 0;
+      border-radius: 7px;
+      height: 34px;
+      padding: 0 16px;
+      background: transparent;
+      color: var(--text-secondary);
+      font-size: 14px;
+      font-weight: 720;
+    }
+
+    .dept-tabs button.active {
+      background: var(--accent);
+      color: white;
+      box-shadow: 0 2px 8px rgba(108, 92, 231, .34);
+    }
+
+    .select-like, .small-btn, .search {
+      height: 34px;
+      border-radius: 9px;
+      border: 1px solid var(--bg-border);
+      background: rgba(15, 17, 23, .56);
+      color: var(--text-secondary);
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 0 11px;
+      font-size: 13px;
+      font-weight: 650;
+    }
+
+    .small-btn.accent {
+      color: var(--accent-sub);
+      background: rgba(108, 92, 231, .16);
+      border-color: rgba(108, 92, 231, .24);
+    }
+
+    .filter-subline {
+      background: rgba(15, 17, 23, .33);
+      border-radius: 9px;
+      padding: 8px 10px;
+    }
+
+    .status-filter {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+    }
+
+    .status-filter button {
+      height: 30px;
+      border: 0;
+      border-radius: 8px;
+      padding: 0 10px;
+      background: transparent;
+      color: var(--text-secondary);
+      font-size: 13px;
+      font-weight: 720;
+    }
+
+    .status-filter button.active {
+      color: var(--accent-sub);
+      background: rgba(108, 92, 231, .18);
+    }
+
+    .icon-tabs {
+      display: inline-flex;
+      border: 1px solid var(--bg-border);
+      border-radius: 9px;
+      overflow: hidden;
+    }
+
+    .icon-tabs button {
+      border-radius: 0;
+      width: 37px;
+      padding: 0;
+    }
+
+    .search {
+      width: 156px;
+      color: var(--text-primary);
+      outline: none;
+    }
+
+    .spacer { flex: 1 1 auto; }
+    .divider { width: 1px; height: 24px; background: var(--bg-border); }
+
+    .progress-strip {
+      border: 1px solid rgba(45, 48, 65, .86);
+      border-radius: 12px;
+      background:
+        radial-gradient(circle at 14% 10%, rgba(108, 92, 231, .12), transparent 34%),
+        radial-gradient(circle at 88% 24%, rgba(0, 184, 148, .09), transparent 28%),
+        rgba(26, 29, 39, .78);
+      padding: 12px;
+      display: grid;
+      gap: 10px;
+      box-shadow: inset 0 1px 0 rgba(255,255,255,.035), 0 10px 28px rgba(0,0,0,.12);
+    }
+
+    .progress-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+    }
+
+    .progress-title {
+      font-size: 13px;
+      color: var(--text-secondary);
+    }
+
+    .progress-title strong {
+      color: var(--text-primary);
+      font-size: 17px;
+      margin-left: 6px;
+    }
+
+    .complete-meta {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      min-height: 32px;
+      padding: 0 11px;
+      border-radius: 999px;
+      border: 1px solid rgba(0, 184, 148, .28);
+      background: rgba(0, 184, 148, .1);
+      color: #BDF4E7;
+      font-size: 12px;
+      font-weight: 720;
+    }
+
+    .complete-meta button {
+      border: 1px solid rgba(0, 184, 148, .36);
+      border-radius: 999px;
+      background: rgba(0, 184, 148, .16);
+      color: #D7FFF3;
+      height: 24px;
+      padding: 0 8px;
+      font-size: 11px;
+      font-weight: 800;
+    }
+
+    .bar {
+      height: 12px;
+      border-radius: 999px;
+      overflow: hidden;
+      position: relative;
+      background:
+        linear-gradient(180deg, rgba(255,255,255,.045), transparent),
+        rgba(15, 17, 23, .86);
+      border: 1px solid rgba(45, 48, 65, .86);
+      box-shadow: inset 0 1px 3px rgba(0,0,0,.55), 0 1px 0 rgba(255,255,255,.03);
+    }
+
+    .bar::before {
+      content: "";
+      position: absolute;
+      inset: 2px;
+      border-radius: 999px;
+      background:
+        repeating-linear-gradient(
+          90deg,
+          rgba(255,255,255,.055) 0 1px,
+          transparent 1px 9.5%
+        );
+      opacity: .38;
+      pointer-events: none;
+    }
+
+    .bar > span {
+      display: block;
+      height: 100%;
+      width: 78%;
+      position: relative;
+      border-radius: 999px;
+      background:
+        linear-gradient(180deg, rgba(255,255,255,.34), transparent 48%),
+        linear-gradient(90deg,
+          #C4BCFA 0%,
+          #8F80F4 26%,
+          #E17055 56%,
+          #FDCB6E 73%,
+          #00B894 100%
+        );
+      box-shadow:
+        0 0 18px rgba(108, 92, 231, .24),
+        0 0 26px rgba(0, 184, 148, .12);
+    }
+
+    .bar > span::before {
+      content: "";
+      position: absolute;
+      inset: 1px 0 auto;
+      height: 42%;
+      border-radius: 999px;
+      background: linear-gradient(90deg, transparent, rgba(255,255,255,.35), transparent);
+      opacity: .55;
+    }
+
+    .bar > span::after {
+      content: "";
+      position: absolute;
+      right: -5px;
+      top: 50%;
+      width: 10px;
+      height: 10px;
+      transform: translateY(-50%);
+      border-radius: 999px;
+      background: #D7FFF3;
+      box-shadow: 0 0 0 3px rgba(0, 184, 148, .18), 0 0 18px rgba(0, 184, 148, .68);
+    }
+
+    .view {
+      min-height: 468px;
+    }
+
+    .card-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(270px, 1fr));
+      gap: 14px;
+    }
+
+    .scene-card {
+      background: var(--bg-card);
+      border: 1px solid var(--bg-border);
+      border-radius: 12px;
+      min-height: 238px;
+      display: flex;
+      flex-direction: column;
+      position: relative;
+      cursor: pointer;
+      box-shadow: 0 2px 6px rgba(0,0,0,.08), 0 8px 20px rgba(0,0,0,.12);
+      transition: transform .18s ease, border-color .18s ease, box-shadow .18s ease, background .18s ease;
+      overflow: visible;
+    }
+
+    .scene-card:hover {
+      transform: translateY(-2px);
+      border-color: rgba(108, 92, 231, .7);
+      box-shadow: 0 3px 8px rgba(0,0,0,.14), 0 10px 24px rgba(0,0,0,.18);
+    }
+
+    body[data-option="a"] .scene-card.is-all-complete,
+    body[data-option="b"] .scene-card.is-all-complete,
+    body[data-option="c"] .scene-card.is-all-complete {
+      border-color: rgba(0, 184, 148, .76);
+      background:
+        radial-gradient(circle at 14% 0%, rgba(0, 184, 148, .34), transparent 36%),
+        linear-gradient(135deg, rgba(0, 184, 148, .2), rgba(26, 29, 39, .96) 58%);
+      box-shadow:
+        inset 0 0 0 1px rgba(0, 184, 148, .15),
+        0 10px 30px rgba(0, 184, 148, .1),
+        0 12px 24px rgba(0,0,0,.18);
+    }
+
+    body[data-option="a"] .scene-card.is-all-complete::before,
+    body[data-option="b"] .scene-card.is-all-complete::before,
+    body[data-option="c"] .scene-card.is-all-complete::before {
+      content: "";
+      position: absolute;
+      inset: 0 auto 0 0;
+      width: 6px;
+      border-radius: 12px 0 0 12px;
+      background: var(--complete);
+      box-shadow: 0 0 18px rgba(0, 184, 148, .72);
+    }
+
+    body[data-option="b"] .scene-card.is-partial-complete {
+      border-color: rgba(0, 184, 148, .38);
+      background: linear-gradient(135deg, rgba(0, 184, 148, .12), rgba(26, 29, 39, .96) 42%);
+    }
+
+    .card-head {
+      padding: 14px 16px 8px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+    }
+
+    .scene-id-wrap {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      min-width: 0;
+    }
+
+    .scene-index {
+      color: rgba(139, 141, 163, .55);
+      font-family: Consolas, "Fira Code", monospace;
+      font-size: 14px;
+    }
+
+    .scene-id {
+      font-family: Consolas, "Fira Code", monospace;
+      font-size: 15px;
+      font-weight: 850;
+      color: white;
+    }
+
+    .layout-chip {
+      color: rgba(139, 141, 163, .68);
+      font-size: 11px;
+      font-style: italic;
+      white-space: nowrap;
+    }
+
+    .badges {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      flex: 0 0 auto;
+    }
+
+    .badge {
+      height: 22px;
+      border-radius: 999px;
+      border: 1px solid rgba(45, 48, 65, .8);
+      display: inline-flex;
+      align-items: center;
+      padding: 0 8px;
+      font-size: 10px;
+      font-weight: 820;
+      color: var(--text-secondary);
+      background: rgba(15, 17, 23, .62);
+    }
+
+    .badge.comment {
+      color: var(--accent-sub);
+      background: rgba(108, 92, 231, .15);
+      border-color: rgba(108, 92, 231, .2);
+    }
+
+    .badge.complete {
+      color: #BDF4E7;
+      background: rgba(0, 184, 148, .17);
+      border-color: rgba(0, 184, 148, .3);
+    }
+
+    .pct {
+      height: 26px;
+      min-width: 52px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border: 1px solid rgba(45, 48, 65, .7);
+      border-radius: 999px;
+      background: rgba(15, 17, 23, .72);
+      color: var(--text-primary);
+      font-size: 12px;
+      font-weight: 780;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .thumbs {
+      margin: 0 16px 6px;
+      display: flex;
+      gap: 1px;
+      border-radius: 9px;
+      overflow: hidden;
+      background: var(--bg-border);
+    }
+
+    .thumb {
+      flex: 1;
+      height: 56px;
+      background:
+        linear-gradient(135deg, rgba(255,255,255,.12), transparent 34%),
+        linear-gradient(135deg, rgba(108,92,231,.28), rgba(15,17,23,.9));
+      display: grid;
+      place-items: center;
+      color: rgba(232, 232, 238, .55);
+      font-size: 10px;
+      font-weight: 800;
+    }
+
+    .memo-lines {
+      margin: 0 16px 4px;
+      display: grid;
+      gap: 4px;
+    }
+
+    .memo-line {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      min-width: 0;
+      overflow: hidden;
+      color: rgba(253, 203, 110, .72);
+      font-size: 11px;
+      line-height: 1.35;
+    }
+
+    .mini-dept {
+      height: 16px;
+      min-width: 26px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 5px;
+      font-size: 9px;
+      font-weight: 900;
+      flex: 0 0 auto;
+    }
+
+    .mini-dept.bg { color: #C4BCFA; background: rgba(108, 92, 231, .16); }
+    .mini-dept.act { color: #F5BEB3; background: rgba(225, 112, 85, .16); }
+
+    .dept-sections {
+      padding: 8px 16px 10px;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      margin-top: auto;
+    }
+
+    .dept-section {
+      border-radius: 10px;
+      transition: background .18s ease, box-shadow .18s ease, border-color .18s ease;
+    }
+
+    body[data-option="a"] .dept-section.is-complete,
+    body[data-option="b"] .dept-section.is-complete {
+      background: rgba(0, 184, 148, .105);
+      box-shadow: inset 0 0 0 1px rgba(0, 184, 148, .22);
+      padding: 7px;
+      margin: -7px;
+    }
+
+    body[data-option="b"] .dept-section.is-complete {
+      background: rgba(0, 184, 148, .18);
+      box-shadow: inset 0 0 0 1px rgba(0, 184, 148, .34), 0 0 18px rgba(0, 184, 148, .09);
+    }
+
+    body[data-option="c"] .dept-section.is-complete .dept-name::after {
+      content: "완료";
+      margin-left: 6px;
+      color: #9AF0D8;
+      background: rgba(0, 184, 148, .16);
+      border: 1px solid rgba(0, 184, 148, .28);
+      border-radius: 999px;
+      padding: 1px 6px;
+      font-size: 9px;
+      font-weight: 900;
+    }
+
+    .dept-top {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      margin-bottom: 6px;
+    }
+
+    .dept-name {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 12px;
+      font-weight: 820;
+    }
+
+    .dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 999px;
+      flex: 0 0 auto;
+    }
+
+    .assignee {
+      color: var(--text-secondary);
+      font-size: 12px;
+    }
+
+    .stage-track {
+      display: flex;
+      gap: 2px;
+      padding: 4px;
+      border: 1px solid rgba(45, 48, 65, .45);
+      border-radius: 9px;
+      background: rgba(15, 17, 23, .72);
+    }
+
+    .stage {
+      flex: 1;
+      min-width: 0;
+      height: 30px;
+      border-radius: 7px;
+      display: grid;
+      place-items: center;
+      color: rgba(139, 141, 163, .74);
+      font-size: 11px;
+      font-weight: 760;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .stage.done-current {
+      color: white;
+      font-weight: 850;
+      box-shadow: 0 2px 8px rgba(108, 92, 231, .25);
+    }
+
+    .stage.done-prev {
+      font-weight: 760;
+    }
+
+    .phase-round {
+      display: flex;
+      justify-content: flex-end;
+      margin-bottom: 5px;
+    }
+
+    .round-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 3px;
+      height: 22px;
+      border-radius: 999px;
+      padding: 0 8px;
+      background: rgba(116, 185, 255, .15);
+      color: var(--phase-work);
+      font-size: 11px;
+      font-weight: 850;
+    }
+
+    .card-footer {
+      height: 24px;
+      position: relative;
+    }
+
+    .sheet-view {
+      display: none;
+      border: 1px solid var(--bg-border);
+      border-radius: 10px;
+      overflow: auto;
+      background: rgba(26, 29, 39, .54);
+    }
+
+    table {
+      width: 100%;
+      min-width: 1240px;
+      border-collapse: collapse;
+      table-layout: fixed;
+      font-size: 12px;
+    }
+
+    thead {
+      position: sticky;
+      top: 0;
+      z-index: 2;
+    }
+
+    th, td {
+      border-bottom: 1px solid rgba(45, 48, 65, .42);
+      padding: 0 8px;
+      height: 39px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    th {
+      background: var(--bg-card);
+      color: var(--text-secondary);
+      font-size: 12px;
+      font-weight: 760;
+      text-align: left;
+      position: relative;
+    }
+
+    th.center, td.center { text-align: center; }
+    th.right, td.right { text-align: right; }
+
+    .group-head th {
+      height: 25px;
+      color: rgba(139, 141, 163, .62);
+      font-size: 10px;
+      font-weight: 700;
+      text-align: center;
+      border-bottom-color: rgba(45, 48, 65, .32);
+    }
+
+    .resize-handle {
+      position: absolute;
+      top: 6px;
+      bottom: 6px;
+      right: -2px;
+      width: 5px;
+      border-radius: 999px;
+      background: transparent;
+      cursor: col-resize;
+      z-index: 3;
+    }
+
+    .resizable:hover .resize-handle,
+    .resize-handle.active {
+      background: rgba(162, 155, 254, .7);
+    }
+
+    tbody tr:nth-child(odd) { background: rgba(26, 29, 39, .2); }
+    tbody tr:nth-child(even) { background: rgba(15, 17, 23, .1); }
+    tbody tr:hover { background: rgba(108, 92, 231, .06); }
+
+    body[data-option="a"] tr.is-all-complete,
+    body[data-option="b"] tr.is-all-complete,
+    body[data-option="c"] tr.is-all-complete {
+      background: rgba(0, 184, 148, .13);
+      box-shadow: inset 5px 0 0 var(--complete);
+    }
+
+    body[data-option="b"] tr.is-partial-complete {
+      background: linear-gradient(90deg, rgba(0, 184, 148, .12), rgba(15, 17, 23, .08) 34%);
+      box-shadow: inset 5px 0 0 rgba(0, 184, 148, .58);
+    }
+
+    .scene-num-glow-wrap {
+      display: inline-block;
+      padding: 3px 9px;
+      border-radius: 7px;
+      color: var(--accent-sub);
+      border: 1px solid rgba(162, 155, 254, .5);
+      box-shadow: 0 0 10px rgba(108, 92, 231, .18);
+      font-family: Consolas, "Fira Code", monospace;
+      font-weight: 850;
+    }
+
+    .comment-chip {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 20px;
+      height: 18px;
+      margin-left: 6px;
+      border-radius: 999px;
+      color: var(--accent-sub);
+      background: rgba(108, 92, 231, .18);
+      font-size: 10px;
+      font-weight: 850;
+    }
+
+    .editable {
+      color: rgba(253, 203, 110, .75);
+    }
+
+    .thumb-cell {
+      display: inline-grid;
+      place-items: center;
+      width: 28px;
+      height: 22px;
+      border-radius: 6px;
+      background:
+        linear-gradient(135deg, rgba(255,255,255,.14), transparent 50%),
+        rgba(108, 92, 231, .18);
+      color: rgba(232, 232, 238, .58);
+      font-size: 9px;
+      font-weight: 850;
+    }
+
+    .assignee-chip {
+      display: inline-flex;
+      align-items: center;
+      max-width: 100%;
+      height: 22px;
+      padding: 0 8px;
+      border-radius: 999px;
+      background: rgba(15, 17, 23, .62);
+      border: 1px solid rgba(45, 48, 65, .75);
+      color: var(--text-primary);
+      font-size: 11px;
+      font-weight: 720;
+    }
+
+    .check-cell {
+      width: 20px;
+      height: 20px;
+      border-radius: 5px;
+      display: inline-grid;
+      place-items: center;
+      border: 1px solid var(--bg-border);
+      color: var(--bg-primary);
+      font-size: 11px;
+      font-weight: 900;
+    }
+
+    .phase-cell {
+      display: flex;
+      gap: 2px;
+      padding: 3px;
+      border: 1px solid rgba(45, 48, 65, .48);
+      border-radius: 8px;
+      background: rgba(15, 17, 23, .7);
+    }
+
+    .phase-chip {
+      flex: 1;
+      height: 24px;
+      border-radius: 6px;
+      display: grid;
+      place-items: center;
+      color: rgba(139, 141, 163, .74);
+      font-size: 10px;
+      font-weight: 800;
+    }
+
+    .phase-chip.active {
+      color: var(--bg-primary);
+      background: var(--phase-work);
+      box-shadow: 0 2px 8px rgba(116, 185, 255, .25);
+    }
+
+    .phase-chip.done {
+      color: var(--bg-primary);
+      background: var(--complete);
+      box-shadow: 0 2px 8px rgba(0, 184, 148, .25);
+    }
+
+    .sheet-pct {
+      display: inline-flex;
+      justify-content: center;
+      align-items: center;
+      min-width: 36px;
+      height: 22px;
+      border-radius: 999px;
+      color: var(--text-primary);
+      background: rgba(15, 17, 23, .64);
+      border: 1px solid rgba(45, 48, 65, .75);
+      font-size: 11px;
+      font-weight: 820;
+      font-variant-numeric: tabular-nums;
+    }
+
+    body[data-view="sheet"] .card-grid { display: none; }
+    body[data-view="sheet"] .sheet-view { display: block; }
+
+    .help {
+      color: var(--text-secondary);
+      font-size: 12px;
+      line-height: 1.45;
+    }
+
+    .sheet-view tbody tr {
+      cursor: pointer;
+    }
+
+    .is-transition-source {
+      opacity: .46 !important;
+      transition: opacity .18s ease, filter .18s ease;
+      filter: saturate(.85);
+    }
+
+    .continuity-overlay {
+      position: fixed;
+      inset: 0;
+      z-index: 80;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 16px;
+    }
+
+    .continuity-backdrop {
+      position: absolute;
+      inset: 0;
+      background: rgba(8, 10, 16, .58);
+      backdrop-filter: blur(7px);
+      opacity: 0;
+      transition: opacity .28s ease;
+    }
+
+    .continuity-overlay.visible .continuity-backdrop {
+      opacity: 1;
+    }
+
+    .continuity-modal {
+      position: fixed;
+      left: 50%;
+      top: 50%;
+      display: flex;
+      align-items: stretch;
+      gap: 12px;
+      max-width: calc(100vw - 32px);
+      max-height: calc(100vh - 32px);
+      transform: translate(-50%, -50%) scale(.982) translateY(8px);
+      opacity: 0;
+      transition: opacity .24s ease, transform .34s cubic-bezier(0.16, 1, 0.3, 1);
+      pointer-events: none;
+      will-change: opacity, transform;
+    }
+
+    .continuity-modal.visible {
+      opacity: 1;
+      transform: translate(-50%, -50%) scale(1) translateY(0);
+      pointer-events: auto;
+    }
+
+    .continuity-modal.preparing {
+      visibility: hidden;
+      opacity: 0;
+    }
+
+    .continuity-modal.loading .modal-inner {
+      opacity: 0;
+      transform: translateY(4px) scale(.996);
+    }
+
+    .continuity-modal.hydrated .modal-inner,
+    .continuity-modal:not(.loading) .modal-inner {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+
+    .continuity-modal.motion-active [data-motion-target] {
+      opacity: 0;
+    }
+
+    .continuity-modal.hydrated [data-motion-target] {
+      opacity: 1;
+      transition: opacity .22s ease;
+    }
+
+    .continuity-main-shell {
+      position: relative;
+      width: min(720px, calc(100vw - 26rem));
+      min-width: 620px;
+      height: min(900px, 92vh);
+      border: 1px solid rgba(45, 48, 65, .96);
+      border-radius: 18px;
+      background:
+        radial-gradient(circle at 14% 0%, rgba(108, 92, 231, .18), transparent 34%),
+        radial-gradient(circle at 88% 105%, rgba(162, 155, 254, .13), transparent 34%),
+        #171A25;
+      box-shadow: 0 40px 80px rgba(0,0,0,.5), inset 0 1px 0 rgba(255,255,255,.04);
+      overflow: hidden;
+    }
+
+    .modal-glow-a,
+    .modal-glow-b {
+      position: absolute;
+      border-radius: 999px;
+      pointer-events: none;
+      filter: blur(44px);
+      opacity: .9;
+    }
+
+    .modal-glow-a {
+      left: -110px;
+      top: -120px;
+      width: 410px;
+      height: 410px;
+      background: radial-gradient(circle, rgba(108, 92, 231, .19), transparent 60%);
+    }
+
+    .modal-glow-b {
+      right: -120px;
+      bottom: -170px;
+      width: 520px;
+      height: 520px;
+      background: radial-gradient(circle, rgba(162, 155, 254, .14), transparent 60%);
+    }
+
+    .modal-inner {
+      position: relative;
+      z-index: 1;
+      height: 100%;
+      min-height: 0;
+      display: flex;
+      flex-direction: column;
+      transition: opacity .24s ease, transform .32s cubic-bezier(0.16, 1, 0.3, 1);
+    }
+
+    .modal-skeleton {
+      position: absolute;
+      inset: 0;
+      z-index: 2;
+      display: flex;
+      flex-direction: column;
+      background:
+        radial-gradient(circle at 14% 0%, rgba(108, 92, 231, .13), transparent 34%),
+        radial-gradient(circle at 88% 105%, rgba(162, 155, 254, .10), transparent 34%),
+        #171A25;
+      opacity: 0;
+      transform: translateY(5px) scale(.996);
+      transition: opacity .22s ease, transform .32s cubic-bezier(0.16, 1, 0.3, 1);
+      pointer-events: none;
+    }
+
+    .continuity-modal.loading.visible .modal-skeleton {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+
+    .continuity-modal.hydrated .modal-skeleton {
+      opacity: 0;
+      transform: translateY(-2px) scale(.997);
+    }
+
+    .skeleton-head,
+    .skeleton-tabs,
+    .skeleton-body,
+    .skeleton-dots {
+      flex: 0 0 auto;
+    }
+
+    .skeleton-head {
+      min-height: 57px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 14px;
+      padding: 12px 20px;
+      border-bottom: 1px solid rgba(45, 48, 65, .48);
+      background: rgba(255, 255, 255, .012);
+    }
+
+    .skeleton-tabs {
+      height: 40px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 0 20px;
+      border-bottom: 1px solid rgba(45, 48, 65, .36);
+    }
+
+    .skeleton-body {
+      flex: 1 1 auto;
+      padding: 16px 20px 10px;
+      display: grid;
+      gap: 12px;
+      overflow: hidden;
+    }
+
+    .skeleton-image-grid,
+    .skeleton-dept-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 12px;
+    }
+
+    .skel {
+      position: relative;
+      overflow: hidden;
+      border-radius: 999px;
+      background: rgba(255,255,255,.07);
+      border: 1px solid rgba(45, 48, 65, .3);
+    }
+
+    .skel::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      transform: translateX(-120%);
+      background: linear-gradient(90deg, transparent, rgba(255,255,255,.105), transparent);
+      animation: skeleton-sweep 1.15s ease-in-out infinite;
+    }
+
+    .skel.id { width: 190px; height: 22px; border-radius: 7px; }
+    .skel.meta { width: 96px; height: 20px; }
+    .skel.button { width: 72px; height: 25px; border-radius: 7px; }
+    .skel.tab { width: 54px; height: 16px; border-radius: 5px; }
+    .skel.image { height: 150px; border-radius: 12px; }
+    .skel.card { height: 235px; border-radius: 12px; }
+    .skel.dot { width: 6px; height: 6px; }
+    .skel.dot.active { width: 20px; }
+
+    .skeleton-dots {
+      height: 38px;
+      border-top: 1px solid rgba(45, 48, 65, .3);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 6px;
+    }
+
+    @keyframes skeleton-sweep {
+      0% { transform: translateX(-120%); }
+      54%, 100% { transform: translateX(120%); }
+    }
+
+    .modal-head {
+      min-height: 57px;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 12px 20px;
+      border-bottom: 1px solid rgba(45, 48, 65, .52);
+      background: rgba(255, 255, 255, .015);
+      backdrop-filter: blur(20px);
+    }
+
+    .modal-title-wrap {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      min-width: 0;
+      flex: 1 1 auto;
+    }
+
+    .modal-scene-no,
+    .modal-scene-id {
+      font-family: Consolas, "Fira Code", monospace;
+      white-space: nowrap;
+    }
+
+    .modal-scene-no {
+      color: rgba(139, 141, 163, .58);
+      font-size: 14px;
+      font-weight: 700;
+    }
+
+    .modal-scene-id {
+      font-size: 18px;
+      font-weight: 900;
+      color: #fff;
+    }
+
+    .modal-layout,
+    .modal-sub {
+      color: var(--text-secondary);
+      font-size: 12px;
+      white-space: nowrap;
+    }
+
+    .modal-layout {
+      color: rgba(139, 141, 163, .58);
+    }
+
+    .modal-total {
+      display: inline-flex;
+      align-items: center;
+      height: 23px;
+      padding: 0 8px;
+      border-radius: 999px;
+      background: rgba(255,255,255,.06);
+      color: var(--text-primary);
+      font-size: 11px;
+      font-weight: 900;
+      font-variant-numeric: tabular-nums;
+      white-space: nowrap;
+    }
+
+    .modal-actions {
+      display: flex;
+      align-items: center;
+      gap: 7px;
+      flex: 0 0 auto;
+    }
+
+    .modal-nav-btn,
+    .modal-close {
+      width: 28px;
+      height: 28px;
+      border: 0;
+      border-radius: 7px;
+      background: transparent;
+      color: var(--text-secondary);
+      font-size: 17px;
+      line-height: 1;
+    }
+
+    .modal-nav-btn:hover,
+    .modal-close:hover {
+      color: white;
+      background: rgba(45, 48, 65, .5);
+    }
+
+    .modal-nav-count {
+      min-width: 56px;
+      text-align: center;
+      color: rgba(139, 141, 163, .72);
+      font-size: 12px;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .modal-delete {
+      height: 27px;
+      border-radius: 7px;
+      border: 1px solid rgba(255, 99, 99, .3);
+      background: rgba(255, 99, 99, .1);
+      color: #ff8f8f;
+      padding: 0 9px;
+      font-size: 11px;
+      font-weight: 800;
+    }
+
+    .modal-dept-toggle {
+      display: inline-flex;
+      gap: 2px;
+      padding: 2px;
+      border-radius: 7px;
+      background: rgba(45, 48, 65, .4);
+    }
+
+    .modal-dept-toggle span {
+      height: 24px;
+      border-radius: 5px;
+      padding: 0 8px;
+      display: inline-flex;
+      align-items: center;
+      color: var(--text-secondary);
+      font-size: 10.5px;
+      font-weight: 800;
+    }
+
+    .modal-dept-toggle span.active {
+      color: var(--accent-sub);
+      background: rgba(108, 92, 231, .22);
+      box-shadow: inset 0 0 0 1px rgba(108, 92, 231, .32);
+    }
+
+    .modal-tabs {
+      display: flex;
+      gap: 4px;
+      padding: 0 20px;
+      border-bottom: 1px solid rgba(45, 48, 65, .42);
+      flex: 0 0 auto;
+    }
+
+    .modal-tabs span {
+      height: 39px;
+      display: inline-flex;
+      align-items: center;
+      border-bottom: 2px solid transparent;
+      color: var(--text-secondary);
+      font-size: 12px;
+      font-weight: 780;
+      padding: 0 8px;
+    }
+
+    .modal-tabs span.active {
+      color: var(--accent-sub);
+      border-bottom-color: var(--accent);
+    }
+
+    .modal-body {
+      flex: 1 1 auto;
+      min-height: 0;
+      overflow: auto;
+      padding: 16px 20px 10px;
+    }
+
+    .modal-image-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 12px;
+      margin-bottom: 12px;
+    }
+
+    .modal-image-slot {
+      min-height: 150px;
+      border-radius: 12px;
+      border: 1px solid rgba(45, 48, 65, .78);
+      background:
+        linear-gradient(135deg, rgba(255,255,255,.10), transparent 40%),
+        linear-gradient(135deg, rgba(108, 92, 231, .22), rgba(15,17,23,.92));
+      position: relative;
+      overflow: hidden;
+      display: grid;
+      place-items: center;
+      color: rgba(232,232,238,.42);
+      font-size: 11px;
+      font-weight: 900;
+      letter-spacing: .03em;
+    }
+
+    .modal-image-slot::before {
+      content: attr(data-label);
+      position: absolute;
+      left: 10px;
+      top: 9px;
+      height: 22px;
+      display: inline-flex;
+      align-items: center;
+      border-radius: 999px;
+      padding: 0 8px;
+      background: rgba(15, 17, 23, .66);
+      border: 1px solid rgba(45, 48, 65, .7);
+      color: var(--text-secondary);
+      font-size: 10px;
+      letter-spacing: 0;
+    }
+
+    .modal-depts {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 12px;
+    }
+
+    .modal-dept-card {
+      border: 1px solid rgba(45, 48, 65, .76);
+      border-radius: 12px;
+      background: rgba(15, 17, 23, .34);
+      padding: 13px;
+      display: grid;
+      gap: 11px;
+      min-width: 0;
+    }
+
+    .modal-dept-card.complete {
+      border-color: rgba(0, 184, 148, .36);
+      background:
+        linear-gradient(180deg, rgba(0, 184, 148, .11), rgba(15, 17, 23, .34));
+      box-shadow: inset 0 0 0 1px rgba(0, 184, 148, .08);
+    }
+
+    .modal-section-label {
+      color: rgba(139, 141, 163, .7);
+      font-size: 11px;
+      font-weight: 850;
+      margin-bottom: -4px;
+    }
+
+    .modal-property-list {
+      display: grid;
+      gap: 0;
+      border: 1px solid rgba(45, 48, 65, .54);
+      border-radius: 10px;
+      overflow: hidden;
+      background: rgba(15, 17, 23, .24);
+    }
+
+    .modal-property-row {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      min-height: 35px;
+      padding: 7px 10px;
+      border-bottom: 1px solid rgba(45, 48, 65, .38);
+      font-size: 12px;
+    }
+
+    .modal-property-row:last-child {
+      border-bottom: 0;
+    }
+
+    .modal-property-row b {
+      width: 58px;
+      color: var(--text-secondary);
+      font-size: 11px;
+      flex: 0 0 auto;
+    }
+
+    .modal-property-row span {
+      color: rgba(232, 232, 238, .86);
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .modal-property-row .memo-text {
+      color: rgba(253, 203, 110, .78);
+      white-space: normal;
+      line-height: 1.35;
+    }
+
+    .modal-meta-row {
+      margin-top: 11px;
+      padding: 10px 2px 0;
+      color: rgba(139, 141, 163, .54);
+      font-size: 11px;
+      display: flex;
+      gap: 14px;
+    }
+
+    .modal-dots {
+      height: 38px;
+      border-top: 1px solid rgba(45, 48, 65, .34);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 6px;
+      flex: 0 0 auto;
+    }
+
+    .modal-dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 999px;
+      background: rgba(139, 141, 163, .3);
+    }
+
+    .modal-dot.active {
+      width: 20px;
+      background: var(--accent);
+      box-shadow: 0 0 6px rgba(108, 92, 231, .68);
+    }
+
+    .continuity-comments {
+      width: clamp(320px, 26vw, 420px);
+      height: min(900px, 92vh);
+      border: 1px solid rgba(45, 48, 65, .96);
+      border-radius: 18px;
+      background: #171A25;
+      box-shadow: 0 40px 80px rgba(0,0,0,.42);
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      transform: translateX(18px);
+      opacity: 0;
+      transition: opacity .26s ease .08s, transform .34s cubic-bezier(0.16, 1, 0.3, 1) .08s;
+    }
+
+    .continuity-modal.visible .continuity-comments {
+      opacity: 1;
+      transform: translateX(0);
+    }
+
+    .continuity-modal.loading .continuity-comments {
+      opacity: 0;
+      transform: translateX(14px);
+    }
+
+    .comment-head {
+      height: 48px;
+      border-bottom: 1px solid rgba(45, 48, 65, .86);
+      padding: 0 16px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      color: var(--text-primary);
+      font-size: 14px;
+      font-weight: 760;
+    }
+
+    .comment-count {
+      color: rgba(139, 141, 163, .68);
+      font-size: 12px;
+      font-weight: 700;
+    }
+
+    .comment-list {
+      padding: 14px;
+      display: grid;
+      gap: 10px;
+      overflow: hidden;
+    }
+
+    .comment-item {
+      border: 1px solid rgba(45, 48, 65, .62);
+      border-radius: 11px;
+      background: rgba(15, 17, 23, .36);
+      padding: 11px;
+      display: grid;
+      gap: 7px;
+    }
+
+    .comment-author {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      color: var(--text-primary);
+      font-size: 12px;
+      font-weight: 820;
+    }
+
+    .comment-author span:last-child {
+      color: rgba(139, 141, 163, .58);
+      font-size: 10px;
+      font-weight: 700;
+    }
+
+    .comment-text {
+      color: rgba(232, 232, 238, .72);
+      font-size: 12px;
+      line-height: 1.45;
+    }
+
+    .continuity-snapshot {
+      position: fixed;
+      z-index: 90;
+      overflow: hidden;
+      pointer-events: none;
+      background: var(--bg-card);
+      border: 1px solid rgba(45, 48, 65, .95);
+      box-shadow: 0 24px 80px rgba(0,0,0,.42);
+      transform-origin: top left;
+      will-change: transform, border-radius, opacity;
+      background:
+        radial-gradient(circle at 14% 0%, rgba(108, 92, 231, .18), transparent 34%),
+        #171A25;
+    }
+
+    .continuity-snapshot.fading-out {
+      transition: opacity .24s ease;
+      opacity: 0;
+    }
+
+    .continuity-snapshot .scene-card {
+      width: 100%;
+      height: 100%;
+      min-height: 0;
+      margin: 0;
+      box-shadow: none;
+      transform: none !important;
+    }
+
+    .continuity-snapshot.to-modal {
+      border-color: rgba(45, 48, 65, .96);
+      box-shadow: 0 40px 80px rgba(0,0,0,.5);
+      background:
+        radial-gradient(circle at 14% 0%, rgba(108, 92, 231, .18), transparent 34%),
+        radial-gradient(circle at 88% 105%, rgba(162, 155, 254, .13), transparent 34%),
+        #171A25;
+    }
+
+    .continuity-snapshot.to-modal > * {
+      transition: opacity .18s ease, transform .18s ease;
+    }
+
+    .continuity-snapshot.to-modal > * {
+      opacity: .18;
+      transform: scale(.985);
+    }
+
+    .continuity-ghost {
+      position: fixed;
+      z-index: 96;
+      overflow: hidden;
+      pointer-events: none;
+      transform-origin: top left;
+      will-change: transform, opacity, border-radius;
+      box-shadow: 0 16px 42px rgba(0,0,0,.26);
+    }
+
+    .continuity-ghost.fading-out {
+      transition: opacity .22s ease;
+      opacity: 0;
+    }
+
+    .continuity-ghost > * {
+      width: 100% !important;
+      height: 100% !important;
+      margin: 0 !important;
+      box-sizing: border-box;
+    }
+
+    .motion-ghost-content {
+      width: 100%;
+      height: 100%;
+      position: relative;
+      overflow: hidden;
+      box-sizing: border-box;
+    }
+
+    .motion-ghost-content::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      transform: translateX(-120%);
+      background: linear-gradient(90deg, transparent, rgba(255,255,255,.10), transparent);
+      animation: skeleton-sweep 1.1s ease-in-out infinite;
+      pointer-events: none;
+    }
+
+    .motion-pill,
+    .motion-line,
+    .motion-stage-seg {
+      display: block;
+      position: relative;
+      border-radius: 999px;
+      background: rgba(255,255,255,.11);
+      box-shadow: inset 0 1px 0 rgba(255,255,255,.035);
+    }
+
+    .motion-title {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 10px;
+      background:
+        linear-gradient(135deg, rgba(108, 92, 231, .13), rgba(15,17,23,.86));
+    }
+
+    .motion-title .idx { width: 42px; height: 12px; opacity: .52; }
+    .motion-title .id { width: 118px; height: 18px; background: rgba(255,255,255,.19); }
+    .motion-title .layout { width: 54px; height: 12px; opacity: .46; }
+    .motion-title .pct { width: 42px; height: 18px; margin-left: auto; opacity: .58; }
+
+    .motion-image {
+      border-radius: inherit;
+      background:
+        radial-gradient(circle at 22% 18%, rgba(162,155,254,.28), transparent 35%),
+        linear-gradient(135deg, rgba(108,92,231,.24), rgba(15,17,23,.94));
+    }
+
+    .motion-image::before {
+      content: "";
+      position: absolute;
+      left: 11px;
+      top: 10px;
+      width: 58px;
+      height: 15px;
+      border-radius: 999px;
+      background: rgba(15,17,23,.56);
+      border: 1px solid rgba(255,255,255,.05);
+    }
+
+    .motion-image .center-mark {
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      width: 92px;
+      height: 15px;
+      transform: translate(-50%, -50%);
+      border-radius: 999px;
+      background: rgba(255,255,255,.12);
+    }
+
+    .motion-stage {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 3px;
+      padding: 5px;
+      background: rgba(15, 17, 23, .86);
+      border: 1px solid rgba(45, 48, 65, .55);
+    }
+
+    .motion-stage-seg {
+      height: 100%;
+      min-height: 14px;
+      border-radius: 7px;
+      opacity: .82;
+    }
+
+    .motion-stage-seg.active {
+      opacity: 1;
+      box-shadow: 0 0 18px rgba(108,92,231,.22), inset 0 1px 0 rgba(255,255,255,.16);
+    }
+
+    .motion-memo {
+      display: grid;
+      grid-template-columns: 32px 1fr;
+      align-items: center;
+      gap: 8px;
+      padding: 7px 9px;
+      background: rgba(23,26,37,.92);
+    }
+
+    .motion-memo .dept-chip {
+      height: 16px;
+      border-radius: 5px;
+      background: rgba(108,92,231,.20);
+    }
+
+    .motion-memo.act .dept-chip {
+      background: rgba(225,112,85,.22);
+    }
+
+    .motion-memo .text-lines {
+      display: grid;
+      gap: 4px;
+    }
+
+    .motion-memo .motion-line {
+      height: 8px;
+      background: rgba(253,203,110,.24);
+    }
+
+    .motion-memo .motion-line.short {
+      width: 68%;
+      opacity: .7;
+    }
+
+    .continuity-skeleton-only {
+      border-radius: inherit;
+      background:
+        radial-gradient(circle at 14% 0%, rgba(108, 92, 231, .18), transparent 36%),
+        linear-gradient(135deg, rgba(26,29,39,.96), rgba(15,17,23,.94));
+      padding: 14px 16px;
+      display: grid;
+      grid-template-rows: auto 56px auto 1fr auto;
+      gap: 12px;
+      width: 100%;
+      height: 100%;
+      box-sizing: border-box;
+    }
+
+    .continuity-skeleton-head,
+    .continuity-skeleton-thumbs,
+    .continuity-skeleton-memos,
+    .continuity-skeleton-depts {
+      display: grid;
+      gap: 8px;
+    }
+
+    .continuity-skeleton-head {
+      grid-template-columns: 1fr 64px;
+      align-items: center;
+    }
+
+    .continuity-skeleton-title {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      min-width: 0;
+    }
+
+    .continuity-skeleton-thumbs {
+      grid-template-columns: 1fr 1fr;
+      gap: 2px;
+      border-radius: 9px;
+      overflow: hidden;
+    }
+
+    .continuity-skeleton-memos {
+      gap: 5px;
+    }
+
+    .continuity-skeleton-depts {
+      align-self: end;
+      gap: 10px;
+    }
+
+    .continuity-skeleton-stage {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 2px;
+      padding: 4px;
+      border-radius: 9px;
+      background: rgba(15,17,23,.7);
+      border: 1px solid rgba(45,48,65,.5);
+      height: 40px;
+    }
+
+    .continuity-skeleton-stage .motion-stage-seg {
+      min-height: 0;
+    }
+
+    .continuity-ghost.ghost-title {
+      border-radius: 10px;
+      background: rgba(23, 26, 37, .88);
+      border: 1px solid rgba(108, 92, 231, .18);
+      box-shadow: 0 12px 34px rgba(0,0,0,.2);
+    }
+
+    .continuity-ghost.ghost-image {
+      border-radius: 10px;
+      border: 1px solid rgba(45, 48, 65, .92);
+      background: rgba(26, 29, 39, .9);
+    }
+
+    .continuity-ghost.ghost-stage {
+      border-radius: 10px;
+      background: rgba(15, 17, 23, .74);
+    }
+
+    .continuity-ghost.ghost-memo {
+      border-radius: 9px;
+      border: 1px solid rgba(253, 203, 110, .13);
+      background: rgba(23, 26, 37, .86);
+      box-shadow: 0 12px 32px rgba(0,0,0,.18);
+    }
+
+    .sheet-row-snapshot {
+      width: 100%;
+      height: 100%;
+      display: grid;
+      grid-template-columns: 96px 1fr 1fr 90px 180px;
+      align-items: center;
+      gap: 8px;
+      padding: 0 12px;
+      background: rgba(26, 29, 39, .94);
+      color: var(--text-primary);
+      font-size: 12px;
+    }
+
+    .sheet-row-snapshot .snap-id {
+      font-family: Consolas, "Fira Code", monospace;
+      font-weight: 900;
+      color: var(--accent-sub);
+    }
+
+    .sheet-row-snapshot .snap-memo {
+      color: rgba(253, 203, 110, .72);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    @media (max-width: 1120px) {
+      .continuity-comments {
+        display: none;
+      }
+      .continuity-main-shell {
+        width: min(720px, calc(100vw - 32px));
+        min-width: min(620px, calc(100vw - 32px));
+      }
+      .modal-depts {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    @media (max-width: 1180px) {
+      .mock-shell {
+        grid-template-columns: 1fr;
+      }
+      .tree { display: none; }
+      .card-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body data-view="card" data-option="c">
+  <div class="mock-shell">
+    <aside class="tree">
+      <div class="tree-head">
+        <div class="tree-title">에피소드</div>
+        <button class="tree-btn">+</button>
+      </div>
+      <div class="ep active">
+        <div class="ep-row"><span>EP03 두근두근 실험실</span><span>78%</span></div>
+        <div class="part-list">
+          <div class="part active"><span>A파트</span><span>전체</span></div>
+          <div class="part"><span>B파트</span><span>63%</span></div>
+          <div class="part"><span>C파트</span><span>41%</span></div>
+        </div>
+      </div>
+      <div class="ep">
+        <div class="ep-row"><span>EP04 준비중</span><span>21%</span></div>
+      </div>
+    </aside>
+
+    <main class="content">
+      <div class="note-bar">
+        <span>실제 Bflow 전체 씬 뷰 구조에 맞춘 완료 색상 시안입니다. 카드뷰/시트뷰를 바꿔 보면서 A/B/C를 비교하세요.</span>
+        <div class="option-tabs" aria-label="완료 색상 시안">
+          <button data-option="a">A안</button>
+          <button data-option="b">B안</button>
+          <button class="active" data-option="c">C안</button>
+        </div>
+      </div>
+
+      <section class="filter">
+        <div class="filter-line">
+          <div class="dept-tabs">
+            <button class="active">전체</button>
+            <button>BG</button>
+            <button>ACT</button>
+          </div>
+          <div class="divider"></div>
+          <div class="select-like">EP03 두근두근 실험실</div>
+          <button class="small-btn accent">+ 에피소드</button>
+          <div class="select-like">A파트</div>
+          <button class="small-btn">+</button>
+          <div class="spacer"></div>
+          <button class="small-btn">옵션 접기</button>
+        </div>
+
+        <div class="filter-line filter-subline">
+          <div class="select-like">작업자: 전체</div>
+          <div class="divider"></div>
+          <div class="status-filter">
+            <button class="active">전체</button>
+            <button>시작 전</button>
+            <button>진행중</button>
+            <button>완료</button>
+          </div>
+          <div class="spacer"></div>
+          <div class="select-like">번호순</div>
+          <button class="small-btn">↑</button>
+          <div class="icon-tabs" aria-label="그룹 모드">
+            <button class="active" title="씬번호별">≡</button>
+            <button title="레이아웃별">▣</button>
+          </div>
+          <div class="icon-tabs" aria-label="보기 모드">
+            <button class="active" data-view="card" title="카드 뷰">▦</button>
+            <button data-view="sheet" title="시트 뷰">▥</button>
+          </div>
+          <input class="search" value="" placeholder="검색..." />
+        </div>
+      </section>
+
+      <section class="progress-strip">
+        <div class="progress-head">
+          <div class="progress-title">현재 화면 진행률 <strong>78%</strong></div>
+          <div class="complete-meta">
+            <span>마지막 완료 · 이다은님 · 방금</span>
+            <button>마지막 체크 취소</button>
+          </div>
+        </div>
+        <div class="bar"><span></span></div>
+        <div class="help" id="option-desc">C안: 부분 완료는 배지 중심으로만 표시합니다. 화면은 조용하지만 한쪽 완료가 덜 눈에 띕니다.</div>
+      </section>
+
+      <section class="view">
+        <div class="card-grid">
+          <article class="scene-card is-partial-complete">
+            <div class="card-head">
+              <div class="scene-id-wrap">
+                <span class="scene-index">#14</span>
+                <span class="scene-id">A014</span>
+                <span class="layout-chip">L#03</span>
+              </div>
+              <div class="badges"><span class="badge comment">3</span><span class="pct">75%</span></div>
+            </div>
+            <div class="thumbs"><div class="thumb">SB</div><div class="thumb">GUIDE</div></div>
+            <div class="memo-lines">
+              <div class="memo-line"><span class="mini-dept bg">BG</span><span>최종 배경 업로드 완료. 컨펌 대기 없음.</span></div>
+              <div class="memo-line"><span class="mini-dept act">ACT</span><span>작업중 2차. 팔 동작 타이밍 재확인.</span></div>
+            </div>
+            <div class="dept-sections">
+              <div class="dept-section is-complete">
+                <div class="dept-top">
+                  <div class="dept-name" style="color:var(--bg-color)"><span class="dot" style="background:var(--bg-color)"></span>BG</div>
+                  <span class="assignee">김OO</span>
+                </div>
+                <div class="stage-track">
+                  <div class="stage done-prev" style="background:rgba(196,188,250,.16);color:var(--bg-lo)">LO</div>
+                  <div class="stage done-prev" style="background:rgba(165,153,245,.16);color:var(--bg-done)">완료</div>
+                  <div class="stage done-prev" style="background:rgba(134,119,239,.16);color:var(--bg-review)">검수</div>
+                  <div class="stage done-current" style="background:var(--bg-png)">PNG</div>
+                </div>
+              </div>
+              <div class="dept-section">
+                <div class="dept-top">
+                  <div class="dept-name" style="color:var(--act-color)"><span class="dot" style="background:var(--act-color)"></span>ACT</div>
+                  <span class="assignee">박OO</span>
+                </div>
+                <div class="phase-round"><span class="round-pill">작업중 2차</span></div>
+                <div class="stage-track">
+                  <div class="stage done-prev" style="background:rgba(110,115,136,.18);color:var(--phase-wait)">대기</div>
+                  <div class="stage done-current" style="background:var(--phase-work);color:var(--bg-primary)">작업중</div>
+                  <div class="stage">피드백</div>
+                  <div class="stage">완료</div>
+                </div>
+              </div>
+            </div>
+            <div class="card-footer"></div>
+          </article>
+
+          <article class="scene-card is-partial-complete">
+            <div class="card-head">
+              <div class="scene-id-wrap">
+                <span class="scene-index">#15</span>
+                <span class="scene-id">A015</span>
+              </div>
+              <div class="badges"><span class="badge complete">ACT 완료</span><span class="pct">62%</span></div>
+            </div>
+            <div class="thumbs"><div class="thumb">SB</div><div class="thumb">GUIDE</div></div>
+            <div class="memo-lines">
+              <div class="memo-line"><span class="mini-dept bg">BG</span><span>검수 전. 창문 밝기만 한 번 더 확인.</span></div>
+              <div class="memo-line"><span class="mini-dept act">ACT</span><span>액팅 최종 완료. 피드백 없음.</span></div>
+            </div>
+            <div class="dept-sections">
+              <div class="dept-section">
+                <div class="dept-top">
+                  <div class="dept-name" style="color:var(--bg-color)"><span class="dot" style="background:var(--bg-color)"></span>BG</div>
+                  <span class="assignee">최OO</span>
+                </div>
+                <div class="stage-track">
+                  <div class="stage done-prev" style="background:rgba(196,188,250,.16);color:var(--bg-lo)">LO</div>
+                  <div class="stage done-current" style="background:var(--bg-done)">완료</div>
+                  <div class="stage">검수</div>
+                  <div class="stage">PNG</div>
+                </div>
+              </div>
+              <div class="dept-section is-complete">
+                <div class="dept-top">
+                  <div class="dept-name" style="color:var(--act-color)"><span class="dot" style="background:var(--act-color)"></span>ACT</div>
+                  <span class="assignee">이OO</span>
+                </div>
+                <div class="stage-track">
+                  <div class="stage done-prev" style="background:rgba(110,115,136,.18);color:var(--phase-wait)">대기</div>
+                  <div class="stage done-prev" style="background:rgba(116,185,255,.16);color:var(--phase-work)">작업중</div>
+                  <div class="stage done-prev" style="background:rgba(253,203,110,.16);color:var(--phase-feedback)">피드백</div>
+                  <div class="stage done-current" style="background:var(--complete);color:var(--bg-primary)">완료</div>
+                </div>
+              </div>
+            </div>
+            <div class="card-footer"></div>
+          </article>
+
+          <article class="scene-card is-all-complete">
+            <div class="card-head">
+              <div class="scene-id-wrap">
+                <span class="scene-index">#16</span>
+                <span class="scene-id">A016</span>
+                <span class="layout-chip">L#04</span>
+              </div>
+              <div class="badges"><span class="badge complete">전체 완료</span><span class="pct">100%</span></div>
+            </div>
+            <div class="thumbs"><div class="thumb">SB</div><div class="thumb">GUIDE</div></div>
+            <div class="memo-lines">
+              <div class="memo-line"><span class="mini-dept bg">BG</span><span>BG 최종 완료. 파일 정리 끝.</span></div>
+              <div class="memo-line"><span class="mini-dept act">ACT</span><span>ACT 최종 완료. 추가 피드백 없음.</span></div>
+            </div>
+            <div class="dept-sections">
+              <div class="dept-section is-complete">
+                <div class="dept-top">
+                  <div class="dept-name" style="color:var(--bg-color)"><span class="dot" style="background:var(--bg-color)"></span>BG</div>
+                  <span class="assignee">한OO</span>
+                </div>
+                <div class="stage-track">
+                  <div class="stage done-prev" style="background:rgba(196,188,250,.16);color:var(--bg-lo)">LO</div>
+                  <div class="stage done-prev" style="background:rgba(165,153,245,.16);color:var(--bg-done)">완료</div>
+                  <div class="stage done-prev" style="background:rgba(134,119,239,.16);color:var(--bg-review)">검수</div>
+                  <div class="stage done-current" style="background:var(--bg-png)">PNG</div>
+                </div>
+              </div>
+              <div class="dept-section is-complete">
+                <div class="dept-top">
+                  <div class="dept-name" style="color:var(--act-color)"><span class="dot" style="background:var(--act-color)"></span>ACT</div>
+                  <span class="assignee">정OO</span>
+                </div>
+                <div class="stage-track">
+                  <div class="stage done-prev" style="background:rgba(110,115,136,.18);color:var(--phase-wait)">대기</div>
+                  <div class="stage done-prev" style="background:rgba(116,185,255,.16);color:var(--phase-work)">작업중</div>
+                  <div class="stage done-prev" style="background:rgba(253,203,110,.16);color:var(--phase-feedback)">피드백</div>
+                  <div class="stage done-current" style="background:var(--complete);color:var(--bg-primary)">완료</div>
+                </div>
+              </div>
+            </div>
+            <div class="card-footer"></div>
+          </article>
+        </div>
+
+        <div class="sheet-view">
+          <table id="sheet-table">
+            <colgroup>
+              <col style="width:96px" />
+              <col style="width:210px" />
+              <col style="width:210px" />
+              <col style="width:56px" />
+              <col style="width:56px" />
+              <col style="width:90px" />
+              <col style="width:40px" />
+              <col style="width:40px" />
+              <col style="width:40px" />
+              <col style="width:40px" />
+              <col style="width:90px" />
+              <col style="width:190px" />
+              <col style="width:34px" />
+            </colgroup>
+            <thead>
+              <tr class="group-head">
+                <th colspan="3"></th>
+                <th></th>
+                <th></th>
+                <th colspan="5"><span style="color:var(--bg-color)">●</span> BG</th>
+                <th colspan="2"><span style="color:var(--act-color)">●</span> ACT</th>
+                <th></th>
+              </tr>
+              <tr>
+                <th class="resizable">씬번호<span class="resize-handle"></span></th>
+                <th class="resizable" style="color:var(--bg-color)">BG 메모<span class="resize-handle"></span></th>
+                <th class="resizable" style="color:var(--act-color)">ACT 메모<span class="resize-handle"></span></th>
+                <th class="center resizable">SB<span class="resize-handle"></span></th>
+                <th class="center resizable">가이드<span class="resize-handle"></span></th>
+                <th class="resizable" style="color:var(--bg-color)">BG담당<span class="resize-handle"></span></th>
+                <th class="center" style="color:var(--bg-lo)">LO</th>
+                <th class="center" style="color:var(--bg-done)">완료</th>
+                <th class="center" style="color:var(--bg-review)">검수</th>
+                <th class="center" style="color:var(--bg-png)">PNG</th>
+                <th class="resizable" style="color:var(--act-color)">ACT담당<span class="resize-handle"></span></th>
+                <th class="center resizable" style="color:var(--act-color)">액팅 단계<span class="resize-handle"></span></th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="is-partial-complete">
+                <td><span class="scene-num-glow-wrap">A014</span><span class="comment-chip">3</span></td>
+                <td class="editable">최종 배경 업로드 완료. 컨펌 대기 없음.</td>
+                <td class="editable">작업중 2차. 팔 동작 타이밍 재확인.</td>
+                <td class="center"><span class="thumb-cell">SB</span></td>
+                <td class="center"><span class="thumb-cell">G</span></td>
+                <td><span class="assignee-chip">김OO</span></td>
+                <td class="center"><span class="check-cell" style="background:var(--bg-lo)">✓</span></td>
+                <td class="center"><span class="check-cell" style="background:var(--bg-done)">✓</span></td>
+                <td class="center"><span class="check-cell" style="background:var(--bg-review)">✓</span></td>
+                <td class="center"><span class="check-cell" style="background:var(--bg-png)">✓</span></td>
+                <td><span class="assignee-chip">박OO</span></td>
+                <td><div class="phase-cell"><span class="phase-chip">대기</span><span class="phase-chip active">작업중</span><span class="phase-chip">피드백</span><span class="phase-chip">완료</span></div></td>
+                <td></td>
+              </tr>
+              <tr class="is-partial-complete">
+                <td><span class="scene-num-glow-wrap">A015</span></td>
+                <td class="editable">검수 전. 창문 밝기만 한 번 더 확인.</td>
+                <td class="editable">액팅 최종 완료. 피드백 없음.</td>
+                <td class="center"><span class="thumb-cell">SB</span></td>
+                <td class="center"><span class="thumb-cell">G</span></td>
+                <td><span class="assignee-chip">최OO</span></td>
+                <td class="center"><span class="check-cell" style="background:var(--bg-lo)">✓</span></td>
+                <td class="center"><span class="check-cell" style="background:var(--bg-done)">✓</span></td>
+                <td class="center"><span class="check-cell"></span></td>
+                <td class="center"><span class="check-cell"></span></td>
+                <td><span class="assignee-chip">이OO</span></td>
+                <td><div class="phase-cell"><span class="phase-chip">대기</span><span class="phase-chip">작업중</span><span class="phase-chip">피드백</span><span class="phase-chip done">완료</span></div></td>
+                <td></td>
+              </tr>
+              <tr class="is-all-complete">
+                <td><span class="scene-num-glow-wrap">A016</span><span class="comment-chip">1</span></td>
+                <td class="editable">BG 최종 완료. 파일 정리 끝.</td>
+                <td class="editable">ACT 최종 완료. 추가 피드백 없음.</td>
+                <td class="center"><span class="thumb-cell">SB</span></td>
+                <td class="center"><span class="thumb-cell">G</span></td>
+                <td><span class="assignee-chip">한OO</span></td>
+                <td class="center"><span class="check-cell" style="background:var(--bg-lo)">✓</span></td>
+                <td class="center"><span class="check-cell" style="background:var(--bg-done)">✓</span></td>
+                <td class="center"><span class="check-cell" style="background:var(--bg-review)">✓</span></td>
+                <td class="center"><span class="check-cell" style="background:var(--bg-png)">✓</span></td>
+                <td><span class="assignee-chip">정OO</span></td>
+                <td><div class="phase-cell"><span class="phase-chip">대기</span><span class="phase-chip">작업중</span><span class="phase-chip">피드백</span><span class="phase-chip done">완료</span></div></td>
+                <td></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <script>
+    const descriptions = {
+      a: 'A안: 한쪽만 완료되면 해당 부서 섹션만 완료 표시, BG+ACT 둘 다 완료될 때만 카드/행 전체가 강하게 변합니다.',
+      b: 'B안: 부분 완료 카드/행에도 초록 기운을 조금 더 줍니다. 완료가 눈에 잘 띄지만, 전체 완료와 헷갈릴 여지가 있습니다.',
+      c: 'C안: 부분 완료는 배지 중심으로만 표시합니다. 화면은 조용하지만 한쪽 완료가 덜 눈에 띕니다.'
+    };
+
+    document.querySelectorAll('.option-tabs [data-option]').forEach((button) => {
+      button.addEventListener('click', () => {
+        const option = button.dataset.option;
+        if (!option) return;
+        document.body.dataset.option = option;
+        document.querySelectorAll('.option-tabs [data-option]').forEach((item) => item.classList.toggle('active', item === button));
+        document.getElementById('option-desc').textContent = descriptions[option];
+      });
+    });
+
+    document.querySelectorAll('.icon-tabs [data-view]').forEach((button) => {
+      button.addEventListener('click', () => {
+        const view = button.dataset.view;
+        if (!view) return;
+        document.body.dataset.view = view;
+        document.querySelectorAll('.icon-tabs [data-view]').forEach((item) => item.classList.toggle('active', item === button));
+      });
+    });
+
+    let resizeState = null;
+    const table = document.getElementById('sheet-table');
+    const cols = table.querySelectorAll('col');
+
+    document.querySelectorAll('.resize-handle').forEach((handle) => {
+      handle.addEventListener('mousedown', (event) => {
+        const th = handle.closest('th');
+        const headerCells = Array.from(th.parentElement.children);
+        const colIndex = headerCells.indexOf(th);
+        const currentWidth = cols[colIndex].getBoundingClientRect().width;
+        resizeState = { handle, colIndex, startX: event.clientX, startWidth: currentWidth };
+        handle.classList.add('active');
+        document.body.style.cursor = 'col-resize';
+        event.preventDefault();
+      });
+    });
+
+    window.addEventListener('mousemove', (event) => {
+      if (!resizeState) return;
+      const nextWidth = Math.max(42, resizeState.startWidth + event.clientX - resizeState.startX);
+      cols[resizeState.colIndex].style.width = `${Math.round(nextWidth)}px`;
+    });
+
+    window.addEventListener('mouseup', () => {
+      if (!resizeState) return;
+      resizeState.handle.classList.remove('active');
+      resizeState = null;
+      document.body.style.cursor = '';
+    });
+
+    let activeTransition = null;
+
+    const getSceneData = (source) => {
+      const isCard = source.classList.contains('scene-card');
+      const sceneId = isCard
+        ? source.querySelector('.scene-id')?.textContent?.trim()
+        : source.querySelector('.scene-num-glow-wrap')?.textContent?.trim();
+      const isComplete = source.classList.contains('is-all-complete');
+      const isPartial = source.classList.contains('is-partial-complete');
+      const bgMemo = isCard
+        ? source.querySelector('.memo-line .mini-dept.bg')?.parentElement?.textContent?.replace('BG', '').trim()
+        : source.children[1]?.textContent?.trim();
+      const actMemo = isCard
+        ? source.querySelector('.memo-line .mini-dept.act')?.parentElement?.textContent?.replace('ACT', '').trim()
+        : source.children[2]?.textContent?.trim();
+
+      return {
+        sceneId: sceneId || 'A014',
+        status: isComplete ? '전체 완료' : isPartial ? '부분 완료' : '진행중',
+        bgMemo: bgMemo || 'BG 메모 없음',
+        actMemo: actMemo || 'ACT 메모 없음',
+        isComplete,
+        isPartial,
+      };
+    };
+
+    const buildSnapshot = (source) => {
+      const snapshot = document.createElement('div');
+      snapshot.className = 'continuity-snapshot';
+      if (source.classList.contains('scene-card')) {
+        snapshot.innerHTML = `
+          <div class="continuity-skeleton-only">
+            <div class="continuity-skeleton-head">
+              <div class="continuity-skeleton-title">
+                <span class="motion-pill idx"></span>
+                <span class="motion-pill id"></span>
+                <span class="motion-pill layout"></span>
+              </div>
+              <span class="motion-pill pct"></span>
+            </div>
+            <div class="continuity-skeleton-thumbs">
+              <div class="motion-image"><span class="center-mark"></span></div>
+              <div class="motion-image"><span class="center-mark"></span></div>
+            </div>
+            <div class="continuity-skeleton-memos">
+              <div class="motion-memo bg"><span class="dept-chip"></span><span class="text-lines"><span class="motion-line"></span><span class="motion-line short"></span></span></div>
+              <div class="motion-memo act"><span class="dept-chip"></span><span class="text-lines"><span class="motion-line"></span><span class="motion-line short"></span></span></div>
+            </div>
+            <div class="continuity-skeleton-depts">
+              <div class="continuity-skeleton-stage">
+                <span class="motion-stage-seg" style="background:rgba(196,188,250,.30)"></span>
+                <span class="motion-stage-seg" style="background:rgba(165,153,245,.30)"></span>
+                <span class="motion-stage-seg" style="background:rgba(134,119,239,.30)"></span>
+                <span class="motion-stage-seg active" style="background:rgba(108,92,231,.78)"></span>
+              </div>
+              <div class="continuity-skeleton-stage">
+                <span class="motion-stage-seg" style="background:rgba(110,115,136,.28)"></span>
+                <span class="motion-stage-seg active" style="background:rgba(116,185,255,.54)"></span>
+                <span class="motion-stage-seg" style="background:rgba(253,203,110,.34)"></span>
+                <span class="motion-stage-seg" style="background:rgba(0,184,148,.55)"></span>
+              </div>
+            </div>
+          </div>
+        `;
+      } else {
+        const data = getSceneData(source);
+        snapshot.innerHTML = `
+          <div class="sheet-row-snapshot">
+            <span class="snap-id">${data.sceneId}</span>
+            <span class="snap-memo">${data.bgMemo}</span>
+            <span class="snap-memo">${data.actMemo}</span>
+            <span>${data.status}</span>
+            <span>${data.isComplete ? 'BG + ACT 완료' : '상세 확인'}</span>
+          </div>
+        `;
+      }
+      return snapshot;
+    };
+
+    const buildModal = (source) => {
+      const data = getSceneData(source);
+      const sceneNo = data.sceneId.match(/\d+$/)?.[0]?.replace(/^0+/, '') || '14';
+      const totalPct = data.isComplete ? '100%' : data.isPartial ? '74%' : '42%';
+      const bgDone = data.isComplete || data.bgMemo.includes('완료');
+      const actDone = data.isComplete || data.actMemo.includes('완료');
+      const overlay = document.createElement('div');
+      overlay.className = 'continuity-overlay';
+      overlay.innerHTML = `
+        <div class="continuity-backdrop"></div>
+        <section class="continuity-modal" role="dialog" aria-modal="true" aria-label="${data.sceneId} 상세">
+          <div class="continuity-main-shell">
+            <div class="modal-glow-a"></div>
+            <div class="modal-glow-b"></div>
+            <div class="modal-skeleton" aria-hidden="true">
+              <div class="skeleton-head">
+                <div style="display:flex;align-items:center;gap:10px;min-width:0;">
+                  <span class="skel id"></span>
+                  <span class="skel meta"></span>
+                </div>
+                <div style="display:flex;align-items:center;gap:8px;">
+                  <span class="skel button"></span>
+                  <span class="skel button"></span>
+                  <span class="skel button"></span>
+                </div>
+              </div>
+              <div class="skeleton-tabs">
+                <span class="skel tab"></span>
+                <span class="skel tab"></span>
+                <span class="skel tab"></span>
+                <span class="skel tab"></span>
+              </div>
+              <div class="skeleton-body">
+                <div class="skeleton-image-grid">
+                  <span class="skel image"></span>
+                  <span class="skel image"></span>
+                </div>
+                <div class="skeleton-dept-grid">
+                  <span class="skel card"></span>
+                  <span class="skel card"></span>
+                </div>
+              </div>
+              <div class="skeleton-dots">
+                <span class="skel dot"></span>
+                <span class="skel dot"></span>
+                <span class="skel dot active"></span>
+                <span class="skel dot"></span>
+                <span class="skel dot"></span>
+              </div>
+            </div>
+            <div class="modal-inner">
+              <div class="modal-head">
+                <div class="modal-title-wrap" data-motion-target="title">
+                  <span class="modal-scene-no">#${sceneNo}</span>
+                  <span class="modal-scene-id">${data.sceneId}</span>
+                  <span class="modal-layout">L#03</span>
+                  <span class="modal-sub">EP03 / A파트</span>
+                  <span class="modal-total">${totalPct}</span>
+                </div>
+                <div class="modal-actions">
+                  <button class="modal-nav-btn" aria-label="이전 씬">‹</button>
+                  <span class="modal-nav-count">14 / 42</span>
+                  <button class="modal-nav-btn" aria-label="다음 씬">›</button>
+                  <button class="modal-delete">씬 삭제</button>
+                  <div class="modal-dept-toggle" aria-label="부서 전환">
+                    <span class="active">통합</span>
+                    <span>BG</span>
+                    <span>액팅</span>
+                  </div>
+                  <button class="modal-close" aria-label="닫기">×</button>
+                </div>
+              </div>
+              <div class="modal-tabs">
+                <span class="active">상세</span>
+                <span>리비전</span>
+                <span>파일</span>
+                <span>히스토리</span>
+              </div>
+              <div class="modal-body">
+                <div class="modal-image-grid">
+                  <div class="modal-image-slot" data-label="스토리보드" data-motion-target="storyboard">STORYBOARD</div>
+                  <div class="modal-image-slot" data-label="가이드" data-motion-target="guide">GUIDE</div>
+                </div>
+                <div class="modal-depts">
+                  <div class="modal-dept-card ${bgDone ? 'complete' : ''}" data-dept="bg">
+                    <div class="dept-top">
+                      <div class="dept-name" style="color:var(--bg-color)"><span class="dot" style="background:var(--bg-color)"></span>BG</div>
+                      <span class="assignee">${bgDone ? '완료' : '담당자'}</span>
+                    </div>
+                    <div class="modal-section-label">진행 단계</div>
+                    <div class="stage-track" data-motion-target="bg-stage">
+                      <div class="stage done-prev" style="background:rgba(196,188,250,.16);color:var(--bg-lo)">LO</div>
+                      <div class="stage done-prev" style="background:rgba(165,153,245,.16);color:var(--bg-done)">완료</div>
+                      <div class="stage done-prev" style="background:rgba(134,119,239,.16);color:var(--bg-review)">검수</div>
+                      <div class="stage done-current" style="background:var(--bg-png)">PNG</div>
+                    </div>
+                    <div class="modal-section-label">속성</div>
+                    <div class="modal-property-list">
+                      <div class="modal-property-row"><b>담당자</b><span>한OO</span></div>
+                      <div class="modal-property-row"><b>레이아웃</b><span>L#03</span></div>
+                      <div class="modal-property-row"><b>메모</b><span class="memo-text" data-motion-target="bg-memo">${data.bgMemo}</span></div>
+                    </div>
+                  </div>
+                  <div class="modal-dept-card ${actDone ? 'complete' : ''}" data-dept="act">
+                    <div class="dept-top">
+                      <div class="dept-name" style="color:var(--act-color)"><span class="dot" style="background:var(--act-color)"></span>ACT</div>
+                      <span class="assignee">${actDone ? '완료' : '작업중'}</span>
+                    </div>
+                    <div class="modal-section-label">액팅 단계</div>
+                    <div class="stage-track" data-motion-target="act-stage">
+                      <div class="stage done-prev" style="background:rgba(110,115,136,.18);color:var(--phase-wait)">대기</div>
+                      <div class="stage done-prev" style="background:rgba(116,185,255,.16);color:var(--phase-work)">작업중</div>
+                      <div class="stage done-prev" style="background:rgba(253,203,110,.16);color:var(--phase-feedback)">피드백</div>
+                      <div class="stage done-current" style="background:var(--complete);color:var(--bg-primary)">완료</div>
+                    </div>
+                    <div class="modal-section-label">속성</div>
+                    <div class="modal-property-list">
+                      <div class="modal-property-row"><b>담당자</b><span>정OO</span></div>
+                      <div class="modal-property-row"><b>회차</b><span>2차 작업</span></div>
+                      <div class="modal-property-row"><b>메모</b><span class="memo-text" data-motion-target="act-memo">${data.actMemo}</span></div>
+                    </div>
+                  </div>
+                </div>
+                <div class="modal-meta-row">
+                  <span>등록 2026-05-22 10:24</span>
+                  <span>수정 2026-05-26 15:08</span>
+                  <span>${data.status}</span>
+                </div>
+              </div>
+              <div class="modal-dots">
+                <span class="modal-dot"></span>
+                <span class="modal-dot"></span>
+                <span class="modal-dot active"></span>
+                <span class="modal-dot"></span>
+                <span class="modal-dot"></span>
+              </div>
+            </div>
+          </div>
+          <aside class="continuity-comments">
+            <div class="comment-head">
+              <span>댓글 및 활동</span>
+              <span class="comment-count">(3)</span>
+            </div>
+            <div class="comment-list">
+              <div class="comment-item">
+                <div class="comment-author"><span>이OO</span><span>오늘 14:20</span></div>
+                <div class="comment-text">가이드 기준으로 손 위치만 한 번 더 확인 부탁드립니다.</div>
+              </div>
+              <div class="comment-item">
+                <div class="comment-author"><span>한OO</span><span>어제</span></div>
+                <div class="comment-text">BG PNG까지 완료. 액팅 확인 후 최종 완료 처리 예정.</div>
+              </div>
+              <div class="comment-item">
+                <div class="comment-author"><span>시스템</span><span>방금</span></div>
+                <div class="comment-text">마지막 체크: ACT 완료</div>
+              </div>
+            </div>
+          </aside>
+        </section>
+      `;
+      return overlay;
+    };
+
+    const animateSnapshot = async (snapshot, fromRect, toRect, direction = 'open') => {
+      snapshot.style.left = `${fromRect.left}px`;
+      snapshot.style.top = `${fromRect.top}px`;
+      snapshot.style.width = `${fromRect.width}px`;
+      snapshot.style.height = `${fromRect.height}px`;
+      snapshot.style.borderRadius = direction === 'open' ? '12px' : '18px';
+      snapshot.style.transform = 'translate3d(0, 0, 0) scale(1, 1)';
+      document.body.appendChild(snapshot);
+
+      const dx = toRect.left - fromRect.left;
+      const dy = toRect.top - fromRect.top;
+      const sx = toRect.width / Math.max(fromRect.width, 1);
+      const sy = toRect.height / Math.max(fromRect.height, 1);
+      const targetTransform = `translate3d(${dx}px, ${dy}px, 0) scale(${sx}, ${sy})`;
+      const animation = snapshot.animate(
+        [
+          {
+            transform: 'translate3d(0, 0, 0) scale(1, 1)',
+            borderRadius: direction === 'open' ? '12px' : '18px',
+            opacity: 1,
+          },
+          {
+            transform: targetTransform,
+            borderRadius: direction === 'open' ? '18px' : '12px',
+            opacity: 1,
+          },
+        ],
+        { duration: direction === 'open' ? 520 : 360, easing: 'cubic-bezier(0.16, 1, 0.3, 1)', fill: 'forwards' },
+      );
+
+      await animation.finished;
+      snapshot.style.transform = targetTransform;
+      snapshot.style.borderRadius = direction === 'open' ? '18px' : '12px';
+      return snapshot;
+    };
+
+    const sharedMotionSpecs = [
+      {
+        key: 'title',
+        ghostClass: 'ghost-title',
+        delay: 0,
+        source: (source) => source.querySelector('.scene-id-wrap') || source.querySelector('.scene-num-glow-wrap'),
+        target: (modal) => modal.querySelector('[data-motion-target="title"]'),
+      },
+      {
+        key: 'storyboard',
+        ghostClass: 'ghost-image',
+        delay: 35,
+        source: (source) => source.querySelector('.thumbs .thumb:nth-child(1)'),
+        target: (modal) => modal.querySelector('[data-motion-target="storyboard"]'),
+      },
+      {
+        key: 'guide',
+        ghostClass: 'ghost-image',
+        delay: 55,
+        source: (source) => source.querySelector('.thumbs .thumb:nth-child(2)'),
+        target: (modal) => modal.querySelector('[data-motion-target="guide"]'),
+      },
+      {
+        key: 'bg-stage',
+        ghostClass: 'ghost-stage',
+        delay: 90,
+        source: (source) => source.querySelector('.dept-sections .dept-section:nth-child(1) .stage-track'),
+        target: (modal) => modal.querySelector('[data-motion-target="bg-stage"]'),
+      },
+      {
+        key: 'act-stage',
+        ghostClass: 'ghost-stage',
+        delay: 115,
+        source: (source) => source.querySelector('.dept-sections .dept-section:nth-child(2) .stage-track'),
+        target: (modal) => modal.querySelector('[data-motion-target="act-stage"]'),
+      },
+      {
+        key: 'bg-memo',
+        ghostClass: 'ghost-memo',
+        delay: 145,
+        source: (source) => source.querySelector('.memo-lines .memo-line:nth-child(1)'),
+        target: (modal) => modal.querySelector('[data-motion-target="bg-memo"]'),
+      },
+      {
+        key: 'act-memo',
+        ghostClass: 'ghost-memo',
+        delay: 165,
+        source: (source) => source.querySelector('.memo-lines .memo-line:nth-child(2)'),
+        target: (modal) => modal.querySelector('[data-motion-target="act-memo"]'),
+      },
+    ];
+
+    const getSharedMotionPairs = (source, modal, reverse = false) => {
+      if (!source.classList.contains('scene-card')) return [];
+      return sharedMotionSpecs
+        .map((spec) => {
+          const sourceEl = spec.source(source);
+          const targetEl = spec.target(modal);
+          if (!sourceEl || !targetEl) return null;
+          return {
+            key: spec.key,
+            ghostClass: spec.ghostClass,
+            delay: reverse ? Math.max(0, 170 - spec.delay) : spec.delay,
+            fromEl: reverse ? targetEl : sourceEl,
+            toEl: reverse ? sourceEl : targetEl,
+            sourceEl,
+          };
+        })
+        .filter(Boolean);
+    };
+
+    const buildMotionGhostContent = ({ key, fromEl, sourceEl }) => {
+      const root = document.createElement('div');
+      root.className = `motion-ghost-content motion-${key}`;
+
+      if (key === 'title') {
+        root.innerHTML = `
+          <span class="motion-pill idx"></span>
+          <span class="motion-pill id"></span>
+          <span class="motion-pill layout"></span>
+          <span class="motion-pill pct"></span>
+        `;
+        return root;
+      }
+
+      if (key === 'storyboard' || key === 'guide') {
+        root.classList.add('motion-image');
+        root.innerHTML = '<span class="center-mark"></span>';
+        return root;
+      }
+
+      if (key === 'bg-stage' || key === 'act-stage') {
+        root.classList.add('motion-stage');
+        const stages = Array.from((sourceEl || fromEl).querySelectorAll('.stage')).slice(0, 4);
+        const fallbackColors = key === 'bg-stage'
+          ? ['rgba(196,188,250,.30)', 'rgba(165,153,245,.30)', 'rgba(134,119,239,.30)', 'rgba(108,92,231,.78)']
+          : ['rgba(110,115,136,.28)', 'rgba(116,185,255,.54)', 'rgba(253,203,110,.34)', 'rgba(0,184,148,.55)'];
+        root.innerHTML = fallbackColors.map((color, index) => {
+          const stage = stages[index];
+          const inlineColor = stage?.style?.background || color;
+          const isActive = stage?.classList?.contains('done-current') || index === fallbackColors.length - 1;
+          return `<span class="motion-stage-seg ${isActive ? 'active' : ''}" style="background:${inlineColor}"></span>`;
+        }).join('');
+        return root;
+      }
+
+      if (key === 'bg-memo' || key === 'act-memo') {
+        root.classList.add('motion-memo', key === 'act-memo' ? 'act' : 'bg');
+        root.innerHTML = `
+          <span class="dept-chip"></span>
+          <span class="text-lines">
+            <span class="motion-line"></span>
+            <span class="motion-line short"></span>
+          </span>
+        `;
+        return root;
+      }
+
+      root.innerHTML = '<span class="motion-line"></span>';
+      return root;
+    };
+
+    const animateSharedPair = ({ key, fromEl, toEl, ghostClass, delay, sourceEl }, direction = 'open') => {
+      const fromRect = fromEl.getBoundingClientRect();
+      const toRect = toEl.getBoundingClientRect();
+      const ghost = document.createElement('div');
+      ghost.className = `continuity-ghost ${ghostClass}`;
+      ghost.appendChild(buildMotionGhostContent({ key, fromEl, sourceEl }));
+      ghost.style.left = `${fromRect.left}px`;
+      ghost.style.top = `${fromRect.top}px`;
+      ghost.style.width = `${fromRect.width}px`;
+      ghost.style.height = `${fromRect.height}px`;
+      ghost.style.borderRadius = getComputedStyle(fromEl).borderRadius || '10px';
+      document.body.appendChild(ghost);
+
+      const dx = toRect.left - fromRect.left;
+      const dy = toRect.top - fromRect.top;
+      const sx = toRect.width / Math.max(fromRect.width, 1);
+      const sy = toRect.height / Math.max(fromRect.height, 1);
+      const targetTransform = `translate3d(${dx}px, ${dy}px, 0) scale(${sx}, ${sy})`;
+      const targetRadius = getComputedStyle(toEl).borderRadius || '10px';
+      const duration = direction === 'open' ? 620 : 410;
+      const animation = ghost.animate(
+        [
+          {
+            transform: 'translate3d(0, 0, 0) scale(1, 1)',
+            opacity: direction === 'open' ? .94 : .88,
+            borderRadius: getComputedStyle(fromEl).borderRadius || '10px',
+            offset: 0,
+          },
+          {
+            transform: targetTransform,
+            opacity: 1,
+            borderRadius: targetRadius,
+            offset: .82,
+          },
+          {
+            transform: targetTransform,
+            opacity: direction === 'open' ? .98 : .72,
+            borderRadius: targetRadius,
+            offset: 1,
+          },
+        ],
+        {
+          duration,
+          delay,
+          easing: 'cubic-bezier(0.16, 1, 0.3, 1)',
+          fill: 'forwards',
+        },
+      );
+
+      return animation.finished.then(() => {
+        ghost.style.transform = targetTransform;
+        return ghost;
+      });
+    };
+
+    const openContinuityModal = async (source) => {
+      if (resizeState || activeTransition) return;
+      activeTransition = { source };
+
+      const sourceRect = source.getBoundingClientRect();
+      const overlay = buildModal(source);
+      document.body.appendChild(overlay);
+      const modal = overlay.querySelector('.continuity-modal');
+      modal.classList.add('preparing', 'loading');
+      const mainShell = overlay.querySelector('.continuity-main-shell');
+      const close = overlay.querySelector('.modal-close');
+      const backdrop = overlay.querySelector('.continuity-backdrop');
+      const targetRect = mainShell.getBoundingClientRect();
+      const snapshot = buildSnapshot(source);
+      source.classList.add('is-transition-source');
+      const useSharedElements = source.classList.contains('scene-card');
+
+      requestAnimationFrame(() => overlay.classList.add('visible'));
+      let skeletonRevealed = false;
+      const revealSkeleton = () => {
+        if (skeletonRevealed) return;
+        skeletonRevealed = true;
+        modal.classList.remove('preparing');
+        modal.getBoundingClientRect();
+        modal.classList.add('visible');
+      };
+      const revealTimer = window.setTimeout(revealSkeleton, 115);
+
+      if (useSharedElements) {
+        modal.classList.add('motion-active');
+        window.setTimeout(revealSkeleton, 80);
+        const pairs = getSharedMotionPairs(source, modal, false);
+        const ghosts = await Promise.all(pairs.map((pair) => animateSharedPair(pair, 'open')));
+        window.clearTimeout(revealTimer);
+        revealSkeleton();
+        modal.classList.add('hydrated');
+        modal.classList.remove('loading');
+        window.setTimeout(() => {
+          modal.classList.remove('motion-active');
+          ghosts.forEach((ghost) => {
+            ghost.classList.add('fading-out');
+            window.setTimeout(() => ghost.remove(), 230);
+          });
+        }, 80);
+      } else {
+        const animatedSnapshot = await animateSnapshot(snapshot, sourceRect, targetRect, 'open');
+        window.clearTimeout(revealTimer);
+        revealSkeleton();
+        animatedSnapshot.classList.add('to-modal');
+        window.setTimeout(() => {
+          modal.classList.add('hydrated');
+          modal.classList.remove('loading');
+          animatedSnapshot.classList.add('fading-out');
+          window.setTimeout(() => animatedSnapshot.remove(), 260);
+        }, 70);
+      }
+
+      let closing = false;
+      const closeModal = async () => {
+        if (closing) return;
+        closing = true;
+
+        if (useSharedElements) {
+          modal.classList.add('motion-active');
+          const pairs = getSharedMotionPairs(source, modal, true);
+          const closingGhosts = pairs.map((pair) => animateSharedPair(pair, 'close'));
+          window.setTimeout(() => {
+            modal.classList.remove('hydrated');
+            modal.classList.remove('visible');
+            overlay.classList.remove('visible');
+          }, 35);
+          const ghosts = await Promise.all(closingGhosts);
+          ghosts.forEach((ghost) => ghost.remove());
+          overlay.remove();
+        } else {
+          const currentSourceRect = source.getBoundingClientRect();
+          const modalRect = mainShell.getBoundingClientRect();
+          const closingSnapshot = buildSnapshot(source);
+          closingSnapshot.classList.add('to-modal');
+          modal.classList.remove('hydrated');
+          modal.classList.remove('visible');
+          overlay.classList.remove('visible');
+          const animatedClosingSnapshot = await animateSnapshot(closingSnapshot, modalRect, currentSourceRect, 'close');
+          animatedClosingSnapshot.remove();
+          overlay.remove();
+        }
+
+        source.classList.remove('is-transition-source');
+        activeTransition = null;
+      };
+
+      close.addEventListener('click', closeModal);
+      backdrop.addEventListener('click', closeModal);
+      window.addEventListener('keydown', function onEsc(event) {
+        if (event.key !== 'Escape') return;
+        window.removeEventListener('keydown', onEsc);
+        closeModal();
+      });
+    };
+
+    document.querySelectorAll('.scene-card').forEach((card) => {
+      card.addEventListener('click', (event) => {
+        if (event.target.closest('button')) return;
+        openContinuityModal(card);
+      });
+    });
+
+    document.querySelectorAll('.sheet-view tbody tr').forEach((row) => {
+      row.addEventListener('click', (event) => {
+        if (event.target.closest('button, .resize-handle')) return;
+        openContinuityModal(row);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/docs/mockups/2026-05-26-scene-complete-ux.html
+++ b/docs/mockups/2026-05-26-scene-complete-ux.html
@@ -1,0 +1,779 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>B flow Scene Complete UX Mockup</title>
+  <style>
+    :root {
+      --bg: #0F1117;
+      --panel: #151824;
+      --card: #1A1D27;
+      --border: #2D3041;
+      --text: #E8E8EE;
+      --muted: #8B8DA3;
+      --accent: #6C5CE7;
+      --lo: #74B9FF;
+      --done: #00B894;
+      --review: #FDCB6E;
+      --png: #A29BFE;
+      --feedback: #FF7675;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: var(--bg);
+      color: var(--text);
+      font-family: Pretendard, Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      letter-spacing: 0;
+    }
+    .page {
+      width: min(1440px, calc(100vw - 40px));
+      margin: 0 auto;
+      padding: 28px 0 48px;
+    }
+    .top {
+      display: flex;
+      align-items: flex-end;
+      justify-content: space-between;
+      gap: 20px;
+      margin-bottom: 18px;
+    }
+    h1 {
+      margin: 0 0 7px;
+      font-size: 22px;
+      line-height: 1.2;
+      font-weight: 750;
+    }
+    .sub {
+      margin: 0;
+      color: var(--muted);
+      font-size: 13px;
+      line-height: 1.5;
+    }
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      height: 30px;
+      padding: 0 11px;
+      border: 1px solid rgba(108, 92, 231, .28);
+      border-radius: 8px;
+      color: #CFCBFF;
+      background: rgba(108, 92, 231, .12);
+      font-size: 12px;
+      font-weight: 650;
+      white-space: nowrap;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 16px;
+    }
+    .section {
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: rgba(26, 29, 39, .72);
+      overflow: hidden;
+    }
+    .section-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      min-height: 50px;
+      padding: 13px 16px;
+      border-bottom: 1px solid rgba(45, 48, 65, .75);
+      background: rgba(21, 24, 36, .9);
+    }
+    h2 {
+      margin: 0;
+      font-size: 14px;
+      font-weight: 750;
+    }
+    .note {
+      color: var(--muted);
+      font-size: 12px;
+      line-height: 1.45;
+    }
+    .mock-body { padding: 16px; }
+    .toolbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 12px;
+    }
+    .tabs, .segmented {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 4px;
+      border: 1px solid rgba(45, 48, 65, .9);
+      border-radius: 8px;
+      background: rgba(15, 17, 23, .72);
+    }
+    .tab, .seg {
+      height: 28px;
+      padding: 0 10px;
+      border: 0;
+      border-radius: 6px;
+      background: transparent;
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 650;
+      cursor: pointer;
+      transition: background .18s ease, color .18s ease;
+    }
+    .tab.active, .seg.active {
+      color: #fff;
+      background: rgba(108, 92, 231, .23);
+    }
+    .complete-banner {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 14px;
+      padding: 12px 14px;
+      margin-bottom: 14px;
+      border: 1px solid rgba(0, 184, 148, .36);
+      border-radius: 8px;
+      background: linear-gradient(90deg, rgba(0, 184, 148, .14), rgba(0, 184, 148, .045));
+    }
+    .complete-title {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      min-width: 0;
+    }
+    .complete-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 999px;
+      background: var(--done);
+      box-shadow: 0 0 18px rgba(0, 184, 148, .65);
+      flex: 0 0 auto;
+    }
+    .complete-copy {
+      min-width: 0;
+    }
+    .complete-copy strong {
+      display: block;
+      font-size: 13px;
+      line-height: 1.25;
+    }
+    .complete-copy span {
+      display: block;
+      color: #B3B7C8;
+      font-size: 12px;
+      line-height: 1.35;
+      margin-top: 2px;
+    }
+    .actions {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex: 0 0 auto;
+    }
+    .btn {
+      height: 32px;
+      padding: 0 11px;
+      border-radius: 7px;
+      border: 1px solid rgba(255,255,255,.10);
+      background: rgba(255,255,255,.05);
+      color: #E8E8EE;
+      font-size: 12px;
+      font-weight: 700;
+      cursor: pointer;
+      transition: transform .18s ease, background .18s ease, border-color .18s ease, color .18s ease;
+    }
+    .btn:hover {
+      transform: translateY(-1px);
+      background: rgba(255,255,255,.08);
+    }
+    .btn.primary {
+      border-color: rgba(0, 184, 148, .46);
+      background: rgba(0, 184, 148, .16);
+      color: #BFF6E8;
+    }
+    .cards {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 12px;
+    }
+    .scene-card {
+      min-height: 168px;
+      padding: 13px;
+      border: 1px solid rgba(45, 48, 65, .95);
+      border-radius: 8px;
+      background: var(--card);
+      position: relative;
+      overflow: hidden;
+      cursor: pointer;
+      transition: transform .18s ease, border-color .18s ease, box-shadow .18s ease, opacity .18s ease;
+    }
+    .scene-card:hover {
+      transform: translateY(-2px);
+    }
+    .scene-card.selected {
+      outline: 2px solid rgba(108, 92, 231, .75);
+      outline-offset: 2px;
+    }
+    .scene-card.done-subtle {
+      border-color: rgba(0, 184, 148, .48);
+      box-shadow: inset 4px 0 0 rgba(0, 184, 148, .9);
+    }
+    .scene-card.done-tint {
+      border-color: rgba(0, 184, 148, .55);
+      background: linear-gradient(135deg, rgba(0, 184, 148, .19), rgba(26, 29, 39, .92) 46%);
+    }
+    .scene-card.done-off {
+      opacity: .72;
+    }
+    .card-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      margin-bottom: 10px;
+    }
+    .scene-no {
+      font-family: "Fira Code", Consolas, monospace;
+      font-size: 15px;
+      font-weight: 800;
+      color: #fff;
+    }
+    .status-badge {
+      height: 22px;
+      padding: 0 8px;
+      border-radius: 999px;
+      background: rgba(0, 184, 148, .16);
+      color: #98F1DA;
+      border: 1px solid rgba(0, 184, 148, .28);
+      font-size: 11px;
+      font-weight: 750;
+      display: inline-flex;
+      align-items: center;
+    }
+    .memo {
+      min-height: 36px;
+      color: #FDCB6E;
+      font-size: 12px;
+      line-height: 1.45;
+      margin-bottom: 13px;
+    }
+    .stage-line {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 6px;
+    }
+    .stage {
+      height: 28px;
+      border-radius: 6px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #07110F;
+      font-size: 11px;
+      font-weight: 800;
+    }
+    .lo { background: var(--lo); }
+    .done { background: var(--done); }
+    .review { background: var(--review); }
+    .png { background: var(--png); }
+    .setting-panel {
+      display: grid;
+      grid-template-columns: 220px 1fr;
+      gap: 12px;
+      margin-top: 12px;
+    }
+    .setting-box {
+      border: 1px solid rgba(45, 48, 65, .9);
+      border-radius: 8px;
+      padding: 12px;
+      background: rgba(15, 17, 23, .42);
+    }
+    .setting-title {
+      margin-bottom: 9px;
+      color: #E8E8EE;
+      font-size: 12px;
+      font-weight: 750;
+    }
+    .check-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      min-height: 30px;
+      color: var(--muted);
+      font-size: 12px;
+    }
+    .switch {
+      width: 36px;
+      height: 20px;
+      border-radius: 999px;
+      background: rgba(0, 184, 148, .28);
+      border: 1px solid rgba(0, 184, 148, .36);
+      position: relative;
+      cursor: pointer;
+      transition: background .18s ease, border-color .18s ease;
+    }
+    .switch::after {
+      content: "";
+      width: 14px;
+      height: 14px;
+      border-radius: 999px;
+      background: #E8FFF8;
+      position: absolute;
+      right: 3px;
+      top: 2px;
+      transition: transform .18s ease, background .18s ease;
+    }
+    .switch.off {
+      background: rgba(139, 141, 163, .16);
+      border-color: rgba(139, 141, 163, .28);
+    }
+    .switch.off::after {
+      transform: translateX(-16px);
+      background: #A8AABC;
+    }
+    .table-wrap {
+      border: 1px solid rgba(45, 48, 65, .9);
+      border-radius: 8px;
+      overflow: auto;
+      background: rgba(15, 17, 23, .46);
+    }
+    table {
+      width: 100%;
+      min-width: 940px;
+      border-collapse: collapse;
+      font-size: 12px;
+    }
+    th {
+      position: sticky;
+      top: 0;
+      z-index: 1;
+      height: 36px;
+      padding: 0 9px;
+      background: #171A25;
+      color: var(--muted);
+      border-bottom: 1px solid var(--border);
+      text-align: left;
+      font-weight: 700;
+    }
+    td {
+      height: 42px;
+      padding: 0 9px;
+      border-bottom: 1px solid rgba(45, 48, 65, .55);
+      color: #D9DBE6;
+      white-space: nowrap;
+    }
+    .row-working { background: rgba(116, 185, 255, .06); box-shadow: inset 4px 0 0 rgba(116, 185, 255, .75); }
+    .row-feedback { background: rgba(255, 118, 117, .06); box-shadow: inset 4px 0 0 rgba(255, 118, 117, .75); }
+    .row-complete { background: rgba(0, 184, 148, .075); box-shadow: inset 4px 0 0 rgba(0, 184, 148, .88); }
+    .table-wrap[data-color-mode="cell"] tbody tr {
+      background: transparent;
+      box-shadow: none;
+    }
+    .table-wrap[data-color-mode="off"] tbody tr {
+      background: transparent;
+      box-shadow: none;
+    }
+    .table-wrap[data-color-mode="off"] .state {
+      color: var(--muted);
+      background: rgba(139, 141, 163, .1);
+      border-color: rgba(139, 141, 163, .18);
+    }
+    .state {
+      display: inline-flex;
+      align-items: center;
+      height: 22px;
+      padding: 0 8px;
+      border-radius: 999px;
+      font-size: 11px;
+      font-weight: 760;
+    }
+    .state.work { color: #BEE1FF; background: rgba(116, 185, 255, .15); border: 1px solid rgba(116, 185, 255, .25); }
+    .state.feed { color: #FFD0D0; background: rgba(255, 118, 117, .13); border: 1px solid rgba(255, 118, 117, .24); }
+    .state.ok { color: #BDF4E7; background: rgba(0, 184, 148, .14); border: 1px solid rgba(0, 184, 148, .25); }
+    .memo-wide { width: 36%; max-width: 520px; overflow: hidden; text-overflow: ellipsis; color: #FDCB6E; }
+    .memo-normal { width: 280px; max-width: 280px; overflow: hidden; text-overflow: ellipsis; color: #FDCB6E; }
+    .memo-compact { width: 210px; max-width: 210px; overflow: hidden; text-overflow: ellipsis; color: #FDCB6E; }
+    .tiny-checks {
+      display: grid;
+      grid-template-columns: repeat(4, 20px);
+      gap: 5px;
+      justify-content: end;
+    }
+    .tiny {
+      width: 20px;
+      height: 20px;
+      border-radius: 5px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      color: #07110F;
+      font-size: 10px;
+      font-weight: 900;
+    }
+    .option-row {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 12px;
+      margin-top: 12px;
+    }
+    .option {
+      border: 1px solid rgba(45, 48, 65, .95);
+      border-radius: 8px;
+      padding: 12px;
+      background: rgba(15, 17, 23, .52);
+      cursor: pointer;
+      transition: transform .18s ease, border-color .18s ease, background .18s ease;
+    }
+    .option:hover { transform: translateY(-1px); }
+    .option.recommended {
+      border-color: rgba(108, 92, 231, .6);
+      background: rgba(108, 92, 231, .09);
+    }
+    .option.selected {
+      border-color: rgba(108, 92, 231, .9);
+      background: rgba(108, 92, 231, .16);
+      box-shadow: 0 0 0 1px rgba(108, 92, 231, .2);
+    }
+    .option strong {
+      display: block;
+      font-size: 12px;
+      margin-bottom: 6px;
+    }
+    .option p {
+      margin: 0;
+      color: var(--muted);
+      font-size: 12px;
+      line-height: 1.45;
+    }
+    @media (max-width: 900px) {
+      .page { width: min(100vw - 24px, 760px); padding-top: 18px; }
+      .top, .toolbar, .complete-banner { align-items: stretch; flex-direction: column; }
+      .cards, .setting-panel, .option-row { grid-template-columns: 1fr; }
+      .actions { width: 100%; }
+      .btn { flex: 1; }
+    }
+  </style>
+</head>
+<body>
+  <main class="page">
+    <div class="top">
+      <div>
+        <h1>씬 뷰 완료 UX 목업</h1>
+        <p class="sub">실제 구현 전 확인용입니다. 앱의 기존 어두운 톤과 단계 색상은 유지하고, 완료 상태를 더 잘 보이게 하는 방향만 비교합니다.</p>
+      </div>
+      <div class="pill">논의용 목업 · production 코드 아님</div>
+    </div>
+
+    <div class="grid">
+      <section class="section">
+        <div class="section-head">
+          <h2>1. 전체 완료 표시 + 마지막 동작 취소</h2>
+          <div class="note">완료가 뜬 직후, 사용자가 방금 누른 체크만 되돌리는 안입니다.</div>
+        </div>
+        <div class="mock-body">
+          <div class="toolbar">
+            <div class="tabs">
+              <button class="tab active">카드</button>
+              <button class="tab">시트</button>
+            </div>
+            <div class="segmented">
+              <button class="seg active">전체</button>
+              <button class="seg">BG</button>
+              <button class="seg">ACT</button>
+            </div>
+          </div>
+
+          <div class="complete-banner">
+            <div class="complete-title">
+              <span class="complete-dot"></span>
+              <div class="complete-copy">
+                <strong>현재 화면의 모든 씬이 완료되었습니다</strong>
+                <span>방금 누른 마지막 체크: EP03 A 014 · PNG 완료</span>
+              </div>
+            </div>
+            <div class="actions">
+              <button class="btn primary">마지막 체크 취소</button>
+              <button class="btn">닫기</button>
+            </div>
+          </div>
+
+          <div class="option-row">
+            <div class="option recommended">
+              <strong>추천: 마지막 체크 1개만 되돌리기</strong>
+              <p>실수 복구가 빠르고, 다른 사람의 변경이나 예전 작업까지 되돌릴 위험이 낮습니다.</p>
+            </div>
+            <div class="option">
+              <strong>넓은 취소: 마지막 일괄 작업 되돌리기</strong>
+              <p>여러 씬을 한 번에 완료한 경우 유용하지만, 실패/부분 저장 처리까지 설계해야 합니다.</p>
+            </div>
+            <div class="option">
+              <strong>단순 안내: 창만 닫기</strong>
+              <p>안전하지만 사용자가 다시 뒤로 가서 체크를 찾아 꺼야 해서 문제 해결력이 낮습니다.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="section-head">
+          <h2>2. 카드 뷰 완료 색상 옵션</h2>
+          <div class="note">사용자 설정으로 켜고 끌 수 있게 두는 전제입니다.</div>
+        </div>
+        <div class="mock-body">
+          <div class="cards">
+            <article class="scene-card done-subtle">
+              <div class="card-row">
+                <div class="scene-no">A014</div>
+                <span class="status-badge">완료</span>
+              </div>
+              <div class="memo">액션 컷 확인 완료. PNG까지 정리됨.</div>
+              <div class="stage-line">
+                <span class="stage lo">LO</span>
+                <span class="stage done">완료</span>
+                <span class="stage review">검수</span>
+                <span class="stage png">PNG</span>
+              </div>
+              <div class="note" style="margin-top:12px">A안: 왼쪽 완료 막대 + 살짝 밝은 테두리</div>
+            </article>
+
+            <article class="scene-card done-tint">
+              <div class="card-row">
+                <div class="scene-no">A015</div>
+                <span class="status-badge">완료</span>
+              </div>
+              <div class="memo">검수 후 수정 없음. 최종 파일 업로드 완료.</div>
+              <div class="stage-line">
+                <span class="stage lo">LO</span>
+                <span class="stage done">완료</span>
+                <span class="stage review">검수</span>
+                <span class="stage png">PNG</span>
+              </div>
+              <div class="note" style="margin-top:12px">B안: 카드 배경 자체를 초록 계열로 틴트</div>
+            </article>
+
+            <article class="scene-card done-off">
+              <div class="card-row">
+                <div class="scene-no">A016</div>
+                <span class="status-badge">완료</span>
+              </div>
+              <div class="memo">표시는 기존과 거의 동일. 완료 뱃지만 유지.</div>
+              <div class="stage-line">
+                <span class="stage lo">LO</span>
+                <span class="stage done">완료</span>
+                <span class="stage review">검수</span>
+                <span class="stage png">PNG</span>
+              </div>
+              <div class="note" style="margin-top:12px">C안: 설정을 꺼둔 사용자용 기본 표시</div>
+            </article>
+          </div>
+
+          <div class="setting-panel">
+            <div class="setting-box">
+              <div class="setting-title">씬 뷰 표시 설정</div>
+              <div class="check-row"><span>완료 카드 색상</span><span class="switch"></span></div>
+              <div class="check-row"><span>시트 상태 색상</span><span class="switch"></span></div>
+              <div class="check-row"><span>설정은 이 PC에 저장</span><span style="color:#B3B7C8">preferences</span></div>
+            </div>
+            <div class="option recommended">
+              <strong>추천: A안을 기본값으로 켜기</strong>
+              <p>완료 상태가 바로 보이면서도 기존 카드 디자인을 크게 흔들지 않습니다. B안은 눈에 잘 띄지만 화면 전체가 초록빛으로 많아질 수 있습니다.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="section-head">
+          <h2>3. 시트 뷰 상태 색상 + 메모 폭</h2>
+          <div class="note">컬럼 전체 드래그 재배치보다 먼저, 한눈에 보기 어려운 지점을 줄이는 작은 변경안입니다.</div>
+        </div>
+        <div class="mock-body">
+          <div class="toolbar">
+            <div class="segmented">
+              <button class="seg">메모 넓게</button>
+              <button class="seg active">메모 보통</button>
+              <button class="seg">메모 좁게</button>
+            </div>
+            <div class="segmented">
+              <button class="seg active">행 색상</button>
+              <button class="seg">셀 색상만</button>
+              <button class="seg">끔</button>
+            </div>
+          </div>
+
+          <div class="table-wrap" data-color-mode="row">
+            <table>
+              <thead>
+                <tr>
+                  <th style="width:88px">씬번호</th>
+                  <th style="width:120px">상태</th>
+                  <th class="memo-compact">메모</th>
+                  <th style="width:92px">스토리보드</th>
+                  <th style="width:92px">가이드</th>
+                  <th style="width:120px">담당자</th>
+                  <th style="text-align:right">진행 단계</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="row-working">
+                  <td style="font-family:Consolas,monospace;font-weight:800">A012</td>
+                  <td><span class="state work">작업중</span></td>
+                  <td class="memo-compact">캐릭터 뒤 배경 라인 정리 필요, 그림자 톤 확인</td>
+                  <td>있음</td>
+                  <td>있음</td>
+                  <td>김OO</td>
+                  <td><div class="tiny-checks"><span class="tiny lo">L</span><span class="tiny done">D</span><span class="tiny" style="border:1px solid var(--border);color:var(--muted)">R</span><span class="tiny" style="border:1px solid var(--border);color:var(--muted)">P</span></div></td>
+                </tr>
+                <tr class="row-feedback">
+                  <td style="font-family:Consolas,monospace;font-weight:800">A013</td>
+                  <td><span class="state feed">피드백</span></td>
+                  <td class="memo-compact">검수 코멘트 반영 중. 창문 밝기만 재확인</td>
+                  <td>있음</td>
+                  <td>-</td>
+                  <td>박OO</td>
+                  <td><div class="tiny-checks"><span class="tiny lo">L</span><span class="tiny done">D</span><span class="tiny review">R</span><span class="tiny" style="border:1px solid var(--border);color:var(--muted)">P</span></div></td>
+                </tr>
+                <tr class="row-complete">
+                  <td style="font-family:Consolas,monospace;font-weight:800">A014</td>
+                  <td><span class="state ok">완료</span></td>
+                  <td class="memo-compact">최종 확인 끝. PNG 업로드 완료</td>
+                  <td>있음</td>
+                  <td>있음</td>
+                  <td>이OO</td>
+                  <td><div class="tiny-checks"><span class="tiny lo">L</span><span class="tiny done">D</span><span class="tiny review">R</span><span class="tiny png">P</span></div></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="option-row">
+            <div class="option recommended">
+              <strong>추천: 씬번호 옆에 상태 컬럼 추가</strong>
+              <p>왼쪽에서 씬번호와 상태를 같이 볼 수 있어, 오른쪽 끝 체크박스를 계속 확인하지 않아도 됩니다.</p>
+            </div>
+            <div class="option">
+              <strong>메모 폭 3단계</strong>
+              <p>넓게, 보통, 좁게 중 선택합니다. 드래그 리사이즈보다 단순하고 저장/복구가 안정적입니다.</p>
+            </div>
+            <div class="option">
+              <strong>컬럼 위치 자유 변경</strong>
+              <p>가장 강력하지만 저장 구조, 키보드 편집, 선택 범위 로직까지 함께 손봐야 해서 별도 작업으로 분리하는 편이 안전합니다.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </main>
+  <script>
+    const setActiveButton = (button) => {
+      const group = button.closest('.tabs, .segmented');
+      if (!group) return;
+      group.querySelectorAll('button').forEach((item) => item.classList.remove('active'));
+      button.classList.add('active');
+    };
+
+    const setSelectedInGroup = (item) => {
+      const group = item.parentElement;
+      if (!group) return;
+      group.querySelectorAll('.option, .scene-card').forEach((sibling) => sibling.classList.remove('selected'));
+      item.classList.add('selected');
+    };
+
+    const setMemoWidth = (label) => {
+      const nextClass = label.includes('넓게')
+        ? 'memo-wide'
+        : label.includes('좁게')
+          ? 'memo-compact'
+          : 'memo-normal';
+      document.querySelectorAll('th, td').forEach((cell) => {
+        if (!['memo-wide', 'memo-normal', 'memo-compact'].some((name) => cell.classList.contains(name))) return;
+        cell.classList.remove('memo-wide', 'memo-normal', 'memo-compact');
+        cell.classList.add(nextClass);
+      });
+    };
+
+    const setRowColorMode = (label) => {
+      const tableWrap = document.querySelector('.table-wrap');
+      if (!tableWrap) return;
+      tableWrap.dataset.colorMode = label.includes('셀')
+        ? 'cell'
+        : label.includes('끔')
+          ? 'off'
+          : 'row';
+    };
+
+    const simulateUndoLastCheck = (button) => {
+      const banner = button.closest('.complete-banner');
+      const title = banner?.querySelector('.complete-copy strong');
+      const detail = banner?.querySelector('.complete-copy span');
+      const row = document.querySelector('.row-complete');
+      const state = row?.querySelector('.state');
+      const png = row?.querySelector('.tiny.png');
+
+      button.textContent = '취소 완료';
+      button.disabled = true;
+      button.style.opacity = '.72';
+      if (title) title.textContent = '마지막 체크를 취소했습니다';
+      if (detail) detail.textContent = 'EP03 A 014 · PNG 완료를 해제한 상태입니다';
+      if (row) {
+        row.classList.remove('row-complete');
+        row.classList.add('row-feedback');
+      }
+      if (state) {
+        state.className = 'state feed';
+        state.textContent = '피드백';
+      }
+      if (png) {
+        png.className = 'tiny';
+        png.style.border = '1px solid var(--border)';
+        png.style.color = 'var(--muted)';
+        png.style.background = 'transparent';
+      }
+    };
+
+    document.querySelectorAll('.tab, .seg').forEach((button) => {
+      button.addEventListener('click', () => {
+        setActiveButton(button);
+        const label = button.textContent || '';
+        if (label.includes('메모')) setMemoWidth(label);
+        if (label.includes('행 색상') || label.includes('셀 색상') || label.includes('끔')) setRowColorMode(label);
+      });
+    });
+
+    document.querySelectorAll('.option').forEach((item) => {
+      item.addEventListener('click', () => setSelectedInGroup(item));
+    });
+
+    document.querySelectorAll('.scene-card').forEach((card) => {
+      card.addEventListener('click', () => setSelectedInGroup(card));
+    });
+
+    document.querySelectorAll('.check-row').forEach((row) => {
+      row.addEventListener('click', () => {
+        const sw = row.querySelector('.switch');
+        if (sw) sw.classList.toggle('off');
+      });
+    });
+
+    document.querySelectorAll('.btn').forEach((button) => {
+      button.addEventListener('click', () => {
+        const label = button.textContent || '';
+        if (label.includes('마지막 체크')) {
+          simulateUndoLastCheck(button);
+          return;
+        }
+        if (label.includes('닫기')) {
+          button.closest('.complete-banner')?.remove();
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bflow",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bflow",
-      "version": "1.31.0",
+      "version": "1.32.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@fontsource/gowun-dodum": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -411,6 +411,8 @@ export default function App() {
           setToastDuration(savedPrefs.notifications.toastDuration);
         }
 
+        useAppStore.getState().setCompletionTintEnabled(savedPrefs?.sceneUi?.completionTintEnabled ?? true);
+
         // v1.27.0: lastSeenVersion 토스트는 *splash 닫힌 후* 별도 effect 에서 처리.
         // 초기에 호출하면 Toaster 가 아직 mount 안 된 상태(splash 화면 동안) 라 안 보이는데
         // lastSeenVersion 은 갱신되어 다음 실행에도 안 보임 — 한솔 v1.27.0 1차 보고.
@@ -2103,7 +2105,11 @@ export default function App() {
   useEffect(() => {
     const cleanup = window.electronAPI?.onPreferencesChanged?.(() => {
       loadPreferences()
-        .then((prefs) => { if (prefs) applyPreferencesToDOM(prefs); })
+        .then((prefs) => {
+          if (!prefs) return;
+          applyPreferencesToDOM(prefs);
+          useAppStore.getState().setCompletionTintEnabled(prefs.sceneUi?.completionTintEnabled ?? true);
+        })
         .catch((err) => console.warn('[설정] 브로드캐스트 재적용 실패', err));
     });
     return () => { cleanup?.(); };

--- a/src/components/scenes/EpisodeTreeNav.tsx
+++ b/src/components/scenes/EpisodeTreeNav.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/utils/cn';
 import type { Episode, Department, ScenesDeptFilter } from '@/types';
 import { DEPARTMENT_CONFIGS } from '@/types';
 import { getCombinedPartMemo, type PartContextMenuTarget } from '@/utils/partMemoHelpers';
+import { normalizePartIdKey, partIdMatches } from '@/utils/partId';
 
 export interface ArchivedEpisodeInfo {
   episodeNumber: number;
@@ -151,6 +152,7 @@ export function EpisodeTreeNav({
 
   // 'all' 모드에서 partId별 그룹핑된 항목 타입
   type GroupedPartItem = {
+    partKey: string;
     partId: string;
     scenes: { lo: boolean; done: boolean; review: boolean; png: boolean }[];
     sceneCount: number;
@@ -175,15 +177,21 @@ export function EpisodeTreeNav({
     for (const ep of episodes) {
       const grouped = new Map<string, GroupedPartItem>();
       for (const part of ep.parts) {
-        const existing = grouped.get(part.partId);
+        const partKey = normalizePartIdKey(part.partId);
+        if (!partKey) continue;
+        const existing = grouped.get(partKey);
         if (existing) {
           existing.scenes.push(...part.scenes);
           existing.sceneCount += part.scenes.length;
+          if (part.department === 'bg') {
+            existing.partId = part.partId;
+          }
           if (!existing.sheetNames.includes(part.sheetName)) {
             existing.sheetNames.push(part.sheetName);
           }
         } else {
-          grouped.set(part.partId, {
+          grouped.set(partKey, {
+            partKey,
             partId: part.partId,
             scenes: [...part.scenes],
             sceneCount: part.scenes.length,
@@ -321,13 +329,13 @@ export function EpisodeTreeNav({
                       /* 'all' 모드: partId 기준 그룹핑 (BG+ACT 합산) */
                       (epGroupedPartsMap.get(ep.episodeNumber) ?? []).map((group) => {
                         const defaultPartId = (epGroupedPartsMap.get(ep.episodeNumber) ?? [])[0]?.partId;
-                        const isPartActive = isEpSelected && (selectedPart ?? defaultPartId) === group.partId;
+                        const isPartActive = isEpSelected && partIdMatches(selectedPart ?? defaultPartId, group.partId);
                         const partProgress = calcPartProgress(group.scenes);
                         const memo = getCombinedPartMemo(partMemos, group.sheetNames);
 
                         return (
                           <div
-                            key={group.partId}
+                            key={group.partKey}
                             className={cn(
                               'group/part flex items-center gap-1.5 px-2 py-1 mx-1 rounded-md cursor-pointer transition-colors',
                               isPartActive
@@ -377,7 +385,7 @@ export function EpisodeTreeNav({
                       /* BG/ACT 개별 모드: 기존 방식 */
                       deptParts.map((part) => {
                         const defaultKey = deptParts[0]?.partId;
-                        const isPartActive = isEpSelected && (selectedPart ?? defaultKey) === part.partId;
+                        const isPartActive = isEpSelected && partIdMatches(selectedPart ?? defaultKey, part.partId);
                         const partProgress = calcPartProgress(part.scenes);
                         const memo = partMemos[part.sheetName];
 

--- a/src/components/scenes/SceneContinuityTransition.tsx
+++ b/src/components/scenes/SceneContinuityTransition.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useRef, type RefObject } from 'react';
+
+interface SceneContinuityTransitionProps {
+  sourceElement: HTMLElement | null;
+  targetRootRef: RefObject<HTMLElement>;
+  onComplete?: () => void;
+}
+
+const DURATION_MS = 520;
+const EASING = 'cubic-bezier(0.16, 1, 0.3, 1)';
+
+function readVisibleRect(element: HTMLElement) {
+  const rect = element.getBoundingClientRect();
+  if (rect.width < 1 || rect.height < 1) return null;
+  return rect;
+}
+
+function buildStartTransform(sourceRect: DOMRect, targetRect: DOMRect) {
+  const scaleX = sourceRect.width / Math.max(targetRect.width, 1);
+  const scaleY = sourceRect.height / Math.max(targetRect.height, 1);
+  const translateX = sourceRect.left - targetRect.left;
+  const translateY = sourceRect.top - targetRect.top;
+
+  return `translate3d(${translateX}px, ${translateY}px, 0) scale(${scaleX}, ${scaleY})`;
+}
+
+export function SceneContinuityTransition({
+  sourceElement,
+  targetRootRef,
+  onComplete,
+}: SceneContinuityTransitionProps) {
+  const completedRef = useRef(false);
+
+  useEffect(() => {
+    const targetRoot = targetRootRef.current;
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    if (!sourceElement || !targetRoot || prefersReducedMotion) {
+      onComplete?.();
+      return;
+    }
+
+    let cancelled = false;
+    let animation: Animation | null = null;
+
+    const finish = () => {
+      if (completedRef.current) return;
+      completedRef.current = true;
+      onComplete?.();
+    };
+
+    const previous = {
+      transformOrigin: targetRoot.style.transformOrigin,
+      willChange: targetRoot.style.willChange,
+      overflow: targetRoot.style.overflow,
+      pointerEvents: targetRoot.style.pointerEvents,
+    };
+
+    const restore = () => {
+      targetRoot.classList.remove('bflow-continuity-live-root');
+      sourceElement.classList.remove('bflow-continuity-source-dim');
+      targetRoot.style.transformOrigin = previous.transformOrigin;
+      targetRoot.style.willChange = previous.willChange;
+      targetRoot.style.overflow = previous.overflow;
+      targetRoot.style.pointerEvents = previous.pointerEvents;
+    };
+
+    const frameId = window.requestAnimationFrame(() => {
+      const sourceRect = readVisibleRect(sourceElement);
+      const targetRect = readVisibleRect(targetRoot);
+
+      if (!sourceRect || !targetRect) {
+        finish();
+        return;
+      }
+
+      sourceElement.classList.add('bflow-continuity-source-dim');
+      targetRoot.classList.add('bflow-continuity-live-root');
+      targetRoot.style.transformOrigin = 'top left';
+      targetRoot.style.willChange = 'transform, opacity, filter';
+      targetRoot.style.overflow = 'hidden';
+      targetRoot.style.pointerEvents = 'none';
+
+      animation = targetRoot.animate(
+        [
+          {
+            transform: buildStartTransform(sourceRect, targetRect),
+            opacity: 0.94,
+            filter: 'saturate(0.88) blur(0.2px)',
+          },
+          {
+            transform: 'translate3d(0, 0, 0) scale(1, 1)',
+            opacity: 1,
+            filter: 'saturate(1) blur(0px)',
+          },
+        ],
+        {
+          duration: DURATION_MS,
+          easing: EASING,
+          fill: 'both',
+        },
+      );
+
+      animation.finished
+        .then(() => {
+          if (cancelled) return;
+          restore();
+          finish();
+        })
+        .catch(() => {
+          if (cancelled) return;
+          restore();
+          finish();
+        });
+    });
+
+    return () => {
+      cancelled = true;
+      window.cancelAnimationFrame(frameId);
+      animation?.cancel();
+      restore();
+    };
+  }, [onComplete, sourceElement, targetRootRef]);
+
+  return null;
+}

--- a/src/components/scenes/ScenePhaseToggle.tsx
+++ b/src/components/scenes/ScenePhaseToggle.tsx
@@ -14,7 +14,7 @@
  */
 
 import { ChevronDown, ChevronUp } from 'lucide-react';
-import { useCallback } from 'react';
+import { useCallback, useRef, type PointerEvent as ReactPointerEvent } from 'react';
 import type { Scene, ScenePhaseState } from '@/types';
 import { SCENE_PHASES, SCENE_PHASE_LABELS_SHORT, SCENE_PHASE_COLORS } from '@/types';
 import { cn } from '@/utils/cn';
@@ -48,6 +48,7 @@ export function ScenePhaseToggle({
   // v1.27.0: BG 카드와 동일한 "진행한 이전 단계 옅게 채움" 패턴. 현재 phase 의 앞 단계는
   // 자기 색의 알파(0x20 ≈ 0.125) 로 살짝 채워 시각 진행도 표현.
   const activeIndex = SCENE_PHASES.indexOf(activeState);
+  const pointerHandledRef = useRef(false);
 
   const handleChipClick = useCallback(
     (target: ScenePhaseState) => {
@@ -61,6 +62,20 @@ export function ScenePhaseToggle({
       onStateClick(target);
     },
     [activeState, disabled, onRequestFeedback, onStateClick],
+  );
+
+  const handleChipPointerDown = useCallback(
+    (event: ReactPointerEvent, target: ScenePhaseState) => {
+      if (event.button !== 0) return;
+      event.preventDefault();
+      event.stopPropagation();
+      pointerHandledRef.current = true;
+      handleChipClick(target);
+      window.setTimeout(() => {
+        pointerHandledRef.current = false;
+      }, 600);
+    },
+    [handleChipClick],
   );
 
   return (
@@ -106,11 +121,21 @@ export function ScenePhaseToggle({
           return (
             <div
               key={state}
+              data-continuity-stage-segment
               role="radio"
               aria-checked={isActive}
               aria-disabled={disabled || undefined}
               tabIndex={disabled ? -1 : 0}
-              onClick={() => handleChipClick(state)}
+              onPointerDown={(e) => handleChipPointerDown(e, state)}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                if (pointerHandledRef.current) {
+                  pointerHandledRef.current = false;
+                  return;
+                }
+                handleChipClick(state);
+              }}
               onKeyDown={(e) => {
                 if (disabled) return;
                 if (e.key === ' ' || e.key === 'Enter') {

--- a/src/components/scenes/SceneSheetView.tsx
+++ b/src/components/scenes/SceneSheetView.tsx
@@ -5,11 +5,17 @@ import { MessageCircle, Trash2 } from 'lucide-react';
 import { STAGES, DEPARTMENT_CONFIGS } from '@/types';
 import type { Scene, Stage, Department } from '@/types';
 import type { SceneGroupMode } from '@/stores/useAppStore';
-import { sceneProgress } from '@/utils/calcStats';
+import { useAppStore } from '@/stores/useAppStore';
+import { isFullyDone } from '@/utils/calcStats';
 import { cn } from '@/utils/cn';
 import { HighlightText } from '@/components/common/HighlightText';
 import { AssigneeSelect } from '@/components/common/AssigneeSelect';
 import { AssigneeMultiSelect, AssigneeChipList } from '@/components/common/AssigneeMultiSelect';
+import {
+  ResizableHeaderCell,
+  useResizableSheetColumns,
+  type SheetColumnDefinition,
+} from './SheetColumnResize';
 
 // ─── Props ───────────────────────────────────────────────────
 
@@ -37,6 +43,31 @@ interface CellId { row: number; col: number }
 const EDITABLE_FIELDS = ['memo', 'assignee'] as const;
 
 function cellKey(row: number, col: number) { return `${row}:${col}`; }
+
+type SingleSheetColumnKey =
+  | 'scene'
+  | 'memo'
+  | 'storyboard'
+  | 'guide'
+  | 'assignee'
+  | 'lo'
+  | 'done'
+  | 'review'
+  | 'png'
+  | 'actions';
+
+const SINGLE_SHEET_COLUMNS: Array<SheetColumnDefinition<SingleSheetColumnKey>> = [
+  { key: 'scene', defaultWidth: 96, minWidth: 76, maxWidth: 180 },
+  { key: 'memo', defaultWidth: 300, minWidth: 80, maxWidth: 620 },
+  { key: 'storyboard', defaultWidth: 82, minWidth: 52, maxWidth: 150 },
+  { key: 'guide', defaultWidth: 82, minWidth: 52, maxWidth: 150 },
+  { key: 'assignee', defaultWidth: 120, minWidth: 76, maxWidth: 240 },
+  { key: 'lo', defaultWidth: 54, minWidth: 36, maxWidth: 108 },
+  { key: 'done', defaultWidth: 58, minWidth: 36, maxWidth: 112 },
+  { key: 'review', defaultWidth: 58, minWidth: 36, maxWidth: 112 },
+  { key: 'png', defaultWidth: 58, minWidth: 36, maxWidth: 112 },
+  { key: 'actions', defaultWidth: 40, minWidth: 32, maxWidth: 72 },
+];
 
 // ─── 인라인 편집 셀 (controlled) ─────────────────────────────
 
@@ -166,7 +197,7 @@ function SheetEditableCell({
     <td
       className={cn(
         'px-2 py-1.5 text-xs text-text-secondary cursor-cell truncate transition-colors',
-        isMemo && 'max-w-0',
+        isMemo && 'min-w-0',
         isSelected
           ? 'ring-2 ring-accent ring-inset bg-accent/5'
           : 'hover:bg-accent/5',
@@ -253,32 +284,6 @@ function SheetThumbnailCell({ url, label }: { url: string; label: string }) {
   );
 }
 
-// ─── 진행률 셀 (퍼센트 + 미니 바) ───────────────────────────
-
-function SheetProgressCell({ pct }: { pct: number }) {
-  return (
-    <td className="px-1.5 py-1.5 text-center">
-      <div className="flex flex-col items-center gap-0.5">
-        <span className={cn(
-          'text-[11px] font-mono leading-none',
-          pct >= 100 ? 'text-green-400' : pct >= 50 ? 'text-yellow-400' : 'text-text-secondary',
-        )}>
-          {Math.round(pct)}%
-        </span>
-        <div className="w-full h-1 bg-bg-primary rounded-full overflow-hidden">
-          <div
-            className="h-full rounded-full transition-all duration-500 ease-out"
-            style={{
-              width: `${pct}%`,
-              background: pct >= 100 ? '#6C5CE7' : pct >= 50 ? '#A599F5' : '#C4BCFA',
-            }}
-          />
-        </div>
-      </div>
-    </td>
-  );
-}
-
 // ─── 메인 컴포넌트 ──────────────────────────────────────────
 
 export function SceneSheetView({
@@ -298,6 +303,13 @@ export function SceneSheetView({
   onCtrlClick,
 }: SceneSheetViewProps) {
   const deptConfig = DEPARTMENT_CONFIGS[department];
+  const completionTintEnabled = useAppStore((s) => s.completionTintEnabled);
+  const stagePointerHandledRef = useRef(false);
+  const {
+    widthOf,
+    totalWidth,
+    startResize,
+  } = useResizableSheetColumns(`bflow_scene_sheet_columns_${department}_v1`, SINGLE_SHEET_COLUMNS);
 
   // ── 레이아웃 그룹핑 ──
   const layoutGroups = useMemo(() => {
@@ -574,35 +586,45 @@ export function SceneSheetView({
         onMouseUp={() => setIsDragging(false)}
         style={{ userSelect: isDragging ? 'none' : undefined }}
       >
-        <table className="w-full text-sm border-collapse">
+        <table
+          className="w-full text-sm border-collapse"
+          style={{ tableLayout: 'fixed', minWidth: totalWidth }}
+        >
+          <colgroup>
+            {SINGLE_SHEET_COLUMNS.map((column) => (
+              <col key={column.key} style={{ width: widthOf(column.key) }} />
+            ))}
+          </colgroup>
           {/* ── 헤더 ── */}
           <thead className="sticky top-0 z-10">
             <tr className="bg-bg-card border-b border-bg-border">
               {/* 한솔 결정 (1-B): 레이아웃 별 보기 시 별도 컬럼 대신 행 위에 그룹 헤더 행을 삽입.
                   컬럼 수가 일반 모드와 동일하게 유지된다. */}
-              <th className="w-20 px-2 py-2 text-left text-xs font-medium text-text-secondary">씬번호</th>
-              <th className="px-2 py-2 text-left text-xs font-medium text-text-secondary">메모</th>
-              <th className="w-14 px-1 py-2 text-center text-xs font-medium text-text-secondary">스토리보드</th>
-              <th className="w-14 px-1 py-2 text-center text-xs font-medium text-text-secondary">가이드</th>
-              <th className="w-24 px-2 py-2 text-left text-xs font-medium text-text-secondary">담당자</th>
+              <ResizableHeaderCell columnKey="scene" width={widthOf('scene')} onResizeStart={startResize}>씬번호</ResizableHeaderCell>
+              <ResizableHeaderCell columnKey="memo" width={widthOf('memo')} onResizeStart={startResize}>메모</ResizableHeaderCell>
+              <ResizableHeaderCell columnKey="storyboard" width={widthOf('storyboard')} onResizeStart={startResize} align="center">스토리보드</ResizableHeaderCell>
+              <ResizableHeaderCell columnKey="guide" width={widthOf('guide')} onResizeStart={startResize} align="center">가이드</ResizableHeaderCell>
+              <ResizableHeaderCell columnKey="assignee" width={widthOf('assignee')} onResizeStart={startResize}>담당자</ResizableHeaderCell>
               {STAGES.map((s) => (
-                <th
+                <ResizableHeaderCell
                   key={s}
-                  className="w-10 px-1 py-2 text-center text-[11px] font-medium"
+                  columnKey={s}
+                  width={widthOf(s)}
+                  onResizeStart={startResize}
+                  align="center"
+                  className="px-1 text-[11px]"
                   style={{ color: deptConfig.stageColors[s] }}
                 >
                   {deptConfig.stageLabels[s]}
-                </th>
+                </ResizableHeaderCell>
               ))}
-              <th className="w-14 px-1 py-2 text-center text-xs font-medium text-text-secondary">진행</th>
-              <th className="w-8 px-1 py-2" />
+              <ResizableHeaderCell columnKey="actions" width={widthOf('actions')} onResizeStart={startResize} align="center" className="px-1" />
             </tr>
           </thead>
 
           {/* ── 본문 ── */}
           <tbody>
             {displayScenes.map((scene, rowIndex) => {
-              const pct = sceneProgress(scene);
               const idx = allScenes.indexOf(scene);
               const meta = layoutMeta.get(scene);
               const isRowSelected = selectedSceneIds?.has(scene.sceneId);
@@ -641,6 +663,7 @@ export function SceneSheetView({
                       isRowSelected && 'bg-accent/10 hover:bg-accent/15',
                       searchQuery && 'bg-accent/5 border-l-2 border-l-accent/60',
                       highlightSceneId && scene.sceneId === highlightSceneId && 'scene-row-highlighted',
+                      completionTintEnabled && isFullyDone(scene) && 'scene-completion-tint-row',
                       isLayoutMode && !isLastInGroup && 'scene-row-group-mid',
                       isLayoutMode && isLastInGroup && 'scene-row-group-last',
                     )}
@@ -720,7 +743,26 @@ export function SceneSheetView({
                   {STAGES.map((stage) => (
                     <td key={stage} className="px-1 py-1.5 text-center">
                       <button
-                        onClick={(e) => { e.stopPropagation(); onToggle(scene.sceneId, stage); }}
+                        type="button"
+                        onPointerDown={(e) => {
+                          if (e.button !== 0) return;
+                          e.preventDefault();
+                          e.stopPropagation();
+                          stagePointerHandledRef.current = true;
+                          onToggle(scene.sceneId, stage);
+                          window.setTimeout(() => {
+                            stagePointerHandledRef.current = false;
+                          }, 600);
+                        }}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          if (stagePointerHandledRef.current) {
+                            stagePointerHandledRef.current = false;
+                            return;
+                          }
+                          onToggle(scene.sceneId, stage);
+                        }}
                         className="w-5 h-5 rounded flex items-center justify-center text-xs transition-all mx-auto"
                         style={
                           scene[stage]
@@ -732,9 +774,6 @@ export function SceneSheetView({
                       </button>
                     </td>
                   ))}
-
-                  {/* 진행률 */}
-                  <SheetProgressCell pct={pct} />
 
                   {/* 삭제 */}
                   <td className="px-1 py-1.5">

--- a/src/components/scenes/SheetColumnResize.tsx
+++ b/src/components/scenes/SheetColumnResize.tsx
@@ -1,0 +1,135 @@
+import { useCallback, useMemo, useState, type CSSProperties, type PointerEvent as ReactPointerEvent, type ReactNode } from 'react';
+import { cn } from '@/utils/cn';
+
+export interface SheetColumnDefinition<K extends string> {
+  key: K;
+  defaultWidth: number;
+  minWidth: number;
+  maxWidth?: number;
+}
+
+function clampWidth(width: number, min: number, max?: number) {
+  return Math.max(min, Math.min(max ?? 720, width));
+}
+
+function readStoredWidths<K extends string>(
+  storageKey: string,
+  columns: Array<SheetColumnDefinition<K>>,
+): Record<K, number> {
+  const defaults = Object.fromEntries(columns.map((column) => [column.key, column.defaultWidth])) as Record<K, number>;
+  try {
+    const raw = localStorage.getItem(storageKey);
+    if (!raw) return defaults;
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const next = { ...defaults };
+    for (const column of columns) {
+      const value = parsed[column.key];
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        next[column.key] = clampWidth(value, column.minWidth, column.maxWidth);
+      }
+    }
+    return next;
+  } catch {
+    return defaults;
+  }
+}
+
+export function useResizableSheetColumns<K extends string>(
+  storageKey: string,
+  columns: Array<SheetColumnDefinition<K>>,
+) {
+  const [widths, setWidths] = useState<Record<K, number>>(() => readStoredWidths(storageKey, columns));
+  const columnByKey = useMemo(() => new Map(columns.map((column) => [column.key, column])), [columns]);
+
+  const widthOf = useCallback((key: K) => {
+    const column = columnByKey.get(key);
+    return widths[key] ?? column?.defaultWidth ?? 80;
+  }, [columnByKey, widths]);
+
+  const totalWidth = useMemo(
+    () => columns.reduce((sum, column) => sum + (widths[column.key] ?? column.defaultWidth), 0),
+    [columns, widths],
+  );
+
+  const persist = useCallback((next: Record<K, number>) => {
+    try {
+      localStorage.setItem(storageKey, JSON.stringify(next));
+    } catch {
+      // PC 로컬 저장 실패는 표 표시 자체를 막지 않는다.
+    }
+  }, [storageKey]);
+
+  const startResize = useCallback((key: K, event: ReactPointerEvent) => {
+    const column = columnByKey.get(key);
+    if (!column) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    const startX = event.clientX;
+    const startWidth = widthOf(key);
+    let latest = startWidth;
+
+    document.documentElement.classList.add('is-resizing', 'is-sheet-column-resizing');
+
+    const onMove = (moveEvent: PointerEvent) => {
+      const nextWidth = clampWidth(startWidth + moveEvent.clientX - startX, column.minWidth, column.maxWidth);
+      latest = nextWidth;
+      setWidths((prev) => ({ ...prev, [key]: nextWidth }));
+    };
+
+    const onUp = () => {
+      document.removeEventListener('pointermove', onMove);
+      document.removeEventListener('pointerup', onUp);
+      document.documentElement.classList.remove('is-resizing', 'is-sheet-column-resizing');
+      setWidths((prev) => {
+        const next = { ...prev, [key]: latest };
+        persist(next);
+        return next;
+      });
+    };
+
+    document.addEventListener('pointermove', onMove);
+    document.addEventListener('pointerup', onUp, { once: true });
+  }, [columnByKey, persist, widthOf]);
+
+  return { widthOf, totalWidth, startResize };
+}
+
+export function ResizableHeaderCell<K extends string>({
+  columnKey,
+  width,
+  className,
+  style,
+  align = 'left',
+  onResizeStart,
+  children,
+}: {
+  columnKey: K;
+  width: number;
+  className?: string;
+  style?: CSSProperties;
+  align?: 'left' | 'center';
+  onResizeStart: (key: K, event: ReactPointerEvent) => void;
+  children?: ReactNode;
+}) {
+  return (
+    <th
+      className={cn(
+        'sheet-resizable-th px-2 py-2 text-xs font-medium text-text-secondary',
+        align === 'center' ? 'text-center' : 'text-left',
+        className,
+      )}
+      style={{ ...style, width, minWidth: width, maxWidth: width }}
+    >
+      <span className="block truncate pr-2">{children}</span>
+      <span
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="컬럼 너비 조절"
+        className="sheet-column-resizer"
+        onPointerDown={(event) => onResizeStart(columnKey, event)}
+        onClick={(event) => event.stopPropagation()}
+      />
+    </th>
+  );
+}

--- a/src/components/scenes/UnifiedSceneCard.tsx
+++ b/src/components/scenes/UnifiedSceneCard.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom';
 import { motion } from 'framer-motion';
 import { MessageCircle, MessageSquareWarning, Check, Trash2 } from 'lucide-react';
 import { cn } from '@/utils/cn';
-import { sceneProgress } from '@/utils/calcStats';
+import { isFullyDone, sceneProgress } from '@/utils/calcStats';
 import { STAGES, DEPARTMENT_CONFIGS } from '@/types';
 import type { MergedScene, Stage, Department, ScenePhaseState } from '@/types';
 import { ScenePhaseToggle } from './ScenePhaseToggle';
@@ -13,6 +13,7 @@ import { Confetti } from '@/components/ui/Confetti';
 import { useBulkOperationsStore, type PendingOp } from '@/stores/useBulkOperationsStore';
 import { useDataStore } from '@/stores/useDataStore';
 import { useRevisionStore } from '@/stores/useRevisionStore';
+import { useAppStore } from '@/stores/useAppStore';
 import { buildSceneKey } from '@/services/revisionService';
 import { LengthIcon } from './LengthIcon';
 import { SceneContextMenu } from './SceneContextMenu';
@@ -44,7 +45,7 @@ interface UnifiedSceneCardProps {
   onToggle: (sheetName: string, sceneId: string, stage: Stage) => void;
   onDelete: (sheetName: string, sceneIndex: number) => void;
   onOpenDetail: (sheetName: string, sceneIndex: number) => void;
-  onOpenMerged?: (merged: MergedScene) => void;
+  onOpenMerged?: (merged: MergedScene, sourceElement?: HTMLElement | null) => void;
   onCelebrationEnd: () => void;
   onSelect: () => void;
   onCtrlSelect?: () => void;
@@ -80,6 +81,7 @@ export function UnifiedSceneCard({
 }: UnifiedSceneCardProps) {
   const { sceneId, mergedKey, bgScene, actScene, bgSceneIndex, actSceneIndex } = merged;
   const primaryScene = bgScene ?? actScene;
+  const completionTintEnabled = useAppStore((s) => s.completionTintEnabled);
 
   const cardRootRef = useRef<HTMLDivElement>(null);
   const prevHighlightedRef = useRef(false);
@@ -165,6 +167,7 @@ export function UnifiedSceneCard({
   const actPct = actScene ? sceneProgress(actScene) : 0;
   const presentCount = (bgScene ? 1 : 0) + (actScene ? 1 : 0);
   const combinedPct = presentCount > 0 ? Math.round((bgPct + actPct) / presentCount) : 0;
+  const isMergedComplete = !!bgScene && !!actScene && isFullyDone(bgScene) && isFullyDone(actScene);
 
   const hasImages = !!(bgScene?.storyboardUrl || bgScene?.guideUrl);
   const layoutId = bgScene?.layoutId || actScene?.layoutId;
@@ -183,7 +186,7 @@ export function UnifiedSceneCard({
   const handleDoubleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     if (onOpenMerged) {
-      onOpenMerged(merged);
+      onOpenMerged(merged, e.currentTarget as HTMLElement);
       return;
     }
     if (bgScene && bgSheetName) {
@@ -234,12 +237,14 @@ export function UnifiedSceneCard({
   return (
     <motion.div
       data-scene-id={mergedKey}
+      data-continuity-card
       className={cn(
         'bg-bg-card border border-bg-border rounded-xl flex flex-col group relative cursor-pointer',
         'shadow-[0_2px_6px_rgba(0,0,0,0.08),0_8px_20px_rgba(0,0,0,0.12)]',
         'hover:shadow-[0_3px_8px_rgba(0,0,0,0.12),0_10px_24px_rgba(0,0,0,0.18)]',
         'scene-card-interactive',
         'hover:-translate-y-0.5 hover:border-accent/70',
+        completionTintEnabled && isMergedComplete && 'scene-completion-tint-card',
         // v1.18.0: 미해결 리비전 있는 카드 → 보더에 액센트 강조 (mockup revision-visibility.html 시안 1)
         openRevCount > 0 && 'border-accent/60',
         isHighlighted && 'scene-highlight',
@@ -277,7 +282,7 @@ export function UnifiedSceneCard({
 
         {/* ── 헤더: 씬 ID + 전체 진행률 배지 ── */}
         <div className="px-4 pt-3.5 pb-2 flex items-center justify-between">
-          <div className="flex items-center gap-2 min-w-0">
+          <div className="flex items-center gap-2 min-w-0" data-continuity-source="title">
             <span className="text-sm font-mono text-text-secondary/50">
               #{sceneId ? (sceneId.match(/\d+$/)?.[0]?.replace(/^0+/, '') || primaryScene.no) : primaryScene.no}
             </span>
@@ -341,10 +346,10 @@ export function UnifiedSceneCard({
         {hasImages && (
           <div className="mx-4 mt-0.5 mb-1 flex gap-px rounded-lg overflow-hidden bg-bg-border">
         {bgScene?.storyboardUrl && (
-          <img src={bgScene.storyboardUrl} alt="SB" className="flex-1 h-20 object-contain bg-bg-card/70 min-w-0" draggable={false} onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
+          <img data-continuity-source="storyboard" src={bgScene.storyboardUrl} alt="SB" className="flex-1 h-20 object-contain bg-bg-card/70 min-w-0" draggable={false} onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
         )}
         {bgScene?.guideUrl && (
-          <img src={bgScene.guideUrl} alt="Guide" className="flex-1 h-20 object-contain bg-bg-card/70 min-w-0" draggable={false} onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
+          <img data-continuity-source="guide" src={bgScene.guideUrl} alt="Guide" className="flex-1 h-20 object-contain bg-bg-card/70 min-w-0" draggable={false} onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
         )}
           </div>
         )}
@@ -353,7 +358,7 @@ export function UnifiedSceneCard({
         {(bgScene?.memo || actScene?.memo) && (
           <div className="mx-4 mt-1 flex flex-col gap-0.5" data-no-lasso>
             {bgScene?.memo && (
-              <div className="flex items-center gap-1.5 overflow-hidden">
+              <div className="flex items-center gap-1.5 overflow-hidden" data-continuity-source="bg-memo">
                 <span className="text-[9px] font-bold tracking-wide px-1 py-px rounded text-blue-300 bg-blue-300/15 flex-shrink-0">BG</span>
                 <p className="text-[11px] text-amber-400/70 leading-relaxed truncate min-w-0">
                   <PathLinkifiedText
@@ -364,7 +369,7 @@ export function UnifiedSceneCard({
               </div>
             )}
             {actScene?.memo && (
-              <div className="flex items-center gap-1.5 overflow-hidden">
+              <div className="flex items-center gap-1.5 overflow-hidden" data-continuity-source="act-memo">
                 <span className="text-[9px] font-bold tracking-wide px-1 py-px rounded text-pink-300 bg-pink-300/15 flex-shrink-0">ACT</span>
                 <p className="text-[11px] text-amber-400/70 leading-relaxed truncate min-w-0">
                   <PathLinkifiedText
@@ -456,6 +461,9 @@ function DeptSection({
   onActRoundBump?: (sheetName: string, sceneId: string, kind: 'work' | 'feedback', delta: 1 | -1) => void;
 }) {
   const cfg = DEPARTMENT_CONFIGS[dept];
+  const completionTintEnabled = useAppStore((s) => s.completionTintEnabled);
+  const isDeptDone = !!scene && isFullyDone(scene);
+  const stagePointerHandledRef = useRef(false);
 
   // stage-toggle 작업에서 이 씬의 targetStage 셀에만 pending/failed 스타일 적용
   const stageCellPendingClass = (stage: Stage): string => {
@@ -473,9 +481,16 @@ function DeptSection({
           <span className="text-xs font-semibold text-text-secondary">{cfg.shortLabel}</span>
           <span className="text-[11px] text-text-secondary/50 italic">(미등록)</span>
         </div>
-        <div className="flex rounded-lg bg-bg-primary/70 border border-bg-border/40 p-1 gap-0.5">
+        <div
+          className="flex rounded-lg bg-bg-primary/70 border border-bg-border/40 p-1 gap-0.5"
+          data-continuity-source={dept === 'bg' ? 'bg-stage' : 'act-stage'}
+        >
           {STAGES.map((stage) => (
-            <div key={stage} className="flex-1 min-w-0 text-center py-1.5 text-[11px] font-medium text-text-secondary/30 rounded-md whitespace-nowrap overflow-hidden text-ellipsis">
+            <div
+              key={stage}
+              data-continuity-stage-segment
+              className="flex-1 min-w-0 text-center py-1.5 text-[11px] font-medium text-text-secondary/30 rounded-md whitespace-nowrap overflow-hidden text-ellipsis"
+            >
               {cfg.stageLabels[stage]}
             </div>
           ))}
@@ -490,6 +505,11 @@ function DeptSection({
         <div className="flex items-center gap-1.5">
           <span className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: cfg.color }} />
           <span className="text-xs font-semibold" style={{ color: cfg.color }}>{cfg.shortLabel}</span>
+          {completionTintEnabled && isDeptDone && (
+            <span className="scene-completion-dept-done rounded-full px-1.5 py-0.5 text-[9px] font-semibold leading-none">
+              완료
+            </span>
+          )}
         </div>
         <div className="flex items-center gap-1.5">
           <span className="text-xs text-text-secondary">
@@ -508,7 +528,10 @@ function DeptSection({
           v1.25.3 (한솔 보고): ScenePhaseToggle 가 자체 컨테이너(flex w-full + bg/border)를
           가지므로 wrapper 는 클릭 이벤트 전파만 막음. 기존 4-stage 토글과 동일한 모양. */}
       {dept === 'acting' && onActPhaseStateClick && onActFeedbackRequest && onActRoundBump ? (
-        <div onClick={(e) => e.stopPropagation()}>
+        <div
+          onClick={(e) => e.stopPropagation()}
+          data-continuity-source="act-stage"
+        >
           <ScenePhaseToggle
             scene={scene}
             onStateClick={(next) => onActPhaseStateClick(sheetName, sceneId, next)}
@@ -517,15 +540,38 @@ function DeptSection({
           />
         </div>
       ) : (
-        <div className="flex rounded-lg bg-bg-primary/70 border border-bg-border/40 p-1 gap-0.5">
+        <div
+          className="flex rounded-lg bg-bg-primary/70 border border-bg-border/40 p-1 gap-0.5"
+          data-continuity-source={dept === 'bg' ? 'bg-stage' : 'act-stage'}
+        >
           {STAGES.map((stage, i) => {
             const isDone = scene[stage];
             const isCurrent = isDone && (i === STAGES.length - 1 || !scene[STAGES[i + 1]]);
 
             return (
               <button
+                type="button"
                 key={stage}
-                onClick={(e) => { e.stopPropagation(); onToggle(sheetName, sceneId, stage); }}
+                data-continuity-stage-segment
+                onPointerDown={(e) => {
+                  if (e.button !== 0) return;
+                  e.preventDefault();
+                  e.stopPropagation();
+                  stagePointerHandledRef.current = true;
+                  onToggle(sheetName, sceneId, stage);
+                  window.setTimeout(() => {
+                    stagePointerHandledRef.current = false;
+                  }, 600);
+                }}
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  if (stagePointerHandledRef.current) {
+                    stagePointerHandledRef.current = false;
+                    return;
+                  }
+                  onToggle(sheetName, sceneId, stage);
+                }}
                 className={cn(
                   'flex-1 min-w-0 text-center py-2 text-[11px] font-medium rounded-md transition-all cursor-pointer whitespace-nowrap overflow-hidden text-ellipsis',
                   !isDone && 'text-text-secondary/60 hover:text-text-primary hover:bg-bg-border/25',

--- a/src/components/scenes/UnifiedSceneDetailModal.tsx
+++ b/src/components/scenes/UnifiedSceneDetailModal.tsx
@@ -36,6 +36,7 @@ import { useAppStore } from '@/stores/useAppStore';
 import { buildSceneKey } from '@/services/revisionService';
 import { buildMergedRevisionSceneId } from '@/utils/mergedSceneHelpers';
 import { findLatestMemoActivity, type MemoAuthorMeta } from './memoAuthorMeta';
+import { SceneContinuityTransition } from './SceneContinuityTransition';
 
 /**
  * 전체 뷰(BG+ACT 통합) 전용 상세 모달.
@@ -105,6 +106,10 @@ export interface UnifiedSceneDetailModalProps {
   onActPhaseStateClick?: (sheetName: string, sceneId: string, newState: ScenePhaseState) => void;
   onActFeedbackRequest?: (sheetName: string, sceneId: string) => void;
   onActRoundBump?: (sheetName: string, sceneId: string, kind: 'work' | 'feedback', delta: 1 | -1) => void;
+  /** 카드 뷰에서 열릴 때 카드 내부 요소를 실제 모달 위치로 연결하는 시작 DOM. */
+  continuitySourceElement?: HTMLElement | null;
+  /** continuity transition 종료 후 source DOM 참조를 비울 때 사용. */
+  onContinuityEnd?: () => void;
   /**
    * v1.30.0+: 컴포지팅 대시보드에서 모달을 열 때 부서 패널 위에 끼울 컴포지팅 단계 섹션.
    * 일반 ScenesView 호출은 이 prop 을 생략하면 normal 모드 (영향 0).
@@ -138,6 +143,8 @@ export function UnifiedSceneDetailModal({
   onActPhaseStateClick,
   onActFeedbackRequest,
   onActRoundBump,
+  continuitySourceElement,
+  onContinuityEnd,
   compositingSection,
 }: UnifiedSceneDetailModalProps) {
   const { bgScene, actScene, bgSceneIndex, actSceneIndex } = merged;
@@ -184,6 +191,7 @@ export function UnifiedSceneDetailModal({
   }, [selectedDepartment, setSelectedDepartment, setDashboardDeptFilter, setPendingSceneModalRequest, onClose, bgScene, actScene, merged.sceneId]);
   // 모달 backdrop 드래그 닫힘 방지 — mousedown 시작 위치를 추적해 backdrop 자체에서 시작한 경우만 onClose 트리거
   const backdropMouseDownRef = useRef(false);
+  const modalMainRef = useRef<HTMLDivElement>(null);
 
   // 댓글 키: BG와 ACT 양쪽 조회 가능하게.
   // primary 는 "실제로 이 merged 에 존재하는 부서" 와 일치해야 한다 —
@@ -564,7 +572,8 @@ export function UnifiedSceneDetailModal({
         >
           {/* ── 본체 ── */}
           <motion.div
-            initial={{ opacity: 0, scale: 0.96, y: 12 }}
+            ref={modalMainRef}
+            initial={continuitySourceElement ? { opacity: 1, scale: 1, y: 0 } : { opacity: 0, scale: 0.96, y: 12 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.96, y: 6 }}
             transition={{ duration: 0.18, ease: [0.16, 1, 0.3, 1] }}
@@ -623,6 +632,7 @@ export function UnifiedSceneDetailModal({
                     exit="exit"
                     transition={{ duration: 0.4, ease: [0.16, 1, 0.3, 1] }}
                     className="flex items-center gap-2 min-w-0"
+                    data-continuity-target="title"
                   >
                     <span className="text-sm font-mono text-text-secondary/50">#{sceneNoDisplay}</span>
                     <span className="text-lg font-mono font-bold text-text-primary truncate">
@@ -752,32 +762,38 @@ export function UnifiedSceneDetailModal({
                         {/* 이미지 (BG 기준) */}
                         {primaryScene && (
                           <div className="grid grid-cols-2 gap-3 px-5 pt-4 pb-2">
-                            <UnifiedImageSlot
-                              label="스토리보드"
-                              url={previewUrls.storyboard ?? bgScene?.storyboardUrl ?? ''}
-                              loading={imageLoading === 'storyboard'}
-                              canEdit={!!bgScene && !!bgSheetName}
-                              onPick={() => pickFile('storyboard')}
-                              onRemove={() => setDeleteConfirm('storyboard')}
-                              onView={() => setShowImageModal('storyboard')}
-                              onDropBlob={(b) => uploadImage(b, 'storyboard')}
-                              onHoverChange={(h) => setHoveredImageSlot(h ? 'storyboard' : (s) => s === 'storyboard' ? null : s)}
-                              pinned={pinnedImageSlot === 'storyboard'}
-                              onPinToggle={() => setPinnedImageSlot((p) => p === 'storyboard' ? null : 'storyboard')}
-                            />
-                            <UnifiedImageSlot
-                              label="가이드"
-                              url={previewUrls.guide ?? bgScene?.guideUrl ?? ''}
-                              loading={imageLoading === 'guide'}
-                              canEdit={!!bgScene && !!bgSheetName}
-                              onPick={() => pickFile('guide')}
-                              onRemove={() => setDeleteConfirm('guide')}
-                              onView={() => setShowImageModal('guide')}
-                              onDropBlob={(b) => uploadImage(b, 'guide')}
-                              onHoverChange={(h) => setHoveredImageSlot(h ? 'guide' : (s) => s === 'guide' ? null : s)}
-                              pinned={pinnedImageSlot === 'guide'}
-                              onPinToggle={() => setPinnedImageSlot((p) => p === 'guide' ? null : 'guide')}
-                            />
+                            <div data-continuity-target="storyboard">
+                              <UnifiedImageSlot
+                                label="스토리보드"
+                                continuityTarget="storyboard"
+                                url={previewUrls.storyboard ?? bgScene?.storyboardUrl ?? ''}
+                                loading={imageLoading === 'storyboard'}
+                                canEdit={!!bgScene && !!bgSheetName}
+                                onPick={() => pickFile('storyboard')}
+                                onRemove={() => setDeleteConfirm('storyboard')}
+                                onView={() => setShowImageModal('storyboard')}
+                                onDropBlob={(b) => uploadImage(b, 'storyboard')}
+                                onHoverChange={(h) => setHoveredImageSlot(h ? 'storyboard' : (s) => s === 'storyboard' ? null : s)}
+                                pinned={pinnedImageSlot === 'storyboard'}
+                                onPinToggle={() => setPinnedImageSlot((p) => p === 'storyboard' ? null : 'storyboard')}
+                              />
+                            </div>
+                            <div data-continuity-target="guide">
+                              <UnifiedImageSlot
+                                label="가이드"
+                                continuityTarget="guide"
+                                url={previewUrls.guide ?? bgScene?.guideUrl ?? ''}
+                                loading={imageLoading === 'guide'}
+                                canEdit={!!bgScene && !!bgSheetName}
+                                onPick={() => pickFile('guide')}
+                                onRemove={() => setDeleteConfirm('guide')}
+                                onView={() => setShowImageModal('guide')}
+                                onDropBlob={(b) => uploadImage(b, 'guide')}
+                                onHoverChange={(h) => setHoveredImageSlot(h ? 'guide' : (s) => s === 'guide' ? null : s)}
+                                pinned={pinnedImageSlot === 'guide'}
+                                onPinToggle={() => setPinnedImageSlot((p) => p === 'guide' ? null : 'guide')}
+                              />
+                            </div>
                           </div>
                         )}
 
@@ -908,6 +924,14 @@ export function UnifiedSceneDetailModal({
           )}
         </motion.div>
       </motion.div>
+
+      {continuitySourceElement && (
+        <SceneContinuityTransition
+          sourceElement={continuitySourceElement}
+          targetRootRef={modalMainRef}
+          onComplete={onContinuityEnd}
+        />
+      )}
 
       {/* 이미지 확대 */}
       {showImageModal && bgScene && (
@@ -1148,20 +1172,26 @@ function DeptSection({
         <span className="block text-xs text-text-secondary mb-1.5">진행 단계</span>
         {/* v1.25.0~: 액팅 + 핸들러 모두 전달 시 새 ScenePhaseToggle, 아니면 기존 4-stage 토글 */}
         {dept === 'acting' && onActPhaseStateClick && onActFeedbackRequest && onActRoundBump ? (
-          <ScenePhaseToggle
-            scene={scene}
-            onStateClick={(next) => onActPhaseStateClick(sheetName, sceneId, next)}
-            onRequestFeedback={() => onActFeedbackRequest(sheetName, sceneId)}
-            onRoundBump={(kind, delta) => onActRoundBump(sheetName, sceneId, kind, delta)}
-          />
+          <div data-continuity-target="act-stage">
+            <ScenePhaseToggle
+              scene={scene}
+              onStateClick={(next) => onActPhaseStateClick(sheetName, sceneId, next)}
+              onRequestFeedback={() => onActFeedbackRequest(sheetName, sceneId)}
+              onRoundBump={(kind, delta) => onActRoundBump(sheetName, sceneId, kind, delta)}
+            />
+          </div>
         ) : (
-          <div className="flex rounded-lg bg-black/[0.06] dark:bg-white/[0.04] p-1 gap-1">
+          <div
+            className="flex rounded-lg bg-black/[0.06] dark:bg-white/[0.04] p-1 gap-1"
+            data-continuity-target={dept === 'bg' ? 'bg-stage' : 'act-stage'}
+          >
             {STAGES.map((stage, i) => {
               const done = scene[stage];
               const isCurrent = done && (i === STAGES.length - 1 || !scene[STAGES[i + 1]]);
               return (
                 <button
                   key={stage}
+                  data-continuity-stage-segment
                   onClick={() => onToggle(sheetName, sceneId, stage)}
                   className={cn(
                     'flex-1 text-center py-2 text-xs font-medium rounded-md transition-all cursor-pointer',
@@ -1188,6 +1218,7 @@ function DeptSection({
         value={scene.memo || ''}
         onSave={(v) => onFieldUpdate(sheetName, sceneIndex, 'memo', v)}
         memoAuthorMeta={memoAuthorMeta}
+        continuityTarget={dept === 'bg' ? 'bg-memo' : 'act-memo'}
       />
     </div>
   );
@@ -1244,8 +1275,8 @@ function InlineAssigneeRow({ label, value, onSave }: {
 
 /* ── 인라인 메모 ── */
 
-function InlineTextareaRow({ label, value, onSave, memoAuthorMeta }: {
-  label: string; value: string; onSave: (v: string) => void; memoAuthorMeta?: MemoAuthorMeta | null;
+function InlineTextareaRow({ label, value, onSave, memoAuthorMeta, continuityTarget }: {
+  label: string; value: string; onSave: (v: string) => void; memoAuthorMeta?: MemoAuthorMeta | null; continuityTarget?: string;
 }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(value);
@@ -1260,7 +1291,7 @@ function InlineTextareaRow({ label, value, onSave, memoAuthorMeta }: {
   };
 
   return (
-    <div>
+    <div data-continuity-target={continuityTarget}>
       <div className="flex items-center justify-between mb-1.5">
         <span className="text-xs text-text-secondary">{label}</span>
         {value && memoAuthorMeta && !editing && (
@@ -1316,6 +1347,7 @@ function InlineTextareaRow({ label, value, onSave, memoAuthorMeta }: {
 
 function UnifiedImageSlot({
   label,
+  continuityTarget,
   url,
   loading,
   canEdit,
@@ -1328,6 +1360,7 @@ function UnifiedImageSlot({
   onPinToggle,
 }: {
   label: string;
+  continuityTarget?: 'storyboard' | 'guide';
   url: string;
   loading: boolean;
   canEdit: boolean;
@@ -1376,7 +1409,10 @@ function UnifiedImageSlot({
     <div className="flex flex-col gap-1">
       <span className="text-[11px] text-text-secondary uppercase tracking-wider font-medium">{label}</span>
       {loading ? (
-        <div className="flex items-center justify-center h-32 bg-bg-primary rounded-lg border border-bg-border">
+        <div
+          data-continuity-target-box={continuityTarget}
+          className="flex items-center justify-center h-32 bg-bg-primary rounded-lg border border-bg-border"
+        >
           <div className="flex items-center gap-2 text-xs text-text-secondary/60">
             <div className="w-3 h-3 border-2 border-accent/40 border-t-accent rounded-full animate-spin" />
             저장 중...
@@ -1385,6 +1421,7 @@ function UnifiedImageSlot({
       ) : url ? (
         <div className="relative group">
           <div
+            data-continuity-target-box={continuityTarget}
             onMouseEnter={handleEnter}
             onMouseLeave={handleLeave}
             onDragOver={canEdit ? (e) => { e.preventDefault(); setDragOver(true); } : undefined}
@@ -1395,7 +1432,7 @@ function UnifiedImageSlot({
             } : undefined}
             onDrop={canEdit ? handleDrop : undefined}
             className={cn(
-              'relative rounded-lg overflow-hidden border-2 transition-all',
+              'relative h-40 rounded-lg overflow-hidden border-2 bg-bg-primary transition-all',
               dragOver ? 'border-accent ring-4 ring-accent/25'
                 : hover && canEdit ? 'border-accent/40 shadow-[0_0_18px_rgba(108,92,231,0.22)]'
                 : 'border-transparent',
@@ -1404,7 +1441,7 @@ function UnifiedImageSlot({
             <img
               src={url}
               alt={label}
-              className={cn('w-full max-h-40 object-contain bg-bg-primary rounded-lg transition-all', dragOver && 'brightness-50')}
+              className={cn('w-full h-full object-contain rounded-lg transition-all', dragOver && 'brightness-50')}
               draggable={false}
               onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
             />
@@ -1432,6 +1469,7 @@ function UnifiedImageSlot({
         </div>
       ) : canEdit ? (
         <button
+          data-continuity-target-box={continuityTarget}
           onClick={handleEmptyClick}
           onMouseEnter={handleEnter}
           onMouseLeave={handleLeave}
@@ -1478,7 +1516,10 @@ function UnifiedImageSlot({
           )}
         </button>
       ) : (
-        <div className="flex items-center justify-center h-32 rounded-lg border-2 border-dashed border-bg-border/50 bg-bg-primary/20 text-text-secondary/40 text-xs">
+        <div
+          data-continuity-target-box={continuityTarget}
+          className="flex items-center justify-center h-32 rounded-lg border-2 border-dashed border-bg-border/50 bg-bg-primary/20 text-text-secondary/40 text-xs"
+        >
           BG 씬이 필요합니다
         </div>
       )}

--- a/src/components/scenes/UnifiedSceneSheetView.tsx
+++ b/src/components/scenes/UnifiedSceneSheetView.tsx
@@ -6,7 +6,7 @@ import { STAGES, DEPARTMENT_CONFIGS } from '@/types';
 import type { MergedScene, Stage, Scene, ScenePhaseState } from '@/types';
 import { ScenePhaseToggle } from './ScenePhaseToggle';
 import type { SceneGroupMode } from '@/stores/useAppStore';
-import { sceneProgress, progressGradient } from '@/utils/calcStats';
+import { isFullyDone } from '@/utils/calcStats';
 import { cn } from '@/utils/cn';
 import { getMergedCommentBadgeCounts } from '@/utils/mergedSceneHelpers';
 import { HighlightText } from '@/components/common/HighlightText';
@@ -18,6 +18,12 @@ import { useRevisionStore } from '@/stores/useRevisionStore';
 import { buildSceneKey } from '@/services/revisionService';
 import { LengthIcon } from './LengthIcon';
 import { SceneContextMenu } from './SceneContextMenu';
+import {
+  ResizableHeaderCell,
+  useResizableSheetColumns,
+  type SheetColumnDefinition,
+} from './SheetColumnResize';
+import { useAppStore } from '@/stores/useAppStore';
 
 // ─── Props ───────────────────────────────────────────────────
 
@@ -54,6 +60,43 @@ interface CellId { row: number; col: number }
 const EDITABLE_FIELDS = ['bgMemo', 'actMemo', 'bgAssignee', 'actAssignee'] as const;
 
 function cellKey(row: number, col: number) { return `${row}:${col}`; }
+
+type UnifiedSheetColumnKey =
+  | 'scene'
+  | 'bgMemo'
+  | 'actMemo'
+  | 'storyboard'
+  | 'guide'
+  | 'bgAssignee'
+  | 'bgLo'
+  | 'bgDone'
+  | 'bgReview'
+  | 'bgPng'
+  | 'actAssignee'
+  | 'actWait'
+  | 'actWork'
+  | 'actFeedback'
+  | 'actDone'
+  | 'actions';
+
+const UNIFIED_SHEET_COLUMNS: Array<SheetColumnDefinition<UnifiedSheetColumnKey>> = [
+  { key: 'scene', defaultWidth: 104, minWidth: 78, maxWidth: 180 },
+  { key: 'bgMemo', defaultWidth: 220, minWidth: 72, maxWidth: 520 },
+  { key: 'actMemo', defaultWidth: 220, minWidth: 72, maxWidth: 520 },
+  { key: 'storyboard', defaultWidth: 64, minWidth: 48, maxWidth: 140 },
+  { key: 'guide', defaultWidth: 64, minWidth: 48, maxWidth: 140 },
+  { key: 'bgAssignee', defaultWidth: 112, minWidth: 72, maxWidth: 220 },
+  { key: 'bgLo', defaultWidth: 48, minWidth: 36, maxWidth: 96 },
+  { key: 'bgDone', defaultWidth: 52, minWidth: 36, maxWidth: 104 },
+  { key: 'bgReview', defaultWidth: 52, minWidth: 36, maxWidth: 104 },
+  { key: 'bgPng', defaultWidth: 52, minWidth: 36, maxWidth: 104 },
+  { key: 'actAssignee', defaultWidth: 112, minWidth: 72, maxWidth: 220 },
+  { key: 'actWait', defaultWidth: 52, minWidth: 36, maxWidth: 104 },
+  { key: 'actWork', defaultWidth: 56, minWidth: 36, maxWidth: 112 },
+  { key: 'actFeedback', defaultWidth: 64, minWidth: 44, maxWidth: 128 },
+  { key: 'actDone', defaultWidth: 56, minWidth: 36, maxWidth: 112 },
+  { key: 'actions', defaultWidth: 40, minWidth: 32, maxWidth: 72 },
+];
 
 // ─── 인라인 편집 셀 ─────────────────────────────────────────
 
@@ -171,7 +214,6 @@ function SheetEditableCell({
     );
   }
 
-  // v1.16.0: 메모 컬럼 분리 (bgMemo/actMemo) — 한 컬럼당 max-width 한계 + 컨텐츠 기반 동적
   const isMemo = field === 'bgMemo' || field === 'actMemo';
   return (
     <td
@@ -179,7 +221,7 @@ function SheetEditableCell({
       title={isMemo && value ? value : undefined}
       className={cn(
         'px-2 py-1.5 text-xs text-text-secondary cursor-cell truncate transition-colors',
-        isMemo && 'max-w-[20rem] min-w-[3.5rem]',
+        isMemo && 'min-w-0',
         isSelected
           ? 'ring-2 ring-accent ring-inset bg-accent/5'
           : 'hover:bg-accent/5',
@@ -274,29 +316,6 @@ function SheetThumbnailCell({ url, label }: { url?: string; label: string }) {
   );
 }
 
-// ─── 진행률 셀 ───────────────────────────────────────────────
-
-function SheetProgressCell({ pct }: { pct: number }) {
-  return (
-    <td className="px-1 py-1.5 text-center">
-      <div className="flex flex-col items-center gap-0.5">
-        <span className={cn(
-          'text-[10px] font-mono font-bold leading-none',
-          pct >= 100 ? 'text-green-400' : pct >= 50 ? 'text-yellow-400' : 'text-text-secondary',
-        )}>
-          {Math.round(pct)}%
-        </span>
-        <div className="w-full h-1 bg-bg-primary rounded-full overflow-hidden">
-          <div
-            className="h-full rounded-full transition-all duration-500"
-            style={{ width: `${pct}%`, background: progressGradient(pct) }}
-          />
-        </div>
-      </div>
-    </td>
-  );
-}
-
 // ─── 메인 컴포넌트 ──────────────────────────────────────────
 
 export function UnifiedSceneSheetView({
@@ -321,6 +340,13 @@ export function UnifiedSceneSheetView({
 }: UnifiedSceneSheetViewProps) {
   const bgCfg = DEPARTMENT_CONFIGS.bg;
   const actCfg = DEPARTMENT_CONFIGS.acting;
+  const completionTintEnabled = useAppStore((s) => s.completionTintEnabled);
+  const stagePointerHandledRef = useRef(false);
+  const {
+    widthOf,
+    totalWidth,
+    startResize,
+  } = useResizableSheetColumns('bflow_unified_scene_sheet_columns_v1', UNIFIED_SHEET_COLUMNS);
 
   // 레이아웃 그루핑
   const layoutGroups = useMemo(() => {
@@ -712,7 +738,15 @@ export function UnifiedSceneSheetView({
         onMouseUp={() => setIsDragging(false)}
         style={{ userSelect: isDragging ? 'none' : undefined }}
       >
-        <table className="w-full text-sm border-collapse">
+        <table
+          className="w-full text-sm border-collapse"
+          style={{ tableLayout: 'fixed', minWidth: totalWidth }}
+        >
+          <colgroup>
+            {UNIFIED_SHEET_COLUMNS.map((column) => (
+              <col key={column.key} style={{ width: widthOf(column.key) }} />
+            ))}
+          </colgroup>
           {/* ── 헤더 ── */}
           <thead className="sticky top-0 z-10">
             {/* 부서 구분 서브헤더 (상단) — v1.16.0: 메모 컬럼 분리에 맞춰 colSpan 조정 (2→3)
@@ -720,50 +754,54 @@ export function UnifiedSceneSheetView({
                 여기만 19칸이 되어 sticky 2단 헤더 정렬이 깨졌음. 한솔 결정 1-B 에 따라 컬럼 수는
                 일반 모드와 동일하므로 별도 분기 불필요. */}
             <tr className="bg-bg-card border-b border-bg-border/50">
-              <th colSpan={3} />
-              <th className="px-2 py-1" />
-              <th colSpan={2} />
-              <th colSpan={4} className="py-1 text-center">
+              <th colSpan={5} />
+              <th colSpan={5} className="py-1 text-center">
                 <span className="inline-flex items-center gap-1 text-[10px] text-text-secondary/60">
                   <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: bgCfg.color }} />
                   {bgCfg.shortLabel}
                 </span>
               </th>
-              <th colSpan={4} className="py-1 text-center">
+              <th colSpan={5} className="py-1 text-center">
                 <span className="inline-flex items-center gap-1 text-[10px] text-text-secondary/60">
                   <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: actCfg.color }} />
                   {actCfg.shortLabel}
                 </span>
               </th>
-              <th colSpan={3} />
               <th />
             </tr>
             <tr className="bg-bg-card border-b border-bg-border">
               {/* 한솔 결정 (1-B): 레이아웃 별 보기 시 별도 컬럼 대신 행 위에 그룹 헤더 행을 삽입.
                   sceneGroupMode === 'layout' 컬럼 분기 제거 — 컬럼 수가 일반 모드와 동일하게 유지된다.
                   v1.16.0: 메모 컬럼을 BG/ACT 두 개로 분리 (한솔 결정 B2). */}
-              <th className="w-24 px-2 py-2 text-left text-xs font-medium text-text-secondary">씬번호</th>
-              <th className="px-2 py-2 text-left text-xs font-medium max-w-[20rem] min-w-[3.5rem]" style={{ color: bgCfg.color }}>BG 메모</th>
-              <th className="px-2 py-2 text-left text-xs font-medium max-w-[20rem] min-w-[3.5rem]" style={{ color: actCfg.color }}>ACT 메모</th>
-              <th className="w-14 px-1 py-2 text-center text-xs font-medium text-text-secondary">SB</th>
-              <th className="w-14 px-1 py-2 text-center text-xs font-medium text-text-secondary">가이드</th>
+              <ResizableHeaderCell columnKey="scene" width={widthOf('scene')} onResizeStart={startResize}>씬번호</ResizableHeaderCell>
+              <ResizableHeaderCell columnKey="bgMemo" width={widthOf('bgMemo')} onResizeStart={startResize} style={{ color: bgCfg.color }}>BG 메모</ResizableHeaderCell>
+              <ResizableHeaderCell columnKey="actMemo" width={widthOf('actMemo')} onResizeStart={startResize} style={{ color: actCfg.color }}>ACT 메모</ResizableHeaderCell>
+              <ResizableHeaderCell columnKey="storyboard" width={widthOf('storyboard')} onResizeStart={startResize} align="center">SB</ResizableHeaderCell>
+              <ResizableHeaderCell columnKey="guide" width={widthOf('guide')} onResizeStart={startResize} align="center">가이드</ResizableHeaderCell>
               {/* BG 담당 + 스테이지 */}
-              <th className="w-20 px-2 py-2 text-left text-xs font-medium" style={{ color: bgCfg.color }}>
+              <ResizableHeaderCell columnKey="bgAssignee" width={widthOf('bgAssignee')} onResizeStart={startResize} style={{ color: bgCfg.color }}>
                 BG담당
-              </th>
-              {STAGES.map((s) => (
-                <th
-                  key={`bg-${s}`}
-                  className="w-10 px-1 py-2 text-center text-[11px] font-medium"
-                  style={{ color: bgCfg.stageColors[s] }}
-                >
-                  {bgCfg.stageLabels[s]}
-                </th>
-              ))}
+              </ResizableHeaderCell>
+              {STAGES.map((s) => {
+                const key = `bg${s[0].toUpperCase()}${s.slice(1)}` as UnifiedSheetColumnKey;
+                return (
+                  <ResizableHeaderCell
+                    key={`bg-${s}`}
+                    columnKey={key}
+                    width={widthOf(key)}
+                    onResizeStart={startResize}
+                    align="center"
+                    className="px-1 text-[11px]"
+                    style={{ color: bgCfg.stageColors[s] }}
+                  >
+                    {bgCfg.stageLabels[s]}
+                  </ResizableHeaderCell>
+                );
+              })}
               {/* ACT 담당 + 스테이지 */}
-              <th className="w-20 px-2 py-2 text-left text-xs font-medium" style={{ color: actCfg.color }}>
+              <ResizableHeaderCell columnKey="actAssignee" width={widthOf('actAssignee')} onResizeStart={startResize} style={{ color: actCfg.color }}>
                 ACT담당
-              </th>
+              </ResizableHeaderCell>
               {/* v1.25.2~: 액팅 새 토글 핸들러가 전달되면 ACT 단계 4셀을 ScenePhaseToggle 1셀로 통합 */}
               {onActPhaseStateClick && onActFeedbackRequest && onActRoundBump ? (
                 <th
@@ -774,20 +812,30 @@ export function UnifiedSceneSheetView({
                   액팅 단계
                 </th>
               ) : (
-                STAGES.map((s) => (
-                  <th
-                    key={`act-${s}`}
-                    className="w-10 px-1 py-2 text-center text-[11px] font-medium"
-                    style={{ color: actCfg.stageColors[s] }}
-                  >
-                    {actCfg.stageLabels[s]}
-                  </th>
-                ))
+                STAGES.map((s) => {
+                  const key = s === 'lo'
+                    ? 'actWait'
+                    : s === 'done'
+                      ? 'actWork'
+                      : s === 'review'
+                        ? 'actFeedback'
+                        : 'actDone';
+                  return (
+                    <ResizableHeaderCell
+                      key={`act-${s}`}
+                      columnKey={key}
+                      width={widthOf(key)}
+                      onResizeStart={startResize}
+                      align="center"
+                      className="px-1 text-[11px]"
+                      style={{ color: actCfg.stageColors[s] }}
+                    >
+                      {actCfg.stageLabels[s]}
+                    </ResizableHeaderCell>
+                  );
+                })
               )}
-              <th className="w-12 px-1 py-2 text-center text-xs font-medium text-text-secondary">BG%</th>
-              <th className="w-12 px-1 py-2 text-center text-xs font-medium text-text-secondary">ACT%</th>
-              <th className="w-12 px-1 py-2 text-center text-xs font-medium text-text-secondary">합계</th>
-              <th className="w-8 px-1 py-2" />
+              <ResizableHeaderCell columnKey="actions" width={widthOf('actions')} onResizeStart={startResize} align="center" className="px-1" />
             </tr>
           </thead>
 
@@ -797,11 +845,6 @@ export function UnifiedSceneSheetView({
               const { sceneId, mergedKey, bgScene, actScene, bgSceneIndex, actSceneIndex } = m;
               const primary = bgScene ?? actScene;
               if (!primary) return null;
-
-              const bgPct = bgScene ? sceneProgress(bgScene) : 0;
-              const actPct = actScene ? sceneProgress(actScene) : 0;
-              const presentCount = (bgScene ? 1 : 0) + (actScene ? 1 : 0);
-              const combinedPct = presentCount > 0 ? Math.round((bgPct + actPct) / presentCount) : 0;
 
               const meta = layoutMeta.get(m);
               const isRowSelected = selectedSceneIds.has(`bg:${mergedKey}`) || selectedSceneIds.has(`act:${mergedKey}`);
@@ -828,6 +871,7 @@ export function UnifiedSceneSheetView({
 
               // v1.18.0: 미해결 리비전 카운트 (행 좌측 막대 + 씬번호 셀 배지)
               const openRevCount = revisionCountByMergedKey.get(mergedKey) ?? 0;
+              const isMergedComplete = !!bgScene && !!actScene && isFullyDone(bgScene) && isFullyDone(actScene);
 
               return (
                 <Fragment key={mergedKey}>
@@ -859,6 +903,7 @@ export function UnifiedSceneSheetView({
                       isLayoutMode && isLastInGroup && 'scene-row-group-last',
                       lengthChange === 'LD' && 'sheet-row-length-up',
                       lengthChange === 'SD' && 'sheet-row-length-down',
+                      completionTintEnabled && isMergedComplete && 'scene-completion-tint-row',
                       // v1.18.0: 미해결 리비전 행 — 액센트 좌측 강조 (셀 배지와 함께 시각적 anchor)
                       openRevCount > 0 && 'sheet-row-revision-open',
                     )}
@@ -998,7 +1043,26 @@ export function UnifiedSceneSheetView({
                     <td key={`bg-${stage}`} className="px-1 py-1.5 text-center">
                       {bgScene && bgSheetName ? (
                         <button
-                          onClick={(e) => { e.stopPropagation(); onToggle(bgSheetName, bgScene.sceneId, stage); }}
+                          type="button"
+                          onPointerDown={(e) => {
+                            if (e.button !== 0) return;
+                            e.preventDefault();
+                            e.stopPropagation();
+                            stagePointerHandledRef.current = true;
+                            onToggle(bgSheetName, bgScene.sceneId, stage);
+                            window.setTimeout(() => {
+                              stagePointerHandledRef.current = false;
+                            }, 600);
+                          }}
+                          onClick={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            if (stagePointerHandledRef.current) {
+                              stagePointerHandledRef.current = false;
+                              return;
+                            }
+                            onToggle(bgSheetName, bgScene.sceneId, stage);
+                          }}
                           className="w-5 h-5 rounded flex items-center justify-center text-xs transition-all mx-auto cursor-pointer"
                           style={
                             bgScene[stage]
@@ -1056,7 +1120,26 @@ export function UnifiedSceneSheetView({
                       <td key={`act-${stage}`} className="px-1 py-1.5 text-center">
                         {actScene && actSheetName ? (
                           <button
-                            onClick={(e) => { e.stopPropagation(); onToggle(actSheetName, actScene.sceneId, stage); }}
+                            type="button"
+                            onPointerDown={(e) => {
+                              if (e.button !== 0) return;
+                              e.preventDefault();
+                              e.stopPropagation();
+                              stagePointerHandledRef.current = true;
+                              onToggle(actSheetName, actScene.sceneId, stage);
+                              window.setTimeout(() => {
+                                stagePointerHandledRef.current = false;
+                              }, 600);
+                            }}
+                            onClick={(e) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                              if (stagePointerHandledRef.current) {
+                                stagePointerHandledRef.current = false;
+                                return;
+                              }
+                              onToggle(actSheetName, actScene.sceneId, stage);
+                            }}
                             className="w-5 h-5 rounded flex items-center justify-center text-xs transition-all mx-auto cursor-pointer"
                             style={
                               actScene[stage]
@@ -1072,15 +1155,6 @@ export function UnifiedSceneSheetView({
                       </td>
                     ))
                   )}
-
-                  {/* BG% */}
-                  <SheetProgressCell pct={bgScene ? bgPct : 0} />
-
-                  {/* ACT% */}
-                  <SheetProgressCell pct={actScene ? actPct : 0} />
-
-                  {/* 합계% */}
-                  <SheetProgressCell pct={combinedPct} />
 
                   {/* 삭제 */}
                   <td className="px-1 py-1.5">

--- a/src/components/settings/EffectsSection.tsx
+++ b/src/components/settings/EffectsSection.tsx
@@ -2,7 +2,7 @@ import { useCallback, useRef, useEffect, useState } from 'react';
 import { Sparkles, RotateCcw, ChevronDown } from 'lucide-react';
 import { SettingsSection } from './SettingsSection';
 import { useAppStore } from '@/stores/useAppStore';
-import { loadPreferences, savePreferences } from '@/services/settingsService';
+import { loadPreferences, savePreferences, type UserPreferences } from '@/services/settingsService';
 import { cn } from '@/utils/cn';
 
 const DEFAULTS = {
@@ -301,11 +301,20 @@ async function persistPlexus(plexus: typeof DEFAULTS) {
   window.electronAPI?.preferencesBroadcastChange?.({ plexus });
 }
 
+async function persistSceneUi(patch: NonNullable<UserPreferences['sceneUi']>) {
+  const existing = await loadPreferences() ?? {};
+  const sceneUi = { ...(existing.sceneUi ?? {}), ...patch };
+  await savePreferences({ ...existing, sceneUi });
+  window.electronAPI?.preferencesBroadcastChange?.({ sceneUi });
+}
+
 /* ── 메인 섹션 ── */
 
 export function EffectsSection() {
   const plexusSettings = useAppStore((s) => s.plexusSettings);
   const setPlexusSettings = useAppStore((s) => s.setPlexusSettings);
+  const completionTintEnabled = useAppStore((s) => s.completionTintEnabled);
+  const setCompletionTintEnabled = useAppStore((s) => s.setCompletionTintEnabled);
   const [showAdvanced, setShowAdvanced] = useState(false);
 
   const update = useCallback((partial: Partial<typeof DEFAULTS>) => {
@@ -317,6 +326,11 @@ export function EffectsSection() {
     setPlexusSettings(DEFAULTS);
     persistPlexus(DEFAULTS);
   }, [setPlexusSettings]);
+
+  const updateCompletionTint = useCallback((enabled: boolean) => {
+    setCompletionTintEnabled(enabled);
+    persistSceneUi({ completionTintEnabled: enabled });
+  }, [setCompletionTintEnabled]);
 
   return (
     <SettingsSection
@@ -334,6 +348,27 @@ export function EffectsSection() {
     >
       {/* 전체 화면 그라데이션 배경 (모든 뷰 공통) */}
       <div className="mb-5 pb-4 border-b border-bg-border/30">
+        <div className="flex items-center justify-between gap-4 mb-4 pb-4 border-b border-bg-border/30">
+          <div>
+            <p className="text-sm font-medium text-text-primary">씬 완료 색상 표시</p>
+            <p className="text-[11px] text-text-secondary/60 mt-0.5">
+              완료된 씬 카드는 색을 더 강하게 틴트하고, 시트 뷰 행도 완료 색상으로 표시합니다.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            {completionTintEnabled !== true && (
+              <button
+                onClick={() => updateCompletionTint(true)}
+                className="text-text-secondary/40 hover:text-accent transition-colors cursor-pointer"
+                title="기본값 (ON)"
+              >
+                <RotateCcw size={11} />
+              </button>
+            )}
+            <Toggle checked={completionTintEnabled} onChange={updateCompletionTint} />
+          </div>
+        </div>
+
         <div className="flex items-center justify-between gap-4">
           <div>
             <p className="text-sm font-medium text-text-primary">전체 화면 그라데이션 배경</p>

--- a/src/hooks/usePartMemos.ts
+++ b/src/hooks/usePartMemos.ts
@@ -10,6 +10,7 @@ import {
   rollbackFailedPartMemoSheets,
   type PartContextMenuTarget,
 } from '@/utils/partMemoHelpers';
+import { partIdMatches } from '@/utils/partId';
 
 interface UsePartMemosArgs {
   episodes: Episode[];
@@ -69,7 +70,7 @@ export function usePartMemos({
 
   const buildMenuTarget = useCallback((partId: string): PartContextMenuTarget | null => {
     const visibleParts = (selectedDepartment === 'all' ? allParts : parts)
-      .filter((part) => part.partId === partId)
+      .filter((part) => partIdMatches(part.partId, partId))
       .map((part) => ({
         partId: part.partId,
         sheetName: part.sheetName,

--- a/src/index.css
+++ b/src/index.css
@@ -226,6 +226,142 @@ body.theme-ready *::after {
     box-shadow 0.25s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
+/* ─── 씬 카드 → 상세 모달 continuity transition ─── */
+.bflow-continuity-source-dim {
+  opacity: 0.38 !important;
+  filter: saturate(0.82) blur(0.2px);
+  transition: opacity 0.18s ease, filter 0.18s ease;
+}
+
+.bflow-continuity-live-root {
+  transform-origin: top left;
+  will-change: transform, opacity, filter;
+  overflow: hidden;
+}
+
+/* ─── 씬 뷰 상단 진행률 바 ─── */
+.scene-top-progress-track {
+  position: relative;
+  height: 10px;
+  overflow: hidden;
+  border-radius: 999px;
+  background:
+    linear-gradient(180deg, rgb(var(--color-bg-primary) / 0.96), rgb(var(--color-bg-primary) / 0.72));
+  box-shadow:
+    inset 0 1px 2px rgb(0 0 0 / 0.32),
+    inset 0 0 0 1px rgb(255 255 255 / 0.045);
+}
+
+.scene-top-progress-fill {
+  position: relative;
+  height: 100%;
+  min-width: 0;
+  border-radius: inherit;
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.26),
+    0 0 18px rgb(var(--color-accent) / 0.22);
+}
+
+.scene-top-progress-fill::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent, rgb(255 255 255 / 0.28), transparent);
+  opacity: 0.38;
+  transform: translateX(-80%);
+  animation: scene-progress-sheen 2.8s ease-in-out infinite;
+}
+
+@keyframes scene-progress-sheen {
+  0%, 28% { transform: translateX(-90%); }
+  72%, 100% { transform: translateX(110%); }
+}
+
+/* ─── 씬 완료 색상 표시 ─── */
+.scene-completion-tint-card {
+  border-color: rgb(52 211 153 / 0.54) !important;
+  background:
+    linear-gradient(135deg, rgb(16 185 129 / 0.20), rgb(var(--color-bg-card) / 0.96) 44%, rgb(34 197 94 / 0.10)),
+    rgb(var(--color-bg-card));
+  box-shadow:
+    0 0 0 1px rgb(16 185 129 / 0.16),
+    0 14px 36px rgb(16 185 129 / 0.10),
+    0 8px 22px rgb(0 0 0 / 0.16);
+}
+
+.scene-completion-tint-row {
+  background:
+    linear-gradient(90deg, rgb(16 185 129 / 0.18), rgb(var(--color-bg-card) / 0.30) 42%, rgb(16 185 129 / 0.08)) !important;
+  box-shadow: inset 3px 0 0 rgb(52 211 153 / 0.72);
+}
+
+.scene-completion-dept-done {
+  color: rgb(110 231 183);
+  background: rgb(16 185 129 / 0.14);
+  border: 1px solid rgb(52 211 153 / 0.22);
+}
+
+:root[data-color-mode="light"] .scene-completion-tint-card {
+  border-color: rgb(5 150 105 / 0.34) !important;
+  background:
+    linear-gradient(135deg, rgb(209 250 229 / 0.88), rgb(255 255 255 / 0.96) 48%, rgb(220 252 231 / 0.72)),
+    rgb(var(--color-bg-card));
+  box-shadow:
+    0 0 0 1px rgb(5 150 105 / 0.12),
+    0 14px 32px rgb(5 150 105 / 0.10);
+}
+
+:root[data-color-mode="light"] .scene-completion-tint-row {
+  background:
+    linear-gradient(90deg, rgb(209 250 229 / 0.84), rgb(255 255 255 / 0.76) 46%, rgb(220 252 231 / 0.64)) !important;
+  box-shadow: inset 3px 0 0 rgb(5 150 105 / 0.54);
+}
+
+:root[data-color-mode="light"] .scene-completion-dept-done {
+  color: rgb(4 120 87);
+  background: rgb(209 250 229 / 0.82);
+  border-color: rgb(5 150 105 / 0.18);
+}
+
+/* ─── 시트 뷰 컬럼 리사이즈 ─── */
+.sheet-resizable-th {
+  position: relative;
+  overflow: visible;
+  user-select: none;
+}
+
+.sheet-column-resizer {
+  position: absolute;
+  top: 6px;
+  right: -3px;
+  bottom: 6px;
+  z-index: 2;
+  width: 7px;
+  cursor: col-resize;
+  border-radius: 999px;
+}
+
+.sheet-column-resizer::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 3px;
+  width: 1px;
+  background: rgb(var(--color-bg-border) / 0.72);
+  transition: background 0.15s ease, box-shadow 0.15s ease;
+}
+
+.sheet-column-resizer:hover::after,
+.is-sheet-column-resizing .sheet-column-resizer::after {
+  background: rgb(var(--color-accent) / 0.96);
+  box-shadow: 0 0 8px rgb(var(--color-accent) / 0.42);
+}
+
+.is-sheet-column-resizing {
+  cursor: col-resize;
+}
+
 /* ─── 스크롤바 (테마 반응형, 다크 UI 통일) ─── */
 /* Firefox scrollbar-color (html+body에 적용, 자식은 inherit) */
 html, body {

--- a/src/mocks/compositingMockSeed.ts
+++ b/src/mocks/compositingMockSeed.ts
@@ -24,8 +24,9 @@ import type { CompositingStatus, Episode, Scene } from '@/types';
 const FPS = 24;
 
 /** 모든 씬에 동일하게 24fps 기준 길이. 시드 정도라 일관성 + 단순화. */
-function makeScene(no: number, sceneId: string, assignee: string, durationSec: number): Scene {
+function makeScene(no: number, sceneId: string, assignee: string, durationSec: number, uuidSeed: string): Scene {
   return {
+    id: `mock-scene-${uuidSeed}`,
     no,
     sceneId,
     memo: '',
@@ -48,8 +49,8 @@ function makePartPair(
   actAssignee: string,
   sceneIds: string[],
 ): Array<Episode['parts'][number]> {
-  const bgScenes = sceneIds.map((sid, i) => makeScene(i + 1, sid, bgAssignee, 4 + (i % 4)));
-  const actScenes = sceneIds.map((sid, i) => makeScene(i + 1, sid, actAssignee, 4 + (i % 4)));
+  const bgScenes = sceneIds.map((sid, i) => makeScene(i + 1, sid, bgAssignee, 4 + (i % 4), `EP05-${partId}-BG-${sid}`));
+  const actScenes = sceneIds.map((sid, i) => makeScene(i + 1, sid, actAssignee, 4 + (i % 4), `EP05-${partId}-ACT-${sid}`));
   const lower = partId.toLowerCase();
   return [
     { partId, department: 'bg', sheetName: `EP05_${partId}_BG`, scenes: bgScenes },

--- a/src/services/settingsService.ts
+++ b/src/services/settingsService.ts
@@ -155,6 +155,7 @@ export interface UserPreferences {
   // 씬 뷰 UI 상태
   sceneUi?: {
     controlsCollapsedByContext?: Record<string, boolean>;
+    completionTintEnabled?: boolean;
   };
 
   // 화이트보드 배경색

--- a/src/stores/useAppStore.ts
+++ b/src/stores/useAppStore.ts
@@ -153,6 +153,10 @@ interface AppState {
   };
   setPlexusSettings: (settings: Partial<AppState['plexusSettings']>) => void;
 
+  // 씬 뷰 완료 색상 표시
+  completionTintEnabled: boolean;
+  setCompletionTintEnabled: (enabled: boolean) => void;
+
   // 휴가 관리 연결 상태
   vacationConnected: boolean;
   vacationConfig: VacationConfig | null;
@@ -287,6 +291,9 @@ export const useAppStore = create<AppState>((set) => ({
   setPlexusSettings: (partial) => set((s) => ({
     plexusSettings: { ...s.plexusSettings, ...partial },
   })),
+
+  completionTintEnabled: true,
+  setCompletionTintEnabled: (enabled) => set({ completionTintEnabled: enabled }),
 
   vacationConnected: false,
   vacationConfig: null,

--- a/src/utils/partId.ts
+++ b/src/utils/partId.ts
@@ -1,0 +1,48 @@
+import type { Department } from '@/types';
+
+export interface PartIdLike {
+  partId: string;
+  department?: Department;
+}
+
+export function normalizePartIdKey(partId: string | null | undefined): string {
+  return (partId ?? '').trim().toLowerCase();
+}
+
+export function partIdMatches(
+  candidate: string | null | undefined,
+  target: string | null | undefined,
+): boolean {
+  const candidateKey = normalizePartIdKey(candidate);
+  const targetKey = normalizePartIdKey(target);
+  return !!candidateKey && !!targetKey && candidateKey === targetKey;
+}
+
+export function findPartById<T extends PartIdLike>(
+  parts: T[],
+  partId: string | null | undefined,
+  department?: Department,
+): T | undefined {
+  const key = normalizePartIdKey(partId);
+  if (!key) return undefined;
+  return parts.find((part) => (
+    (!department || part.department === department)
+    && normalizePartIdKey(part.partId) === key
+  ));
+}
+
+export function getCanonicalPartIds(parts: PartIdLike[]): string[] {
+  const grouped = new Map<string, string>();
+
+  for (const part of parts) {
+    const key = normalizePartIdKey(part.partId);
+    if (!key) continue;
+
+    const current = grouped.get(key);
+    if (!current || part.department === 'bg') {
+      grouped.set(key, part.partId);
+    }
+  }
+
+  return Array.from(grouped.values());
+}

--- a/src/views/ScenesView.tsx
+++ b/src/views/ScenesView.tsx
@@ -9,6 +9,7 @@ import { FeedbackRequestModal } from '@/components/scenes/FeedbackRequestModal';
 import { updateScenePhaseInSupabase, dispatchActingFeedbackNotification } from '@/services/supabaseService';
 import { sceneProgress, isFullyDone, isNotStarted, progressGradient } from '@/utils/calcStats';
 import { normalizeSceneIdKey } from '@/utils/sceneIdKey';
+import { findPartById, getCanonicalPartIds, partIdMatches } from '@/utils/partId';
 import {
   buildUnifiedSceneId,
   getMergedCommentBadgeCounts,
@@ -16,7 +17,7 @@ import {
 } from '@/utils/mergedSceneHelpers';
 import { getAllViewCompletionState, getSingleViewCompletionState } from '@/utils/visibleCompletion';
 import { motion, AnimatePresence } from 'framer-motion';
-import { ArrowUpDown, LayoutGrid, Grid3x3, Layers, List, ChevronUp, ChevronDown, ClipboardPaste, ImagePlus, ArrowLeft, CheckSquare, Trash2, X, MessageCircle, Pencil, MoreVertical, StickyNote, Archive, Film } from 'lucide-react';
+import { ArrowUpDown, LayoutGrid, Grid3x3, Layers, List, ChevronUp, ChevronDown, ClipboardPaste, ImagePlus, ArrowLeft, CheckSquare, Trash2, X, MessageCircle, Pencil, MoreVertical, StickyNote, Archive, Film, RotateCcw } from 'lucide-react';
 import { AssigneeSelect } from '@/components/common/AssigneeSelect';
 import { HighlightText } from '@/components/common/HighlightText';
 import { EpisodeTreeNav } from '@/components/scenes/EpisodeTreeNav';
@@ -318,8 +319,9 @@ function formatCompletedMeta(iso: string | undefined, completedBy: string | unde
 }
 
 /* ── 파트 완료 오버레이 ── */
-function PartCompleteOverlay({ completedMeta }: {
+function PartCompleteOverlay({ completedMeta, onUndoLastAction }: {
   completedMeta?: ReturnType<typeof formatCompletedMeta>;
+  onUndoLastAction?: () => void;
 }) {
   const colorMode = useAppStore((s) => s.colorMode);
   const isLight = colorMode === 'light';
@@ -581,6 +583,24 @@ function PartCompleteOverlay({ completedMeta }: {
                 고생 많으셨습니다! 다음 작업 이어서 하시기 전에, 잠깐 쉬셔요~ 띵호와
               </p>
             </div>
+            {onUndoLastAction && (
+              <button
+                type="button"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onUndoLastAction();
+                }}
+                className={cn(
+                  'pointer-events-auto inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold transition-all',
+                  isLight
+                    ? 'border border-emerald-200 bg-white/80 text-emerald-800 hover:bg-white'
+                    : 'border border-emerald-300/20 bg-white/8 text-emerald-100 hover:bg-white/12',
+                )}
+              >
+                <RotateCcw size={14} />
+                마지막 체크 취소
+              </button>
+            )}
           </div>
         </motion.div>
       </div>
@@ -701,10 +721,13 @@ interface SceneCardProps {
 
 function SceneCard({ scene, sceneIndex, celebrating, department, isHighlighted, isSelected, searchQuery, commentCount = 0, revisionCount = 0, selectionId, fallbackStoryboardUrl, fallbackGuideUrl, onToggle, onDelete, onOpenDetail, onCelebrationEnd, onCtrlClick, onShiftClick }: SceneCardProps) {
   const deptConfig = DEPARTMENT_CONFIGS[department];
+  const completionTintEnabled = useAppStore((s) => s.completionTintEnabled);
   const pct = sceneProgress(scene);
+  const isComplete = isFullyDone(scene);
   const storyboardUrl = scene.storyboardUrl || fallbackStoryboardUrl || '';
   const guideUrl = scene.guideUrl || fallbackGuideUrl || '';
   const hasImages = !!(storyboardUrl || guideUrl);
+  const stagePointerHandledRef = useRef(false);
 
   const borderColor = pct >= 100 ? '#6C5CE7' : pct >= 50 ? '#A599F5' : pct > 0 ? '#E17055' : 'rgb(var(--color-bg-border))';
 
@@ -730,6 +753,7 @@ function SceneCard({ scene, sceneIndex, celebrating, department, isHighlighted, 
         'hover:shadow-[0_3px_8px_rgba(0,0,0,0.12),0_10px_24px_rgba(0,0,0,0.18)]',
         'scene-card-interactive',
         'hover:-translate-y-0.5 hover:border-accent/70',
+        completionTintEnabled && isComplete && 'scene-completion-tint-card',
         isHighlighted && 'scene-highlight',
         isSelected && 'scene-card-selected',
       )}
@@ -862,8 +886,27 @@ function SceneCard({ scene, sceneIndex, celebrating, department, isHighlighted, 
 
             return (
               <button
+                type="button"
                 key={stage}
-                onClick={(e) => { e.stopPropagation(); onToggle(scene.sceneId, stage); }}
+                onPointerDown={(e) => {
+                  if (e.button !== 0) return;
+                  e.preventDefault();
+                  e.stopPropagation();
+                  stagePointerHandledRef.current = true;
+                  onToggle(scene.sceneId, stage);
+                  window.setTimeout(() => {
+                    stagePointerHandledRef.current = false;
+                  }, 600);
+                }}
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  if (stagePointerHandledRef.current) {
+                    stagePointerHandledRef.current = false;
+                    return;
+                  }
+                  onToggle(scene.sceneId, stage);
+                }}
                 className={cn(
                   'flex-1 text-center py-2 text-[11px] font-medium rounded-md transition-all cursor-pointer',
                   !isDone && 'text-text-secondary/60 hover:text-text-primary hover:bg-bg-border/25',
@@ -892,6 +935,24 @@ function SceneCard({ scene, sceneIndex, celebrating, department, isHighlighted, 
 const ALPHABET_PREFIXES = 'abcdefghijklmnopqrstuvwx'.split('');
 
 type PrefixMode = 'alphabet' | 'sc' | 'custom';
+
+type CompletionUndoAction =
+  | {
+      kind: 'stage';
+      sheetName: string;
+      sceneId: string;
+      stage: Stage;
+    }
+  | {
+      kind: 'phase';
+      sheetName: string;
+      sceneId: string;
+      previousState: ScenePhaseState;
+      previousWorkRound: number;
+      previousFeedbackRound: number;
+      previousCompletedBy: string;
+      previousCompletedAt: string;
+    };
 
 function suggestNextNumber(prefix: string, existingIds: string[]): string {
   const lp = prefix.toLowerCase();
@@ -1544,15 +1605,61 @@ export function ScenesView() {
   //   명시적 복원. setScenePhaseOptimistic 만 부르면 전이 규칙이 다시 적용되어 차수가 잘못 복구됨.
   const handleActPhaseStateClick = useCallback(
     async (sheetName: string, sceneId: string, newState: ScenePhaseState) => {
-      const scene = findSceneInSheet(sheetName, sceneId);
-      if (!scene?.id) return;
+      const latestPart = useDataStore.getState().episodes
+        .flatMap((ep) => ep.parts)
+        .find((part) => part.sheetName === sheetName);
+      const sceneIndex = latestPart?.scenes.findIndex((candidate) => candidate.sceneId === sceneId) ?? -1;
+      const scene = sceneIndex >= 0 ? latestPart?.scenes[sceneIndex] : undefined;
+      if (!scene?.id || sceneIndex < 0) return;
       const sceneUuid = scene.id;
       const prevState: ScenePhaseState = scene.sceneState ?? 'wait';
       const prevWork = scene.workRound ?? 0;
       const prevFb = scene.feedbackRound ?? 0;
       // 코덱스 5차 P1 #11 fix: legacy boolean 도 캡처해 롤백 시 복원
       const prevLegacy = { lo: scene.lo, done: scene.done, review: scene.review, png: scene.png };
+      const prevCompletedBy = scene.completedBy ?? '';
+      const prevCompletedAt = scene.completedAt ?? '';
+      const wasFullyDone = Boolean(scene.lo && scene.done && scene.review && scene.png);
+      const willBeFullyDone = newState === 'done';
+      const completionMeta = (() => {
+        if (willBeFullyDone && !wasFullyDone) {
+          return {
+            nextCompletedBy: currentUser?.name ?? '알 수 없음',
+            nextCompletedAt: new Date().toISOString(),
+            prevCompletedBy,
+            prevCompletedAt,
+          };
+        }
+        if (wasFullyDone && !willBeFullyDone && (prevCompletedBy || prevCompletedAt)) {
+          return {
+            nextCompletedBy: '',
+            nextCompletedAt: '',
+            prevCompletedBy,
+            prevCompletedAt,
+          };
+        }
+        return null;
+      })();
+
       setScenePhaseOptimistic(sheetName, sceneId, newState);
+      if (completionMeta) {
+        if (completionMeta.nextCompletedBy && completionMeta.nextCompletedAt) {
+          setCelebratingId(sceneId);
+          setLastCompletionUndoAction({
+            kind: 'phase',
+            sheetName,
+            sceneId,
+            previousState: prevState,
+            previousWorkRound: prevWork,
+            previousFeedbackRound: prevFb,
+            previousCompletedBy: prevCompletedBy,
+            previousCompletedAt: prevCompletedAt,
+          });
+        }
+        updateSceneFieldOptimistic(sheetName, sceneIndex, 'completedBy', completionMeta.nextCompletedBy);
+        updateSceneFieldOptimistic(sheetName, sceneIndex, 'completedAt', completionMeta.nextCompletedAt);
+      }
+
       // 새 round 값을 store와 동일한 규칙으로 다시 계산해 Supabase 동기화
       // 코덱스 2차 P2 fix: 99 상한 클램프 (store 전이 규칙과 일치)
       let workRound = prevWork;
@@ -1578,10 +1685,30 @@ export function ScenesView() {
           workRound: prevWork,
           feedbackRound: prevFb,
           ...prevLegacy,
+          completedBy: prevCompletedBy,
+          completedAt: prevCompletedAt,
         });
+        return;
+      }
+
+      if (completionMeta) {
+        try {
+          await updateSceneCompletionMeta(
+            sheetName,
+            sceneIndex,
+            completionMeta.nextCompletedBy && completionMeta.nextCompletedAt
+              ? {
+                  completedBy: completionMeta.nextCompletedBy,
+                  completedAt: completionMeta.nextCompletedAt,
+                }
+              : null,
+          );
+        } catch (metaErr) {
+          console.error('[완료 메타 저장 실패]', metaErr);
+        }
       }
     },
-    [findSceneInSheet, setScenePhaseOptimistic, updateSceneByUuid, currentUser?.id],
+    [setScenePhaseOptimistic, updateSceneByUuid, updateSceneFieldOptimistic, currentUser?.id, currentUser?.name],
   );
 
   const handleActFeedbackRequest = useCallback(
@@ -1955,25 +2082,25 @@ export function ScenesView() {
 
   // 'all' 모드: partId 기준 unique partIds
   const uniquePartIds = useMemo(() => {
-    return [...new Set(parts.map((p) => p.partId))];
+    return getCanonicalPartIds(parts);
   }, [parts]);
 
   // 'all' 모드에서 현재 partId 도출
   const currentPartId = selectedDepartment === 'all'
-    ? (uniquePartIds.includes(selectedPart ?? '') ? selectedPart : (uniquePartIds[0] ?? null))
+    ? (uniquePartIds.find((partId) => partIdMatches(partId, selectedPart)) ?? (uniquePartIds[0] ?? null))
     : null;
 
   // 'all' 모드: bgPart + actPart 분리
   const bgPart = selectedDepartment === 'all'
-    ? allParts.find((p) => p.partId === currentPartId && p.department === 'bg') ?? null
+    ? findPartById(allParts, currentPartId, 'bg') ?? null
     : null;
   const actPart = selectedDepartment === 'all'
-    ? allParts.find((p) => p.partId === currentPartId && p.department === 'acting') ?? null
+    ? findPartById(allParts, currentPartId, 'acting') ?? null
     : null;
 
   // 개별 모드: 기존 currentPart
   const currentPart = selectedDepartment !== 'all' && parts.length > 0
-    ? (parts.find((p) => p.partId === selectedPart) ?? parts[0])
+    ? (findPartById(parts, selectedPart) ?? parts[0])
     : (bgPart ?? actPart ?? undefined);  // 'all' 모드 fallback (기존 로직 호환)
   const mergedScenePartId = currentPartId ?? bgPart?.partId ?? actPart?.partId ?? '';
   const {
@@ -2045,6 +2172,11 @@ export function ScenesView() {
 
   // 상세 모달 컨텍스트: sheetName + sceneIndex 추적
   const [detailContext, setDetailContext] = useState<{ sheetName: string; sceneIndex: number } | null>(null);
+  const [continuitySourceElement, setContinuitySourceElement] = useState<HTMLElement | null>(null);
+  const [lastCompletionUndoAction, setLastCompletionUndoAction] = useState<CompletionUndoAction | null>(null);
+  const clearContinuitySource = useCallback(() => {
+    setContinuitySourceElement(null);
+  }, []);
 
   // 딥링크 처리: bflow://scene/sheetName/sceneId → 해당 씬 모달 자동 오픈
   // sceneId는 씬번호(예: a003) 또는 씬 인덱스(예: 12) 모두 지원
@@ -2378,7 +2510,7 @@ export function ScenesView() {
       setSelectedEpisode(detail.episodeNumber);
       return; // 다음 render 까지 대기
     }
-    if (detail.partId && selectedPart !== detail.partId) {
+    if (detail.partId && !partIdMatches(selectedPart, detail.partId)) {
       setSelectedPart(detail.partId);
       return; // 다음 render 까지 대기
     }
@@ -2422,9 +2554,7 @@ export function ScenesView() {
   // ACT 단독 뷰에서는 대응하는 BG 이미지를 폴백으로 사용한다.
   const actToBgImageMap = useMemo(() => {
     if (selectedDepartment !== 'acting') return null;
-    const bgSibling = allParts.find(
-      (p) => p.partId === (currentPart?.partId ?? '') && p.department === 'bg',
-    );
+    const bgSibling = findPartById(allParts, currentPart?.partId, 'bg');
     if (!bgSibling) return null;
     const map = new Map<string, { storyboard?: string; guide?: string }>();
     for (const bgScene of bgSibling.scenes) {
@@ -2507,6 +2637,14 @@ export function ScenesView() {
     ),
     [visibleCompletionState.completedMeta],
   );
+  const canUndoLastCompletionAction = useMemo(() => {
+    if (!lastCompletionUndoAction) return false;
+    if (selectedDepartment === 'all') {
+      return lastCompletionUndoAction.sheetName === bgPart?.sheetName
+        || lastCompletionUndoAction.sheetName === actPart?.sheetName;
+    }
+    return lastCompletionUndoAction.sheetName === currentPart?.sheetName;
+  }, [actPart?.sheetName, bgPart?.sheetName, currentPart?.sheetName, lastCompletionUndoAction, selectedDepartment]);
   const sceneControlsSummary = useMemo(() => {
     const items = [
       { label: '작업자', value: selectedAssignee ?? '전체' },
@@ -2544,7 +2682,12 @@ export function ScenesView() {
   const toggleQueueRef = useRef<Promise<void>>(Promise.resolve());
 
   // 공통 토글 로직 (sheetName 파라미터)
-  const handleToggleForSheet = (sheetName: string, sceneId: string, stage: Stage) => {
+  const handleToggleForSheet = (
+    sheetName: string,
+    sceneId: string,
+    stage: Stage,
+    options?: { skipCompletionUndoCapture?: boolean },
+  ) => {
     if (!currentEp) return;
 
     // 현재 스토어에서 최신 씬 상태 직접 조회 (stale closure 방지)
@@ -2588,6 +2731,9 @@ export function ScenesView() {
     if (completionMeta) {
       if (completionMeta.nextCompletedBy && completionMeta.nextCompletedAt) {
         setCelebratingId(sceneId);
+        if (!options?.skipCompletionUndoCapture) {
+          setLastCompletionUndoAction({ kind: 'stage', sheetName, sceneId, stage });
+        }
       }
       updateSceneFieldOptimistic(sheetName, sceneIndex, 'completedBy', completionMeta.nextCompletedBy);
       updateSceneFieldOptimistic(sheetName, sceneIndex, 'completedAt', completionMeta.nextCompletedAt);
@@ -2682,6 +2828,67 @@ export function ScenesView() {
     if (!currentPart) return;
     handleToggleForSheet(currentPart.sheetName, sceneId, stage);
   };
+
+  const handleUndoLastCompletionAction = useCallback(() => {
+    const action = lastCompletionUndoAction;
+    if (!action) return;
+    const latestPart = useDataStore.getState().episodes
+      .flatMap((ep) => ep.parts)
+      .find((part) => part.sheetName === action.sheetName);
+    const latestSceneIndex = latestPart?.scenes.findIndex((scene) => scene.sceneId === action.sceneId) ?? -1;
+    const latestScene = latestSceneIndex >= 0 ? latestPart?.scenes[latestSceneIndex] : undefined;
+
+    if (action.kind === 'stage') {
+      if (!latestScene?.[action.stage]) {
+        setLastCompletionUndoAction(null);
+        return;
+      }
+      setLastCompletionUndoAction(null);
+      handleToggleForSheet(action.sheetName, action.sceneId, action.stage, { skipCompletionUndoCapture: true });
+      return;
+    }
+
+    if (!latestScene?.id || latestSceneIndex < 0) {
+      setLastCompletionUndoAction(null);
+      return;
+    }
+
+    setLastCompletionUndoAction(null);
+    const legacy = legacyStagesFor(action.previousState);
+    updateSceneByUuid(latestScene.id, {
+      sceneState: action.previousState,
+      workRound: action.previousWorkRound,
+      feedbackRound: action.previousFeedbackRound,
+      ...legacy,
+      completedBy: action.previousCompletedBy,
+      completedAt: action.previousCompletedAt,
+    });
+
+    void (async () => {
+      try {
+        await updateScenePhaseInSupabase(
+          latestScene.id!,
+          action.previousState,
+          action.previousWorkRound,
+          action.previousFeedbackRound,
+          currentUser?.id,
+        );
+        await updateSceneCompletionMeta(
+          action.sheetName,
+          latestSceneIndex,
+          action.previousCompletedBy && action.previousCompletedAt
+            ? {
+                completedBy: action.previousCompletedBy,
+                completedAt: action.previousCompletedAt,
+              }
+            : null,
+        );
+      } catch (err) {
+        console.error('[완료 취소 실패]', err);
+        sonnerToast.error('마지막 완료 취소 저장에 실패했습니다. 새로고침 후 다시 확인해주세요.');
+      }
+    })();
+  }, [currentUser?.id, lastCompletionUndoAction, updateSceneByUuid]);
 
   // 일괄 stage 토글: 선택된 씬들을 RPC 한 번에 처리 (Tasks 13-17)
   const handleBulkStageToggle = async (stage: Stage, onlyDept?: 'bg' | 'acting') => {
@@ -3919,7 +4126,9 @@ export function ScenesView() {
                       sublabel: getPartMemoText([p.sheetName]) || undefined,
                     }));
                   })()}
-                  value={selectedPart ?? (uniquePartIds[0] ?? (parts[0]?.partId ?? null))}
+                  value={selectedDepartment === 'all'
+                    ? (currentPartId ?? uniquePartIds[0] ?? null)
+                    : (currentPart?.partId ?? parts[0]?.partId ?? null)}
                   onChange={(v) => setSelectedPart(v)}
                   label="파트 선택"
                   onItemContextMenu={(v, e) => {
@@ -4124,9 +4333,9 @@ export function ScenesView() {
             {activeScenes.length}씬 표시 중
           </span>
           <div className="flex min-w-[220px] flex-1 items-center gap-4">
-            <div className="flex-1 h-2.5 bg-bg-primary rounded-full overflow-hidden">
+            <div className="scene-top-progress-track flex-1">
               <div
-                className="h-full rounded-full transition-all duration-700 ease-out"
+                className="scene-top-progress-fill transition-all duration-700 ease-out"
                 style={{ width: `${overallPct}%`, background: progressGradient(overallPct) }}
               />
             </div>
@@ -4230,7 +4439,12 @@ export function ScenesView() {
           )}
         >
           <AnimatePresence>
-            {isVisibleComplete && <PartCompleteOverlay completedMeta={visibleCompletedMeta} />}
+            {isVisibleComplete && (
+              <PartCompleteOverlay
+                completedMeta={visibleCompletedMeta}
+                onUndoLastAction={canUndoLastCompletionAction ? handleUndoLastCompletionAction : undefined}
+              />
+            )}
           </AnimatePresence>
           <div className="relative z-10 flex h-full min-h-0 flex-col">
             {mergedScenes.length === 0 ? (
@@ -4298,7 +4512,10 @@ export function ScenesView() {
                             onToggle={(sheet, id, stage) => handleToggleForSheet(sheet, id, stage)}
                             onDelete={(sheet, idx) => handleDeleteSceneForSheet(sheet, idx)}
                             onOpenDetail={(sheet, idx) => { setDetailContext({ sheetName: sheet, sceneIndex: idx }); setDetailSceneIndex(idx); }}
-                            onOpenMerged={(merged) => setDetailMerged(merged)}
+                            onOpenMerged={(merged, sourceElement) => {
+                              setContinuitySourceElement(sourceElement ?? null);
+                              setDetailMerged(merged);
+                            }}
                             onCelebrationEnd={clearCelebration}
                             onSelect={() => {
                               const ids = new Set<string>();
@@ -4348,7 +4565,10 @@ export function ScenesView() {
                       onToggle={(sheet, id, stage) => handleToggleForSheet(sheet, id, stage)}
                       onDelete={(sheet, idx) => handleDeleteSceneForSheet(sheet, idx)}
                       onOpenDetail={(sheet, idx) => { setDetailContext({ sheetName: sheet, sceneIndex: idx }); setDetailSceneIndex(idx); }}
-                      onOpenMerged={(merged) => setDetailMerged(merged)}
+                      onOpenMerged={(merged, sourceElement) => {
+                        setContinuitySourceElement(sourceElement ?? null);
+                        setDetailMerged(merged);
+                      }}
                       onCelebrationEnd={clearCelebration}
                       onSelect={() => {
                         const ids = new Set<string>();
@@ -4382,7 +4602,12 @@ export function ScenesView() {
       >
         {/* 파트 완료 보케 오버레이 */}
         <AnimatePresence>
-          {isVisibleComplete && <PartCompleteOverlay completedMeta={visibleCompletedMeta} />}
+          {isVisibleComplete && (
+            <PartCompleteOverlay
+              completedMeta={visibleCompletedMeta}
+              onUndoLastAction={canUndoLastCompletionAction ? handleUndoLastCompletionAction : undefined}
+            />
+          )}
         </AnimatePresence>
         <div className="relative z-10 flex h-full min-h-0 flex-col">
           {scenes.length === 0 ? (
@@ -4936,9 +5161,7 @@ export function ScenesView() {
           const currentDetailPart = allParts.find((p) => p.sheetName === detailSheetName);
           if (!currentDetailPart) return null;
           const otherDept: Department = currentDetailPart.department === 'bg' ? 'acting' : 'bg';
-          const otherPart = allParts.find(
-            (p) => p.partId === currentDetailPart.partId && p.department === otherDept,
-          );
+          const otherPart = findPartById(allParts, currentDetailPart.partId, otherDept);
           if (!otherPart) return null;
           // 정규화된 sceneId 키로 매칭 (예: ac001 ↔ a001)
           const targetKey = normalizeSceneIdKey(detailScene.sceneId, currentDetailPart.partId);
@@ -5000,7 +5223,7 @@ export function ScenesView() {
             initialTab={modalRouting?.initialTab}
             focusRevisionId={modalRouting?.focusRevisionId}
             focusCommentId={modalRouting?.focusCommentId}
-            onClose={() => { setDetailMerged(null); setModalRouting(null); }}
+            onClose={() => { setDetailMerged(null); setModalRouting(null); clearContinuitySource(); }}
             onToggle={(sheet, id, stage) => handleToggleForSheet(sheet, id, stage)}
             onFieldUpdate={(sheet, idx, field, value) => handleFieldUpdateForSheet(sheet, idx, field, value)}
             onDeleteDept={(sheet, idx) => handleDeleteSceneForSheet(sheet, idx)}
@@ -5057,6 +5280,8 @@ export function ScenesView() {
             onActPhaseStateClick={handleActPhaseStateClick}
             onActFeedbackRequest={handleActFeedbackRequest}
             onActRoundBump={handleActRoundBump}
+            continuitySourceElement={continuitySourceElement}
+            onContinuityEnd={clearContinuitySource}
           />
         );
       })()}

--- a/tests/partIdPairing.test.ts
+++ b/tests/partIdPairing.test.ts
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  findPartById,
+  getCanonicalPartIds,
+  normalizePartIdKey,
+  partIdMatches,
+} from '../src/utils/partId.ts';
+
+test('part id matching is case-insensitive for BG and ACT pairing', () => {
+  assert.equal(normalizePartIdKey(' A '), 'a');
+  assert.equal(partIdMatches('A', 'a'), true);
+  assert.equal(partIdMatches('B', 'a'), false);
+});
+
+test('canonical part list merges uppercase BG and lowercase ACT into one visible part', () => {
+  const parts = [
+    { partId: 'A', department: 'bg' as const },
+    { partId: 'a', department: 'acting' as const },
+    { partId: 'B', department: 'bg' as const },
+    { partId: 'b', department: 'acting' as const },
+  ];
+
+  assert.deepEqual(getCanonicalPartIds(parts), ['A', 'B']);
+});
+
+test('findPartById locates lowercase ACT part when selected part is uppercase', () => {
+  const parts = [
+    { partId: 'A', department: 'bg' as const, sheetName: 'EP05_A_BG' },
+    { partId: 'a', department: 'acting' as const, sheetName: 'EP05_A_ACT' },
+  ];
+
+  assert.equal(findPartById(parts, 'A', 'bg')?.sheetName, 'EP05_A_BG');
+  assert.equal(findPartById(parts, 'A', 'acting')?.sheetName, 'EP05_A_ACT');
+});

--- a/tests/sceneCompletionUx.test.ts
+++ b/tests/sceneCompletionUx.test.ts
@@ -1,0 +1,120 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const readRepoFile = (...segments: string[]) =>
+  readFile(path.join(process.cwd(), ...segments), 'utf-8');
+
+test('complete overlay can undo the exact last completion action', async () => {
+  const scenesView = await readRepoFile('src', 'views', 'ScenesView.tsx');
+
+  assert.match(scenesView, /마지막 체크 취소/);
+  assert.match(scenesView, /lastCompletionUndoAction/);
+  assert.match(scenesView, /skipCompletionUndoCapture/);
+  assert.match(scenesView, /setLastCompletionUndoAction\(\{\s*kind: 'stage'/);
+  assert.match(scenesView, /setLastCompletionUndoAction\(\{\s*kind: 'phase'/);
+  assert.match(scenesView, /previousState: ScenePhaseState/);
+  assert.match(scenesView, /updateScenePhaseInSupabase\(/);
+  assert.match(scenesView, /updateSceneCompletionMeta\(/);
+});
+
+test('completion tint is a default-on setting persisted in scene UI preferences', async () => {
+  const appStore = await readRepoFile('src', 'stores', 'useAppStore.ts');
+  const settingsService = await readRepoFile('src', 'services', 'settingsService.ts');
+  const effectsSection = await readRepoFile('src', 'components', 'settings', 'EffectsSection.tsx');
+  const app = await readRepoFile('src', 'App.tsx');
+
+  assert.match(appStore, /completionTintEnabled: true/);
+  assert.match(appStore, /setCompletionTintEnabled/);
+  assert.match(settingsService, /completionTintEnabled\?: boolean/);
+  assert.match(effectsSection, /씬 완료 색상 표시/);
+  assert.match(effectsSection, /persistSceneUi\(\{ completionTintEnabled: enabled \}\)/);
+  assert.match(app, /sceneUi\?\.completionTintEnabled \?\? true/);
+});
+
+test('card and sheet views use completion tint classes', async () => {
+  const scenesView = await readRepoFile('src', 'views', 'ScenesView.tsx');
+  const unifiedCard = await readRepoFile('src', 'components', 'scenes', 'UnifiedSceneCard.tsx');
+  const singleSheet = await readRepoFile('src', 'components', 'scenes', 'SceneSheetView.tsx');
+  const unifiedSheet = await readRepoFile('src', 'components', 'scenes', 'UnifiedSceneSheetView.tsx');
+  const css = await readRepoFile('src', 'index.css');
+
+  assert.match(scenesView, /scene-completion-tint-card/);
+  assert.match(unifiedCard, /isMergedComplete/);
+  assert.match(unifiedCard, /scene-completion-tint-card/);
+  assert.match(unifiedCard, /scene-completion-dept-done/);
+  assert.match(singleSheet, /scene-completion-tint-row/);
+  assert.match(unifiedSheet, /scene-completion-tint-row/);
+  assert.match(css, /\.scene-completion-tint-card/);
+  assert.match(css, /\.scene-completion-tint-row/);
+});
+
+test('sheet percentage columns are removed and main columns are resizable', async () => {
+  const singleSheet = await readRepoFile('src', 'components', 'scenes', 'SceneSheetView.tsx');
+  const unifiedSheet = await readRepoFile('src', 'components', 'scenes', 'UnifiedSceneSheetView.tsx');
+  const resize = await readRepoFile('src', 'components', 'scenes', 'SheetColumnResize.tsx');
+
+  assert.match(singleSheet, /ResizableHeaderCell/);
+  assert.match(singleSheet, /bflow_scene_sheet_columns_\$\{department\}_v1/);
+  assert.doesNotMatch(singleSheet, />진행</);
+  assert.doesNotMatch(singleSheet, /SheetProgressCell|sceneProgress|progressGradient/);
+
+  assert.match(unifiedSheet, /ResizableHeaderCell/);
+  assert.match(unifiedSheet, /bflow_unified_scene_sheet_columns_v1/);
+  assert.doesNotMatch(unifiedSheet, />BG%</);
+  assert.doesNotMatch(unifiedSheet, />ACT%</);
+  assert.doesNotMatch(unifiedSheet, />합계</);
+  assert.doesNotMatch(unifiedSheet, /SheetProgressCell|sceneProgress|progressGradient/);
+
+  assert.match(resize, /localStorage\.setItem/);
+  assert.match(resize, /role="separator"/);
+  assert.match(resize, /onPointerDown/);
+});
+
+test('scene top progress bar uses the polished progress track styles', async () => {
+  const scenesView = await readRepoFile('src', 'views', 'ScenesView.tsx');
+  const css = await readRepoFile('src', 'index.css');
+
+  assert.match(scenesView, /scene-top-progress-track/);
+  assert.match(scenesView, /scene-top-progress-fill/);
+  assert.match(css, /\.scene-top-progress-track/);
+  assert.match(css, /scene-progress-sheen/);
+});
+
+test('stage and phase controls commit on pointer down in card and sheet views', async () => {
+  const phaseToggle = await readRepoFile('src', 'components', 'scenes', 'ScenePhaseToggle.tsx');
+  const unifiedCard = await readRepoFile('src', 'components', 'scenes', 'UnifiedSceneCard.tsx');
+  const singleCard = await readRepoFile('src', 'views', 'ScenesView.tsx');
+  const singleSheet = await readRepoFile('src', 'components', 'scenes', 'SceneSheetView.tsx');
+  const unifiedSheet = await readRepoFile('src', 'components', 'scenes', 'UnifiedSceneSheetView.tsx');
+
+  assert.match(phaseToggle, /handleChipPointerDown/);
+  assert.match(phaseToggle, /pointerHandledRef/);
+  assert.match(phaseToggle, /onPointerDown=\{\(e\) => handleChipPointerDown\(e, state\)\}/);
+
+  assert.match(unifiedCard, /onPointerDown=\{\(e\) => \{/);
+  assert.match(unifiedCard, /stagePointerHandledRef/);
+  assert.match(unifiedCard, /onToggle\(sheetName, sceneId, stage\)/);
+
+  assert.match(singleCard, /onPointerDown=\{\(e\) => \{/);
+  assert.match(singleCard, /stagePointerHandledRef/);
+  assert.match(singleCard, /onToggle\(scene\.sceneId, stage\)/);
+
+  assert.match(singleSheet, /onPointerDown=\{\(e\) => \{/);
+  assert.match(singleSheet, /stagePointerHandledRef/);
+  assert.match(singleSheet, /onToggle\(scene\.sceneId, stage\)/);
+
+  assert.match(unifiedSheet, /onPointerDown=\{\(e\) => \{/);
+  assert.match(unifiedSheet, /stagePointerHandledRef/);
+  assert.match(unifiedSheet, /onToggle\(bgSheetName, bgScene\.sceneId, stage\)/);
+  assert.match(unifiedSheet, /onToggle\(actSheetName, actScene\.sceneId, stage\)/);
+});
+
+test('dev preview mock scenes include stable UUIDs for real toggle flow', async () => {
+  const mockSeed = await readRepoFile('src', 'mocks', 'compositingMockSeed.ts');
+
+  assert.match(mockSeed, /id: `mock-scene-\$\{uuidSeed\}`/);
+  assert.match(mockSeed, /`EP05-\$\{partId\}-BG-\$\{sid\}`/);
+  assert.match(mockSeed, /`EP05-\$\{partId\}-ACT-\$\{sid\}`/);
+});

--- a/tests/sceneContinuityTransition.test.ts
+++ b/tests/sceneContinuityTransition.test.ts
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const readRepoFile = (...segments: string[]) =>
+  readFile(path.join(process.cwd(), ...segments), 'utf-8');
+
+test('scene continuity transition animates the real detail modal without graphic ghosts', async () => {
+  const transition = await readRepoFile('src', 'components', 'scenes', 'SceneContinuityTransition.tsx');
+
+  assert.match(transition, /buildStartTransform/);
+  assert.match(transition, /targetRoot\.animate/);
+  assert.match(transition, /bflow-continuity-live-root/);
+  assert.doesNotMatch(transition, /buildSkeletonGhost/);
+  assert.doesNotMatch(transition, /buildModalShellGhost/);
+  assert.doesNotMatch(transition, /animateModalShell/);
+  assert.doesNotMatch(transition, /bflow-continuity-modal-shell/);
+  assert.doesNotMatch(transition, /bflow-continuity-ghost/);
+  assert.doesNotMatch(transition, /\.cloneNode\(/);
+  assert.doesNotMatch(transition, /innerText|textContent/);
+});
+
+test('unified scene card exposes continuity source anchors for card details', async () => {
+  const card = await readRepoFile('src', 'components', 'scenes', 'UnifiedSceneCard.tsx');
+
+  assert.match(card, /data-continuity-card/);
+  assert.match(card, /data-continuity-source="title"/);
+  assert.match(card, /data-continuity-source="storyboard"/);
+  assert.match(card, /data-continuity-source="guide"/);
+  assert.match(card, /data-continuity-source="bg-memo"/);
+  assert.match(card, /data-continuity-source="act-memo"/);
+  assert.match(card, /data-continuity-source=\{dept === 'bg' \? 'bg-stage' : 'act-stage'\}/);
+  assert.match(card, /data-continuity-stage-segment/);
+});
+
+test('unified scene detail modal exposes measured continuity targets', async () => {
+  const modal = await readRepoFile('src', 'components', 'scenes', 'UnifiedSceneDetailModal.tsx');
+
+  assert.match(modal, /SceneContinuityTransition/);
+  assert.match(modal, /continuitySourceElement/);
+  assert.match(modal, /data-continuity-target="title"/);
+  assert.match(modal, /data-continuity-target="storyboard"/);
+  assert.match(modal, /data-continuity-target="guide"/);
+  assert.match(modal, /data-continuity-target-box/);
+  assert.match(modal, /continuityTarget="storyboard"/);
+  assert.match(modal, /continuityTarget="guide"/);
+  assert.match(modal, /data-continuity-target=\{dept === 'bg' \? 'bg-stage' : 'act-stage'\}/);
+  assert.match(modal, /data-continuity-stage-segment/);
+  assert.match(modal, /continuityTarget=\{dept === 'bg' \? 'bg-memo' : 'act-memo'\}/);
+});
+
+test('acting phase toggle exposes continuity stage segments', async () => {
+  const phaseToggle = await readRepoFile('src', 'components', 'scenes', 'ScenePhaseToggle.tsx');
+
+  assert.match(phaseToggle, /data-continuity-stage-segment/);
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,36 +5,42 @@ import renderer from 'vite-plugin-electron-renderer';
 import path from 'path';
 import pkg from './package.json';
 
+const rendererOnly = process.env.BFLOW_RENDERER_ONLY === '1';
+
 export default defineConfig({
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
   },
   plugins: [
     react(),
-    electron([
-      {
-        entry: 'electron/main.ts',
-        vite: {
-          build: {
-            outDir: 'dist-electron',
-            rollupOptions: {
-              external: ['ws', 'bufferutil', 'utf-8-validate', 'googleapis', 'google-auth-library'],
+    ...(!rendererOnly
+      ? [
+          electron([
+            {
+              entry: 'electron/main.ts',
+              vite: {
+                build: {
+                  outDir: 'dist-electron',
+                  rollupOptions: {
+                    external: ['ws', 'bufferutil', 'utf-8-validate', 'googleapis', 'google-auth-library'],
+                  },
+                },
+              },
             },
-          },
-        },
-      },
-      {
-        entry: 'electron/preload.ts',
-        onstart(args) {
-          args.reload();
-        },
-        vite: {
-          build: {
-            outDir: 'dist-electron',
-          },
-        },
-      },
-    ]),
+            {
+              entry: 'electron/preload.ts',
+              onstart(args) {
+                args.reload();
+              },
+              vite: {
+                build: {
+                  outDir: 'dist-electron',
+                },
+              },
+            },
+          ]),
+        ]
+      : []),
     renderer(),
   ],
   resolve: {


### PR DESCRIPTION
## 📋 업데이트 요약

✅ 씬 완료 후 뜨는 완료 창에서, 실수로 마지막 완료를 눌렀을 때 바로 취소할 수 있습니다.

🎨 완료된 카드와 시트 행은 더 명확한 색상으로 표시됩니다. 이 표시는 설정에서 켜고 끌 수 있으며, 기본값은 켜짐입니다.

📊 시트 뷰에서 주요 컬럼 폭을 PC에서 직접 드래그해 조절할 수 있습니다. 메모 칸처럼 길게 보이는 영역을 줄여 한눈에 보기 쉬워집니다.

🔘 전체 뷰의 카드/시트에서 BG 체크와 ACT 상태 버튼이 실제로 눌리도록 안정화했습니다.

🪟 씬 카드에서 상세 모달로 들어갈 때 더 자연스럽게 이어지는 전환을 적용했습니다.

## 🔧 상세 기술 설명

- `ScenesView.tsx`
  - 완료 오버레이에 마지막 완료 동작 취소 로직을 추가했습니다.
  - stage 완료와 ACT phase 완료 모두 이전 상태를 저장해 되돌릴 수 있게 했습니다.
  - 전체 뷰에서 BG/ACT 파트 매칭을 대소문자 차이 없이 처리하도록 변경했습니다.
  - 상단 진행률 바 스타일을 `scene-top-progress-track/fill`로 정리했습니다.

- `ScenePhaseToggle.tsx`, `UnifiedSceneCard.tsx`, `UnifiedSceneSheetView.tsx`, `SceneSheetView.tsx`
  - 버튼 입력을 `pointerdown` 기준으로 즉시 반응하게 보강했습니다.
  - 브라우저/키보드 환경처럼 `click`만 들어오는 경우도 처리하고, 중복 토글은 막았습니다.

- `SheetColumnResize.tsx`
  - 카드/시트 주요 컬럼 폭 조절 공통 유틸을 추가했습니다.
  - 컬럼 폭은 로컬 저장소에 저장됩니다.

- `SceneContinuityTransition.tsx`, `UnifiedSceneDetailModal.tsx`
  - 씬 카드에서 상세 모달로 이어지는 continuity transition을 추가했습니다.
  - 깨지기 쉬운 요소는 스켈레톤 형태로 전환되게 구성했습니다.

- `useAppStore.ts`, `settingsService.ts`, `EffectsSection.tsx`, `App.tsx`
  - 완료 색상 표시 설정을 추가하고 개인 설정으로 저장/복원되게 했습니다.

- `partId.ts`, `EpisodeTreeNav.tsx`, `usePartMemos.ts`
  - `A`와 `a`처럼 대소문자만 다른 BG/ACT 파트를 같은 파트로 묶도록 정규화했습니다.

- `compositingMockSeed.ts`
  - Vite 프리뷰 mock 씬에 안정적인 UUID를 넣어 버튼 클릭 검증이 실제 저장 흐름을 통과하게 했습니다.

## 🚧 개발 난항

- 초기 목업 전환은 실제 상세 모달 위치와 크기가 맞지 않아 어색하게 보였습니다.
- 카드 안 요소가 상세 모달의 실제 자리로 자연스럽게 이어져야 해서, 전환용 타깃 측정과 스켈레톤 전환을 분리했습니다.
- 전체 뷰에서 ACT가 “없음”처럼 보인 원인은 BG 파트는 `A`, ACT 파트는 `a`로 저장된 대소문자 차이였습니다.
- 버튼이 안 눌리는 것처럼 보인 문제는 두 가지가 겹쳐 있었습니다.
  - 입력 이벤트가 일부 환경에서 `click`까지 안정적으로 이어지지 않았습니다.
  - 프리뷰 mock 데이터에는 UUID가 없어 저장 단계에서 바로 롤백되었습니다.

## ✅ 테스트 가이드

### 실사용자용

1. 씬 목록 > 전체 > 카드 뷰에서 BG의 `LO/완료/검수/PNG` 버튼을 눌러 색상이 바뀌는지 확인합니다.
2. 같은 카드에서 ACT의 `대기/작업중/피드백/완료` 상태가 바뀌는지 확인합니다.
3. 시트 뷰에서도 같은 동작이 되는지 확인합니다.
4. 모든 단계를 완료해 완료 창이 뜨면 `마지막 체크 취소`가 동작하는지 확인합니다.
5. 시트 뷰에서 주요 컬럼 헤더를 드래그해 폭이 바뀌는지 확인합니다.
6. 설정 > 효과에서 `씬 완료 색상 표시`를 끄고 켤 수 있는지 확인합니다.

### 개발자용

- `node --test .\tests\partIdPairing.test.ts .\tests\sceneCompletionUx.test.ts .\tests\sceneContinuityTransition.test.ts`
- `npm run typecheck`
- `npm run build:vite`

확인 결과:
- 씬 완료 UX 테스트 14개 통과
- 자동 업데이트 테스트 25개 통과
- `npm run build:vite` 통과
