### PR TITLE
[v1.35.0] 시트/카드 뷰 폴리싱 및 StarNest 배경 설정 추가

### DIFF
--- a/.agents/skills/design-taste-frontend/SKILL.md
+++ b/.agents/skills/design-taste-frontend/SKILL.md
@@ -1,0 +1,1206 @@
+---
+name: design-taste-frontend
+description: Anti-slop frontend skill for landing pages, portfolios, and redesigns. The agent reads the brief, infers the right design direction, and ships interfaces that do not look templated. Real design systems when applicable, audit-first on redesigns, strict pre-flight check.
+---
+
+# tasteskill: Anti-Slop Frontend Skill
+
+> Landing pages, portfolios, and redesigns. Not dashboards, not data tables, not multi-step product UI.
+> Every rule below is **contextual**. None of it fires automatically. First read the brief, then pull only what fits.
+
+---
+
+## 0. BRIEF INFERENCE (Read the Room Before Anything Else)
+
+Before touching code or tweaking dials, **infer what the user actually wants**. Most LLM design output is bad because the model jumps to a default aesthetic instead of reading the room.
+
+### 0.A Read these signals first
+1. **Page kind** - landing (SaaS / consumer / agency / event), portfolio (dev / designer / creative studio), redesign (preserve vs overhaul), editorial / blog.
+2. **Vibe words** the user used - "minimalist", "calm", "Linear-style", "Awwwards", "brutalist", "premium consumer", "Apple-y", "playful", "serious B2B", "editorial", "agency-y", "glassy", "dark tech".
+3. **Reference signals** - URLs they linked, screenshots they pasted, products they named, brands they're competing with.
+4. **Audience** - B2B procurement panel vs. design-conscious consumer vs. recruiter scanning a portfolio. The audience picks the aesthetic, not your taste.
+5. **Brand assets that already exist** - logo, color, type, photography. For redesigns, these are starting material, not optional input (see Section 11).
+6. **Quiet constraints** - accessibility-first audiences, public-sector, regulated industries, trust-first commerce, kids' products. These constraints OVERRIDE aesthetic preference.
+
+### 0.B Output a one-line "Design Read" before generating
+Before any code, state in one line: **"Reading this as: \<page kind> for \<audience>, with a \<vibe> language, leaning toward \<design system or aesthetic family>."**
+
+Example reads:
+- *"Reading this as: B2B SaaS landing for technical buyers, with a Linear-style minimalist language, leaning toward Tailwind utilities + Geist + restrained motion."*
+- *"Reading this as: solo designer portfolio for hiring managers, with an editorial / kinetic-type language, leaning toward native CSS + scroll-driven animation + custom typography."*
+- *"Reading this as: redesign of a public-sector service site, with a trust-first language, leaning toward GOV.UK Frontend or USWDS."*
+
+### 0.C If the brief is ambiguous, ask one question, do not guess
+Ask exactly **one** clarifying question - never a multi-question dump - and only when the design read genuinely diverges. Example: *"Should this feel closer to Linear-clean or Awwwards-experimental?"*
+
+If you can confidently infer from context, **do not ask**. Just declare the design read and proceed.
+
+### 0.D Anti-Default Discipline
+Do not default to: AI-purple gradients, centered hero over dark mesh, three equal feature cards, generic glassmorphism on everything, infinite-loop micro-animations everywhere, Inter + slate-900. These are the LLM defaults. Reach past them deliberately based on the design read.
+
+---
+
+## 1. THE THREE DIALS (Core Configuration)
+
+After the design read, set three dials. Every layout, motion, and density decision below is gated by these.
+
+* **`DESIGN_VARIANCE: 8`** - 1 = Perfect Symmetry, 10 = Artsy Chaos
+* **`MOTION_INTENSITY: 6`** - 1 = Static, 10 = Cinematic / Physics
+* **`VISUAL_DENSITY: 4`** - 1 = Art Gallery / Airy, 10 = Cockpit / Packed Data
+
+**Baseline:** `8 / 6 / 4`. Use these unless the design read overrides them. Do not ask the user to edit this file - overrides happen conversationally.
+
+### 1.A Dial Inference (design read → dial values)
+| Signal | VARIANCE | MOTION | DENSITY |
+|---|---|---|---|
+| "minimalist / clean / calm / editorial / Linear-style" | 5-6 | 3-4 | 2-3 |
+| "premium consumer / Apple-y / luxury / brand" | 7-8 | 5-7 | 3-4 |
+| "playful / wild / Dribbble / Awwwards / experimental / agency" | 9-10 | 8-10 | 3-4 |
+| "landing page / portfolio / marketing site (default)" | 7-9 | 6-8 | 3-5 |
+| "trust-first / public-sector / regulated / accessibility-critical" | 3-4 | 2-3 | 4-5 |
+| "redesign - preserve" | match existing | +1 | match existing |
+| "redesign - overhaul" | +2 | +2 | match existing |
+
+### 1.B Use-Case Presets
+| Use case | VARIANCE | MOTION | DENSITY |
+|---|---|---|---|
+| Landing (SaaS, mainstream) | 7 | 6 | 4 |
+| Landing (Agency / creative) | 9 | 8 | 3 |
+| Landing (Premium consumer) | 7 | 6 | 3 |
+| Portfolio (Designer / studio) | 8 | 7 | 3 |
+| Portfolio (Developer) | 6 | 5 | 4 |
+| Editorial / Blog | 6 | 4 | 3 |
+| Public-sector service | 3 | 2 | 5 |
+| Redesign - preserve | match | match+1 | match |
+| Redesign - overhaul | +2 | +2 | match |
+
+### 1.C How the Dials Drive Output
+Use these (or user-overridden values) as global variables. Cross-references throughout this document refer to these exact variable names - never invent aliases like `LAYOUT_VARIANCE` or `ANIM_LEVEL`.
+
+---
+
+## 2. BRIEF → DESIGN SYSTEM MAP
+
+Once you have the design read (Section 0) and dials (Section 1), pick the right foundation. Do not invent CSS for things that have an official package. Do not pretend an aesthetic trend is an official system.
+
+### 2.A When to reach for a real design system (use official packages)
+| Brief reads as… | Reach for | Why |
+|---|---|---|
+| Microsoft / enterprise SaaS / dashboards | `@fluentui/react-components` or `@fluentui/web-components` | Official Fluent UI, Microsoft tokens, accessibility done |
+| Google-ish UI, Material-flavored product | `@material/web` + Material 3 tokens | Official, theme-able via Material Theming |
+| IBM-style B2B / enterprise analytics | `@carbon/react` + `@carbon/styles` | Official Carbon, mature data-density patterns |
+| Shopify app surfaces | `polaris.js` web components / Polaris React | Required for Shopify admin UI |
+| Atlassian / Jira-style product | `@atlaskit/*` + `@atlaskit/tokens` | Official Atlassian DS |
+| GitHub-style devtool / community page | `@primer/css` or `@primer/react-brand` | Official Primer; Brand variant for marketing |
+| Public-sector UK service | `govuk-frontend` | Legally / regulatorily expected |
+| US public-sector / trust-first | `uswds` | Same |
+| Fast local-business / agency MVP | Bootstrap 5.3 | Boring, fast, works |
+| Modern accessible React foundation | `@radix-ui/themes` | Primitives + polished theme |
+| Modern SaaS where you own the components | shadcn/ui (`npx shadcn@latest add ...`) | You own the code, easy to customise; never ship default state |
+| Tailwind-based modern SaaS / AI marketing | Tailwind v4 utilities + `dark:` variant | Default for indie + small team builds |
+
+**Honesty rule:** if the brief reads as one of the systems above, install and use the **official** package. Do not recreate its CSS by hand. Do not import a system's tokens but then override 90% of them.
+
+**One system per project.** Do not mix Fluent React with Carbon in the same tree. Do not import shadcn/ui components into a Material 3 app.
+
+### 2.B When the brief is an aesthetic, not a system
+For these directions, there is **no single official package**. Build with native CSS + Tailwind + a maintained component library. Be honest in code comments about what is borrowed inspiration vs. official material.
+
+| Aesthetic | Honest implementation |
+|---|---|
+| Glassmorphism / "frosted glass" | `backdrop-filter`, layered borders, highlight overlays. Provide solid-fill fallback for `prefers-reduced-transparency`. |
+| Bento (Apple-style tile grids) | CSS Grid with mixed cell sizes. No single library owns this. |
+| Brutalism | Native CSS, monospace, raw borders. No library. |
+| Editorial / magazine | Serif type, asymmetric grid, generous whitespace. No library. |
+| Dark tech / hacker | Mono + accent neon, terminal motifs. No library. |
+| Aurora / mesh gradients | SVG or layered radial gradients. No library. |
+| Kinetic typography | Native CSS animations, scroll-driven animations, GSAP for hijacks. No library. |
+| **Apple Liquid Glass** | Apple documents this for Apple platforms only. **There is no official `liquid-glass.css`.** Web implementations are approximations using `backdrop-filter` + layered borders + highlights. Label clearly as approximation. |
+
+---
+
+## 3. DEFAULT ARCHITECTURE & CONVENTIONS
+
+Unless the design read picks a real design system (Section 2.A), these are the defaults:
+
+### 3.A Stack
+* **Framework:** React or Next.js. Default to Server Components (RSC).
+  * **RSC SAFETY:** Global state works ONLY in Client Components. In Next.js, wrap providers in a `"use client"` component.
+  * **INTERACTIVITY ISOLATION:** Any component using Motion, scroll listeners, or pointer physics MUST be an isolated leaf with `'use client'` at the top. Server Components render static layouts only.
+* **Styling:** **Tailwind v4** (default). Tailwind v3 only if the existing project demands it.
+  * For v4: do NOT use `tailwindcss` plugin in `postcss.config.js`. Use `@tailwindcss/postcss` or the Vite plugin.
+* **Animation:** **Motion** (the library formerly known as Framer Motion). Import from `motion/react` (`import { motion } from "motion/react"`). The `framer-motion` package still works as a legacy alias - prefer `motion/react` in new code.
+* **Fonts:** Always use `next/font` (Next.js) or self-host with `@font-face` + `font-display: swap`. Never link Google Fonts via `<link>` in production.
+
+### 3.B State
+* Local `useState` / `useReducer` for isolated UI.
+* Global state ONLY for deep prop-drilling avoidance - Zustand, Jotai, or React context.
+* **NEVER** use `useState` to track continuous values driven by user input (mouse position, scroll progress, pointer physics, magnetic hover). Use Motion's `useMotionValue` / `useTransform` / `useScroll`. `useState` re-renders the React tree on every change and collapses on mobile.
+
+### 3.C Icons
+* **Allowed libraries (priority order):** `@phosphor-icons/react`, `hugeicons-react`, `@radix-ui/react-icons`, `@tabler/icons-react`.
+* **Discouraged:** `lucide-react`. Acceptable only when the user explicitly asks for it or the project already depends on it.
+* **NEVER hand-roll SVG icons.** If a glyph is missing, install a second library or compose from primitives - do not draw icon paths from scratch.
+* **One family per project.** Do not mix Phosphor with Lucide in the same component tree.
+* **Standardize `strokeWidth` globally** (e.g. `1.5` or `2.0`).
+
+### 3.D Emoji Policy
+Discouraged by default in code, markup, and visible text. Replace symbols with icon-library glyphs. **Override:** allow emojis only when the user explicitly asks for a playful / chat-style / social-native vibe - and even then use them sparingly with intent.
+
+### 3.E Responsiveness & Layout Mechanics
+* Standardize breakpoints (`sm 640`, `md 768`, `lg 1024`, `xl 1280`, `2xl 1536`).
+* Contain page layouts using `max-w-[1400px] mx-auto` or `max-w-7xl`.
+* **Viewport Stability:** NEVER use `h-screen` for full-height Hero sections. ALWAYS use `min-h-[100dvh]` to prevent layout jumping on mobile (iOS Safari address bar).
+* **Grid over Flex-Math:** NEVER use complex flexbox percentage math (`w-[calc(33%-1rem)]`). ALWAYS use CSS Grid (`grid grid-cols-1 md:grid-cols-3 gap-6`).
+
+### 3.F Dependency Verification (mandatory)
+Before importing ANY 3rd-party library, check `package.json`. If the package is missing, output the install command first. **Never** assume a library exists.
+
+---
+
+## 4. DESIGN ENGINEERING DIRECTIVES (Bias Correction)
+
+LLMs default to clichés. Override these defaults proactively. Each rule has a context-aware override path.
+
+### 4.1 Typography
+* **Display / Headlines:** Default `text-4xl md:text-6xl tracking-tighter leading-none`.
+* **Body / Paragraphs:** Default `text-base text-gray-600 leading-relaxed max-w-[65ch]`.
+* **Sans font choice:**
+  * **Discouraged as default:** `Inter`. Pick `Geist`, `Outfit`, `Cabinet Grotesk`, `Satoshi`, or a brand-appropriate serif first.
+  * **Override:** Inter is acceptable when the user explicitly asks for a neutral / standard / Linear-style feel, or when the brief is a public-sector / accessibility-first site.
+* **Pairings to know:** `Geist` + `Geist Mono`, `Satoshi` + `JetBrains Mono`, `Cabinet Grotesk` + `Inter Tight`, `GT America` + `IBM Plex Mono`.
+
+* **SERIF DISCIPLINE (VERY DISCOURAGED AS DEFAULT):**
+  * Serif is **very discouraged as the default font for any project.** "It feels creative / premium / editorial" is NOT a reason to reach for serif. The agent's default mental model that "creative brief = serif" is the single most-tested AI tell in production rounds.
+  * **Serif is only acceptable when ONE of these is explicitly true:**
+    - The brand brief literally names a serif font, OR
+    - The aesthetic family is genuinely editorial / luxury / publication / manuscript / heritage / vintage AND you can articulate why this specific serif fits this specific brand
+  * For everything else (creative agency, design studio, modern brand, premium consumer, portfolio, lifestyle), **default sans-serif display** (Geist Display, ABC Diatype, Söhne Breit, Cabinet Grotesk Display, Migra Sans, GT Walsheim, Inter Display, PP Neue Montreal). Sans display fonts are not "boring" — they are the default for the same reason black is the default in fashion.
+  * **EMPHASIS RULE (related):** When you want to emphasize a word within a headline (the kinetic "and `spatial` design" type move), use **italic or bold of the SAME font**. Do NOT inject a random serif word into a sans headline (or vice versa) just to add visual interest. Mixed-family emphasis is amateur. Italic/bold emphasis in the same family is the right move.
+  * **Specifically BANNED as defaults:** `Fraunces` and `Instrument_Serif` (the two LLM-favorite display serifs).
+  * **If a serif is justified** (rare, per the above), rotate from this pool, do NOT reuse the same serif across consecutive projects: PP Editorial New, GT Sectra Display, Cardinal Grotesque, Reckless Neue, Tiempos Headline, Recoleta, Cormorant Garamond, Playfair Display, EB Garamond, IvyPresto, Migra, Editorial Old, Saol Display, Söhne Breit Kursiv, Domaine Display, Canela, Schnyder, Tobias, NB Architekt, ITC Galliard.
+
+* **ITALIC DESCENDER CLEARANCE (mandatory):** When italic is used in display type and the word contains a descender letter (`y g j p q`), `leading-[1]` or `leading-none` will clip the descender. Use `leading-[1.1]` minimum and add `pb-1` or `mb-1` reserve on the wrapping element. Audit every italic word in display headlines before shipping.
+
+### 4.2 Color Calibration
+* Max 1 accent color. Saturation < 80% by default.
+* **THE LILA RULE:** The "AI Purple / Blue glow" aesthetic is discouraged as a default. No automatic purple button glows, no random neon gradients. Use neutral bases (Zinc / Slate / Stone) with high-contrast singular accents (Emerald, Electric Blue, Deep Rose, Burnt Orange, etc.).
+* **Override:** if the brand or brief explicitly asks for purple / violet / lila, embrace it. But execute with intent: consistent palette, harmonised neutrals, restrained gradients. Not generic AI gradient slop.
+* **One palette per project.** Do not fluctuate between warm and cool grays within the same project.
+* **COLOR CONSISTENCY LOCK (mandatory):** Once an accent color is chosen for a page, it is used on the WHOLE page. A warm-grey site does not suddenly get a blue CTA in section 7. A rose-accented site does not get a teal status badge in the footer. Pick one accent, lock it, audit every component before shipping.
+
+* **PREMIUM-CONSUMER PALETTE BAN (mandatory, second-most-recurring AI-tell):**
+  * For premium-consumer briefs (cookware, wellness, artisan, luxury, heritage craft, DTC home goods, etc.) the LLM default is **warm beige/cream + brass/clay/oxblood/ochre + espresso/ink dark text**. Concretely banned hex families as default backgrounds and accents:
+    - Backgrounds: `#f5f1ea`, `#f7f5f1`, `#fbf8f1`, `#efeae0`, `#ece6db`, `#faf7f1`, `#e8dfcb` (all "warm paper / cream / chalk / bone")
+    - Accents: `#b08947`, `#b6553a`, `#9a2436`, `#9c6e2a`, `#bc7c3a`, `#7d5621` (all "brass / clay / oxblood / ochre")
+    - Text: `#1a1714`, `#1a1814`, `#1b1814` (all "espresso / warm near-black")
+  * This palette is BANNED as the default reach for premium-consumer briefs. Every premium-consumer site you have ever shipped uses this exact palette. The brand becomes invisible.
+  * **Default alternatives (rotate, do not reuse):**
+    - **Cold Luxury:** silver-grey + chrome + smoke (think Tesla, Apple Watch Hermes-without-the-leather)
+    - **Forest:** deep green + bone + amber accent (think Filson, Patagonia premium)
+    - **Black and Tan:** true off-black + warm tan, sharp contrast, no beige
+    - **Cobalt + Cream:** saturated blue against a single neutral, no brass
+    - **Terracotta + Slate:** warm rust against cool grey, no brass
+    - **Olive + Brick + Paper:** muted olive plus brick-red accent
+    - **Pure monochrome + single saturated pop:** off-white + off-black + one bright accent (electric blue, emerald, hot pink, etc.)
+  * **Palette-rotation rule:** if the previous premium-consumer project you generated used the beige+brass family, this one MUST use a different family. Do not ship the same warm-craft palette twice in a row.
+  * **Override:** the beige+brass+espresso palette is acceptable ONLY when the brand brief explicitly names those colors, or when the brand identity is genuinely vintage / artisan / warm-craft AND you can articulate why this specific palette fits this specific brand. Default-reaching for it because "this is a cookware brief" is banned.
+
+### 4.3 Layout Diversification
+* **ANTI-CENTER BIAS:** Centered Hero / H1 sections are avoided when `DESIGN_VARIANCE > 4`. Force "Split Screen" (50/50), "Left-aligned content / right-aligned asset", "Asymmetric white-space", or scroll-pinned structures.
+* **Override:** centered hero is OK for editorial / manifesto / launch-announcement briefs where the message itself is the design.
+
+### 4.4 Materiality, Shadows, Cards
+* Use cards ONLY when elevation communicates real hierarchy. Otherwise group with `border-t`, `divide-y`, or negative space.
+* When a shadow is used, tint it to the background hue. No pure-black drop shadows on light backgrounds.
+* For `VISUAL_DENSITY > 7`: generic card containers are banned. Data metrics breathe in plain layout.
+* **SHAPE CONSISTENCY LOCK (mandatory):** Pick ONE corner-radius scale for the page and stick to it. Options: all-sharp (radius 0), all-soft (radius 12-16px), all-pill (full radius for interactive). Mixed systems are allowed only when there is a documented rule (e.g. "buttons are full-pill, cards are 16px, inputs are 8px") and that rule is followed everywhere. Round buttons in a square layout, or square cards on a pill-button page, is broken design.
+
+### 4.5 Interactive UI States
+LLMs default to "static successful state only." Always implement full cycles:
+* **Loading:** Skeletal loaders matching the final layout's shape. Avoid generic circular spinners.
+* **Empty States:** Beautifully composed; indicate how to populate.
+* **Error States:** Clear, inline (forms), or contextual (toasts only for transient).
+* **Tactile Feedback:** On `:active`, use `-translate-y-[1px]` or `scale-[0.98]` to simulate a physical push.
+* **BUTTON CONTRAST CHECK (mandatory, a11y):** Before shipping any button, verify the button text is readable against the button background. White button + white text, `bg-white` CTA with `text-white` label, transparent button against the page background with no border → all banned. Audit every CTA: contrast ratio WCAG AA min (4.5:1 for body, 3:1 for large text 18px+). Same rule applies to ghost buttons over photographic backgrounds (use a backdrop, scrim, or stroke).
+* **CTA BUTTON WRAP BAN (mandatory):** Button text MUST fit on one line at desktop. If a label like "VIEW SELECTED WORK" wraps to 2 or 3 lines, the button is broken. Fix by EITHER shortening the label (3 words max for primary CTAs, ideally 1-2) OR widening the button (do not artificially constrain `max-width` on CTAs). Wrapped CTAs at desktop are a Pre-Flight Fail.
+* **NO DUPLICATE CTA INTENT (mandatory):** Two CTAs with the same intent on one page is a Pre-Flight Fail. Examples of same intent: "Get in touch" + "Contact us" + "Let's talk" + "Start a project" + "Start something" + "Reach out" = all "contact" intent → pick ONE label and use it everywhere on the page (nav, hero, footer). Same for "Try free" + "Get started" + "Sign up free" (all "signup" intent) and "View work" + "See selected work" + "Browse projects" (all "portfolio" intent). One label per intent.
+* **FORM CONTRAST CHECK (mandatory, a11y):** Form inputs, placeholder text, focus rings, helper text, and error text all pass WCAG AA contrast against the section background. Light placeholders on a near-white form, white form on white page section, form labels grayer than 4.5:1 contrast → all banned. Audit every form before shipping.
+
+### 4.6 Data & Form Patterns
+* Label ABOVE input. Helper text optional but present in markup. Error text BELOW input. Standard `gap-2` for input blocks.
+* No placeholder-as-label. Ever.
+
+### 4.7 Layout Discipline (Hard Rules. Failing any of these is shipping broken work)
+
+* **Hero MUST fit in the initial viewport.** Headline max 2 lines on desktop, subtext max **20 words** AND max 3-4 lines, CTAs visible without scroll. If the copy is too long: reduce font scale OR cut copy. If you cannot describe the value-prop in 20 words of subtext, the value-prop is unclear, not the rule too tight. Never let the hero overflow and force scroll to find the CTA.
+* **Hero font-scale discipline.** Plan font size and image size *together*. If the hero asset is large and the headline is more than 6 words, do not start at `text-7xl/text-8xl`. Default sensible range: `text-4xl md:text-5xl lg:text-6xl` for most heroes; `text-6xl md:text-7xl` only when the headline is 3-5 words. A 4-line hero headline is always a font-size error, never a copy-length error.
+* **HERO TOP PADDING CAP (mandatory):** Hero top padding max `pt-24` (≈6rem) at desktop. More than that means the hero content floats halfway down the viewport and reads as a layout bug, not as intentional space. If your hero needs more breathing room, increase font scale or asset size, not top padding.
+* **HERO STACK DISCIPLINE (max 4 text elements).** The hero is a single moment, not a feature list. Allowed text elements, max 4 in total:
+  1. Eyebrow (small uppercase label) OR brand strip OR neither - pick zero or one
+  2. Headline (max 2 lines, see above)
+  3. Subtext (max 20 words, max 4 lines)
+  4. CTAs (1 primary + max 1 secondary)
+  - **BANNED in the hero:** tiny tagline below CTAs ("Works with GitHub, GitLab, and self-hosted Git"), trust micro-strip ("Used by engineering teams at..."), pricing teaser ("Free for solo, $10/user for teams"), feature bullet list, social-proof avatar row. All of those move to dedicated sections directly below the hero.
+  - If you have an eyebrow AND a tagline below CTAs in the same hero, drop the tagline. If you have a brand strip AND a tagline, drop the tagline. One small text element per hero, max.
+* **"Used by" / "Trusted by" logo wall belongs UNDER the hero, never inside it.** The hero is for the value prop and primary CTA. The logo wall is a separate section directly below. Do not stuff trust logos into the same flex row as the hero copy.
+* **Navigation MUST render on a single line on desktop.** If items don't fit at `lg` (1024px), condense labels, drop secondary items, or move to a hamburger. A two-line nav at desktop is broken design.
+* **Navigation height cap: 80px max desktop, default 64-72px.** No huge "agency" nav bars that eat 15% of the viewport.
+* **Bento grids MUST have rhythm, not one-sided repetition.** Do not stack 6 left-image / right-text rows. Vary the composition: alternate full-width feature rows, asymmetric tile sizes, vertical breaks.
+* **BENTO CELL COUNT RULE (mandatory):** A bento grid has EXACTLY as many cells as you have content for. 3 items → 3 cells (1+2 split, or 2+1, or asymmetric trio). 5 items → 5 cells (2+3, 3+2, hero+4, etc.). If your grid has an empty cell in the middle or at the end, you planned wrong. Re-shape the grid; do not paste a blank tile.
+* **Section-Layout-Repetition Ban.** Once you use a layout family for a section (e.g., 3-column-image-cards, full-width-quote, split-text-image), that family can appear at most ONCE on the page. "Selected commissions" must not look like "What we do." A landing page with 8 sections must use at least 4 different layout families.
+* **ZIGZAG ALTERNATION CAP (mandatory).** Alternating "left-image + right-text" then "left-text + right-image" zigzag layout = banal. Max 2 sections in a row with this image+text-split pattern. The 3rd consecutive image+text split is a Pre-Flight Fail. Break the pattern with a full-width section, a vertical-stack section, a bento grid, a marquee, or a different layout family.
+* **EYEBROW RESTRAINT (mandatory, the #1 violated rule in production tests).** An "eyebrow" is the small uppercase wide-tracking label sitting above a section headline (e.g. `FOUR COLORWAYS`, `SELECTED WORK`, `THE HARDWARE`, `Git-native task management`). Typical CSS signature: `text-[11px] uppercase tracking-[0.18em]`, `font-mono text-[10.5px] uppercase tracking-[0.22em]`. Every AI-built site puts an eyebrow above EVERY section header, producing the same templated rhythm. Hard rule:
+  - **Maximum 1 eyebrow per 3 sections.** Hero counts as 1. So a page with 9 sections may use at most 3 eyebrows total.
+  - If section A has an eyebrow, the next 2 sections cannot have one.
+  - **Pre-Flight Check is mechanical:** count instances of `uppercase tracking` (or similar small-caps mono labels above headlines) across all section components. If count > ceil(sectionCount / 3), the output fails.
+  - **What to do instead of an eyebrow:** drop it entirely. The headline alone is enough. If you need to categorize a section, the section's location on the page already categorizes it; no label needed.
+* **SPLIT-HEADER BAN (mandatory).** The pattern "left big headline + right small explainer paragraph" as a section header (left col-span-7/8, right col-span-4/5 with a small body paragraph floating in the right column) is **banned as default**. Sections should have ONE focused message. If you genuinely need both a headline and an explainer paragraph, stack them vertically (headline on top, body below, max-width 65ch). Reach for the split-header pattern only when there is a real compositional reason (e.g., the right column carries a visual or interactive element, not just filler text).
+* **Bento Background Diversity (mandatory).** Bento and feature-grid sections cannot be 6 white-on-white cards with text inside. At least 2-3 cells in any multi-cell grid need real visual variation: a real image, a brand-appropriate gradient (not AI-purple), a pattern, a tinted background. A cream-on-cream bento with only typography inside reads as boring AI default, even when the rest of the page is good.
+* **Mobile collapse must be explicit per section.** For every multi-column layout, declare the `< 768px` fallback in the same component. No "it'll work, Tailwind handles it" assumptions.
+
+### 4.8 Image & Visual Asset Strategy
+
+Landing pages and portfolios are **visual products**. Text-only pages with fake-screenshot divs are slop.
+
+**Priority order for visual assets:**
+1. **Image-generation tool first.** If ANY image-gen tool is available in the environment (`generate_image`, MCP image tool, IDE-integrated gen, OpenAI image tools, etc.) you MUST use it to create section-specific assets: hero photography, product shots, texture backgrounds, mood images. Generate at the right aspect ratio for the section. Do not skip this step because hand-rolled CSS feels faster.
+2. **Real web images second.** When no gen tool is available, use real photography sources. Acceptable defaults:
+   * `https://picsum.photos/seed/{descriptive-seed}/{w}/{h}` for placeholder photography (seed should describe the section, e.g. `marrow-cookware-kitchen`)
+   * Actual stock or brand URLs when the brief provides them
+   * Open-license sources (Unsplash via direct URL, Pexels) if explicitly allowed
+3. **Last resort: tell the user.** If neither is possible, do NOT fill the page with hand-rolled SVG illustrations or div-based "fake screenshots." Instead, leave clearly-labeled placeholder slots (`<!-- TODO: hero product photo, 1600x1200 -->`) and at the end of the response say: *"This page needs real images at: \[list of placements\]. Please generate or provide them."*
+
+**Even minimalist sites need real images.** A pure-text page is not minimalism. It is incomplete work. Even an editorial Linear-style site needs at least 2-3 real images (hero, one product/lifestyle shot, one supporting image). Generate B&W minimalist photography if the brief is restrained; do not skip images entirely because the dial is low.
+
+**Real company logos for social proof.** When the brief calls for a "Trusted by / Used by / Customers" logo wall, do NOT default to plain text wordmarks (`<span>Acme Co</span>` styled in a row). Use real SVG logos:
+* **Source: Simple Icons** (`https://cdn.simpleicons.org/{slug}/ffffff` for any color, or `simple-icons` npm package). Covers most known brands.
+* **Alternative: devicon** for tech-stack logos (`@svgr/cli` or CDN).
+* **Make-up the brand name? Then make-up an SVG mark too.** Generate a simple monogram (one letter in a circle, two-letter ligature, abstract glyph) rendered as an inline `<svg>` matching the page style. Plain text wordmarks for invented brand names look generic.
+* **Always** ensure logos render in both light and dark mode (white-on-dark, black-on-light, or single-color theme variable).
+* **LOGO-ONLY rule (mandatory):** logo wall = logos and nothing else. Do NOT print industry / category labels below each logo (no `Vercel` + `hosting` underneath, no `Stripe` + `payments`, no `Cloudflare` + `infra`). The logo is the credibility, the label adds nothing the user does not already know. Optional: brand name as alt-text for screen readers, optional link to the brand's site. That is it.
+
+**Hand-rolled illustrations:**
+* SVG icons from libraries: fine (see Section 3.C).
+* Hand-rolled decorative SVGs (custom illustrations, logos, marks): **strongly discouraged**, never as default. Acceptable only when:
+  - The brief explicitly calls for it ("draw me an SVG logo")
+  - It's a single, simple geometric mark (a square, a circle, a wordmark in display type)
+  - You're confident in the output quality
+
+**Div-based fake screenshots are banned.** A "hand-built product preview" rendered with `<div>` rectangles, fake task lists, fake dashboards, fake terminal windows is a Tell. If you need to show a product:
+* Use a real screenshot URL if one exists
+* Generate one via image tool
+* Use a real component preview (an actual mini-version of the UI inside the page)
+* Or skip the preview entirely and use editorial photography
+
+**Hero needs a real visual.** Text + gradient blob is not a hero - it's a placeholder.
+
+### 4.9 Content Density
+
+Landing pages live on the **first impression**, not the full read. Cut ruthlessly.
+
+* **Default content shape per section:** short headline (≤ 8 words) + short sub-paragraph (≤ 25 words) + one visual asset OR one CTA. Anything more must be justified by the section's job.
+* **No data-dump sections.** A 20-row publication table, a 30-row award list, a giant pricing matrix on a marketing page = wrong layout. Use:
+  - Top 3-5 highlights + "View full list" link
+  - Marquee / carousel for breadth
+  - Different page entirely if the data is the product
+* **Long lists need a different UI component, not a longer list.** Default `<ul>` with bullets / `divide-y` rows is the lazy choice. If you have > 5 items, reach for one of these instead:
+  - 2-column split with grouped items
+  - Card grid with image + label per item
+  - Tabs / accordion if items are categorisable
+  - Horizontal scroll-snap pills
+  - Carousel for breadth-heavy lists (testimonials, logos, capabilities)
+  - Marquee for "lots-of-things-that-don't-need-individual-attention"
+  A spec sheet with 10 rows + a hairline under every row is the WORST default. Either group rows into 2-3 chunks with sparse dividers, or move to a card-per-spec layout.
+* **Spec sheets specifically (the Marrow-cookware pattern).** A long product specification table with `border-b` on every row is the AI default for cookware / hardware / apparel / artisan-goods briefs. Banned. Concrete alternatives:
+  - **2-col card grid:** each spec gets its own card with the spec name, the value (large display number), and a one-line "why it matters" body. Cards arranged 2-col on desktop, 1-col mobile.
+  - **Scroll-snap horizontal pills:** each spec is a pill, user can flick through.
+  - **Grouped chunks:** group 10 specs into 3 logical clusters (e.g. "Materials", "Cooking", "Warranty"), each cluster gets ONE soft divider and a cluster heading.
+  - **Featured-vs-rest:** 3-4 hero specs visualised as large display tiles, the rest collapsed under a "View full specifications" disclosure.
+
+* **COPY SELF-AUDIT (mandatory before ship):** Before declaring any task done, re-read every visible string on the page (headlines, subheads, eyebrows, button labels, body copy, captions, alt text, footer text, error messages). Flag any string that is:
+  - **Grammatically broken** ("free on its past", "two plans but one is honest", "to put it on the table" out of context)
+  - **Has unclear referents** ("we plan to stay that way" without prior context)
+  - **Sounds like AI hallucination** (cute-but-wrong wordplay, forced metaphors that don't track, "elegant nothing" phrases)
+  - **Reads like an LLM trying to sound thoughtful** (passive-aggressive humility, fake-craftsman labels, mock-poetic micro-meta)
+  Rewrite every flagged string. If unsure whether a string makes sense, replace it with a plain functional sentence. AI-generated cute copy is worse than boring copy.
+* **Fake-precise numbers are flagged.** Numbers like `92%`, `4.1×`, `48k`, `5.8 mm`, `13.4 lb` either:
+  - Come from real data (brief, brand guidelines, public metrics) - fine
+  - Are explicitly labeled as mock (`<!-- mock -->`, "example", "sample data") - fine
+  - Are AI-invented spec aesthetics - banned. Don't fake engineering precision the brand doesn't claim.
+* **One copy register per page.** Don't mix technical mono ("47 tasks · 0.6 ctx-switches/day"), editorial prose, and marketing punch in the same composition unless the brand voice explicitly calls for it.
+
+### 4.10 Quotes & Testimonials
+
+* **Max 3 lines** of quote body. Never 6. If the original quote is longer → cut it. A landing-page quote is a snippet, not the full review.
+* For very small font sizes (e.g. footer-style testimonials), the line cap can stretch slightly. Spirit: "fits in a glance."
+* **No em-dashes inside the quote text** as design flourish (long pauses, kinetic em-dashes, em-dash-bullets). See Section 9.G - em-dash is completely banned.
+* Attribution: name + role + (optionally) company. Never name only ("- Sarah").
+* Quote marks: use real typographic quotes ( " " ) or none at all. Not straight ASCII ( " ).
+
+### 4.11 Page Theme Lock (Light / Dark Mode Consistency)
+
+The page has ONE theme. Sections do not invert.
+
+* If the page is dark mode, ALL sections are dark mode. No light-mode-warm-paper section sandwiched between dark sections (or vice versa). The user must not feel they walked into a different website mid-scroll.
+* The exception: if the brief explicitly calls for a "Color Block Story" or "Theme Switch on Scroll" device AND that is a deliberate composition (one full theme switch with a strong transition, not random alternation), it is allowed once per page.
+* Default behaviour: pick light, dark, or auto (`prefers-color-scheme`) at the page level and lock it. Section-level background tints within the same theme family are fine (`bg-zinc-950` next to `bg-zinc-900`); flipping to `bg-amber-50` in the middle of a `bg-zinc-950` page is broken.
+* When using a design system with built-in theming (Radix Themes, shadcn/ui with `<Theme>`), set the theme ONCE in `layout.tsx` or the page root. Do not let individual sections override.
+
+---
+
+## 5. CONTEXT-AWARE PROACTIVITY
+
+These are tools, not defaults. Use them when the design read calls for them. **None of these fire automatically.**
+
+* **Liquid Glass / Glassmorphism:** Appropriate for premium consumer, Apple-adjacent, luxury brand, or media-overlay vibes. Inappropriate for dashboards, public-sector, or "boring B2B." When used, go beyond `backdrop-blur`: add a 1px inner border (`border-white/10`) and a subtle inner shadow (`shadow-[inset_0_1px_0_rgba(255,255,255,0.1)]`) for physical edge refraction. Provide a solid-fill fallback under `prefers-reduced-transparency`.
+* **Magnetic Micro-physics:** Use when `MOTION_INTENSITY > 5` AND the brief reads premium / playful / agency. Implement EXCLUSIVELY with Motion's `useMotionValue` / `useTransform` outside the React render cycle. Never `useState`. See Section 3.B.
+* **Perpetual Micro-Interactions** (Pulse, Typewriter, Float, Shimmer, Carousel): Use when `MOTION_INTENSITY > 5` AND the section actively benefits from motion (status indicators, live feeds, AI-feel). **Not every card needs an infinite loop.** If a section is informational, leave it still. Apply Spring Physics (`type: "spring", stiffness: 100, damping: 20`) - no linear easing.
+* **"Motion claimed, motion shown."** If `MOTION_INTENSITY > 4`, the page must actually move: entry transitions on hero, scroll-reveal on key sections, hover physics on CTAs, at minimum. A static page that claims `MOTION_INTENSITY: 7` is broken. Conversely, if you cannot ship working motion in the available scope, drop the dial to 3 and ship a clean static page. Never half-build motion that breaks (cut-off ScrollTriggers, jumpy enters, missing cleanups).
+* **MOTION MUST BE MOTIVATED (mandatory).** Before adding any animation, ask: "what does this animation communicate?" Valid answers: hierarchy (drawing attention to the right thing), storytelling (revealing content in sequence that matches a narrative), feedback (acknowledging a user action), state transition (showing something changed). Invalid answer: "it looked cool". GSAP everywhere because GSAP is available is amateur. Each ScrollTrigger, each marquee, each pinned section needs a reason. If you cannot articulate the reason in one sentence, drop the animation.
+* **MARQUEE MAX-ONE-PER-PAGE (mandatory).** Horizontal scrolling text marquees ("logos endlessly scrolling", "manifesto scrolling sideways", "kinetic word strip") are appropriate at most ONCE per page. Two or more marquees on the same page reads as lazy filler. Pick the one section where the marquee actually serves the content; the others get a different layout.
+* **GSAP Sticky-Stack Pattern (when scroll-stack is used).** A "card stack on scroll" must be a REAL sticky-stack, not a sequential reveal list. See Section 5.A below for the canonical code skeleton. Common failure: trigger fires halfway through scroll instead of pinning at viewport top. Fix: `start: "top top"` not `start: "top center"` or `"top 80%"`.
+* **GSAP Horizontal-Pan Pattern (when horizontal scroll-hijack is used).** See Section 5.B below for the canonical skeleton. Common failure: animation starts before the section is pinned, so the user sees half a slide. Same fix: `start: "top top"`, pin the wrapper, scrub the inner track.
+
+### 5.A Sticky-Stack - Canonical Skeleton
+
+```tsx
+"use client";
+import { useRef, useEffect } from "react";
+import { gsap } from "gsap";
+import { ScrollTrigger } from "gsap/ScrollTrigger";
+import { useReducedMotion } from "motion/react";
+
+gsap.registerPlugin(ScrollTrigger);
+
+export function StickyStack({ cards }: { cards: React.ReactNode[] }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const reduce = useReducedMotion();
+
+  useEffect(() => {
+    if (reduce || !ref.current) return;
+    const ctx = gsap.context(() => {
+      const cardEls = gsap.utils.toArray<HTMLElement>(".stack-card");
+      cardEls.forEach((card, i) => {
+        if (i === cardEls.length - 1) return;
+        ScrollTrigger.create({
+          trigger: card,
+          start: "top top",                              // pin at viewport top
+          endTrigger: cardEls[cardEls.length - 1],
+          end: "top top",
+          pin: true,
+          pinSpacing: false,
+        });
+        gsap.to(card, {
+          scale: 0.92,
+          opacity: 0.55,
+          ease: "none",
+          scrollTrigger: {
+            trigger: cardEls[i + 1],
+            start: "top bottom",
+            end: "top top",
+            scrub: true,
+          },
+        });
+      });
+    }, ref);
+    return () => ctx.revert();
+  }, [reduce]);
+
+  return (
+    <div ref={ref} className="relative">
+      {cards.map((card, i) => (
+        <div
+          key={i}
+          className="stack-card sticky top-0 min-h-[100dvh] flex items-center justify-center"
+        >
+          {card}
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+Critical points: `start: "top top"`, `pin: true`, every card except the last is pinned, the scale/opacity transform is driven by the NEXT card's scroll trigger (so previous card shrinks as next one arrives).
+
+### 5.B Horizontal-Pan - Canonical Skeleton
+
+```tsx
+"use client";
+import { useRef, useEffect } from "react";
+import { gsap } from "gsap";
+import { ScrollTrigger } from "gsap/ScrollTrigger";
+import { useReducedMotion } from "motion/react";
+
+gsap.registerPlugin(ScrollTrigger);
+
+export function HorizontalPan({ children }: { children: React.ReactNode }) {
+  const wrap = useRef<HTMLDivElement>(null);
+  const track = useRef<HTMLDivElement>(null);
+  const reduce = useReducedMotion();
+
+  useEffect(() => {
+    if (reduce || !wrap.current || !track.current) return;
+    const ctx = gsap.context(() => {
+      const distance = track.current!.scrollWidth - window.innerWidth;
+      gsap.to(track.current, {
+        x: -distance,
+        ease: "none",
+        scrollTrigger: {
+          trigger: wrap.current,
+          start: "top top",                              // pin starts when section top hits viewport top
+          end: () => `+=${distance}`,                    // scroll distance = track width minus viewport
+          pin: true,
+          scrub: 1,
+          invalidateOnRefresh: true,
+        },
+      });
+    }, wrap);
+    return () => ctx.revert();
+  }, [reduce]);
+
+  return (
+    <section ref={wrap} className="relative overflow-hidden">
+      <div ref={track} className="flex h-[100dvh] items-center">
+        {children}
+      </div>
+    </section>
+  );
+}
+```
+
+Critical points: `start: "top top"`, `pin: true`, `end: "+=${distance}"` (scroll length = horizontal travel needed), `scrub: 1`. The wrapper is pinned, the inner track slides horizontally as the user scrolls vertically.
+
+### 5.C Scroll-Reveal Stagger - Canonical Skeleton (lighter alternative)
+
+For simple "items appear as they enter viewport" (no pinning), prefer Motion's `whileInView` over GSAP - lighter, no ScrollTrigger needed:
+
+```tsx
+"use client";
+import { motion, useReducedMotion } from "motion/react";
+
+export function RevealStagger({ items }: { items: string[] }) {
+  const reduce = useReducedMotion();
+  return (
+    <ul className="grid gap-6">
+      {items.map((item, i) => (
+        <motion.li
+          key={item}
+          initial={reduce ? false : { opacity: 0, y: 24 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, amount: 0.3 }}
+          transition={{
+            duration: 0.6,
+            delay: i * 0.06,
+            ease: [0.16, 1, 0.3, 1],
+          }}
+        >
+          {item}
+        </motion.li>
+      ))}
+    </ul>
+  );
+}
+```
+
+Use this for: feature lists, testimonial grids, logo walls, anything that just needs "enter on scroll." Save GSAP for actual pin/scrub work.
+
+### 5.D Forbidden Animation Patterns
+
+* **`window.addEventListener("scroll", ...)`** is banned. It runs on every scroll frame, jank-prone, no batching. Use Motion's `useScroll()`, GSAP's `ScrollTrigger`, IntersectionObserver, or CSS `scroll-driven animations` (`animation-timeline: view()`).
+* **Custom scroll progress calculations using `window.scrollY`** in React state. Same reason. Re-renders on every frame.
+* **`requestAnimationFrame` loops that touch React state.** Use motion values (`useMotionValue` + `useTransform`) instead.
+* **Layout Transitions:** Use Motion's `layout` and `layoutId` props for visible state changes (re-ordering lists, expanding modals, shared elements between routes). Do not wrap static content in `layout` props "for safety" - it costs measurement work.
+* **Staggered Orchestration:** Use `staggerChildren` (Motion) or CSS cascade (`animation-delay: calc(var(--index) * 100ms)`) for reveal moments where sequence matters. For `staggerChildren`, parent (`variants`) and children MUST share the same Client Component tree.
+
+---
+
+## 6. PERFORMANCE & ACCESSIBILITY GUARDRAILS
+
+### 6.A Hardware Acceleration
+* Animate ONLY `transform` and `opacity`. Never animate `top`, `left`, `width`, `height`.
+* Use `will-change: transform` sparingly - only on elements that will actually animate.
+
+### 6.B Reduced Motion (mandatory)
+* **Any motion above `MOTION_INTENSITY > 3` MUST honor `prefers-reduced-motion`.** This is non-negotiable.
+* In Motion: wrap with `useReducedMotion()` and degrade to static.
+* In CSS: gate animations behind `@media (prefers-reduced-motion: no-preference)` or provide an override block under `@media (prefers-reduced-motion: reduce)` that disables.
+* Infinite loops, parallax, scroll-hijack, and magnetic physics MUST collapse to static / instant under reduced motion.
+
+### 6.C Dark Mode (mandatory for any consumer-facing page)
+* Design for **both modes from the start**. Never ship light-only or dark-only without explicit user instruction.
+* Use Tailwind `dark:` variant OR CSS variables for tokens. Pick one strategy per project.
+* **Do not prescribe specific dark-mode colors here.** The brief decides. Maintain visual hierarchy, brand identity, and WCAG AA contrast (AAA for body) across both modes.
+* Respect `prefers-color-scheme: dark`. Default to system preference unless the brand insists on one mode.
+
+### 6.D Core Web Vitals Targets
+* **LCP** < 2.5s. Hero image must be `next/image priority` or preloaded.
+* **INP** < 200ms. Heavy work off main thread.
+* **CLS** < 0.1. Reserve space for images, fonts, embeds.
+* Run Lighthouse before declaring a page done.
+
+### 6.E DOM Cost
+* Apply grain / noise filters EXCLUSIVELY to fixed, `pointer-events-none` pseudo-elements (e.g., `fixed inset-0 z-[60] pointer-events-none`). NEVER on scrolling containers - continuous GPU repaints destroy mobile FPS.
+* Be aware of bundle size. Motion is not tiny. Three.js is large. Lazy-load anything that's not above-the-fold.
+
+### 6.F Z-Index Restraint
+NEVER spam arbitrary `z-50` or `z-10`. Use z-index strictly for systemic layer contexts (sticky navbars, modals, overlays, grain). Document the z-index scale in a project constants file.
+
+---
+
+## 7. DIAL DEFINITIONS (Technical Reference)
+
+### DESIGN_VARIANCE (Level 1-10)
+* **1-3 (Predictable):** Symmetrical CSS Grid (12-col, equal fr-units), equal paddings, centered alignment.
+* **4-7 (Offset):** `margin-top: -2rem` overlaps, varied image aspect ratios (4:3 next to 16:9), left-aligned headers over center-aligned data.
+* **8-10 (Asymmetric):** Masonry layouts, CSS Grid with fractional units (`grid-template-columns: 2fr 1fr 1fr`), massive empty zones (`padding-left: 20vw`).
+* **MOBILE OVERRIDE:** For levels 4-10, asymmetric layouts above `md:` MUST collapse to strict single-column (`w-full`, `px-4`, `py-8`) on viewports `< 768px`.
+
+### MOTION_INTENSITY (Level 1-10)
+* **1-3 (Static):** No automatic animations. CSS `:hover` and `:active` states only. `prefers-reduced-motion` is the default mode anyway.
+* **4-7 (Fluid CSS):** `transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1)`. `animation-delay` cascades for load-ins. Focus on `transform` and `opacity`.
+* **8-10 (Advanced Choreography):** Complex scroll-triggered reveals, parallax, scroll-driven animation (CSS `animation-timeline` or GSAP ScrollTrigger). Use Motion hooks. **NEVER use `window.addEventListener('scroll')`** - it is a hard ban, not a "prefer-not." See Section 5.D for the allowed alternatives.
+
+### VISUAL_DENSITY (Level 1-10)
+* **1-3 (Art Gallery):** Lots of white space. Huge section gaps (`py-32` to `py-48`). Expensive, clean.
+* **4-7 (Daily App):** Standard web app spacing (`py-16` to `py-24`).
+* **8-10 (Cockpit):** Tight paddings. No card boxes; 1px lines separate data. Mandatory: `font-mono` for all numbers.
+
+---
+
+## 8. DARK MODE PROTOCOL
+
+Dual-mode by default. Never assume light-only unless the brief is print-emulating editorial.
+
+### 8.A Token Strategy (pick one, stick to it)
+* **Tailwind `dark:` variant** (default for utility-first projects): every color utility paired with its dark variant (`bg-white dark:bg-zinc-950`, `text-gray-900 dark:text-gray-100`).
+* **CSS variables** (for shadcn/ui, Radix Themes, or component libraries with theming): define semantic tokens (`--surface`, `--surface-elevated`, `--text-primary`, `--accent`) and swap values under `[data-theme="dark"]` or `@media (prefers-color-scheme: dark)`.
+
+### 8.B Do Not Prescribe Specific Colors Here
+The brief and brand decide. This skill enforces only:
+* **Contrast** - WCAG AA minimum for body text, AAA target for hero copy.
+* **Hierarchy parity** - visual hierarchy that works in light must work in dark. If a CTA pops in light, it pops in dark.
+* **Brand fidelity** - primary brand color stays recognisable. Don't desaturate the brand into a dark mode.
+* **No pure `#000000` and no pure `#ffffff`** - use off-black (zinc-950, near-black warm gray) and off-white. Pure values kill depth.
+
+### 8.C Default Mode
+Respect `prefers-color-scheme` unless the brand insists. Add a manual toggle if either mode would lose key brand expression.
+
+### 8.D Test in Both Modes Before Finishing
+Open the page in both modes during development. Do not ship a page you've only seen in one mode.
+
+---
+
+## 9. AI TELLS (Forbidden Patterns)
+
+Avoid these signatures unless the brief explicitly asks for them.
+
+### 9.A Visual & CSS
+* **NO neon / outer glows** by default. Use inner borders or subtle tinted shadows.
+* **NO pure black (`#000000`).** Off-black, zinc-950, or charcoal.
+* **NO oversaturated accents.** Desaturate to blend with neutrals.
+* **NO excessive gradient text** for large headers.
+* **NO custom mouse cursors.** Outdated, accessibility-hostile, perf-hostile.
+
+### 9.B Typography
+* **AVOID Inter as default.** See Section 4.1. Override path exists.
+* **NO oversized H1s** that just scream. Control hierarchy with weight + color, not raw scale.
+* **Serif constraints:** Serif for editorial / luxury / publication. Not for dashboards.
+
+### 9.C Layout & Spacing
+* **Mathematically perfect** padding and margins. No floating elements with awkward gaps.
+* **NO 3-column equal feature cards.** The generic "three identical cards horizontally" feature row is banned. Use 2-column zig-zag, asymmetric grid, scroll-pinned, or horizontal-scroll alternative.
+
+### 9.D Content & Data ("Jane Doe" Effect)
+* **NO generic names.** "John Doe", "Sarah Chan", "Jack Su" → use creative, realistic, locale-appropriate names.
+* **NO generic avatars.** No SVG "egg" or Lucide user icons → use believable photo placeholders or specific styling.
+* **NO fake-perfect numbers.** Avoid `99.99%`, `50%`, `1234567`. Use organic, messy data (`47.2%`, `+1 (312) 847-1928`).
+* **NO startup-slop brand names.** "Acme", "Nexus", "SmartFlow", "Cloudly" → invent contextual, premium names that sound real.
+* **NO filler verbs.** "Elevate", "Seamless", "Unleash", "Next-Gen", "Revolutionize" → concrete verbs only.
+
+### 9.E External Resources & Components
+* **NO hand-rolled SVG icons.** Use Phosphor / HugeIcons / Radix / Tabler. Lucide on explicit request only.
+* **Hand-rolled decorative SVGs strongly discouraged** as default (see Section 4.8).
+* **NO div-based fake screenshots.** Never build a fake product UI out of `<div>` rectangles to simulate a screenshot. Use real images, generated images, or skip the preview.
+* **NO broken Unsplash links.** Use `https://picsum.photos/seed/{descriptive-string}/{w}/{h}`, or generated photo placeholders, or actual assets.
+* **shadcn/ui customization:** Allowed, but NEVER in default state. Customize radii, colors, shadows, typography to the project aesthetic.
+* **Production-Ready Cleanliness:** Code visually clean, memorable, meticulously refined.
+
+### 9.F Production-Test Tells (banned outright)
+
+These patterns came out of real LLM-generated landing-page tests. They are the signatures the model defaults to when it tries to "look designed." Treat them as hard bans unless the brief explicitly calls for one.
+
+**Hero & top-of-page**
+* **NO version labels in the hero.** `V0.6`, `v2.0`, `BETA`, `INVITE-ONLY PREVIEW`, `EARLY ACCESS`, `ALPHA` - banned as default eyebrows. Only acceptable when the brief is explicitly about a product launch / preview status.
+* **NO "Brand · No. 01"-style sub-eyebrows.** "Marrow · No. 01 · The 6-quart" type micro-meta lines. Skip them.
+
+**Section numbering & micro-labels**
+* **NO section-number eyebrows.** `00 / INDEX`, `001 · Capabilities`, `002 · Featured commission`, `06 · how it works`, `05 · The honest table` - banned. Eyebrows should name the topic in plain language, not enumerate.
+* **NO `01 / 4`-style pagination on images or bento tiles.** If the user can count, they don't need the label.
+* **NO `Scroll · 001 Capabilities`-style scroll cues.** A simple arrow or "Scroll" is enough; no section-number prefix.
+* **NO "Index of Work, 2018 - 2026"-style range labels** as eyebrows. Just say what the section is.
+
+**Separators & dots**
+* **The middle-dot (`·`) is rationed.** Maximum 1 per line in metadata strips. Do NOT use it as the default separator for everything ("foo · bar · baz · qux · quux"). If you need a separator family, prefer line breaks, hairlines, or columns.
+* **NO decorative colored status dots on every list/nav/badge.** A colored dot before "ONE Q4 SLOT OPEN" or before every nav link, or every task row - banned by default. Acceptable only when the dot conveys actual semantic state (a server status, an availability flag) and is used sparingly.
+
+**Em-dashes & typography flourishes**
+* **NO em-dash (`—`) as a design element OR anywhere else.** See Section 9.G below for the complete, non-negotiable ban. The em-dash character is forbidden in headlines, eyebrows, pills, body copy, quotes, attribution, captions, button text, and alt text. Use the regular hyphen (`-`).
+* **NO `<br>`-broken-and-italicized headlines** as a default "design move." "for thirty\<br\>*years.*" type splits. Headlines should read naturally first, get clever only when the brief demands it.
+* **NO vertical rotated text** ("INDEX OF WORK, 2018 - 2026" rotated 90°). Agency-portfolio cliché. Use it only when the brief is explicitly agency / Awwwards / experimental AND it serves a real composition purpose.
+* **NO crosshair / hairline grid lines as decoration.** Vertical and horizontal lines drawn just to make the page "feel designed" - banned. Use them only when they organize real content.
+
+**Fake product previews**
+* **NO div-based fake product UI in the hero** (fake task list, fake terminal, fake dashboard built from styled divs). It is the #1 LLM-design Tell. Use a real screenshot, a generated image, a real component preview, or none at all.
+* **NO fake version footers** ("v0.6.2-rc.1", "last sync 4s ago · main") inside fake screenshots. Adds nothing, screams AI.
+
+**Marketing-copy Tells**
+* **NO "Quietly in use at" / "Quietly trusted by"** social-proof headers. Use natural language: "Trusted by", "Used at", "Customers include", or skip the heading entirely if the logos speak.
+* **NO "From the field" / "Field notes" / "Currently on the bench" / "On our desks" / "Loose plates" style poetic labels** on quote, blog, or sidebar sections. Reads as performative-craftsman. Use plain functional labels ("Testimonials", "Latest writing", "Now working on") or skip the label.
+* **NO "We respect the French ones"-style** mock-humble industry-references in body copy. Cute and AI-y.
+* **NO weather / locale strips** ("LIS 14:23 · 18°C") in headers/footers unless the brief is explicitly about a place / time-zone-distributed studio.
+* **NO micro-meta-sentences under eyebrows.** Sentences like *"Each of these is a feature we ship today, not a roadmap promise. The list will stay short on purpose."* sitting under a section heading are clutter. Eyebrow + Headline + Body is enough.
+* **NO generic step labels.** "Stage 1 / Stage 2 / Stage 3", "Step 1 / Step 2 / Step 3", "Phase 01 / Phase 02 / Phase 03", "Pass One / Pass Two / Pass Three". Banned. The actual step content is the label. If you must show progression, use the verb-noun directly ("Install", "Configure", "Ship") not "Stage 1: Install".
+
+**Pills, labels and version stamps**
+* **NO pills/labels/tags overlaid on images.** No `<span>` overlays on photos with tags like `Brand · 02`, `PLATE · BRAND`, `Field notes - journal`. Either let the image speak alone, or add a caption directly below (outside the image).
+* **NO photo-credit captions as decoration.** Strings like `Field study no. 12 · Ines Caetano`, `Plate 03 · House archive`, `Frame XII · 35mm` under stock/picsum images are pretentious. Photo credit is allowed ONLY when there is a real photographer being credited for a real photo (with permission). Otherwise: skip the caption or use a one-line functional caption ("The 6-quart, in Sage.").
+* **NO version footers on marketing pages.** Footer strings like `v1.4.2`, `Build 0048`, `last sync 4s ago · main` are CLI / devtool fixtures, not landing-page content. Banned on marketing/landing/portfolio pages.
+* **NO "Reservation 412 of 800"-style live-stock counters** as decoration. Only if the brief is explicitly a limited-run waitlist with real data.
+
+**Decoration text strips**
+* **NO decoration text strip at hero bottom.** Patterns like `BRAND. MOTION. SPATIAL.`, `TYPE / FORM / MOTION`, `DESIGN · BUILD · SHIP`, `ESTD. 2018 · LISBON · BRAND. MOTION. SPATIAL.` as a small mono-caps strip across the bottom of the hero are an agency-portfolio cliché. Banned by default. Only acceptable when the strip carries real, navigable links (sticky bottom nav) or real status info (cookie banner, build info on a docs site).
+* **NO floating top-right sub-text in section headings.** Pattern: section has a giant left-aligned headline; in the top-right corner of the same section header there is a small explainer paragraph floating with no clear alignment to anything else. That floater is the Tell. Either put the sub-text directly under the headline, or build a clean 2-column header (left: headline, right: aligned body), but not a tiny corner paragraph.
+
+**Lists, dividers and scoring**
+* **NO `border-t` + `border-b` on every row of a long list / spec table.** Pick one (bottom-border between rows OR top-border above the group) and use it sparsely. A 10-row spec table with hairlines under each row is the laziest layout - see Section 4.9 for alternative UI components.
+* **NO scoring/progress bars with filled background tracks** as comparison visuals. If you need to show "X out of Y" comparisons, prefer a number + small icon, or a tiny inline bar WITHOUT a background track. Big filled `bg-zinc-200` tracks with a partial fill on top are dashboard-UI clutter on a landing page.
+
+**Locale, time, scroll cues**
+* **Locale / city-name / time / weather strips are banned for 99% of briefs.** "Lisbon, working with founders" in the hero, "1200-690 Lisbon, Portugal" in the footer, "Lisbon 14:23 · 18°C" in the nav. These are agency-portfolio decoration tells. Allowed ONLY when: the brief explicitly describes a globally-distributed studio with timezone-relevant work, OR a travel-focused brand, OR a real-world physical venue. A single contact-address mention in the footer is fine; an atmospheric locale strip is not.
+* **Scroll cues are banned.** `Scroll`, `↓ scroll`, `Scroll to explore`, `Scroll to walk through it`, animated mouse-wheel icons. If the user has not scrolled yet, they are looking at the hero. They know what scroll is. The bottom of the viewport does not need a label.
+* **ZERO decorative status dots by default.** A coloured dot before nav items, before list rows, before badges, before status labels is a Tell. Only acceptable when conveying real semantic state (a live indicator on actual server status, a live availability flag) and limited to one per page section.
+
+### 9.G EM-DASH BAN (the single most-violated Tell)
+
+**Em-dash (`—`) is COMPLETELY banned.** It is the LLM's signature stylistic crutch and it is the #1 visual Tell in production tests. There is no "limited use" allowance, no "natural language frequency" allowance, no "in body copy is fine" allowance. None.
+
+* **Banned in headlines.** Use a period or a comma.
+* **Banned in eyebrows / labels / pills / button text / image captions / nav items.** Replace with line breaks, columns, or hairlines.
+* **Banned in body copy.** Restructure the sentence: two sentences with a period, OR a comma, OR parentheses, OR a colon.
+* **Banned in quote attribution.** Use a normal hyphen with spaces (` - `) or a line break + smaller-weight name.
+* **Banned in en-dash form too (`–`) when used as a separator.** Date ranges (`2018-2026`) use a hyphen. Number ranges (`€40-80k`) use a hyphen.
+
+The ONLY permitted dash characters on the page are:
+* Regular hyphen `-` (for compound words, ranges, line dividers in markup)
+* Minus sign in math (`-5°C`)
+
+If your output contains a single `—` or `–` anywhere visible to the user, the output fails the Pre-Flight Check and must be rewritten.
+
+This rule is non-negotiable. The agent has historically ignored em-dash limits when phrased as "use sparingly." The phrasing here is binary: zero em-dashes.
+
+---
+
+## 10. REFERENCE VOCABULARY (Pattern Names the Agent Should Know)
+
+This is a vocabulary, not a library. The agent should KNOW these pattern names to communicate about them, design with them in mind, and reach for them when the design read calls for them. **Implementations and code sketches live in the Block Library (Section 12), which is populated iteratively.**
+
+### Hero Paradigms
+* **Asymmetric Split Hero** - Text on one side, asset on the other, generous white space.
+* **Editorial Manifesto Hero** - Large type, no asset, almost-poster.
+* **Video / Media Mask Hero** - Type cut out as mask over video background.
+* **Kinetic-Type Hero** - Animated typography as the primary visual.
+* **Curtain-Reveal Hero** - Hero parts on scroll like a curtain.
+* **Scroll-Pinned Hero** - Hero stays pinned while content scrolls behind.
+
+### Navigation & Menus
+* **Mac OS Dock Magnification** - Edge nav, icons scale fluidly on hover.
+* **Magnetic Button** - Pulls toward cursor.
+* **Gooey Menu** - Sub-items detach like viscous liquid.
+* **Dynamic Island** - Morphing pill for status / alerts.
+* **Contextual Radial Menu** - Circular menu expanding at click point.
+* **Floating Speed Dial** - FAB springing into curved secondary actions.
+* **Mega Menu Reveal** - Full-screen dropdown, stagger-fade content.
+
+### Layout & Grids
+* **Bento Grid** - Asymmetric tile grouping (Apple Control Center).
+* **Masonry Layout** - Staggered grid, no fixed row height.
+* **Chroma Grid** - Borders / tiles with subtle animating gradients.
+* **Split-Screen Scroll** - Two halves sliding in opposite directions.
+* **Sticky-Stack Sections** - Sections that pin and stack on scroll.
+
+### Cards & Containers
+* **Parallax Tilt Card** - 3D tilt tracking mouse coordinates.
+* **Spotlight Border Card** - Borders illuminate under cursor.
+* **Glassmorphism Panel** - Frosted glass with inner refraction.
+* **Holographic Foil Card** - Iridescent rainbow shift on hover.
+* **Tinder Swipe Stack** - Physical card stack, swipe-away.
+* **Morphing Modal** - Button expands into its own dialog.
+
+### Scroll Animations
+* **Sticky Scroll Stack** - Cards stick and physically stack.
+* **Horizontal Scroll Hijack** - Vertical scroll → horizontal pan.
+* **Locomotive / Sequence Scroll** - Video / 3D sequence tied to scrollbar.
+* **Zoom Parallax** - Central background image zooming on scroll.
+* **Scroll Progress Path** - SVG line drawing along scroll.
+* **Liquid Swipe Transition** - Page transition like viscous liquid.
+
+### Galleries & Media
+* **Dome Gallery** - 3D panoramic gallery.
+* **Coverflow Carousel** - 3D carousel with angled edges.
+* **Drag-to-Pan Grid** - Boundless draggable canvas.
+* **Accordion Image Slider** - Narrow strips expanding on hover.
+* **Hover Image Trail** - Mouse leaves popping image trail.
+* **Glitch Effect Image** - RGB-channel shift on hover.
+
+### Typography & Text
+* **Kinetic Marquee** - Endless text bands reversing on scroll.
+* **Text Mask Reveal** - Massive type as transparent window to video.
+* **Text Scramble Effect** - Matrix-style decoding on load / hover.
+* **Circular Text Path** - Text curving along spinning circle.
+* **Gradient Stroke Animation** - Outlined text with running gradient.
+* **Kinetic Typography Grid** - Letters dodging the cursor.
+
+### Micro-Interactions & Effects
+* **Particle Explosion Button** - CTA shatters into particles on success.
+* **Liquid Pull-to-Refresh** - Reload indicator like detaching droplets.
+* **Skeleton Shimmer** - Shifting light reflection across placeholders.
+* **Directional Hover-Aware Button** - Fill enters from cursor's exact side.
+* **Ripple Click Effect** - Wave from click coordinates.
+* **Animated SVG Line Drawing** - Vectors drawing themselves in real time.
+* **Mesh Gradient Background** - Organic lava-lamp blobs.
+* **Lens Blur Depth** - Background UI blurred to focus foreground action.
+
+### Animation Library Choice
+* **Motion (`motion/react`)** - default for UI / Bento / state-change motion.
+* **GSAP + ScrollTrigger** - for full-page scrolltelling and scroll hijacks. Isolate in dedicated leaf components with `useEffect` cleanup.
+* **Three.js / WebGL** - for canvas backgrounds and 3D scenes. Same isolation rule.
+* **NEVER mix GSAP / Three.js with Motion in the same component tree.** They fight over the same frames.
+
+---
+
+## 11. REDESIGN PROTOCOL
+
+This skill handles **greenfield builds AND redesigns**. Misclassifying the mode is the single biggest source of bad redesign output.
+
+### 11.A Detect the Mode (first action)
+* **Greenfield** - no existing site, or full overhaul approved. Dial baseline from Section 1.
+* **Redesign - Preserve** - modernise without breaking the brand. Audit first, extract brand tokens, evolve gradually.
+* **Redesign - Overhaul** - new visual language on top of existing content. Treat as greenfield for visuals; preserve content and IA.
+
+If ambiguous, ask **once**: *"Should this redesign preserve the existing brand, or are we starting visually from scratch?"*
+
+### 11.B Audit Before Touching
+Document the current state before proposing changes:
+* **Brand tokens** - primary / accent colors, type stack, logo treatment, radii.
+* **Information architecture** - page tree, primary nav, key conversion paths.
+* **Content blocks** - what exists, what's doing work, what's filler.
+* **Patterns to preserve** - signature interactions, recognisable hero, copy voice.
+* **Patterns to retire** - AI-slop tells, broken layouts, dead links, generic stock imagery, perf traps.
+* **Dial reading of the existing site** - infer current `DESIGN_VARIANCE` / `MOTION_INTENSITY` / `VISUAL_DENSITY`. That's your starting point, not the baseline.
+* **SEO baseline** - current ranking pages, meta titles, structured data, OG cards. **SEO migration is the #1 redesign risk.**
+
+### 11.C Preservation Rules
+* **Do not change information architecture** unless asked. Keep page slugs, anchor IDs, primary nav labels stable for SEO and muscle memory.
+* **Extract brand colors before applying Section 4.2.** A brand that is already purple stays purple - apply the LILA RULE's override.
+* **Preserve copy voice** unless asked for a rewrite. Visual modernisation ≠ content rewrite.
+* **Honor existing accessibility wins.** Do not regress focus states, alt text, keyboard nav, contrast.
+* **Respect existing analytics events.** Do not rename buttons, form fields, section IDs that downstream tracking depends on.
+
+### 11.D Modernisation Levers (priority order)
+Apply in order - stop when the brief is satisfied:
+1. **Typography refresh** - biggest visual lift per unit of risk.
+2. **Spacing & rhythm** - increase section padding, fix vertical rhythm.
+3. **Color recalibration** - desaturate, unify neutrals, keep brand accent.
+4. **Motion layer** - add `MOTION_INTENSITY`-appropriate micro-interactions to existing components.
+5. **Hero & key-section recomposition** - restructure top-of-funnel using Section 10 vocabulary.
+6. **Full block replacement** - only when the existing block is unsalvageable.
+
+### 11.E Decision Tree: Targeted Evolution vs Full Redesign
+* IA, content, and SEO sound → **targeted evolution** (Levers 1-4). ~70% of value at ~40% of risk.
+* Visual debt is structural (broken IA, no design system, broken mobile) → **full redesign** with strict content preservation.
+* Brand itself is changing → **greenfield**.
+
+### 11.F What Never Changes Silently
+Never modify without explicit user approval:
+* URL structure / route slugs.
+* Primary nav labels.
+* Form field names or order (breaks analytics + autofill).
+* Brand logo or wordmark.
+* Existing legal / consent / cookie copy.
+
+---
+
+## 12. THE BLOCK LIBRARY (Contract - Implementations Land Here Iteratively)
+
+The Reference Vocabulary (Section 10) names patterns. The Block Library implements them with real props, real motion specs, and real code sketches.
+
+**Status:** schema defined here. Blocks will be added iteratively. Do not freelance new blocks without following this schema.
+
+### 12.A File Location
+```
+skills/taste-skill/blocks/
+  hero/
+    asymmetric-split.md
+    editorial-manifesto.md
+    kinetic-type.md
+    ...
+  feature/
+    bento-grid.md
+    sticky-scroll-stack.md
+    zig-zag.md
+    ...
+  social-proof/
+  pricing/
+  cta/
+  footer/
+  navigation/
+  portfolio/
+  transition/
+```
+
+### 12.B Required Frontmatter
+```yaml
+---
+name: asymmetric-split-hero
+category: hero
+dial_compatibility:
+  variance: [6, 10]
+  motion: [3, 10]
+  density: [2, 5]
+when_to_use: "Landing pages with one strong asset and one strong message. Default hero for SaaS, agency, premium consumer."
+not_for: "Editorial / manifesto launches where the message IS the design."
+stack: ["react", "next", "tailwind", "motion"]
+---
+```
+
+### 12.C Required Body Sections
+1. **Visual sketch** - short ASCII or description of the layout.
+2. **Props API** - the component's interface.
+3. **Code sketch** - minimal working implementation (Server Component default, Client island for motion).
+4. **Mobile fallback** - explicit collapse rules for `< 768px`.
+5. **Motion variants** - one variant per `MOTION_INTENSITY` band (1-3, 4-7, 8-10). Reduced-motion fallback explicit.
+6. **Dark-mode notes** - token strategy specific to this block.
+7. **Anti-patterns** - common ways this block goes wrong.
+8. **References** - links to real examples in production.
+
+### 12.D Block-Library Discipline
+* One block per file. No multi-block files.
+* Every block must work standalone (drop it into a page, it renders).
+* Every block must pass the Pre-Flight Check (Section 14).
+* Blocks that depend on a design system from Section 2.A live under `blocks/<category>/<name>--<system>.md` (e.g. `feature/bento-grid--material.md`).
+
+---
+
+## 13. OUT OF SCOPE
+
+This skill is NOT for:
+* Dashboards / dense product UI / admin panels (use Fluent, Carbon, Atlassian, or Polaris from Section 2.A).
+* Data tables (use TanStack Table or AG Grid).
+* Multi-step forms / wizards (use Form-specific patterns; this skill won't make them better).
+* Code editors (use Monaco / CodeMirror with their official skinning).
+* Native mobile (use Apple HIG / Material directly).
+* Realtime collab UIs (presence, cursors, OT-aware - different problem class).
+
+If the brief is one of the above, **say so explicitly**, point to the right tool, and only apply this skill's marketing-page / about-page / landing-page parts to the surfaces where they apply.
+
+---
+
+## 14. FINAL PRE-FLIGHT CHECK
+
+Run this matrix before outputting code. This is the last filter.
+
+**THIS IS NOT OPTIONAL. Run every box. If any box fails, the output is not done.**
+
+- [ ] **Brief inference** declared (Section 0.B one-liner)?
+- [ ] **Dial values** explicit and reasoned from the brief, not silently using baseline?
+- [ ] **Design system** chosen from Section 2 if applicable, or aesthetic labeled honestly?
+- [ ] **Redesign mode** detected and audit performed (if applicable, Section 11)?
+- [ ] **ZERO em-dashes (`—`) anywhere on the page.** Headlines, eyebrows, pills, body, quotes, attribution, captions, buttons, alt text. Zero. (Section 9.G - non-negotiable.)
+- [ ] **Page Theme Lock**: ONE theme (light, dark, or auto) for the whole page. No section flips to inverted mode mid-page (Section 4.11)?
+- [ ] **Color Consistency Lock**: one accent color used identically across all sections (Section 4.2)?
+- [ ] **Shape Consistency Lock**: one corner-radius system applied consistently (Section 4.4)?
+- [ ] **Button Contrast Check**: every CTA text is readable against its background (no white-on-white, WCAG AA 4.5:1)?
+- [ ] **CTA Button Wrap**: no CTA label wraps to 2+ lines at desktop?
+- [ ] **Form Contrast Check**: form inputs, placeholders, focus rings, labels all pass WCAG AA against the section background?
+- [ ] **Serif discipline**: if a serif is used, it is NOT Fraunces or Instrument_Serif (or it is, with explicit brand justification)? Different serif from your previous project?
+- [ ] **Premium-consumer palette check**: if the brief is premium-consumer (cookware / wellness / artisan / luxury), the palette is NOT the AI-default beige+brass+oxblood+espresso family? Different family from your previous premium-consumer project?
+- [ ] **Italic descender clearance**: every italic word with `y g j p q` has `leading-[1.1]` min + `pb-1` reserve?
+- [ ] **Hero fits the viewport**: headline ≤ 2 lines, subtext ≤ 20 words AND ≤ 4 lines, CTA visible without scroll, font scale planned around image?
+- [ ] **Hero top padding**: max `pt-24` at desktop, hero content does not float halfway down the viewport?
+- [ ] **Hero stack discipline**: max 4 text elements in hero (eyebrow OR brand strip, headline, subtext, CTAs)? No tiny tagline below CTAs, no trust micro-strip in hero?
+- [ ] **EYEBROW COUNT (mechanical)**: count instances of `uppercase tracking` micro-labels above section headlines across all components. Count ≤ ceil(sectionCount / 3)? Hero counts as 1.
+- [ ] **Split-Header Ban**: no "left big headline + right small explainer paragraph" pattern as a section header (vertical stack instead)?
+- [ ] **Zigzag Alternation Cap**: no 3+ consecutive sections with the same image+text-split layout?
+- [ ] **No Duplicate CTA Intent**: no two CTAs with the same intent ("Get in touch" + "Let's talk" both on page = Fail)?
+- [ ] **Logo wall = logo only**: no industry / category labels printed below logos?
+- [ ] **Bento Background Diversity**: at least 2-3 bento cells have real visual variation (image, gradient, pattern), not all white-on-white text cards?
+- [ ] **"Used by / Trusted by" logo wall** lives UNDER the hero, not inside it, uses REAL SVG logos (Simple Icons / devicon) or generated SVG marks, NOT plain text wordmarks?
+- [ ] **Copy Self-Audit**: every visible string re-read, no grammatically-broken or AI-hallucinated phrases ("free on its past" type) shipped?
+- [ ] **Motion motivated**: every animation can be justified in one sentence (hierarchy / storytelling / feedback / state transition), no GSAP-for-show?
+- [ ] **Marquee max-one-per-page**: no two horizontal marquees on the same page?
+- [ ] **Navigation on ONE line** at desktop, height ≤ 80px?
+- [ ] **Section-Layout-Repetition** check: no two sections share the same layout family (at least 4 different families across 8 sections)?
+- [ ] **Bento has rhythm AND exact cell count** (N items → N cells, no empty cells in middle or at end)?
+- [ ] **Long lists use the right UI component** (not default `<ul>` with `divide-y` for > 5 items - see Section 4.9 alternatives)?
+- [ ] **Real images used** (gen-tool first, then Picsum-seed, then explicit placeholder slots) - NO div-based fake screenshots, NO hand-rolled decorative SVGs, NO pure-text minimalism?
+- [ ] **No pills/labels overlaid on images** (no `Plate · Brand`, no `Field notes - journal`)?
+- [ ] **No photo-credit captions as decoration** (`Field study no. 12 · Ines Caetano`)?
+- [ ] **No version footers** (`v1.4.2`, `Build 0048`) on marketing pages?
+- [ ] **No micro-meta-sentences** under eyebrows ("Each of these is a feature we ship today...")?
+- [ ] **No decoration text strip at hero bottom** (`BRAND. MOTION. SPATIAL.`)?
+- [ ] **No floating top-right sub-text** in section headings?
+- [ ] **No scoring/progress bars with filled background tracks** as comparison visuals?
+- [ ] **No locale / city-name / time / weather strips** unless brief is genuinely globally-distributed or place-focused?
+- [ ] **No scroll cues** (`Scroll`, `↓ scroll`, `Scroll to explore`)?
+- [ ] **No version labels in hero** (V0.6, BETA, INVITE-ONLY) unless the brief is a launch?
+- [ ] **No section-numbering eyebrows** (`00 / INDEX`, `001 · Capabilities`, `06 · how it works`)?
+- [ ] **No decorative dots** (zero by default, only for real semantic state)?
+- [ ] **No `border-t` + `border-b` on every row** of long lists / spec tables?
+- [ ] **Content density** sane: no 20-row data tables, no fake-precise specs without justification, ≤ 25-word sub-paragraphs by default?
+- [ ] **Quotes ≤ 3 lines** of body, attribution clean (no em-dash)?
+- [ ] **Motion claimed = motion shown**: if `MOTION_INTENSITY > 4`, page actually animates, not just claimed?
+- [ ] **GSAP sticky-stack / horizontal-pan** implemented per Section 5.A / 5.B canonical skeleton (`start: "top top"`, `pin: true`, correct scrub)?
+- [ ] **No `window.addEventListener('scroll')`** - using Motion `useScroll()` / ScrollTrigger / IntersectionObserver / CSS scroll-driven animations only?
+- [ ] **Reduced motion** wrapped for everything `MOTION_INTENSITY > 3`?
+- [ ] **Dark mode** tokens defined and tested in both modes?
+- [ ] **Mobile collapse** explicit (`w-full`, `px-4`, `max-w-7xl mx-auto`) for high-variance layouts?
+- [ ] **Viewport stability**: `min-h-[100dvh]`, never `h-screen`?
+- [ ] **`useEffect` animations** have strict cleanup functions?
+- [ ] **Empty / loading / error** states provided?
+- [ ] **Cards omitted** in favor of spacing where possible?
+- [ ] **Icons** from an allowed library only (Phosphor / HugeIcons / Radix / Tabler), no hand-rolled SVG paths?
+- [ ] **Motion** isolated in client-leaf components with `'use client'` at the top, memoized?
+- [ ] **No AI Tells** from Section 9 (Inter as default, AI-purple, three-equal cards, Jane Doe, Acme, "Quietly in use at")?
+- [ ] **Core Web Vitals** plausibly hit (LCP < 2.5s, INP < 200ms, CLS < 0.1)?
+- [ ] **One design system** per project (no Material + shadcn mixed)?
+
+If a single checkbox cannot be honestly ticked, the page is not done. Fix it before delivering.
+
+---
+
+# APPENDICES - Real Source-Backed Reference Material
+
+The sections below are vendored reference content. They give the agent real install commands, real canonical doc links, and real working starter snippets for each design system named in Section 2. Use them to ground decisions in production reality, not training-data fiction.
+
+## Appendix A - Install Commands per Design System
+
+```bash
+# Material Web (Material 3)
+npm install @material/web
+
+# Fluent UI React (v9)
+npm install @fluentui/react-components
+
+# Fluent UI Web Components (framework-free)
+npm install @fluentui/web-components @fluentui/tokens
+
+# IBM Carbon
+npm install @carbon/react @carbon/styles
+
+# Radix Themes
+npm install @radix-ui/themes
+
+# shadcn/ui (open code, owned components)
+npx shadcn@latest init
+npx shadcn@latest add button card badge separator input
+
+# Primer CSS (GitHub product/devtool UI)
+npm install --save @primer/css
+
+# Primer Brand (GitHub marketing UI)
+npm install @primer/react-brand
+
+# GOV.UK Frontend
+npm install govuk-frontend
+
+# USWDS (US Web Design System)
+npm install uswds
+
+# Atlassian Design System (Atlaskit)
+yarn add @atlaskit/css-reset @atlaskit/tokens @atlaskit/button @atlaskit/badge @atlaskit/section-message @atlaskit/card
+
+# Bootstrap 5.3
+npm install bootstrap
+
+# Shopify Polaris Web Components (Shopify apps only)
+# Add this to your app HTML head:
+#   <meta name="shopify-api-key" content="%SHOPIFY_API_KEY%" />
+#   <script src="https://cdn.shopify.com/shopifycloud/polaris.js"></script>
+```
+
+## Appendix B - Canonical Sources (read these before reinventing)
+
+### Material Web
+- https://github.com/material-components/material-web
+- https://material-web.dev/theming/material-theming/
+- https://m3.material.io/develop/web
+
+### Fluent UI
+- https://fluent2.microsoft.design/get-started/develop
+- https://fluent2.microsoft.design/components/web/react/
+- https://github.com/microsoft/fluentui
+- https://learn.microsoft.com/en-us/fluent-ui/web-components/
+
+### Carbon
+- https://carbondesignsystem.com/
+- https://github.com/carbon-design-system/carbon
+- https://carbondesignsystem.com/developing/react-tutorial/overview/
+- https://carbondesignsystem.com/developing/web-components-tutorial/overview/
+
+### Shopify Polaris
+- https://shopify.dev/docs/api/app-home/web-components
+- https://github.com/Shopify/polaris-react
+- https://polaris-react.shopify.com/components
+
+### Atlassian
+- https://atlassian.design/get-started/develop
+- https://atlassian.design/components/button/examples
+- https://atlaskit.atlassian.com/packages/design-system/button/example/disabled
+- https://atlassian.design/tokens/design-tokens
+
+### Primer
+- https://primer.style/
+- https://github.com/primer/css
+- https://github.com/primer/brand
+
+### GOV.UK
+- https://design-system.service.gov.uk/components/button/
+- https://design-system.service.gov.uk/styles/layout/
+- https://github.com/alphagov/govuk-frontend
+
+### USWDS
+- https://designsystem.digital.gov/documentation/developers/
+- https://designsystem.digital.gov/components/button/
+- https://designsystem.digital.gov/components/card/
+- https://github.com/uswds/uswds
+
+### Bootstrap
+- https://getbootstrap.com/docs/5.3/layout/grid/
+- https://getbootstrap.com/docs/5.3/components/card/
+
+### Tailwind
+- https://tailwindcss.com/docs/dark-mode
+- https://tailwindcss.com/blog/tailwindcss-v4
+
+### Radix
+- https://www.radix-ui.com/themes/docs/components/theme
+- https://www.radix-ui.com/themes/docs/components/card
+- https://github.com/radix-ui/themes
+
+### shadcn/ui
+- https://ui.shadcn.com/docs
+- https://ui.shadcn.com/docs/components/card
+- https://github.com/shadcn-ui/ui
+
+### Native CSS / W3C standards
+- https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/backdrop-filter
+- https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/prefers-color-scheme
+- https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/prefers-reduced-motion
+- https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Grid_layout
+- https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Scroll-driven_animations
+- https://drafts.csswg.org/scroll-animations-1/
+
+### Apple Liquid Glass (Apple platforms only)
+- https://developer.apple.com/design/human-interface-guidelines/materials
+- https://developer.apple.com/documentation/TechnologyOverviews/liquid-glass
+- https://developer.apple.com/documentation/TechnologyOverviews/adopting-liquid-glass
+- https://developer.apple.com/documentation/SwiftUI/Material
+
+---
+
+## Appendix C - Apple Liquid Glass: Honest Web Approximation
+
+Do **not** treat random CSS snippets as official Apple Liquid Glass.
+
+### What is official
+Apple documents Liquid Glass inside Apple's Human Interface Guidelines and Developer Documentation for **Apple platforms**. It is a dynamic material used across Apple platform UI. Apple's native implementation belongs to Apple platform APIs and system components, **not a public web CSS package**.
+
+Relevant official docs:
+- Apple Human Interface Guidelines → Materials
+- Apple Developer Documentation → Liquid Glass
+- Apple Developer Documentation → Adopting Liquid Glass
+- SwiftUI → Material
+
+### What is NOT official
+There is no `liquid-glass.css` from Apple for normal websites.
+
+A web approximation can use:
+- `backdrop-filter`
+- transparent backgrounds
+- layered borders
+- highlight overlays
+- gradients
+- motion
+- strong contrast fallbacks
+
+But that is **web glassmorphism / frosted-glass approximation**, not official Apple Liquid Glass. Label it as such in comments.
+
+### Safer web approximation skeleton
+
+```css
+.liquid-glass-web-approx {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  border-radius: 999px;
+  border: 1px solid rgb(255 255 255 / .32);
+  background:
+    linear-gradient(135deg, rgb(255 255 255 / .30), rgb(255 255 255 / .08)),
+    rgb(255 255 255 / .12);
+  backdrop-filter: blur(24px) saturate(180%) contrast(1.05);
+  -webkit-backdrop-filter: blur(24px) saturate(180%) contrast(1.05);
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / .48),
+    inset 0 -1px 0 rgb(255 255 255 / .12),
+    0 18px 60px rgb(0 0 0 / .18);
+}
+
+.liquid-glass-web-approx::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: inherit;
+  background:
+    radial-gradient(circle at 20% 0%, rgb(255 255 255 / .55), transparent 34%),
+    linear-gradient(90deg, rgb(255 255 255 / .18), transparent 42%, rgb(255 255 255 / .14));
+  pointer-events: none;
+}
+
+.liquid-glass-web-approx::after {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border-radius: inherit;
+  border: 1px solid rgb(255 255 255 / .14);
+  pointer-events: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  .liquid-glass-web-approx {
+    border-color: rgb(255 255 255 / .18);
+    background:
+      linear-gradient(135deg, rgb(255 255 255 / .16), rgb(255 255 255 / .04)),
+      rgb(15 23 42 / .42);
+    box-shadow:
+      inset 0 1px 0 rgb(255 255 255 / .22),
+      0 18px 60px rgb(0 0 0 / .42);
+  }
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .liquid-glass-web-approx {
+    background: rgb(255 255 255 / .96);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+}
+```
+
+**Important:** `prefers-reduced-transparency` has uneven browser support; test it. Always provide enough contrast even without blur.
+
+---
+
+**End of appendices.** Install commands above are reality anchors. The Apple Liquid Glass skeleton is a labeled approximation, not an Apple-issued package. For canonical docs per design system, consult the system's official docs (links in Section 2 plus Appendix B).

--- a/.claude/skills/design-taste-frontend/SKILL.md
+++ b/.claude/skills/design-taste-frontend/SKILL.md
@@ -1,0 +1,1206 @@
+---
+name: design-taste-frontend
+description: Anti-slop frontend skill for landing pages, portfolios, and redesigns. The agent reads the brief, infers the right design direction, and ships interfaces that do not look templated. Real design systems when applicable, audit-first on redesigns, strict pre-flight check.
+---
+
+# tasteskill: Anti-Slop Frontend Skill
+
+> Landing pages, portfolios, and redesigns. Not dashboards, not data tables, not multi-step product UI.
+> Every rule below is **contextual**. None of it fires automatically. First read the brief, then pull only what fits.
+
+---
+
+## 0. BRIEF INFERENCE (Read the Room Before Anything Else)
+
+Before touching code or tweaking dials, **infer what the user actually wants**. Most LLM design output is bad because the model jumps to a default aesthetic instead of reading the room.
+
+### 0.A Read these signals first
+1. **Page kind** - landing (SaaS / consumer / agency / event), portfolio (dev / designer / creative studio), redesign (preserve vs overhaul), editorial / blog.
+2. **Vibe words** the user used - "minimalist", "calm", "Linear-style", "Awwwards", "brutalist", "premium consumer", "Apple-y", "playful", "serious B2B", "editorial", "agency-y", "glassy", "dark tech".
+3. **Reference signals** - URLs they linked, screenshots they pasted, products they named, brands they're competing with.
+4. **Audience** - B2B procurement panel vs. design-conscious consumer vs. recruiter scanning a portfolio. The audience picks the aesthetic, not your taste.
+5. **Brand assets that already exist** - logo, color, type, photography. For redesigns, these are starting material, not optional input (see Section 11).
+6. **Quiet constraints** - accessibility-first audiences, public-sector, regulated industries, trust-first commerce, kids' products. These constraints OVERRIDE aesthetic preference.
+
+### 0.B Output a one-line "Design Read" before generating
+Before any code, state in one line: **"Reading this as: \<page kind> for \<audience>, with a \<vibe> language, leaning toward \<design system or aesthetic family>."**
+
+Example reads:
+- *"Reading this as: B2B SaaS landing for technical buyers, with a Linear-style minimalist language, leaning toward Tailwind utilities + Geist + restrained motion."*
+- *"Reading this as: solo designer portfolio for hiring managers, with an editorial / kinetic-type language, leaning toward native CSS + scroll-driven animation + custom typography."*
+- *"Reading this as: redesign of a public-sector service site, with a trust-first language, leaning toward GOV.UK Frontend or USWDS."*
+
+### 0.C If the brief is ambiguous, ask one question, do not guess
+Ask exactly **one** clarifying question - never a multi-question dump - and only when the design read genuinely diverges. Example: *"Should this feel closer to Linear-clean or Awwwards-experimental?"*
+
+If you can confidently infer from context, **do not ask**. Just declare the design read and proceed.
+
+### 0.D Anti-Default Discipline
+Do not default to: AI-purple gradients, centered hero over dark mesh, three equal feature cards, generic glassmorphism on everything, infinite-loop micro-animations everywhere, Inter + slate-900. These are the LLM defaults. Reach past them deliberately based on the design read.
+
+---
+
+## 1. THE THREE DIALS (Core Configuration)
+
+After the design read, set three dials. Every layout, motion, and density decision below is gated by these.
+
+* **`DESIGN_VARIANCE: 8`** - 1 = Perfect Symmetry, 10 = Artsy Chaos
+* **`MOTION_INTENSITY: 6`** - 1 = Static, 10 = Cinematic / Physics
+* **`VISUAL_DENSITY: 4`** - 1 = Art Gallery / Airy, 10 = Cockpit / Packed Data
+
+**Baseline:** `8 / 6 / 4`. Use these unless the design read overrides them. Do not ask the user to edit this file - overrides happen conversationally.
+
+### 1.A Dial Inference (design read → dial values)
+| Signal | VARIANCE | MOTION | DENSITY |
+|---|---|---|---|
+| "minimalist / clean / calm / editorial / Linear-style" | 5-6 | 3-4 | 2-3 |
+| "premium consumer / Apple-y / luxury / brand" | 7-8 | 5-7 | 3-4 |
+| "playful / wild / Dribbble / Awwwards / experimental / agency" | 9-10 | 8-10 | 3-4 |
+| "landing page / portfolio / marketing site (default)" | 7-9 | 6-8 | 3-5 |
+| "trust-first / public-sector / regulated / accessibility-critical" | 3-4 | 2-3 | 4-5 |
+| "redesign - preserve" | match existing | +1 | match existing |
+| "redesign - overhaul" | +2 | +2 | match existing |
+
+### 1.B Use-Case Presets
+| Use case | VARIANCE | MOTION | DENSITY |
+|---|---|---|---|
+| Landing (SaaS, mainstream) | 7 | 6 | 4 |
+| Landing (Agency / creative) | 9 | 8 | 3 |
+| Landing (Premium consumer) | 7 | 6 | 3 |
+| Portfolio (Designer / studio) | 8 | 7 | 3 |
+| Portfolio (Developer) | 6 | 5 | 4 |
+| Editorial / Blog | 6 | 4 | 3 |
+| Public-sector service | 3 | 2 | 5 |
+| Redesign - preserve | match | match+1 | match |
+| Redesign - overhaul | +2 | +2 | match |
+
+### 1.C How the Dials Drive Output
+Use these (or user-overridden values) as global variables. Cross-references throughout this document refer to these exact variable names - never invent aliases like `LAYOUT_VARIANCE` or `ANIM_LEVEL`.
+
+---
+
+## 2. BRIEF → DESIGN SYSTEM MAP
+
+Once you have the design read (Section 0) and dials (Section 1), pick the right foundation. Do not invent CSS for things that have an official package. Do not pretend an aesthetic trend is an official system.
+
+### 2.A When to reach for a real design system (use official packages)
+| Brief reads as… | Reach for | Why |
+|---|---|---|
+| Microsoft / enterprise SaaS / dashboards | `@fluentui/react-components` or `@fluentui/web-components` | Official Fluent UI, Microsoft tokens, accessibility done |
+| Google-ish UI, Material-flavored product | `@material/web` + Material 3 tokens | Official, theme-able via Material Theming |
+| IBM-style B2B / enterprise analytics | `@carbon/react` + `@carbon/styles` | Official Carbon, mature data-density patterns |
+| Shopify app surfaces | `polaris.js` web components / Polaris React | Required for Shopify admin UI |
+| Atlassian / Jira-style product | `@atlaskit/*` + `@atlaskit/tokens` | Official Atlassian DS |
+| GitHub-style devtool / community page | `@primer/css` or `@primer/react-brand` | Official Primer; Brand variant for marketing |
+| Public-sector UK service | `govuk-frontend` | Legally / regulatorily expected |
+| US public-sector / trust-first | `uswds` | Same |
+| Fast local-business / agency MVP | Bootstrap 5.3 | Boring, fast, works |
+| Modern accessible React foundation | `@radix-ui/themes` | Primitives + polished theme |
+| Modern SaaS where you own the components | shadcn/ui (`npx shadcn@latest add ...`) | You own the code, easy to customise; never ship default state |
+| Tailwind-based modern SaaS / AI marketing | Tailwind v4 utilities + `dark:` variant | Default for indie + small team builds |
+
+**Honesty rule:** if the brief reads as one of the systems above, install and use the **official** package. Do not recreate its CSS by hand. Do not import a system's tokens but then override 90% of them.
+
+**One system per project.** Do not mix Fluent React with Carbon in the same tree. Do not import shadcn/ui components into a Material 3 app.
+
+### 2.B When the brief is an aesthetic, not a system
+For these directions, there is **no single official package**. Build with native CSS + Tailwind + a maintained component library. Be honest in code comments about what is borrowed inspiration vs. official material.
+
+| Aesthetic | Honest implementation |
+|---|---|
+| Glassmorphism / "frosted glass" | `backdrop-filter`, layered borders, highlight overlays. Provide solid-fill fallback for `prefers-reduced-transparency`. |
+| Bento (Apple-style tile grids) | CSS Grid with mixed cell sizes. No single library owns this. |
+| Brutalism | Native CSS, monospace, raw borders. No library. |
+| Editorial / magazine | Serif type, asymmetric grid, generous whitespace. No library. |
+| Dark tech / hacker | Mono + accent neon, terminal motifs. No library. |
+| Aurora / mesh gradients | SVG or layered radial gradients. No library. |
+| Kinetic typography | Native CSS animations, scroll-driven animations, GSAP for hijacks. No library. |
+| **Apple Liquid Glass** | Apple documents this for Apple platforms only. **There is no official `liquid-glass.css`.** Web implementations are approximations using `backdrop-filter` + layered borders + highlights. Label clearly as approximation. |
+
+---
+
+## 3. DEFAULT ARCHITECTURE & CONVENTIONS
+
+Unless the design read picks a real design system (Section 2.A), these are the defaults:
+
+### 3.A Stack
+* **Framework:** React or Next.js. Default to Server Components (RSC).
+  * **RSC SAFETY:** Global state works ONLY in Client Components. In Next.js, wrap providers in a `"use client"` component.
+  * **INTERACTIVITY ISOLATION:** Any component using Motion, scroll listeners, or pointer physics MUST be an isolated leaf with `'use client'` at the top. Server Components render static layouts only.
+* **Styling:** **Tailwind v4** (default). Tailwind v3 only if the existing project demands it.
+  * For v4: do NOT use `tailwindcss` plugin in `postcss.config.js`. Use `@tailwindcss/postcss` or the Vite plugin.
+* **Animation:** **Motion** (the library formerly known as Framer Motion). Import from `motion/react` (`import { motion } from "motion/react"`). The `framer-motion` package still works as a legacy alias - prefer `motion/react` in new code.
+* **Fonts:** Always use `next/font` (Next.js) or self-host with `@font-face` + `font-display: swap`. Never link Google Fonts via `<link>` in production.
+
+### 3.B State
+* Local `useState` / `useReducer` for isolated UI.
+* Global state ONLY for deep prop-drilling avoidance - Zustand, Jotai, or React context.
+* **NEVER** use `useState` to track continuous values driven by user input (mouse position, scroll progress, pointer physics, magnetic hover). Use Motion's `useMotionValue` / `useTransform` / `useScroll`. `useState` re-renders the React tree on every change and collapses on mobile.
+
+### 3.C Icons
+* **Allowed libraries (priority order):** `@phosphor-icons/react`, `hugeicons-react`, `@radix-ui/react-icons`, `@tabler/icons-react`.
+* **Discouraged:** `lucide-react`. Acceptable only when the user explicitly asks for it or the project already depends on it.
+* **NEVER hand-roll SVG icons.** If a glyph is missing, install a second library or compose from primitives - do not draw icon paths from scratch.
+* **One family per project.** Do not mix Phosphor with Lucide in the same component tree.
+* **Standardize `strokeWidth` globally** (e.g. `1.5` or `2.0`).
+
+### 3.D Emoji Policy
+Discouraged by default in code, markup, and visible text. Replace symbols with icon-library glyphs. **Override:** allow emojis only when the user explicitly asks for a playful / chat-style / social-native vibe - and even then use them sparingly with intent.
+
+### 3.E Responsiveness & Layout Mechanics
+* Standardize breakpoints (`sm 640`, `md 768`, `lg 1024`, `xl 1280`, `2xl 1536`).
+* Contain page layouts using `max-w-[1400px] mx-auto` or `max-w-7xl`.
+* **Viewport Stability:** NEVER use `h-screen` for full-height Hero sections. ALWAYS use `min-h-[100dvh]` to prevent layout jumping on mobile (iOS Safari address bar).
+* **Grid over Flex-Math:** NEVER use complex flexbox percentage math (`w-[calc(33%-1rem)]`). ALWAYS use CSS Grid (`grid grid-cols-1 md:grid-cols-3 gap-6`).
+
+### 3.F Dependency Verification (mandatory)
+Before importing ANY 3rd-party library, check `package.json`. If the package is missing, output the install command first. **Never** assume a library exists.
+
+---
+
+## 4. DESIGN ENGINEERING DIRECTIVES (Bias Correction)
+
+LLMs default to clichés. Override these defaults proactively. Each rule has a context-aware override path.
+
+### 4.1 Typography
+* **Display / Headlines:** Default `text-4xl md:text-6xl tracking-tighter leading-none`.
+* **Body / Paragraphs:** Default `text-base text-gray-600 leading-relaxed max-w-[65ch]`.
+* **Sans font choice:**
+  * **Discouraged as default:** `Inter`. Pick `Geist`, `Outfit`, `Cabinet Grotesk`, `Satoshi`, or a brand-appropriate serif first.
+  * **Override:** Inter is acceptable when the user explicitly asks for a neutral / standard / Linear-style feel, or when the brief is a public-sector / accessibility-first site.
+* **Pairings to know:** `Geist` + `Geist Mono`, `Satoshi` + `JetBrains Mono`, `Cabinet Grotesk` + `Inter Tight`, `GT America` + `IBM Plex Mono`.
+
+* **SERIF DISCIPLINE (VERY DISCOURAGED AS DEFAULT):**
+  * Serif is **very discouraged as the default font for any project.** "It feels creative / premium / editorial" is NOT a reason to reach for serif. The agent's default mental model that "creative brief = serif" is the single most-tested AI tell in production rounds.
+  * **Serif is only acceptable when ONE of these is explicitly true:**
+    - The brand brief literally names a serif font, OR
+    - The aesthetic family is genuinely editorial / luxury / publication / manuscript / heritage / vintage AND you can articulate why this specific serif fits this specific brand
+  * For everything else (creative agency, design studio, modern brand, premium consumer, portfolio, lifestyle), **default sans-serif display** (Geist Display, ABC Diatype, Söhne Breit, Cabinet Grotesk Display, Migra Sans, GT Walsheim, Inter Display, PP Neue Montreal). Sans display fonts are not "boring" — they are the default for the same reason black is the default in fashion.
+  * **EMPHASIS RULE (related):** When you want to emphasize a word within a headline (the kinetic "and `spatial` design" type move), use **italic or bold of the SAME font**. Do NOT inject a random serif word into a sans headline (or vice versa) just to add visual interest. Mixed-family emphasis is amateur. Italic/bold emphasis in the same family is the right move.
+  * **Specifically BANNED as defaults:** `Fraunces` and `Instrument_Serif` (the two LLM-favorite display serifs).
+  * **If a serif is justified** (rare, per the above), rotate from this pool, do NOT reuse the same serif across consecutive projects: PP Editorial New, GT Sectra Display, Cardinal Grotesque, Reckless Neue, Tiempos Headline, Recoleta, Cormorant Garamond, Playfair Display, EB Garamond, IvyPresto, Migra, Editorial Old, Saol Display, Söhne Breit Kursiv, Domaine Display, Canela, Schnyder, Tobias, NB Architekt, ITC Galliard.
+
+* **ITALIC DESCENDER CLEARANCE (mandatory):** When italic is used in display type and the word contains a descender letter (`y g j p q`), `leading-[1]` or `leading-none` will clip the descender. Use `leading-[1.1]` minimum and add `pb-1` or `mb-1` reserve on the wrapping element. Audit every italic word in display headlines before shipping.
+
+### 4.2 Color Calibration
+* Max 1 accent color. Saturation < 80% by default.
+* **THE LILA RULE:** The "AI Purple / Blue glow" aesthetic is discouraged as a default. No automatic purple button glows, no random neon gradients. Use neutral bases (Zinc / Slate / Stone) with high-contrast singular accents (Emerald, Electric Blue, Deep Rose, Burnt Orange, etc.).
+* **Override:** if the brand or brief explicitly asks for purple / violet / lila, embrace it. But execute with intent: consistent palette, harmonised neutrals, restrained gradients. Not generic AI gradient slop.
+* **One palette per project.** Do not fluctuate between warm and cool grays within the same project.
+* **COLOR CONSISTENCY LOCK (mandatory):** Once an accent color is chosen for a page, it is used on the WHOLE page. A warm-grey site does not suddenly get a blue CTA in section 7. A rose-accented site does not get a teal status badge in the footer. Pick one accent, lock it, audit every component before shipping.
+
+* **PREMIUM-CONSUMER PALETTE BAN (mandatory, second-most-recurring AI-tell):**
+  * For premium-consumer briefs (cookware, wellness, artisan, luxury, heritage craft, DTC home goods, etc.) the LLM default is **warm beige/cream + brass/clay/oxblood/ochre + espresso/ink dark text**. Concretely banned hex families as default backgrounds and accents:
+    - Backgrounds: `#f5f1ea`, `#f7f5f1`, `#fbf8f1`, `#efeae0`, `#ece6db`, `#faf7f1`, `#e8dfcb` (all "warm paper / cream / chalk / bone")
+    - Accents: `#b08947`, `#b6553a`, `#9a2436`, `#9c6e2a`, `#bc7c3a`, `#7d5621` (all "brass / clay / oxblood / ochre")
+    - Text: `#1a1714`, `#1a1814`, `#1b1814` (all "espresso / warm near-black")
+  * This palette is BANNED as the default reach for premium-consumer briefs. Every premium-consumer site you have ever shipped uses this exact palette. The brand becomes invisible.
+  * **Default alternatives (rotate, do not reuse):**
+    - **Cold Luxury:** silver-grey + chrome + smoke (think Tesla, Apple Watch Hermes-without-the-leather)
+    - **Forest:** deep green + bone + amber accent (think Filson, Patagonia premium)
+    - **Black and Tan:** true off-black + warm tan, sharp contrast, no beige
+    - **Cobalt + Cream:** saturated blue against a single neutral, no brass
+    - **Terracotta + Slate:** warm rust against cool grey, no brass
+    - **Olive + Brick + Paper:** muted olive plus brick-red accent
+    - **Pure monochrome + single saturated pop:** off-white + off-black + one bright accent (electric blue, emerald, hot pink, etc.)
+  * **Palette-rotation rule:** if the previous premium-consumer project you generated used the beige+brass family, this one MUST use a different family. Do not ship the same warm-craft palette twice in a row.
+  * **Override:** the beige+brass+espresso palette is acceptable ONLY when the brand brief explicitly names those colors, or when the brand identity is genuinely vintage / artisan / warm-craft AND you can articulate why this specific palette fits this specific brand. Default-reaching for it because "this is a cookware brief" is banned.
+
+### 4.3 Layout Diversification
+* **ANTI-CENTER BIAS:** Centered Hero / H1 sections are avoided when `DESIGN_VARIANCE > 4`. Force "Split Screen" (50/50), "Left-aligned content / right-aligned asset", "Asymmetric white-space", or scroll-pinned structures.
+* **Override:** centered hero is OK for editorial / manifesto / launch-announcement briefs where the message itself is the design.
+
+### 4.4 Materiality, Shadows, Cards
+* Use cards ONLY when elevation communicates real hierarchy. Otherwise group with `border-t`, `divide-y`, or negative space.
+* When a shadow is used, tint it to the background hue. No pure-black drop shadows on light backgrounds.
+* For `VISUAL_DENSITY > 7`: generic card containers are banned. Data metrics breathe in plain layout.
+* **SHAPE CONSISTENCY LOCK (mandatory):** Pick ONE corner-radius scale for the page and stick to it. Options: all-sharp (radius 0), all-soft (radius 12-16px), all-pill (full radius for interactive). Mixed systems are allowed only when there is a documented rule (e.g. "buttons are full-pill, cards are 16px, inputs are 8px") and that rule is followed everywhere. Round buttons in a square layout, or square cards on a pill-button page, is broken design.
+
+### 4.5 Interactive UI States
+LLMs default to "static successful state only." Always implement full cycles:
+* **Loading:** Skeletal loaders matching the final layout's shape. Avoid generic circular spinners.
+* **Empty States:** Beautifully composed; indicate how to populate.
+* **Error States:** Clear, inline (forms), or contextual (toasts only for transient).
+* **Tactile Feedback:** On `:active`, use `-translate-y-[1px]` or `scale-[0.98]` to simulate a physical push.
+* **BUTTON CONTRAST CHECK (mandatory, a11y):** Before shipping any button, verify the button text is readable against the button background. White button + white text, `bg-white` CTA with `text-white` label, transparent button against the page background with no border → all banned. Audit every CTA: contrast ratio WCAG AA min (4.5:1 for body, 3:1 for large text 18px+). Same rule applies to ghost buttons over photographic backgrounds (use a backdrop, scrim, or stroke).
+* **CTA BUTTON WRAP BAN (mandatory):** Button text MUST fit on one line at desktop. If a label like "VIEW SELECTED WORK" wraps to 2 or 3 lines, the button is broken. Fix by EITHER shortening the label (3 words max for primary CTAs, ideally 1-2) OR widening the button (do not artificially constrain `max-width` on CTAs). Wrapped CTAs at desktop are a Pre-Flight Fail.
+* **NO DUPLICATE CTA INTENT (mandatory):** Two CTAs with the same intent on one page is a Pre-Flight Fail. Examples of same intent: "Get in touch" + "Contact us" + "Let's talk" + "Start a project" + "Start something" + "Reach out" = all "contact" intent → pick ONE label and use it everywhere on the page (nav, hero, footer). Same for "Try free" + "Get started" + "Sign up free" (all "signup" intent) and "View work" + "See selected work" + "Browse projects" (all "portfolio" intent). One label per intent.
+* **FORM CONTRAST CHECK (mandatory, a11y):** Form inputs, placeholder text, focus rings, helper text, and error text all pass WCAG AA contrast against the section background. Light placeholders on a near-white form, white form on white page section, form labels grayer than 4.5:1 contrast → all banned. Audit every form before shipping.
+
+### 4.6 Data & Form Patterns
+* Label ABOVE input. Helper text optional but present in markup. Error text BELOW input. Standard `gap-2` for input blocks.
+* No placeholder-as-label. Ever.
+
+### 4.7 Layout Discipline (Hard Rules. Failing any of these is shipping broken work)
+
+* **Hero MUST fit in the initial viewport.** Headline max 2 lines on desktop, subtext max **20 words** AND max 3-4 lines, CTAs visible without scroll. If the copy is too long: reduce font scale OR cut copy. If you cannot describe the value-prop in 20 words of subtext, the value-prop is unclear, not the rule too tight. Never let the hero overflow and force scroll to find the CTA.
+* **Hero font-scale discipline.** Plan font size and image size *together*. If the hero asset is large and the headline is more than 6 words, do not start at `text-7xl/text-8xl`. Default sensible range: `text-4xl md:text-5xl lg:text-6xl` for most heroes; `text-6xl md:text-7xl` only when the headline is 3-5 words. A 4-line hero headline is always a font-size error, never a copy-length error.
+* **HERO TOP PADDING CAP (mandatory):** Hero top padding max `pt-24` (≈6rem) at desktop. More than that means the hero content floats halfway down the viewport and reads as a layout bug, not as intentional space. If your hero needs more breathing room, increase font scale or asset size, not top padding.
+* **HERO STACK DISCIPLINE (max 4 text elements).** The hero is a single moment, not a feature list. Allowed text elements, max 4 in total:
+  1. Eyebrow (small uppercase label) OR brand strip OR neither - pick zero or one
+  2. Headline (max 2 lines, see above)
+  3. Subtext (max 20 words, max 4 lines)
+  4. CTAs (1 primary + max 1 secondary)
+  - **BANNED in the hero:** tiny tagline below CTAs ("Works with GitHub, GitLab, and self-hosted Git"), trust micro-strip ("Used by engineering teams at..."), pricing teaser ("Free for solo, $10/user for teams"), feature bullet list, social-proof avatar row. All of those move to dedicated sections directly below the hero.
+  - If you have an eyebrow AND a tagline below CTAs in the same hero, drop the tagline. If you have a brand strip AND a tagline, drop the tagline. One small text element per hero, max.
+* **"Used by" / "Trusted by" logo wall belongs UNDER the hero, never inside it.** The hero is for the value prop and primary CTA. The logo wall is a separate section directly below. Do not stuff trust logos into the same flex row as the hero copy.
+* **Navigation MUST render on a single line on desktop.** If items don't fit at `lg` (1024px), condense labels, drop secondary items, or move to a hamburger. A two-line nav at desktop is broken design.
+* **Navigation height cap: 80px max desktop, default 64-72px.** No huge "agency" nav bars that eat 15% of the viewport.
+* **Bento grids MUST have rhythm, not one-sided repetition.** Do not stack 6 left-image / right-text rows. Vary the composition: alternate full-width feature rows, asymmetric tile sizes, vertical breaks.
+* **BENTO CELL COUNT RULE (mandatory):** A bento grid has EXACTLY as many cells as you have content for. 3 items → 3 cells (1+2 split, or 2+1, or asymmetric trio). 5 items → 5 cells (2+3, 3+2, hero+4, etc.). If your grid has an empty cell in the middle or at the end, you planned wrong. Re-shape the grid; do not paste a blank tile.
+* **Section-Layout-Repetition Ban.** Once you use a layout family for a section (e.g., 3-column-image-cards, full-width-quote, split-text-image), that family can appear at most ONCE on the page. "Selected commissions" must not look like "What we do." A landing page with 8 sections must use at least 4 different layout families.
+* **ZIGZAG ALTERNATION CAP (mandatory).** Alternating "left-image + right-text" then "left-text + right-image" zigzag layout = banal. Max 2 sections in a row with this image+text-split pattern. The 3rd consecutive image+text split is a Pre-Flight Fail. Break the pattern with a full-width section, a vertical-stack section, a bento grid, a marquee, or a different layout family.
+* **EYEBROW RESTRAINT (mandatory, the #1 violated rule in production tests).** An "eyebrow" is the small uppercase wide-tracking label sitting above a section headline (e.g. `FOUR COLORWAYS`, `SELECTED WORK`, `THE HARDWARE`, `Git-native task management`). Typical CSS signature: `text-[11px] uppercase tracking-[0.18em]`, `font-mono text-[10.5px] uppercase tracking-[0.22em]`. Every AI-built site puts an eyebrow above EVERY section header, producing the same templated rhythm. Hard rule:
+  - **Maximum 1 eyebrow per 3 sections.** Hero counts as 1. So a page with 9 sections may use at most 3 eyebrows total.
+  - If section A has an eyebrow, the next 2 sections cannot have one.
+  - **Pre-Flight Check is mechanical:** count instances of `uppercase tracking` (or similar small-caps mono labels above headlines) across all section components. If count > ceil(sectionCount / 3), the output fails.
+  - **What to do instead of an eyebrow:** drop it entirely. The headline alone is enough. If you need to categorize a section, the section's location on the page already categorizes it; no label needed.
+* **SPLIT-HEADER BAN (mandatory).** The pattern "left big headline + right small explainer paragraph" as a section header (left col-span-7/8, right col-span-4/5 with a small body paragraph floating in the right column) is **banned as default**. Sections should have ONE focused message. If you genuinely need both a headline and an explainer paragraph, stack them vertically (headline on top, body below, max-width 65ch). Reach for the split-header pattern only when there is a real compositional reason (e.g., the right column carries a visual or interactive element, not just filler text).
+* **Bento Background Diversity (mandatory).** Bento and feature-grid sections cannot be 6 white-on-white cards with text inside. At least 2-3 cells in any multi-cell grid need real visual variation: a real image, a brand-appropriate gradient (not AI-purple), a pattern, a tinted background. A cream-on-cream bento with only typography inside reads as boring AI default, even when the rest of the page is good.
+* **Mobile collapse must be explicit per section.** For every multi-column layout, declare the `< 768px` fallback in the same component. No "it'll work, Tailwind handles it" assumptions.
+
+### 4.8 Image & Visual Asset Strategy
+
+Landing pages and portfolios are **visual products**. Text-only pages with fake-screenshot divs are slop.
+
+**Priority order for visual assets:**
+1. **Image-generation tool first.** If ANY image-gen tool is available in the environment (`generate_image`, MCP image tool, IDE-integrated gen, OpenAI image tools, etc.) you MUST use it to create section-specific assets: hero photography, product shots, texture backgrounds, mood images. Generate at the right aspect ratio for the section. Do not skip this step because hand-rolled CSS feels faster.
+2. **Real web images second.** When no gen tool is available, use real photography sources. Acceptable defaults:
+   * `https://picsum.photos/seed/{descriptive-seed}/{w}/{h}` for placeholder photography (seed should describe the section, e.g. `marrow-cookware-kitchen`)
+   * Actual stock or brand URLs when the brief provides them
+   * Open-license sources (Unsplash via direct URL, Pexels) if explicitly allowed
+3. **Last resort: tell the user.** If neither is possible, do NOT fill the page with hand-rolled SVG illustrations or div-based "fake screenshots." Instead, leave clearly-labeled placeholder slots (`<!-- TODO: hero product photo, 1600x1200 -->`) and at the end of the response say: *"This page needs real images at: \[list of placements\]. Please generate or provide them."*
+
+**Even minimalist sites need real images.** A pure-text page is not minimalism. It is incomplete work. Even an editorial Linear-style site needs at least 2-3 real images (hero, one product/lifestyle shot, one supporting image). Generate B&W minimalist photography if the brief is restrained; do not skip images entirely because the dial is low.
+
+**Real company logos for social proof.** When the brief calls for a "Trusted by / Used by / Customers" logo wall, do NOT default to plain text wordmarks (`<span>Acme Co</span>` styled in a row). Use real SVG logos:
+* **Source: Simple Icons** (`https://cdn.simpleicons.org/{slug}/ffffff` for any color, or `simple-icons` npm package). Covers most known brands.
+* **Alternative: devicon** for tech-stack logos (`@svgr/cli` or CDN).
+* **Make-up the brand name? Then make-up an SVG mark too.** Generate a simple monogram (one letter in a circle, two-letter ligature, abstract glyph) rendered as an inline `<svg>` matching the page style. Plain text wordmarks for invented brand names look generic.
+* **Always** ensure logos render in both light and dark mode (white-on-dark, black-on-light, or single-color theme variable).
+* **LOGO-ONLY rule (mandatory):** logo wall = logos and nothing else. Do NOT print industry / category labels below each logo (no `Vercel` + `hosting` underneath, no `Stripe` + `payments`, no `Cloudflare` + `infra`). The logo is the credibility, the label adds nothing the user does not already know. Optional: brand name as alt-text for screen readers, optional link to the brand's site. That is it.
+
+**Hand-rolled illustrations:**
+* SVG icons from libraries: fine (see Section 3.C).
+* Hand-rolled decorative SVGs (custom illustrations, logos, marks): **strongly discouraged**, never as default. Acceptable only when:
+  - The brief explicitly calls for it ("draw me an SVG logo")
+  - It's a single, simple geometric mark (a square, a circle, a wordmark in display type)
+  - You're confident in the output quality
+
+**Div-based fake screenshots are banned.** A "hand-built product preview" rendered with `<div>` rectangles, fake task lists, fake dashboards, fake terminal windows is a Tell. If you need to show a product:
+* Use a real screenshot URL if one exists
+* Generate one via image tool
+* Use a real component preview (an actual mini-version of the UI inside the page)
+* Or skip the preview entirely and use editorial photography
+
+**Hero needs a real visual.** Text + gradient blob is not a hero - it's a placeholder.
+
+### 4.9 Content Density
+
+Landing pages live on the **first impression**, not the full read. Cut ruthlessly.
+
+* **Default content shape per section:** short headline (≤ 8 words) + short sub-paragraph (≤ 25 words) + one visual asset OR one CTA. Anything more must be justified by the section's job.
+* **No data-dump sections.** A 20-row publication table, a 30-row award list, a giant pricing matrix on a marketing page = wrong layout. Use:
+  - Top 3-5 highlights + "View full list" link
+  - Marquee / carousel for breadth
+  - Different page entirely if the data is the product
+* **Long lists need a different UI component, not a longer list.** Default `<ul>` with bullets / `divide-y` rows is the lazy choice. If you have > 5 items, reach for one of these instead:
+  - 2-column split with grouped items
+  - Card grid with image + label per item
+  - Tabs / accordion if items are categorisable
+  - Horizontal scroll-snap pills
+  - Carousel for breadth-heavy lists (testimonials, logos, capabilities)
+  - Marquee for "lots-of-things-that-don't-need-individual-attention"
+  A spec sheet with 10 rows + a hairline under every row is the WORST default. Either group rows into 2-3 chunks with sparse dividers, or move to a card-per-spec layout.
+* **Spec sheets specifically (the Marrow-cookware pattern).** A long product specification table with `border-b` on every row is the AI default for cookware / hardware / apparel / artisan-goods briefs. Banned. Concrete alternatives:
+  - **2-col card grid:** each spec gets its own card with the spec name, the value (large display number), and a one-line "why it matters" body. Cards arranged 2-col on desktop, 1-col mobile.
+  - **Scroll-snap horizontal pills:** each spec is a pill, user can flick through.
+  - **Grouped chunks:** group 10 specs into 3 logical clusters (e.g. "Materials", "Cooking", "Warranty"), each cluster gets ONE soft divider and a cluster heading.
+  - **Featured-vs-rest:** 3-4 hero specs visualised as large display tiles, the rest collapsed under a "View full specifications" disclosure.
+
+* **COPY SELF-AUDIT (mandatory before ship):** Before declaring any task done, re-read every visible string on the page (headlines, subheads, eyebrows, button labels, body copy, captions, alt text, footer text, error messages). Flag any string that is:
+  - **Grammatically broken** ("free on its past", "two plans but one is honest", "to put it on the table" out of context)
+  - **Has unclear referents** ("we plan to stay that way" without prior context)
+  - **Sounds like AI hallucination** (cute-but-wrong wordplay, forced metaphors that don't track, "elegant nothing" phrases)
+  - **Reads like an LLM trying to sound thoughtful** (passive-aggressive humility, fake-craftsman labels, mock-poetic micro-meta)
+  Rewrite every flagged string. If unsure whether a string makes sense, replace it with a plain functional sentence. AI-generated cute copy is worse than boring copy.
+* **Fake-precise numbers are flagged.** Numbers like `92%`, `4.1×`, `48k`, `5.8 mm`, `13.4 lb` either:
+  - Come from real data (brief, brand guidelines, public metrics) - fine
+  - Are explicitly labeled as mock (`<!-- mock -->`, "example", "sample data") - fine
+  - Are AI-invented spec aesthetics - banned. Don't fake engineering precision the brand doesn't claim.
+* **One copy register per page.** Don't mix technical mono ("47 tasks · 0.6 ctx-switches/day"), editorial prose, and marketing punch in the same composition unless the brand voice explicitly calls for it.
+
+### 4.10 Quotes & Testimonials
+
+* **Max 3 lines** of quote body. Never 6. If the original quote is longer → cut it. A landing-page quote is a snippet, not the full review.
+* For very small font sizes (e.g. footer-style testimonials), the line cap can stretch slightly. Spirit: "fits in a glance."
+* **No em-dashes inside the quote text** as design flourish (long pauses, kinetic em-dashes, em-dash-bullets). See Section 9.G - em-dash is completely banned.
+* Attribution: name + role + (optionally) company. Never name only ("- Sarah").
+* Quote marks: use real typographic quotes ( " " ) or none at all. Not straight ASCII ( " ).
+
+### 4.11 Page Theme Lock (Light / Dark Mode Consistency)
+
+The page has ONE theme. Sections do not invert.
+
+* If the page is dark mode, ALL sections are dark mode. No light-mode-warm-paper section sandwiched between dark sections (or vice versa). The user must not feel they walked into a different website mid-scroll.
+* The exception: if the brief explicitly calls for a "Color Block Story" or "Theme Switch on Scroll" device AND that is a deliberate composition (one full theme switch with a strong transition, not random alternation), it is allowed once per page.
+* Default behaviour: pick light, dark, or auto (`prefers-color-scheme`) at the page level and lock it. Section-level background tints within the same theme family are fine (`bg-zinc-950` next to `bg-zinc-900`); flipping to `bg-amber-50` in the middle of a `bg-zinc-950` page is broken.
+* When using a design system with built-in theming (Radix Themes, shadcn/ui with `<Theme>`), set the theme ONCE in `layout.tsx` or the page root. Do not let individual sections override.
+
+---
+
+## 5. CONTEXT-AWARE PROACTIVITY
+
+These are tools, not defaults. Use them when the design read calls for them. **None of these fire automatically.**
+
+* **Liquid Glass / Glassmorphism:** Appropriate for premium consumer, Apple-adjacent, luxury brand, or media-overlay vibes. Inappropriate for dashboards, public-sector, or "boring B2B." When used, go beyond `backdrop-blur`: add a 1px inner border (`border-white/10`) and a subtle inner shadow (`shadow-[inset_0_1px_0_rgba(255,255,255,0.1)]`) for physical edge refraction. Provide a solid-fill fallback under `prefers-reduced-transparency`.
+* **Magnetic Micro-physics:** Use when `MOTION_INTENSITY > 5` AND the brief reads premium / playful / agency. Implement EXCLUSIVELY with Motion's `useMotionValue` / `useTransform` outside the React render cycle. Never `useState`. See Section 3.B.
+* **Perpetual Micro-Interactions** (Pulse, Typewriter, Float, Shimmer, Carousel): Use when `MOTION_INTENSITY > 5` AND the section actively benefits from motion (status indicators, live feeds, AI-feel). **Not every card needs an infinite loop.** If a section is informational, leave it still. Apply Spring Physics (`type: "spring", stiffness: 100, damping: 20`) - no linear easing.
+* **"Motion claimed, motion shown."** If `MOTION_INTENSITY > 4`, the page must actually move: entry transitions on hero, scroll-reveal on key sections, hover physics on CTAs, at minimum. A static page that claims `MOTION_INTENSITY: 7` is broken. Conversely, if you cannot ship working motion in the available scope, drop the dial to 3 and ship a clean static page. Never half-build motion that breaks (cut-off ScrollTriggers, jumpy enters, missing cleanups).
+* **MOTION MUST BE MOTIVATED (mandatory).** Before adding any animation, ask: "what does this animation communicate?" Valid answers: hierarchy (drawing attention to the right thing), storytelling (revealing content in sequence that matches a narrative), feedback (acknowledging a user action), state transition (showing something changed). Invalid answer: "it looked cool". GSAP everywhere because GSAP is available is amateur. Each ScrollTrigger, each marquee, each pinned section needs a reason. If you cannot articulate the reason in one sentence, drop the animation.
+* **MARQUEE MAX-ONE-PER-PAGE (mandatory).** Horizontal scrolling text marquees ("logos endlessly scrolling", "manifesto scrolling sideways", "kinetic word strip") are appropriate at most ONCE per page. Two or more marquees on the same page reads as lazy filler. Pick the one section where the marquee actually serves the content; the others get a different layout.
+* **GSAP Sticky-Stack Pattern (when scroll-stack is used).** A "card stack on scroll" must be a REAL sticky-stack, not a sequential reveal list. See Section 5.A below for the canonical code skeleton. Common failure: trigger fires halfway through scroll instead of pinning at viewport top. Fix: `start: "top top"` not `start: "top center"` or `"top 80%"`.
+* **GSAP Horizontal-Pan Pattern (when horizontal scroll-hijack is used).** See Section 5.B below for the canonical skeleton. Common failure: animation starts before the section is pinned, so the user sees half a slide. Same fix: `start: "top top"`, pin the wrapper, scrub the inner track.
+
+### 5.A Sticky-Stack - Canonical Skeleton
+
+```tsx
+"use client";
+import { useRef, useEffect } from "react";
+import { gsap } from "gsap";
+import { ScrollTrigger } from "gsap/ScrollTrigger";
+import { useReducedMotion } from "motion/react";
+
+gsap.registerPlugin(ScrollTrigger);
+
+export function StickyStack({ cards }: { cards: React.ReactNode[] }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const reduce = useReducedMotion();
+
+  useEffect(() => {
+    if (reduce || !ref.current) return;
+    const ctx = gsap.context(() => {
+      const cardEls = gsap.utils.toArray<HTMLElement>(".stack-card");
+      cardEls.forEach((card, i) => {
+        if (i === cardEls.length - 1) return;
+        ScrollTrigger.create({
+          trigger: card,
+          start: "top top",                              // pin at viewport top
+          endTrigger: cardEls[cardEls.length - 1],
+          end: "top top",
+          pin: true,
+          pinSpacing: false,
+        });
+        gsap.to(card, {
+          scale: 0.92,
+          opacity: 0.55,
+          ease: "none",
+          scrollTrigger: {
+            trigger: cardEls[i + 1],
+            start: "top bottom",
+            end: "top top",
+            scrub: true,
+          },
+        });
+      });
+    }, ref);
+    return () => ctx.revert();
+  }, [reduce]);
+
+  return (
+    <div ref={ref} className="relative">
+      {cards.map((card, i) => (
+        <div
+          key={i}
+          className="stack-card sticky top-0 min-h-[100dvh] flex items-center justify-center"
+        >
+          {card}
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+Critical points: `start: "top top"`, `pin: true`, every card except the last is pinned, the scale/opacity transform is driven by the NEXT card's scroll trigger (so previous card shrinks as next one arrives).
+
+### 5.B Horizontal-Pan - Canonical Skeleton
+
+```tsx
+"use client";
+import { useRef, useEffect } from "react";
+import { gsap } from "gsap";
+import { ScrollTrigger } from "gsap/ScrollTrigger";
+import { useReducedMotion } from "motion/react";
+
+gsap.registerPlugin(ScrollTrigger);
+
+export function HorizontalPan({ children }: { children: React.ReactNode }) {
+  const wrap = useRef<HTMLDivElement>(null);
+  const track = useRef<HTMLDivElement>(null);
+  const reduce = useReducedMotion();
+
+  useEffect(() => {
+    if (reduce || !wrap.current || !track.current) return;
+    const ctx = gsap.context(() => {
+      const distance = track.current!.scrollWidth - window.innerWidth;
+      gsap.to(track.current, {
+        x: -distance,
+        ease: "none",
+        scrollTrigger: {
+          trigger: wrap.current,
+          start: "top top",                              // pin starts when section top hits viewport top
+          end: () => `+=${distance}`,                    // scroll distance = track width minus viewport
+          pin: true,
+          scrub: 1,
+          invalidateOnRefresh: true,
+        },
+      });
+    }, wrap);
+    return () => ctx.revert();
+  }, [reduce]);
+
+  return (
+    <section ref={wrap} className="relative overflow-hidden">
+      <div ref={track} className="flex h-[100dvh] items-center">
+        {children}
+      </div>
+    </section>
+  );
+}
+```
+
+Critical points: `start: "top top"`, `pin: true`, `end: "+=${distance}"` (scroll length = horizontal travel needed), `scrub: 1`. The wrapper is pinned, the inner track slides horizontally as the user scrolls vertically.
+
+### 5.C Scroll-Reveal Stagger - Canonical Skeleton (lighter alternative)
+
+For simple "items appear as they enter viewport" (no pinning), prefer Motion's `whileInView` over GSAP - lighter, no ScrollTrigger needed:
+
+```tsx
+"use client";
+import { motion, useReducedMotion } from "motion/react";
+
+export function RevealStagger({ items }: { items: string[] }) {
+  const reduce = useReducedMotion();
+  return (
+    <ul className="grid gap-6">
+      {items.map((item, i) => (
+        <motion.li
+          key={item}
+          initial={reduce ? false : { opacity: 0, y: 24 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, amount: 0.3 }}
+          transition={{
+            duration: 0.6,
+            delay: i * 0.06,
+            ease: [0.16, 1, 0.3, 1],
+          }}
+        >
+          {item}
+        </motion.li>
+      ))}
+    </ul>
+  );
+}
+```
+
+Use this for: feature lists, testimonial grids, logo walls, anything that just needs "enter on scroll." Save GSAP for actual pin/scrub work.
+
+### 5.D Forbidden Animation Patterns
+
+* **`window.addEventListener("scroll", ...)`** is banned. It runs on every scroll frame, jank-prone, no batching. Use Motion's `useScroll()`, GSAP's `ScrollTrigger`, IntersectionObserver, or CSS `scroll-driven animations` (`animation-timeline: view()`).
+* **Custom scroll progress calculations using `window.scrollY`** in React state. Same reason. Re-renders on every frame.
+* **`requestAnimationFrame` loops that touch React state.** Use motion values (`useMotionValue` + `useTransform`) instead.
+* **Layout Transitions:** Use Motion's `layout` and `layoutId` props for visible state changes (re-ordering lists, expanding modals, shared elements between routes). Do not wrap static content in `layout` props "for safety" - it costs measurement work.
+* **Staggered Orchestration:** Use `staggerChildren` (Motion) or CSS cascade (`animation-delay: calc(var(--index) * 100ms)`) for reveal moments where sequence matters. For `staggerChildren`, parent (`variants`) and children MUST share the same Client Component tree.
+
+---
+
+## 6. PERFORMANCE & ACCESSIBILITY GUARDRAILS
+
+### 6.A Hardware Acceleration
+* Animate ONLY `transform` and `opacity`. Never animate `top`, `left`, `width`, `height`.
+* Use `will-change: transform` sparingly - only on elements that will actually animate.
+
+### 6.B Reduced Motion (mandatory)
+* **Any motion above `MOTION_INTENSITY > 3` MUST honor `prefers-reduced-motion`.** This is non-negotiable.
+* In Motion: wrap with `useReducedMotion()` and degrade to static.
+* In CSS: gate animations behind `@media (prefers-reduced-motion: no-preference)` or provide an override block under `@media (prefers-reduced-motion: reduce)` that disables.
+* Infinite loops, parallax, scroll-hijack, and magnetic physics MUST collapse to static / instant under reduced motion.
+
+### 6.C Dark Mode (mandatory for any consumer-facing page)
+* Design for **both modes from the start**. Never ship light-only or dark-only without explicit user instruction.
+* Use Tailwind `dark:` variant OR CSS variables for tokens. Pick one strategy per project.
+* **Do not prescribe specific dark-mode colors here.** The brief decides. Maintain visual hierarchy, brand identity, and WCAG AA contrast (AAA for body) across both modes.
+* Respect `prefers-color-scheme: dark`. Default to system preference unless the brand insists on one mode.
+
+### 6.D Core Web Vitals Targets
+* **LCP** < 2.5s. Hero image must be `next/image priority` or preloaded.
+* **INP** < 200ms. Heavy work off main thread.
+* **CLS** < 0.1. Reserve space for images, fonts, embeds.
+* Run Lighthouse before declaring a page done.
+
+### 6.E DOM Cost
+* Apply grain / noise filters EXCLUSIVELY to fixed, `pointer-events-none` pseudo-elements (e.g., `fixed inset-0 z-[60] pointer-events-none`). NEVER on scrolling containers - continuous GPU repaints destroy mobile FPS.
+* Be aware of bundle size. Motion is not tiny. Three.js is large. Lazy-load anything that's not above-the-fold.
+
+### 6.F Z-Index Restraint
+NEVER spam arbitrary `z-50` or `z-10`. Use z-index strictly for systemic layer contexts (sticky navbars, modals, overlays, grain). Document the z-index scale in a project constants file.
+
+---
+
+## 7. DIAL DEFINITIONS (Technical Reference)
+
+### DESIGN_VARIANCE (Level 1-10)
+* **1-3 (Predictable):** Symmetrical CSS Grid (12-col, equal fr-units), equal paddings, centered alignment.
+* **4-7 (Offset):** `margin-top: -2rem` overlaps, varied image aspect ratios (4:3 next to 16:9), left-aligned headers over center-aligned data.
+* **8-10 (Asymmetric):** Masonry layouts, CSS Grid with fractional units (`grid-template-columns: 2fr 1fr 1fr`), massive empty zones (`padding-left: 20vw`).
+* **MOBILE OVERRIDE:** For levels 4-10, asymmetric layouts above `md:` MUST collapse to strict single-column (`w-full`, `px-4`, `py-8`) on viewports `< 768px`.
+
+### MOTION_INTENSITY (Level 1-10)
+* **1-3 (Static):** No automatic animations. CSS `:hover` and `:active` states only. `prefers-reduced-motion` is the default mode anyway.
+* **4-7 (Fluid CSS):** `transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1)`. `animation-delay` cascades for load-ins. Focus on `transform` and `opacity`.
+* **8-10 (Advanced Choreography):** Complex scroll-triggered reveals, parallax, scroll-driven animation (CSS `animation-timeline` or GSAP ScrollTrigger). Use Motion hooks. **NEVER use `window.addEventListener('scroll')`** - it is a hard ban, not a "prefer-not." See Section 5.D for the allowed alternatives.
+
+### VISUAL_DENSITY (Level 1-10)
+* **1-3 (Art Gallery):** Lots of white space. Huge section gaps (`py-32` to `py-48`). Expensive, clean.
+* **4-7 (Daily App):** Standard web app spacing (`py-16` to `py-24`).
+* **8-10 (Cockpit):** Tight paddings. No card boxes; 1px lines separate data. Mandatory: `font-mono` for all numbers.
+
+---
+
+## 8. DARK MODE PROTOCOL
+
+Dual-mode by default. Never assume light-only unless the brief is print-emulating editorial.
+
+### 8.A Token Strategy (pick one, stick to it)
+* **Tailwind `dark:` variant** (default for utility-first projects): every color utility paired with its dark variant (`bg-white dark:bg-zinc-950`, `text-gray-900 dark:text-gray-100`).
+* **CSS variables** (for shadcn/ui, Radix Themes, or component libraries with theming): define semantic tokens (`--surface`, `--surface-elevated`, `--text-primary`, `--accent`) and swap values under `[data-theme="dark"]` or `@media (prefers-color-scheme: dark)`.
+
+### 8.B Do Not Prescribe Specific Colors Here
+The brief and brand decide. This skill enforces only:
+* **Contrast** - WCAG AA minimum for body text, AAA target for hero copy.
+* **Hierarchy parity** - visual hierarchy that works in light must work in dark. If a CTA pops in light, it pops in dark.
+* **Brand fidelity** - primary brand color stays recognisable. Don't desaturate the brand into a dark mode.
+* **No pure `#000000` and no pure `#ffffff`** - use off-black (zinc-950, near-black warm gray) and off-white. Pure values kill depth.
+
+### 8.C Default Mode
+Respect `prefers-color-scheme` unless the brand insists. Add a manual toggle if either mode would lose key brand expression.
+
+### 8.D Test in Both Modes Before Finishing
+Open the page in both modes during development. Do not ship a page you've only seen in one mode.
+
+---
+
+## 9. AI TELLS (Forbidden Patterns)
+
+Avoid these signatures unless the brief explicitly asks for them.
+
+### 9.A Visual & CSS
+* **NO neon / outer glows** by default. Use inner borders or subtle tinted shadows.
+* **NO pure black (`#000000`).** Off-black, zinc-950, or charcoal.
+* **NO oversaturated accents.** Desaturate to blend with neutrals.
+* **NO excessive gradient text** for large headers.
+* **NO custom mouse cursors.** Outdated, accessibility-hostile, perf-hostile.
+
+### 9.B Typography
+* **AVOID Inter as default.** See Section 4.1. Override path exists.
+* **NO oversized H1s** that just scream. Control hierarchy with weight + color, not raw scale.
+* **Serif constraints:** Serif for editorial / luxury / publication. Not for dashboards.
+
+### 9.C Layout & Spacing
+* **Mathematically perfect** padding and margins. No floating elements with awkward gaps.
+* **NO 3-column equal feature cards.** The generic "three identical cards horizontally" feature row is banned. Use 2-column zig-zag, asymmetric grid, scroll-pinned, or horizontal-scroll alternative.
+
+### 9.D Content & Data ("Jane Doe" Effect)
+* **NO generic names.** "John Doe", "Sarah Chan", "Jack Su" → use creative, realistic, locale-appropriate names.
+* **NO generic avatars.** No SVG "egg" or Lucide user icons → use believable photo placeholders or specific styling.
+* **NO fake-perfect numbers.** Avoid `99.99%`, `50%`, `1234567`. Use organic, messy data (`47.2%`, `+1 (312) 847-1928`).
+* **NO startup-slop brand names.** "Acme", "Nexus", "SmartFlow", "Cloudly" → invent contextual, premium names that sound real.
+* **NO filler verbs.** "Elevate", "Seamless", "Unleash", "Next-Gen", "Revolutionize" → concrete verbs only.
+
+### 9.E External Resources & Components
+* **NO hand-rolled SVG icons.** Use Phosphor / HugeIcons / Radix / Tabler. Lucide on explicit request only.
+* **Hand-rolled decorative SVGs strongly discouraged** as default (see Section 4.8).
+* **NO div-based fake screenshots.** Never build a fake product UI out of `<div>` rectangles to simulate a screenshot. Use real images, generated images, or skip the preview.
+* **NO broken Unsplash links.** Use `https://picsum.photos/seed/{descriptive-string}/{w}/{h}`, or generated photo placeholders, or actual assets.
+* **shadcn/ui customization:** Allowed, but NEVER in default state. Customize radii, colors, shadows, typography to the project aesthetic.
+* **Production-Ready Cleanliness:** Code visually clean, memorable, meticulously refined.
+
+### 9.F Production-Test Tells (banned outright)
+
+These patterns came out of real LLM-generated landing-page tests. They are the signatures the model defaults to when it tries to "look designed." Treat them as hard bans unless the brief explicitly calls for one.
+
+**Hero & top-of-page**
+* **NO version labels in the hero.** `V0.6`, `v2.0`, `BETA`, `INVITE-ONLY PREVIEW`, `EARLY ACCESS`, `ALPHA` - banned as default eyebrows. Only acceptable when the brief is explicitly about a product launch / preview status.
+* **NO "Brand · No. 01"-style sub-eyebrows.** "Marrow · No. 01 · The 6-quart" type micro-meta lines. Skip them.
+
+**Section numbering & micro-labels**
+* **NO section-number eyebrows.** `00 / INDEX`, `001 · Capabilities`, `002 · Featured commission`, `06 · how it works`, `05 · The honest table` - banned. Eyebrows should name the topic in plain language, not enumerate.
+* **NO `01 / 4`-style pagination on images or bento tiles.** If the user can count, they don't need the label.
+* **NO `Scroll · 001 Capabilities`-style scroll cues.** A simple arrow or "Scroll" is enough; no section-number prefix.
+* **NO "Index of Work, 2018 - 2026"-style range labels** as eyebrows. Just say what the section is.
+
+**Separators & dots**
+* **The middle-dot (`·`) is rationed.** Maximum 1 per line in metadata strips. Do NOT use it as the default separator for everything ("foo · bar · baz · qux · quux"). If you need a separator family, prefer line breaks, hairlines, or columns.
+* **NO decorative colored status dots on every list/nav/badge.** A colored dot before "ONE Q4 SLOT OPEN" or before every nav link, or every task row - banned by default. Acceptable only when the dot conveys actual semantic state (a server status, an availability flag) and is used sparingly.
+
+**Em-dashes & typography flourishes**
+* **NO em-dash (`—`) as a design element OR anywhere else.** See Section 9.G below for the complete, non-negotiable ban. The em-dash character is forbidden in headlines, eyebrows, pills, body copy, quotes, attribution, captions, button text, and alt text. Use the regular hyphen (`-`).
+* **NO `<br>`-broken-and-italicized headlines** as a default "design move." "for thirty\<br\>*years.*" type splits. Headlines should read naturally first, get clever only when the brief demands it.
+* **NO vertical rotated text** ("INDEX OF WORK, 2018 - 2026" rotated 90°). Agency-portfolio cliché. Use it only when the brief is explicitly agency / Awwwards / experimental AND it serves a real composition purpose.
+* **NO crosshair / hairline grid lines as decoration.** Vertical and horizontal lines drawn just to make the page "feel designed" - banned. Use them only when they organize real content.
+
+**Fake product previews**
+* **NO div-based fake product UI in the hero** (fake task list, fake terminal, fake dashboard built from styled divs). It is the #1 LLM-design Tell. Use a real screenshot, a generated image, a real component preview, or none at all.
+* **NO fake version footers** ("v0.6.2-rc.1", "last sync 4s ago · main") inside fake screenshots. Adds nothing, screams AI.
+
+**Marketing-copy Tells**
+* **NO "Quietly in use at" / "Quietly trusted by"** social-proof headers. Use natural language: "Trusted by", "Used at", "Customers include", or skip the heading entirely if the logos speak.
+* **NO "From the field" / "Field notes" / "Currently on the bench" / "On our desks" / "Loose plates" style poetic labels** on quote, blog, or sidebar sections. Reads as performative-craftsman. Use plain functional labels ("Testimonials", "Latest writing", "Now working on") or skip the label.
+* **NO "We respect the French ones"-style** mock-humble industry-references in body copy. Cute and AI-y.
+* **NO weather / locale strips** ("LIS 14:23 · 18°C") in headers/footers unless the brief is explicitly about a place / time-zone-distributed studio.
+* **NO micro-meta-sentences under eyebrows.** Sentences like *"Each of these is a feature we ship today, not a roadmap promise. The list will stay short on purpose."* sitting under a section heading are clutter. Eyebrow + Headline + Body is enough.
+* **NO generic step labels.** "Stage 1 / Stage 2 / Stage 3", "Step 1 / Step 2 / Step 3", "Phase 01 / Phase 02 / Phase 03", "Pass One / Pass Two / Pass Three". Banned. The actual step content is the label. If you must show progression, use the verb-noun directly ("Install", "Configure", "Ship") not "Stage 1: Install".
+
+**Pills, labels and version stamps**
+* **NO pills/labels/tags overlaid on images.** No `<span>` overlays on photos with tags like `Brand · 02`, `PLATE · BRAND`, `Field notes - journal`. Either let the image speak alone, or add a caption directly below (outside the image).
+* **NO photo-credit captions as decoration.** Strings like `Field study no. 12 · Ines Caetano`, `Plate 03 · House archive`, `Frame XII · 35mm` under stock/picsum images are pretentious. Photo credit is allowed ONLY when there is a real photographer being credited for a real photo (with permission). Otherwise: skip the caption or use a one-line functional caption ("The 6-quart, in Sage.").
+* **NO version footers on marketing pages.** Footer strings like `v1.4.2`, `Build 0048`, `last sync 4s ago · main` are CLI / devtool fixtures, not landing-page content. Banned on marketing/landing/portfolio pages.
+* **NO "Reservation 412 of 800"-style live-stock counters** as decoration. Only if the brief is explicitly a limited-run waitlist with real data.
+
+**Decoration text strips**
+* **NO decoration text strip at hero bottom.** Patterns like `BRAND. MOTION. SPATIAL.`, `TYPE / FORM / MOTION`, `DESIGN · BUILD · SHIP`, `ESTD. 2018 · LISBON · BRAND. MOTION. SPATIAL.` as a small mono-caps strip across the bottom of the hero are an agency-portfolio cliché. Banned by default. Only acceptable when the strip carries real, navigable links (sticky bottom nav) or real status info (cookie banner, build info on a docs site).
+* **NO floating top-right sub-text in section headings.** Pattern: section has a giant left-aligned headline; in the top-right corner of the same section header there is a small explainer paragraph floating with no clear alignment to anything else. That floater is the Tell. Either put the sub-text directly under the headline, or build a clean 2-column header (left: headline, right: aligned body), but not a tiny corner paragraph.
+
+**Lists, dividers and scoring**
+* **NO `border-t` + `border-b` on every row of a long list / spec table.** Pick one (bottom-border between rows OR top-border above the group) and use it sparsely. A 10-row spec table with hairlines under each row is the laziest layout - see Section 4.9 for alternative UI components.
+* **NO scoring/progress bars with filled background tracks** as comparison visuals. If you need to show "X out of Y" comparisons, prefer a number + small icon, or a tiny inline bar WITHOUT a background track. Big filled `bg-zinc-200` tracks with a partial fill on top are dashboard-UI clutter on a landing page.
+
+**Locale, time, scroll cues**
+* **Locale / city-name / time / weather strips are banned for 99% of briefs.** "Lisbon, working with founders" in the hero, "1200-690 Lisbon, Portugal" in the footer, "Lisbon 14:23 · 18°C" in the nav. These are agency-portfolio decoration tells. Allowed ONLY when: the brief explicitly describes a globally-distributed studio with timezone-relevant work, OR a travel-focused brand, OR a real-world physical venue. A single contact-address mention in the footer is fine; an atmospheric locale strip is not.
+* **Scroll cues are banned.** `Scroll`, `↓ scroll`, `Scroll to explore`, `Scroll to walk through it`, animated mouse-wheel icons. If the user has not scrolled yet, they are looking at the hero. They know what scroll is. The bottom of the viewport does not need a label.
+* **ZERO decorative status dots by default.** A coloured dot before nav items, before list rows, before badges, before status labels is a Tell. Only acceptable when conveying real semantic state (a live indicator on actual server status, a live availability flag) and limited to one per page section.
+
+### 9.G EM-DASH BAN (the single most-violated Tell)
+
+**Em-dash (`—`) is COMPLETELY banned.** It is the LLM's signature stylistic crutch and it is the #1 visual Tell in production tests. There is no "limited use" allowance, no "natural language frequency" allowance, no "in body copy is fine" allowance. None.
+
+* **Banned in headlines.** Use a period or a comma.
+* **Banned in eyebrows / labels / pills / button text / image captions / nav items.** Replace with line breaks, columns, or hairlines.
+* **Banned in body copy.** Restructure the sentence: two sentences with a period, OR a comma, OR parentheses, OR a colon.
+* **Banned in quote attribution.** Use a normal hyphen with spaces (` - `) or a line break + smaller-weight name.
+* **Banned in en-dash form too (`–`) when used as a separator.** Date ranges (`2018-2026`) use a hyphen. Number ranges (`€40-80k`) use a hyphen.
+
+The ONLY permitted dash characters on the page are:
+* Regular hyphen `-` (for compound words, ranges, line dividers in markup)
+* Minus sign in math (`-5°C`)
+
+If your output contains a single `—` or `–` anywhere visible to the user, the output fails the Pre-Flight Check and must be rewritten.
+
+This rule is non-negotiable. The agent has historically ignored em-dash limits when phrased as "use sparingly." The phrasing here is binary: zero em-dashes.
+
+---
+
+## 10. REFERENCE VOCABULARY (Pattern Names the Agent Should Know)
+
+This is a vocabulary, not a library. The agent should KNOW these pattern names to communicate about them, design with them in mind, and reach for them when the design read calls for them. **Implementations and code sketches live in the Block Library (Section 12), which is populated iteratively.**
+
+### Hero Paradigms
+* **Asymmetric Split Hero** - Text on one side, asset on the other, generous white space.
+* **Editorial Manifesto Hero** - Large type, no asset, almost-poster.
+* **Video / Media Mask Hero** - Type cut out as mask over video background.
+* **Kinetic-Type Hero** - Animated typography as the primary visual.
+* **Curtain-Reveal Hero** - Hero parts on scroll like a curtain.
+* **Scroll-Pinned Hero** - Hero stays pinned while content scrolls behind.
+
+### Navigation & Menus
+* **Mac OS Dock Magnification** - Edge nav, icons scale fluidly on hover.
+* **Magnetic Button** - Pulls toward cursor.
+* **Gooey Menu** - Sub-items detach like viscous liquid.
+* **Dynamic Island** - Morphing pill for status / alerts.
+* **Contextual Radial Menu** - Circular menu expanding at click point.
+* **Floating Speed Dial** - FAB springing into curved secondary actions.
+* **Mega Menu Reveal** - Full-screen dropdown, stagger-fade content.
+
+### Layout & Grids
+* **Bento Grid** - Asymmetric tile grouping (Apple Control Center).
+* **Masonry Layout** - Staggered grid, no fixed row height.
+* **Chroma Grid** - Borders / tiles with subtle animating gradients.
+* **Split-Screen Scroll** - Two halves sliding in opposite directions.
+* **Sticky-Stack Sections** - Sections that pin and stack on scroll.
+
+### Cards & Containers
+* **Parallax Tilt Card** - 3D tilt tracking mouse coordinates.
+* **Spotlight Border Card** - Borders illuminate under cursor.
+* **Glassmorphism Panel** - Frosted glass with inner refraction.
+* **Holographic Foil Card** - Iridescent rainbow shift on hover.
+* **Tinder Swipe Stack** - Physical card stack, swipe-away.
+* **Morphing Modal** - Button expands into its own dialog.
+
+### Scroll Animations
+* **Sticky Scroll Stack** - Cards stick and physically stack.
+* **Horizontal Scroll Hijack** - Vertical scroll → horizontal pan.
+* **Locomotive / Sequence Scroll** - Video / 3D sequence tied to scrollbar.
+* **Zoom Parallax** - Central background image zooming on scroll.
+* **Scroll Progress Path** - SVG line drawing along scroll.
+* **Liquid Swipe Transition** - Page transition like viscous liquid.
+
+### Galleries & Media
+* **Dome Gallery** - 3D panoramic gallery.
+* **Coverflow Carousel** - 3D carousel with angled edges.
+* **Drag-to-Pan Grid** - Boundless draggable canvas.
+* **Accordion Image Slider** - Narrow strips expanding on hover.
+* **Hover Image Trail** - Mouse leaves popping image trail.
+* **Glitch Effect Image** - RGB-channel shift on hover.
+
+### Typography & Text
+* **Kinetic Marquee** - Endless text bands reversing on scroll.
+* **Text Mask Reveal** - Massive type as transparent window to video.
+* **Text Scramble Effect** - Matrix-style decoding on load / hover.
+* **Circular Text Path** - Text curving along spinning circle.
+* **Gradient Stroke Animation** - Outlined text with running gradient.
+* **Kinetic Typography Grid** - Letters dodging the cursor.
+
+### Micro-Interactions & Effects
+* **Particle Explosion Button** - CTA shatters into particles on success.
+* **Liquid Pull-to-Refresh** - Reload indicator like detaching droplets.
+* **Skeleton Shimmer** - Shifting light reflection across placeholders.
+* **Directional Hover-Aware Button** - Fill enters from cursor's exact side.
+* **Ripple Click Effect** - Wave from click coordinates.
+* **Animated SVG Line Drawing** - Vectors drawing themselves in real time.
+* **Mesh Gradient Background** - Organic lava-lamp blobs.
+* **Lens Blur Depth** - Background UI blurred to focus foreground action.
+
+### Animation Library Choice
+* **Motion (`motion/react`)** - default for UI / Bento / state-change motion.
+* **GSAP + ScrollTrigger** - for full-page scrolltelling and scroll hijacks. Isolate in dedicated leaf components with `useEffect` cleanup.
+* **Three.js / WebGL** - for canvas backgrounds and 3D scenes. Same isolation rule.
+* **NEVER mix GSAP / Three.js with Motion in the same component tree.** They fight over the same frames.
+
+---
+
+## 11. REDESIGN PROTOCOL
+
+This skill handles **greenfield builds AND redesigns**. Misclassifying the mode is the single biggest source of bad redesign output.
+
+### 11.A Detect the Mode (first action)
+* **Greenfield** - no existing site, or full overhaul approved. Dial baseline from Section 1.
+* **Redesign - Preserve** - modernise without breaking the brand. Audit first, extract brand tokens, evolve gradually.
+* **Redesign - Overhaul** - new visual language on top of existing content. Treat as greenfield for visuals; preserve content and IA.
+
+If ambiguous, ask **once**: *"Should this redesign preserve the existing brand, or are we starting visually from scratch?"*
+
+### 11.B Audit Before Touching
+Document the current state before proposing changes:
+* **Brand tokens** - primary / accent colors, type stack, logo treatment, radii.
+* **Information architecture** - page tree, primary nav, key conversion paths.
+* **Content blocks** - what exists, what's doing work, what's filler.
+* **Patterns to preserve** - signature interactions, recognisable hero, copy voice.
+* **Patterns to retire** - AI-slop tells, broken layouts, dead links, generic stock imagery, perf traps.
+* **Dial reading of the existing site** - infer current `DESIGN_VARIANCE` / `MOTION_INTENSITY` / `VISUAL_DENSITY`. That's your starting point, not the baseline.
+* **SEO baseline** - current ranking pages, meta titles, structured data, OG cards. **SEO migration is the #1 redesign risk.**
+
+### 11.C Preservation Rules
+* **Do not change information architecture** unless asked. Keep page slugs, anchor IDs, primary nav labels stable for SEO and muscle memory.
+* **Extract brand colors before applying Section 4.2.** A brand that is already purple stays purple - apply the LILA RULE's override.
+* **Preserve copy voice** unless asked for a rewrite. Visual modernisation ≠ content rewrite.
+* **Honor existing accessibility wins.** Do not regress focus states, alt text, keyboard nav, contrast.
+* **Respect existing analytics events.** Do not rename buttons, form fields, section IDs that downstream tracking depends on.
+
+### 11.D Modernisation Levers (priority order)
+Apply in order - stop when the brief is satisfied:
+1. **Typography refresh** - biggest visual lift per unit of risk.
+2. **Spacing & rhythm** - increase section padding, fix vertical rhythm.
+3. **Color recalibration** - desaturate, unify neutrals, keep brand accent.
+4. **Motion layer** - add `MOTION_INTENSITY`-appropriate micro-interactions to existing components.
+5. **Hero & key-section recomposition** - restructure top-of-funnel using Section 10 vocabulary.
+6. **Full block replacement** - only when the existing block is unsalvageable.
+
+### 11.E Decision Tree: Targeted Evolution vs Full Redesign
+* IA, content, and SEO sound → **targeted evolution** (Levers 1-4). ~70% of value at ~40% of risk.
+* Visual debt is structural (broken IA, no design system, broken mobile) → **full redesign** with strict content preservation.
+* Brand itself is changing → **greenfield**.
+
+### 11.F What Never Changes Silently
+Never modify without explicit user approval:
+* URL structure / route slugs.
+* Primary nav labels.
+* Form field names or order (breaks analytics + autofill).
+* Brand logo or wordmark.
+* Existing legal / consent / cookie copy.
+
+---
+
+## 12. THE BLOCK LIBRARY (Contract - Implementations Land Here Iteratively)
+
+The Reference Vocabulary (Section 10) names patterns. The Block Library implements them with real props, real motion specs, and real code sketches.
+
+**Status:** schema defined here. Blocks will be added iteratively. Do not freelance new blocks without following this schema.
+
+### 12.A File Location
+```
+skills/taste-skill/blocks/
+  hero/
+    asymmetric-split.md
+    editorial-manifesto.md
+    kinetic-type.md
+    ...
+  feature/
+    bento-grid.md
+    sticky-scroll-stack.md
+    zig-zag.md
+    ...
+  social-proof/
+  pricing/
+  cta/
+  footer/
+  navigation/
+  portfolio/
+  transition/
+```
+
+### 12.B Required Frontmatter
+```yaml
+---
+name: asymmetric-split-hero
+category: hero
+dial_compatibility:
+  variance: [6, 10]
+  motion: [3, 10]
+  density: [2, 5]
+when_to_use: "Landing pages with one strong asset and one strong message. Default hero for SaaS, agency, premium consumer."
+not_for: "Editorial / manifesto launches where the message IS the design."
+stack: ["react", "next", "tailwind", "motion"]
+---
+```
+
+### 12.C Required Body Sections
+1. **Visual sketch** - short ASCII or description of the layout.
+2. **Props API** - the component's interface.
+3. **Code sketch** - minimal working implementation (Server Component default, Client island for motion).
+4. **Mobile fallback** - explicit collapse rules for `< 768px`.
+5. **Motion variants** - one variant per `MOTION_INTENSITY` band (1-3, 4-7, 8-10). Reduced-motion fallback explicit.
+6. **Dark-mode notes** - token strategy specific to this block.
+7. **Anti-patterns** - common ways this block goes wrong.
+8. **References** - links to real examples in production.
+
+### 12.D Block-Library Discipline
+* One block per file. No multi-block files.
+* Every block must work standalone (drop it into a page, it renders).
+* Every block must pass the Pre-Flight Check (Section 14).
+* Blocks that depend on a design system from Section 2.A live under `blocks/<category>/<name>--<system>.md` (e.g. `feature/bento-grid--material.md`).
+
+---
+
+## 13. OUT OF SCOPE
+
+This skill is NOT for:
+* Dashboards / dense product UI / admin panels (use Fluent, Carbon, Atlassian, or Polaris from Section 2.A).
+* Data tables (use TanStack Table or AG Grid).
+* Multi-step forms / wizards (use Form-specific patterns; this skill won't make them better).
+* Code editors (use Monaco / CodeMirror with their official skinning).
+* Native mobile (use Apple HIG / Material directly).
+* Realtime collab UIs (presence, cursors, OT-aware - different problem class).
+
+If the brief is one of the above, **say so explicitly**, point to the right tool, and only apply this skill's marketing-page / about-page / landing-page parts to the surfaces where they apply.
+
+---
+
+## 14. FINAL PRE-FLIGHT CHECK
+
+Run this matrix before outputting code. This is the last filter.
+
+**THIS IS NOT OPTIONAL. Run every box. If any box fails, the output is not done.**
+
+- [ ] **Brief inference** declared (Section 0.B one-liner)?
+- [ ] **Dial values** explicit and reasoned from the brief, not silently using baseline?
+- [ ] **Design system** chosen from Section 2 if applicable, or aesthetic labeled honestly?
+- [ ] **Redesign mode** detected and audit performed (if applicable, Section 11)?
+- [ ] **ZERO em-dashes (`—`) anywhere on the page.** Headlines, eyebrows, pills, body, quotes, attribution, captions, buttons, alt text. Zero. (Section 9.G - non-negotiable.)
+- [ ] **Page Theme Lock**: ONE theme (light, dark, or auto) for the whole page. No section flips to inverted mode mid-page (Section 4.11)?
+- [ ] **Color Consistency Lock**: one accent color used identically across all sections (Section 4.2)?
+- [ ] **Shape Consistency Lock**: one corner-radius system applied consistently (Section 4.4)?
+- [ ] **Button Contrast Check**: every CTA text is readable against its background (no white-on-white, WCAG AA 4.5:1)?
+- [ ] **CTA Button Wrap**: no CTA label wraps to 2+ lines at desktop?
+- [ ] **Form Contrast Check**: form inputs, placeholders, focus rings, labels all pass WCAG AA against the section background?
+- [ ] **Serif discipline**: if a serif is used, it is NOT Fraunces or Instrument_Serif (or it is, with explicit brand justification)? Different serif from your previous project?
+- [ ] **Premium-consumer palette check**: if the brief is premium-consumer (cookware / wellness / artisan / luxury), the palette is NOT the AI-default beige+brass+oxblood+espresso family? Different family from your previous premium-consumer project?
+- [ ] **Italic descender clearance**: every italic word with `y g j p q` has `leading-[1.1]` min + `pb-1` reserve?
+- [ ] **Hero fits the viewport**: headline ≤ 2 lines, subtext ≤ 20 words AND ≤ 4 lines, CTA visible without scroll, font scale planned around image?
+- [ ] **Hero top padding**: max `pt-24` at desktop, hero content does not float halfway down the viewport?
+- [ ] **Hero stack discipline**: max 4 text elements in hero (eyebrow OR brand strip, headline, subtext, CTAs)? No tiny tagline below CTAs, no trust micro-strip in hero?
+- [ ] **EYEBROW COUNT (mechanical)**: count instances of `uppercase tracking` micro-labels above section headlines across all components. Count ≤ ceil(sectionCount / 3)? Hero counts as 1.
+- [ ] **Split-Header Ban**: no "left big headline + right small explainer paragraph" pattern as a section header (vertical stack instead)?
+- [ ] **Zigzag Alternation Cap**: no 3+ consecutive sections with the same image+text-split layout?
+- [ ] **No Duplicate CTA Intent**: no two CTAs with the same intent ("Get in touch" + "Let's talk" both on page = Fail)?
+- [ ] **Logo wall = logo only**: no industry / category labels printed below logos?
+- [ ] **Bento Background Diversity**: at least 2-3 bento cells have real visual variation (image, gradient, pattern), not all white-on-white text cards?
+- [ ] **"Used by / Trusted by" logo wall** lives UNDER the hero, not inside it, uses REAL SVG logos (Simple Icons / devicon) or generated SVG marks, NOT plain text wordmarks?
+- [ ] **Copy Self-Audit**: every visible string re-read, no grammatically-broken or AI-hallucinated phrases ("free on its past" type) shipped?
+- [ ] **Motion motivated**: every animation can be justified in one sentence (hierarchy / storytelling / feedback / state transition), no GSAP-for-show?
+- [ ] **Marquee max-one-per-page**: no two horizontal marquees on the same page?
+- [ ] **Navigation on ONE line** at desktop, height ≤ 80px?
+- [ ] **Section-Layout-Repetition** check: no two sections share the same layout family (at least 4 different families across 8 sections)?
+- [ ] **Bento has rhythm AND exact cell count** (N items → N cells, no empty cells in middle or at end)?
+- [ ] **Long lists use the right UI component** (not default `<ul>` with `divide-y` for > 5 items - see Section 4.9 alternatives)?
+- [ ] **Real images used** (gen-tool first, then Picsum-seed, then explicit placeholder slots) - NO div-based fake screenshots, NO hand-rolled decorative SVGs, NO pure-text minimalism?
+- [ ] **No pills/labels overlaid on images** (no `Plate · Brand`, no `Field notes - journal`)?
+- [ ] **No photo-credit captions as decoration** (`Field study no. 12 · Ines Caetano`)?
+- [ ] **No version footers** (`v1.4.2`, `Build 0048`) on marketing pages?
+- [ ] **No micro-meta-sentences** under eyebrows ("Each of these is a feature we ship today...")?
+- [ ] **No decoration text strip at hero bottom** (`BRAND. MOTION. SPATIAL.`)?
+- [ ] **No floating top-right sub-text** in section headings?
+- [ ] **No scoring/progress bars with filled background tracks** as comparison visuals?
+- [ ] **No locale / city-name / time / weather strips** unless brief is genuinely globally-distributed or place-focused?
+- [ ] **No scroll cues** (`Scroll`, `↓ scroll`, `Scroll to explore`)?
+- [ ] **No version labels in hero** (V0.6, BETA, INVITE-ONLY) unless the brief is a launch?
+- [ ] **No section-numbering eyebrows** (`00 / INDEX`, `001 · Capabilities`, `06 · how it works`)?
+- [ ] **No decorative dots** (zero by default, only for real semantic state)?
+- [ ] **No `border-t` + `border-b` on every row** of long lists / spec tables?
+- [ ] **Content density** sane: no 20-row data tables, no fake-precise specs without justification, ≤ 25-word sub-paragraphs by default?
+- [ ] **Quotes ≤ 3 lines** of body, attribution clean (no em-dash)?
+- [ ] **Motion claimed = motion shown**: if `MOTION_INTENSITY > 4`, page actually animates, not just claimed?
+- [ ] **GSAP sticky-stack / horizontal-pan** implemented per Section 5.A / 5.B canonical skeleton (`start: "top top"`, `pin: true`, correct scrub)?
+- [ ] **No `window.addEventListener('scroll')`** - using Motion `useScroll()` / ScrollTrigger / IntersectionObserver / CSS scroll-driven animations only?
+- [ ] **Reduced motion** wrapped for everything `MOTION_INTENSITY > 3`?
+- [ ] **Dark mode** tokens defined and tested in both modes?
+- [ ] **Mobile collapse** explicit (`w-full`, `px-4`, `max-w-7xl mx-auto`) for high-variance layouts?
+- [ ] **Viewport stability**: `min-h-[100dvh]`, never `h-screen`?
+- [ ] **`useEffect` animations** have strict cleanup functions?
+- [ ] **Empty / loading / error** states provided?
+- [ ] **Cards omitted** in favor of spacing where possible?
+- [ ] **Icons** from an allowed library only (Phosphor / HugeIcons / Radix / Tabler), no hand-rolled SVG paths?
+- [ ] **Motion** isolated in client-leaf components with `'use client'` at the top, memoized?
+- [ ] **No AI Tells** from Section 9 (Inter as default, AI-purple, three-equal cards, Jane Doe, Acme, "Quietly in use at")?
+- [ ] **Core Web Vitals** plausibly hit (LCP < 2.5s, INP < 200ms, CLS < 0.1)?
+- [ ] **One design system** per project (no Material + shadcn mixed)?
+
+If a single checkbox cannot be honestly ticked, the page is not done. Fix it before delivering.
+
+---
+
+# APPENDICES - Real Source-Backed Reference Material
+
+The sections below are vendored reference content. They give the agent real install commands, real canonical doc links, and real working starter snippets for each design system named in Section 2. Use them to ground decisions in production reality, not training-data fiction.
+
+## Appendix A - Install Commands per Design System
+
+```bash
+# Material Web (Material 3)
+npm install @material/web
+
+# Fluent UI React (v9)
+npm install @fluentui/react-components
+
+# Fluent UI Web Components (framework-free)
+npm install @fluentui/web-components @fluentui/tokens
+
+# IBM Carbon
+npm install @carbon/react @carbon/styles
+
+# Radix Themes
+npm install @radix-ui/themes
+
+# shadcn/ui (open code, owned components)
+npx shadcn@latest init
+npx shadcn@latest add button card badge separator input
+
+# Primer CSS (GitHub product/devtool UI)
+npm install --save @primer/css
+
+# Primer Brand (GitHub marketing UI)
+npm install @primer/react-brand
+
+# GOV.UK Frontend
+npm install govuk-frontend
+
+# USWDS (US Web Design System)
+npm install uswds
+
+# Atlassian Design System (Atlaskit)
+yarn add @atlaskit/css-reset @atlaskit/tokens @atlaskit/button @atlaskit/badge @atlaskit/section-message @atlaskit/card
+
+# Bootstrap 5.3
+npm install bootstrap
+
+# Shopify Polaris Web Components (Shopify apps only)
+# Add this to your app HTML head:
+#   <meta name="shopify-api-key" content="%SHOPIFY_API_KEY%" />
+#   <script src="https://cdn.shopify.com/shopifycloud/polaris.js"></script>
+```
+
+## Appendix B - Canonical Sources (read these before reinventing)
+
+### Material Web
+- https://github.com/material-components/material-web
+- https://material-web.dev/theming/material-theming/
+- https://m3.material.io/develop/web
+
+### Fluent UI
+- https://fluent2.microsoft.design/get-started/develop
+- https://fluent2.microsoft.design/components/web/react/
+- https://github.com/microsoft/fluentui
+- https://learn.microsoft.com/en-us/fluent-ui/web-components/
+
+### Carbon
+- https://carbondesignsystem.com/
+- https://github.com/carbon-design-system/carbon
+- https://carbondesignsystem.com/developing/react-tutorial/overview/
+- https://carbondesignsystem.com/developing/web-components-tutorial/overview/
+
+### Shopify Polaris
+- https://shopify.dev/docs/api/app-home/web-components
+- https://github.com/Shopify/polaris-react
+- https://polaris-react.shopify.com/components
+
+### Atlassian
+- https://atlassian.design/get-started/develop
+- https://atlassian.design/components/button/examples
+- https://atlaskit.atlassian.com/packages/design-system/button/example/disabled
+- https://atlassian.design/tokens/design-tokens
+
+### Primer
+- https://primer.style/
+- https://github.com/primer/css
+- https://github.com/primer/brand
+
+### GOV.UK
+- https://design-system.service.gov.uk/components/button/
+- https://design-system.service.gov.uk/styles/layout/
+- https://github.com/alphagov/govuk-frontend
+
+### USWDS
+- https://designsystem.digital.gov/documentation/developers/
+- https://designsystem.digital.gov/components/button/
+- https://designsystem.digital.gov/components/card/
+- https://github.com/uswds/uswds
+
+### Bootstrap
+- https://getbootstrap.com/docs/5.3/layout/grid/
+- https://getbootstrap.com/docs/5.3/components/card/
+
+### Tailwind
+- https://tailwindcss.com/docs/dark-mode
+- https://tailwindcss.com/blog/tailwindcss-v4
+
+### Radix
+- https://www.radix-ui.com/themes/docs/components/theme
+- https://www.radix-ui.com/themes/docs/components/card
+- https://github.com/radix-ui/themes
+
+### shadcn/ui
+- https://ui.shadcn.com/docs
+- https://ui.shadcn.com/docs/components/card
+- https://github.com/shadcn-ui/ui
+
+### Native CSS / W3C standards
+- https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/backdrop-filter
+- https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/prefers-color-scheme
+- https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/prefers-reduced-motion
+- https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Grid_layout
+- https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Scroll-driven_animations
+- https://drafts.csswg.org/scroll-animations-1/
+
+### Apple Liquid Glass (Apple platforms only)
+- https://developer.apple.com/design/human-interface-guidelines/materials
+- https://developer.apple.com/documentation/TechnologyOverviews/liquid-glass
+- https://developer.apple.com/documentation/TechnologyOverviews/adopting-liquid-glass
+- https://developer.apple.com/documentation/SwiftUI/Material
+
+---
+
+## Appendix C - Apple Liquid Glass: Honest Web Approximation
+
+Do **not** treat random CSS snippets as official Apple Liquid Glass.
+
+### What is official
+Apple documents Liquid Glass inside Apple's Human Interface Guidelines and Developer Documentation for **Apple platforms**. It is a dynamic material used across Apple platform UI. Apple's native implementation belongs to Apple platform APIs and system components, **not a public web CSS package**.
+
+Relevant official docs:
+- Apple Human Interface Guidelines → Materials
+- Apple Developer Documentation → Liquid Glass
+- Apple Developer Documentation → Adopting Liquid Glass
+- SwiftUI → Material
+
+### What is NOT official
+There is no `liquid-glass.css` from Apple for normal websites.
+
+A web approximation can use:
+- `backdrop-filter`
+- transparent backgrounds
+- layered borders
+- highlight overlays
+- gradients
+- motion
+- strong contrast fallbacks
+
+But that is **web glassmorphism / frosted-glass approximation**, not official Apple Liquid Glass. Label it as such in comments.
+
+### Safer web approximation skeleton
+
+```css
+.liquid-glass-web-approx {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  border-radius: 999px;
+  border: 1px solid rgb(255 255 255 / .32);
+  background:
+    linear-gradient(135deg, rgb(255 255 255 / .30), rgb(255 255 255 / .08)),
+    rgb(255 255 255 / .12);
+  backdrop-filter: blur(24px) saturate(180%) contrast(1.05);
+  -webkit-backdrop-filter: blur(24px) saturate(180%) contrast(1.05);
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / .48),
+    inset 0 -1px 0 rgb(255 255 255 / .12),
+    0 18px 60px rgb(0 0 0 / .18);
+}
+
+.liquid-glass-web-approx::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: inherit;
+  background:
+    radial-gradient(circle at 20% 0%, rgb(255 255 255 / .55), transparent 34%),
+    linear-gradient(90deg, rgb(255 255 255 / .18), transparent 42%, rgb(255 255 255 / .14));
+  pointer-events: none;
+}
+
+.liquid-glass-web-approx::after {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border-radius: inherit;
+  border: 1px solid rgb(255 255 255 / .14);
+  pointer-events: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  .liquid-glass-web-approx {
+    border-color: rgb(255 255 255 / .18);
+    background:
+      linear-gradient(135deg, rgb(255 255 255 / .16), rgb(255 255 255 / .04)),
+      rgb(15 23 42 / .42);
+    box-shadow:
+      inset 0 1px 0 rgb(255 255 255 / .22),
+      0 18px 60px rgb(0 0 0 / .42);
+  }
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .liquid-glass-web-approx {
+    background: rgb(255 255 255 / .96);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+}
+```
+
+**Important:** `prefers-reduced-transparency` has uneven browser support; test it. Always provide enough contrast even without blur.
+
+---
+
+**End of appendices.** Install commands above are reality anchors. The Apple Liquid Glass skeleton is a labeled approximation, not an Apple-issued package. For canonical docs per design system, consult the system's official docs (links in Section 2 plus Appendix B).

--- a/docs/mockups/2026-06-01-sheet-card-polish-options.html
+++ b/docs/mockups/2026-06-01-sheet-card-polish-options.html
@@ -1,0 +1,806 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>B flow 시트/카드 폴리싱 시안</title>
+  <style>
+    :root {
+      --bg: #0f1117;
+      --panel: #171a24;
+      --panel-2: #1d2130;
+      --line: #2d3041;
+      --line-soft: rgba(141, 146, 178, 0.22);
+      --text: #e8e8ee;
+      --muted: #8b8da3;
+      --accent: #6c5ce7;
+      --act: #e17055;
+      --bgdept: #6c5ce7;
+      --yellow: #fdcb6e;
+      --green: #00b894;
+      --blue: #74b9ff;
+      color-scheme: dark;
+      font-family: Inter, "IBM Plex Sans KR", "Noto Sans KR", system-ui, sans-serif;
+    }
+
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: radial-gradient(circle at 20% 0%, rgba(108,92,231,0.16), transparent 24rem), var(--bg);
+      color: var(--text);
+    }
+    button, input { font: inherit; }
+    .app {
+      min-height: 100vh;
+      display: grid;
+      grid-template-columns: 72px minmax(0, 1fr);
+      background: rgba(15,17,23,0.94);
+    }
+    .rail {
+      border-right: 1px solid var(--line);
+      background: #121520;
+      padding: 16px 10px;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      align-items: center;
+    }
+    .logo {
+      width: 46px;
+      height: 46px;
+      border-radius: 14px;
+      background: linear-gradient(135deg, #6c5ce7, #2d3041);
+      display: grid;
+      place-items: center;
+      color: #c9c5ff;
+      font-weight: 800;
+      box-shadow: 0 10px 28px rgba(108,92,231,0.26);
+    }
+    .rail-icon {
+      width: 36px;
+      height: 36px;
+      border-radius: 10px;
+      display: grid;
+      place-items: center;
+      color: var(--muted);
+    }
+    .rail-icon.active {
+      background: rgba(108,92,231,0.22);
+      color: #a599f5;
+    }
+    main {
+      min-width: 0;
+      padding: 22px 24px 44px;
+    }
+    .topbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 18px;
+    }
+    h1 {
+      margin: 0;
+      font-size: 24px;
+      letter-spacing: 0;
+    }
+    .tabs {
+      display: flex;
+      gap: 8px;
+      padding: 4px;
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      background: rgba(18,21,32,0.72);
+    }
+    .tab {
+      border: 0;
+      border-radius: 9px;
+      padding: 8px 12px;
+      color: var(--muted);
+      background: transparent;
+      cursor: pointer;
+    }
+    .tab.active {
+      color: var(--text);
+      background: rgba(108,92,231,0.24);
+    }
+    .layout {
+      display: grid;
+      grid-template-columns: 260px minmax(0, 1fr);
+      gap: 18px;
+    }
+    .episode {
+      border: 1px solid var(--line);
+      border-radius: 14px;
+      background: rgba(26,29,39,0.74);
+      padding: 16px;
+      height: fit-content;
+    }
+    .episode-title {
+      color: var(--muted);
+      font-weight: 700;
+      font-size: 13px;
+      margin-bottom: 14px;
+    }
+    .ep-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 10px 12px;
+      border-radius: 10px;
+      color: var(--text);
+    }
+    .ep-row.active {
+      background: rgba(108,92,231,0.2);
+      color: #ddd9ff;
+    }
+    .content {
+      min-width: 0;
+      display: grid;
+      gap: 18px;
+    }
+    .panel {
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      background: rgba(26,29,39,0.78);
+      overflow: hidden;
+    }
+    .panel-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 14px 16px;
+      border-bottom: 1px solid var(--line);
+      background: rgba(22,25,36,0.82);
+    }
+    .panel-title {
+      display: flex;
+      gap: 8px;
+      align-items: center;
+      font-weight: 800;
+      letter-spacing: 0;
+    }
+    .dot {
+      width: 9px;
+      height: 9px;
+      border-radius: 50%;
+      background: var(--accent);
+      box-shadow: 0 0 10px rgba(108,92,231,0.5);
+    }
+    .selector {
+      display: flex;
+      gap: 6px;
+      flex-wrap: wrap;
+    }
+    .choice {
+      border: 1px solid var(--line);
+      background: rgba(15,17,23,0.6);
+      color: var(--muted);
+      border-radius: 999px;
+      padding: 6px 10px;
+      cursor: pointer;
+      font-size: 12px;
+    }
+    .choice.active {
+      color: var(--text);
+      border-color: rgba(108,92,231,0.6);
+      background: rgba(108,92,231,0.2);
+    }
+    .mock-body {
+      padding: 16px;
+    }
+    .table-wrap {
+      position: relative;
+      overflow: hidden;
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      background: #11141d;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      table-layout: fixed;
+      font-size: 12px;
+    }
+    th, td {
+      border-right: 1px solid rgba(45,48,65,0.85);
+      border-bottom: 1px solid rgba(45,48,65,0.74);
+      height: 52px;
+      padding: 8px 10px;
+      vertical-align: middle;
+      color: var(--muted);
+      position: relative;
+    }
+    th {
+      height: 44px;
+      color: #a8abc4;
+      background: #181b27;
+      text-align: left;
+      font-weight: 700;
+      user-select: none;
+    }
+    .resize-handle {
+      position: absolute;
+      top: 0;
+      right: -4px;
+      width: 8px;
+      height: 100%;
+      cursor: col-resize;
+      z-index: 4;
+    }
+    .resize-handle::after {
+      content: "";
+      position: absolute;
+      top: 8px;
+      bottom: 8px;
+      left: 3px;
+      width: 2px;
+      border-radius: 2px;
+      background: transparent;
+    }
+    th:hover .resize-handle::after,
+    .resize-handle.dragging::after {
+      background: #a599f5;
+      box-shadow: 0 0 14px rgba(108,92,231,0.65);
+    }
+    .scene-id {
+      display: inline-flex;
+      align-items: center;
+      min-width: 64px;
+      border: 1px solid rgba(108,92,231,0.58);
+      color: #9e91ff;
+      border-radius: 8px;
+      padding: 5px 9px;
+      font-family: "Fira Code", ui-monospace, monospace;
+      font-weight: 700;
+    }
+    .memo {
+      color: #b6b8cc;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+    .alert-cell {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      min-width: 0;
+    }
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 4px;
+      height: 22px;
+      min-width: 22px;
+      padding: 0 7px;
+      border-radius: 999px;
+      border: 1px solid var(--line-soft);
+      background: rgba(139,141,163,0.1);
+      color: #b9bad0;
+      font-size: 11px;
+      font-weight: 800;
+      white-space: nowrap;
+    }
+    .badge.revision {
+      border-color: rgba(108,92,231,0.36);
+      background: rgba(108,92,231,0.16);
+      color: #aaa0ff;
+    }
+    .badge.comment {
+      border-color: rgba(253,203,110,0.32);
+      background: rgba(253,203,110,0.12);
+      color: #f4cf86;
+    }
+    .row-pin {
+      position: absolute;
+      right: 12px;
+      top: 50%;
+      transform: translateY(-50%);
+      display: flex;
+      gap: 6px;
+      pointer-events: none;
+    }
+    .sheet-option-b .scene-line {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+    }
+    .sheet-option-c td:first-child {
+      overflow: visible;
+    }
+    .sheet-option-c .scene-id {
+      border-color: rgba(108,92,231,0.42);
+    }
+    .cards {
+      display: flex;
+      gap: 18px;
+      align-items: stretch;
+      flex-wrap: wrap;
+    }
+    .card {
+      position: relative;
+      width: var(--card-w, 282px);
+      min-height: 230px;
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      background: #171a24;
+      padding: 14px;
+      box-shadow: 0 12px 28px rgba(0,0,0,0.22);
+      overflow: hidden;
+      transition: width 180ms ease, border-color 160ms ease;
+    }
+    .card.active {
+      border-color: rgba(108,92,231,0.72);
+    }
+    .card-head {
+      display: flex;
+      justify-content: space-between;
+      gap: 8px;
+      align-items: center;
+      margin-bottom: 12px;
+    }
+    .card-id {
+      font-family: "Fira Code", ui-monospace, monospace;
+      font-weight: 800;
+      color: var(--text);
+    }
+    .percent {
+      padding: 4px 8px;
+      border-radius: 999px;
+      border: 1px solid var(--line);
+      background: rgba(15,17,23,0.66);
+      color: #d8d8e4;
+      font-size: 12px;
+      font-weight: 800;
+    }
+    .dept {
+      margin-top: 12px;
+    }
+    .dept-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 8px;
+      color: var(--muted);
+      font-size: 13px;
+    }
+    .dept-name {
+      display: inline-flex;
+      align-items: center;
+      gap: 7px;
+      font-weight: 800;
+    }
+    .dept-name.bg { color: #8f81ff; }
+    .dept-name.act { color: #ff8c70; }
+    .stage-track {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 4px;
+      padding: 5px;
+      border-radius: 10px;
+      border: 1px solid rgba(45,48,65,0.7);
+      background: rgba(15,17,23,0.7);
+      min-width: 0;
+    }
+    .seg {
+      height: 38px;
+      min-width: 0;
+      border: 0;
+      border-radius: 8px;
+      color: #8b8da3;
+      background: transparent;
+      display: grid;
+      place-items: center;
+      overflow: hidden;
+      cursor: pointer;
+      position: relative;
+    }
+    .seg.active {
+      color: #0f1117;
+      background: #848ba1;
+      box-shadow: 0 2px 10px rgba(132,139,161,0.34);
+      font-weight: 800;
+    }
+    .seg .label,
+    .seg .ico {
+      grid-area: 1 / 1;
+      transition: opacity 120ms ease;
+    }
+    .ico {
+      width: 16px;
+      height: 16px;
+      opacity: 0;
+    }
+    .stage-mode-text .ico,
+    .stage-mode-current .ico { opacity: 0; }
+    .stage-mode-text .label { opacity: 1; }
+    .stage-mode-icon .label { opacity: 0; }
+    .stage-mode-icon .ico { opacity: 1; }
+    .stage-mode-current .seg:not(.active) .label { opacity: 0; }
+    .stage-mode-current .seg:not(.active) .ico { opacity: 1; }
+    .stage-mode-current .seg.active .label { opacity: 1; }
+    .card.narrow .stage-mode-auto .label {
+      opacity: 0;
+    }
+    .card.narrow .stage-mode-auto .ico {
+      opacity: 1;
+    }
+    .card:not(.narrow) .stage-mode-auto .label {
+      opacity: 1;
+    }
+    .card:not(.narrow) .stage-mode-auto .ico {
+      opacity: 0;
+    }
+    .revision-a::before {
+      content: "";
+      position: absolute;
+      left: 16px;
+      right: 16px;
+      top: 0;
+      height: 2px;
+      border-radius: 999px;
+      background: #8f81ff;
+      box-shadow: 0 0 14px rgba(108,92,231,0.45);
+    }
+    .revision-b::before {
+      content: "";
+      position: absolute;
+      top: 0;
+      right: 0;
+      border-style: solid;
+      border-width: 0 36px 36px 0;
+      border-color: transparent #6c5ce7 transparent transparent;
+      opacity: 0.82;
+    }
+    .revision-c {
+      box-shadow: inset 0 0 0 1px rgba(108,92,231,0.44), 0 12px 28px rgba(0,0,0,0.22);
+    }
+    .card-badge {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 4px;
+      min-width: 24px;
+      height: 24px;
+      padding: 0 7px;
+      border-radius: 999px;
+      border: 1px solid rgba(108,92,231,0.38);
+      background: rgba(108,92,231,0.16);
+      color: #b4a9ff;
+      font-weight: 900;
+      font-size: 11px;
+    }
+    .revision-strip {
+      margin: -2px 0 10px;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      color: #aaa0ff;
+      font-size: 11px;
+      font-weight: 800;
+    }
+    .range-row {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      color: var(--muted);
+      font-size: 12px;
+      min-width: 240px;
+    }
+    .range-row input { accent-color: var(--accent); }
+    .hidden { display: none !important; }
+    svg {
+      width: 14px;
+      height: 14px;
+      stroke: currentColor;
+      stroke-width: 2.2;
+      fill: none;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+  </style>
+</head>
+<body>
+  <div class="app">
+    <aside class="rail">
+      <div class="logo">B</div>
+      <div class="rail-icon"><svg viewBox="0 0 24 24" width="17" height="17" aria-hidden="true"><rect x="5" y="5" width="14" height="14" rx="3" fill="none" stroke="currentColor" stroke-width="2"/></svg></div>
+      <div class="rail-icon active"><svg viewBox="0 0 24 24" width="17" height="17" aria-hidden="true"><path d="M6 7h12M6 12h12M6 17h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></div>
+      <div class="rail-icon"><svg viewBox="0 0 24 24" width="17" height="17" aria-hidden="true"><circle cx="12" cy="12" r="6" fill="none" stroke="currentColor" stroke-width="2"/></svg></div>
+      <div class="rail-icon"><svg viewBox="0 0 24 24" width="17" height="17" aria-hidden="true"><path d="M5 8h14M5 16h14M9 5v6M15 13v6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></div>
+    </aside>
+    <main>
+      <div class="topbar">
+        <h1>씬 목록 폴리싱 시안</h1>
+        <div class="tabs">
+          <button class="tab active" data-tab="sheet">시트</button>
+          <button class="tab" data-tab="card">카드</button>
+          <button class="tab" data-tab="stage">단계</button>
+        </div>
+      </div>
+      <div class="layout">
+        <aside class="episode">
+          <div class="episode-title">에피소드</div>
+          <div class="ep-row active"><span>EP.05</span><span>24</span></div>
+          <div class="ep-row"><span>a파트</span><span>6</span></div>
+          <div class="ep-row"><span>b파트</span><span>6</span></div>
+          <div class="ep-row"><span>c파트</span><span>6</span></div>
+        </aside>
+        <section class="content">
+          <div class="panel view" data-view="sheet">
+            <div class="panel-head">
+              <div class="panel-title"><span class="dot"></span>시트 배지/컬럼 리사이즈</div>
+              <div class="selector" data-group="sheet">
+                <button class="choice active" data-option="a">A 씬번호 우측 칸</button>
+                <button class="choice" data-option="b">B 씬번호 우측 포켓</button>
+                <button class="choice" data-option="c">C 빈 공간 고정</button>
+              </div>
+            </div>
+            <div class="mock-body">
+              <div id="sheetMock" class="table-wrap sheet-option-a">
+                <table>
+                  <colgroup id="mockCols">
+                    <col data-col="scene" />
+                    <col data-col="alerts" />
+                    <col data-col="bgMemo" />
+                    <col data-col="actMemo" />
+                    <col data-col="assignee" />
+                    <col data-col="stage" />
+                  </colgroup>
+                  <thead>
+                    <tr>
+                      <th data-col="scene">씬번호<span class="resize-handle" data-boundary="scene:alerts"></span></th>
+                      <th data-col="alerts"><span class="resize-handle" data-boundary="alerts:bgMemo"></span></th>
+                      <th data-col="bgMemo">BG 메모<span class="resize-handle" data-boundary="bgMemo:actMemo"></span></th>
+                      <th data-col="actMemo">ACT 메모<span class="resize-handle" data-boundary="actMemo:assignee"></span></th>
+                      <th data-col="assignee">ACT담당<span class="resize-handle" data-boundary="assignee:stage"></span></th>
+                      <th data-col="stage">액팅 단계</th>
+                    </tr>
+                  </thead>
+                  <tbody id="sheetRows"></tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+
+          <div class="panel view hidden" data-view="card">
+            <div class="panel-head">
+              <div class="panel-title"><span class="dot"></span>카드 리비전 표기</div>
+              <div class="selector" data-group="revision">
+                <button class="choice" data-option="a">A 상단 라인</button>
+                <button class="choice active" data-option="b">B 코너 플래그</button>
+                <button class="choice" data-option="c">C 내부 스트립</button>
+              </div>
+            </div>
+            <div class="mock-body">
+              <div class="cards" id="revisionCards"></div>
+            </div>
+          </div>
+
+          <div class="panel view hidden" data-view="stage">
+            <div class="panel-head">
+              <div class="panel-title"><span class="dot"></span>카드 단계 전환</div>
+              <div class="range-row">
+                카드 폭
+                <input id="cardWidth" type="range" min="172" max="330" value="250" />
+                <span id="cardWidthText">250</span>
+              </div>
+              <div class="selector" data-group="stage">
+                <button class="choice active" data-option="auto">A 텍스트에서 아이콘</button>
+                <button class="choice" data-option="current">B 현재만 텍스트</button>
+                <button class="choice" data-option="text">C 텍스트 고정</button>
+              </div>
+            </div>
+            <div class="mock-body">
+              <div class="cards" id="stageCards"></div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+  </div>
+
+  <template id="stageTrack">
+    <div class="stage-track">
+      <button class="seg active" type="button" aria-label="대기">
+        <span class="label">대기</span>
+        <svg class="ico" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"></circle><path d="M12 7v6l4 2"></path></svg>
+      </button>
+      <button class="seg" type="button" aria-label="작업중">
+        <span class="label">작업중</span>
+        <svg class="ico" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"></circle><path d="M10 8l6 4-6 4z"></path></svg>
+      </button>
+      <button class="seg" type="button" aria-label="피드백">
+        <span class="label">피드백</span>
+        <svg class="ico" viewBox="0 0 24 24"><path d="M21 15a4 4 0 0 1-4 4H8l-5 3V7a4 4 0 0 1 4-4h10a4 4 0 0 1 4 4z"></path><path d="M12 7v5"></path><path d="M12 15h.01"></path></svg>
+      </button>
+      <button class="seg" type="button" aria-label="완료">
+        <span class="label">완료</span>
+        <svg class="ico" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"></circle><path d="M8 12l3 3 5-6"></path></svg>
+      </button>
+    </div>
+  </template>
+
+  <script>
+    const rows = [
+      { id: "a001", bg: "-", act: "레이아웃 기준 동선 확인", assignee: "원동우", rev: 0, comment: 0 },
+      { id: "a002", bg: "-", act: "입 모양 타이밍 재확인", assignee: "이혜민", rev: 1, comment: 2 },
+      { id: "a003", bg: "창밖 빛 방향 체크", act: "-", assignee: "김가은", rev: 0, comment: 1 },
+      { id: "a004", bg: "-", act: "손 포즈 리테이크 반영", assignee: "박소율", rev: 2, comment: 0 },
+      { id: "a005", bg: "비 소스 최신화", act: "-", assignee: "한솔", rev: 0, comment: 0 }
+    ];
+    const icons = {
+      rev: '<svg viewBox="0 0 24 24"><path d="M21 15a4 4 0 0 1-4 4H7l-4 3V7a4 4 0 0 1 4-4h10a4 4 0 0 1 4 4z"></path><path d="M12 7v5"></path><path d="M12 15h.01"></path></svg>',
+      comment: '<svg viewBox="0 0 24 24"><path d="M21 15a4 4 0 0 1-4 4H8l-5 3V7a4 4 0 0 1 4-4h10a4 4 0 0 1 4 4z"></path></svg>'
+    };
+    const colWidths = { scene: 130, alerts: 58, bgMemo: 230, actMemo: 230, assignee: 126, stage: 250 };
+    const minWidths = { scene: 92, bgMemo: 120, actMemo: 120, assignee: 96, stage: 180, alerts: 80 };
+    let sheetOption = "a";
+    let revisionOption = "b";
+    let stageOption = "auto";
+
+    function setCols() {
+      document.querySelectorAll("#mockCols col").forEach((col) => {
+        const key = col.dataset.col;
+        col.style.width = colWidths[key] + "px";
+      });
+    }
+
+    function badge(kind, n) {
+      if (!n) return "";
+      return `<span class="badge ${kind}">${icons[kind]}<span>${n}</span></span>`;
+    }
+
+    function renderSheet() {
+      const body = document.getElementById("sheetRows");
+      body.innerHTML = rows.map((row) => {
+        const badges = `${badge("revision", row.rev)}${badge("comment", row.comment)}`;
+        if (sheetOption === "a") {
+          return `<tr>
+            <td><span class="scene-id">${row.id}</span></td>
+            <td><div class="alert-cell">${badges}</div></td>
+            <td class="memo">${row.bg}</td>
+            <td class="memo">${row.act}</td>
+            <td>${row.assignee}</td>
+            <td>${trackHtml("stage-mode-text")}</td>
+          </tr>`;
+        }
+        if (sheetOption === "b") {
+          return `<tr>
+            <td><div class="scene-line"><span class="scene-id">${row.id}</span><span class="alert-cell">${badges}</span></div></td>
+            <td></td>
+            <td class="memo">${row.bg}</td>
+            <td class="memo">${row.act}</td>
+            <td>${row.assignee}</td>
+            <td>${trackHtml("stage-mode-text")}</td>
+          </tr>`;
+        }
+        return `<tr>
+          <td><span class="scene-id">${row.id}</span><span class="row-pin">${badges}</span></td>
+          <td></td>
+          <td class="memo">${row.bg}</td>
+          <td class="memo">${row.act}</td>
+          <td>${row.assignee}</td>
+          <td>${trackHtml("stage-mode-text")}</td>
+        </tr>`;
+      }).join("");
+      const wrap = document.getElementById("sheetMock");
+      wrap.className = `table-wrap sheet-option-${sheetOption}`;
+    }
+
+    function trackHtml(mode) {
+      const template = document.getElementById("stageTrack");
+      const node = template.content.firstElementChild.cloneNode(true);
+      node.classList.add(mode);
+      return node.outerHTML;
+    }
+
+    function renderRevisionCards() {
+      const host = document.getElementById("revisionCards");
+      host.innerHTML = [1, 2, 3].map((n) => {
+        const cls = revisionOption === "a" ? "revision-a" : revisionOption === "b" ? "revision-b" : "revision-c";
+        const strip = revisionOption === "c" ? `<div class="revision-strip">${icons.rev}<span>${n}</span></div>` : "";
+        return `<article class="card active ${cls}">
+          <div class="card-head">
+            <span class="card-id">a00${n + 1}</span>
+            <span class="card-badge">${icons.rev}<span>${n}</span></span>
+          </div>
+          ${strip}
+          <div class="memo">입 모양 타이밍과 손 포즈 리비전 반영 필요</div>
+          <div class="dept">
+            <div class="dept-row"><span class="dept-name bg"><span class="dot"></span>BG</span><span>원동우</span></div>
+            ${trackHtml("stage-mode-text")}
+          </div>
+          <div class="dept">
+            <div class="dept-row"><span class="dept-name act"><span class="dot" style="background: var(--act)"></span>ACT</span><span>이혜민</span></div>
+            ${trackHtml("stage-mode-text")}
+          </div>
+        </article>`;
+      }).join("");
+    }
+
+    function renderStageCards() {
+      const host = document.getElementById("stageCards");
+      const width = Number(document.getElementById("cardWidth").value);
+      document.documentElement.style.setProperty("--card-w", width + "px");
+      document.getElementById("cardWidthText").textContent = width;
+      const narrow = width < 224 ? "narrow" : "";
+      const mode = stageOption === "auto" ? "stage-mode-auto" : stageOption === "current" ? "stage-mode-current" : "stage-mode-text";
+      host.innerHTML = [1, 2, 3].map((n) => `<article class="card ${n === 1 ? "active" : ""} ${narrow}">
+        <div class="card-head">
+          <span class="card-id">a00${n}</span>
+          <span class="percent">${n === 1 ? 25 : n === 2 ? 50 : 75}%</span>
+        </div>
+        <div class="memo">카드 폭에 따라 텍스트와 SVG 아이콘이 겹치지 않게 전환</div>
+        <div class="dept">
+          <div class="dept-row"><span class="dept-name act"><span class="dot" style="background: var(--act)"></span>ACT</span><span>이혜민</span></div>
+          ${trackHtml(mode)}
+        </div>
+      </article>`).join("");
+    }
+
+    function bindChoices() {
+      document.querySelectorAll(".choice").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          const group = btn.closest(".selector").dataset.group;
+          btn.closest(".selector").querySelectorAll(".choice").forEach((b) => b.classList.remove("active"));
+          btn.classList.add("active");
+          if (group === "sheet") { sheetOption = btn.dataset.option; renderSheet(); }
+          if (group === "revision") { revisionOption = btn.dataset.option; renderRevisionCards(); }
+          if (group === "stage") { stageOption = btn.dataset.option; renderStageCards(); }
+        });
+      });
+      document.querySelectorAll(".tab").forEach((tab) => {
+        tab.addEventListener("click", () => {
+          document.querySelectorAll(".tab").forEach((t) => t.classList.remove("active"));
+          tab.classList.add("active");
+          const id = tab.dataset.tab;
+          document.querySelectorAll(".view").forEach((view) => view.classList.toggle("hidden", view.dataset.view !== id));
+        });
+      });
+      document.getElementById("cardWidth").addEventListener("input", renderStageCards);
+    }
+
+    function bindResize() {
+      let active = null;
+      document.querySelectorAll(".resize-handle").forEach((handle) => {
+        handle.addEventListener("pointerdown", (event) => {
+          const [left, right] = handle.dataset.boundary.split(":");
+          active = {
+            handle,
+            left,
+            right,
+            x: event.clientX,
+            leftW: colWidths[left],
+            rightW: colWidths[right]
+          };
+          handle.classList.add("dragging");
+          handle.setPointerCapture(event.pointerId);
+        });
+        handle.addEventListener("pointermove", (event) => {
+          if (!active || active.handle !== handle) return;
+          const delta = event.clientX - active.x;
+          const total = active.leftW + active.rightW;
+          const nextLeft = Math.max(minWidths[active.left], Math.min(total - minWidths[active.right], active.leftW + delta));
+          colWidths[active.left] = nextLeft;
+          colWidths[active.right] = total - nextLeft;
+          setCols();
+        });
+        handle.addEventListener("pointerup", () => {
+          if (!active) return;
+          active.handle.classList.remove("dragging");
+          active = null;
+        });
+      });
+    }
+
+    setCols();
+    renderSheet();
+    renderRevisionCards();
+    renderStageCards();
+    bindChoices();
+    bindResize();
+  </script>
+</body>
+</html>

--- a/electron/broadcast.ts
+++ b/electron/broadcast.ts
@@ -298,6 +298,7 @@ export function broadcastCommentAdded(
   commentId?: string,
   parentCommentId?: string | null,
   partId?: string,
+  revisionId?: string | null,
 ): void {
   safeSend('comment-added', {
     sceneId,
@@ -308,6 +309,7 @@ export function broadcastCommentAdded(
     commentId: commentId ?? null,
     parentCommentId: parentCommentId ?? null,
     partId: partId ?? null,
+    revisionId: revisionId ?? null,
     ts: Date.now(),
   });
 }

--- a/electron/supabase.ts
+++ b/electron/supabase.ts
@@ -194,6 +194,29 @@ function throwIfError(error: { message: string } | null) {
   if (error) throw new Error(error.message);
 }
 
+type SupabaseErrorLike = {
+  code?: string | null;
+  message?: string | null;
+};
+
+function isMissingCommentReadStateRpcError(error: SupabaseErrorLike | null): boolean {
+  if (!error) return false;
+
+  const message = String(error.message ?? '').toLowerCase();
+  return error.code === 'PGRST202'
+    || (
+      message.includes('upsert_comment_read_state')
+      && message.includes('could not find the function')
+      && message.includes('schema cache')
+    );
+}
+
+function isDuplicateKeyError(error: SupabaseErrorLike | null): boolean {
+  if (!error) return false;
+  const message = String(error.message ?? '').toLowerCase();
+  return error.code === '23505' || message.includes('duplicate key');
+}
+
 const SCENE_COMPLETION_META_TYPE = 'scene-completion';
 
 function parseSceneCompletionMeta(value: string | null | undefined): { completedBy: string; completedAt: string } | null {
@@ -1337,13 +1360,54 @@ export async function upsertCommentReadState(
     throw new Error('invalid comment read state input');
   }
 
+  const normalizedLastReadAt = new Date(readMs).toISOString();
   const { error } = await supabase.rpc('upsert_comment_read_state', {
     p_user_id: safeUserId,
     p_scene_thread_key: safeSceneThreadKey,
-    p_last_read_at: new Date(readMs).toISOString(),
+    p_last_read_at: normalizedLastReadAt,
   });
 
-  throwIfError(error);
+  if (!error) return;
+  if (!isMissingCommentReadStateRpcError(error)) {
+    throwIfError(error);
+    return;
+  }
+
+  await upsertCommentReadStateViaTable(safeUserId, safeSceneThreadKey, normalizedLastReadAt);
+}
+
+async function upsertCommentReadStateViaTable(
+  userId: string,
+  sceneThreadKey: string,
+  lastReadAt: string,
+): Promise<void> {
+  const updatedAt = new Date().toISOString();
+  const { error: insertError } = await supabase
+    .from('comment_read_states')
+    .insert({
+      user_id: userId,
+      scene_thread_key: sceneThreadKey,
+      last_read_at: lastReadAt,
+      updated_at: updatedAt,
+    });
+
+  if (!insertError) return;
+  if (!isDuplicateKeyError(insertError)) {
+    throwIfError(insertError);
+    return;
+  }
+
+  const { error: updateError } = await supabase
+    .from('comment_read_states')
+    .update({
+      last_read_at: lastReadAt,
+      updated_at: updatedAt,
+    })
+    .eq('user_id', userId)
+    .eq('scene_thread_key', sceneThreadKey)
+    .lt('last_read_at', lastReadAt);
+
+  throwIfError(updateError);
 }
 
 /** 댓글 추가 */

--- a/electron/supabase.ts
+++ b/electron/supabase.ts
@@ -1395,7 +1395,7 @@ export async function addComment(
   throwIfError(error);
   // v1.24.0 P0 #1: broadcast 페이로드에 commentId/parentCommentId/partId 추가 →
   //   렌더러가 realtime/broadcast 어느 쪽에서 먼저 도착하든 같은 알림 분기 호출 가능.
-  broadcastCommentAdded(sceneId, userName, userId, text, mentions, commentId, safeParent, partUuid);
+  broadcastCommentAdded(sceneId, userName, userId, text, mentions, commentId, safeParent, partUuid, revisionId);
 }
 
 /** 댓글 수정.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bflow",
-  "version": "1.34.3",
+  "version": "1.35.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bflow",
-      "version": "1.34.3",
+      "version": "1.35.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@fontsource/gowun-dodum": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bflow",
-  "version": "1.34.3",
+  "version": "1.35.0",
   "description": "B flow - Studio JBBJ 워크플로우 대시보드",
   "main": "dist-electron/main.js",
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -258,6 +258,71 @@ export default function App() {
     return true; // 처리 가능
   }, []);
 
+  const dispatchRevisionCommentNotification = useCallback((newComment: {
+    id?: string | null;
+    scene_id?: string | null;
+    scene_uuid?: string | null;
+    part_id?: string | null;
+    user_name?: string | null;
+    user_id?: string | null;
+    text?: string | null;
+    mentions?: string[] | null;
+    revision_id?: string | null;
+  }): boolean => {
+    if (!newComment.revision_id) return false;
+
+    const me = useAuthStore.getState().currentUser;
+    if (!me || newComment.user_id === me.id) return true;
+
+    const notiSettings = notiSettingsRef.current;
+    if (notiSettings.commentNotify === false) return true;
+
+    import('@/stores/useRevisionStore').then(async ({ useRevisionStore }) => {
+      let rev = useRevisionStore.getState().revisions.find((r) => r.id === newComment.revision_id);
+      // 리비전 store 가 비어있으면 fresh 세션에서도 알림이 빠지지 않게 lazy load 후 재시도.
+      if (!rev) {
+        await useRevisionStore.getState().loadRevisions();
+        rev = useRevisionStore.getState().revisions.find((r) => r.id === newComment.revision_id);
+        if (!rev) return;
+      }
+
+      const revisionNotifyIds = Array.isArray(rev.notifyUserIds) ? rev.notifyUserIds : [];
+      const mentionedNames = Array.isArray(newComment.mentions) ? newComment.mentions : [];
+      const mentionedUserIds = useAuthStore.getState().users
+        .filter((user) => mentionedNames.includes(user.name))
+        .map((user) => user.id);
+      const targets = new Set([...revisionNotifyIds, ...mentionedUserIds]);
+      const isMentioned = mentionedNames.includes(me.name);
+      if (!targets.has(me.id)) return;
+
+      const dedupeKey = `revcomment:${newComment.id ?? ''}:${newComment.revision_id}`;
+      if (!dedupeNotification(dedupeKey)) return;
+
+      const sceneByUuid = newComment.scene_uuid
+        ? useDataStore.getState().findSceneByUuid(newComment.scene_uuid)
+        : null;
+      const body = newComment.text
+        ? (newComment.text.length > 60 ? newComment.text.slice(0, 60) + '...' : newComment.text)
+        : `${newComment.user_name || '누군가'}님 댓글`;
+
+      dispatchNotification({
+        type: 'revision',
+        title: `${isMentioned ? '리비전 댓글 멘션' : '리비전 댓글'} — ${sceneByUuid?.sceneId || newComment.scene_id || ''}`,
+        body,
+        metadata: {
+          sceneId: sceneByUuid?.id ?? newComment.scene_uuid ?? undefined,
+          sceneName: sceneByUuid?.sceneId,
+          commentSceneId: newComment.scene_id ?? undefined,
+          commentPartId: newComment.part_id ?? undefined,
+          revisionId: newComment.revision_id,
+          revisionAction: 'comment',
+        } as Record<string, unknown>,
+      }, notiSettings);
+    }).catch(() => { /* 무시 */ });
+
+    return true;
+  }, [dedupeNotification]);
+
   // 테마 초기화 완료 가드 (init에서 로드 전까지 저장 방지)
   const themeInitRef = useRef(false);
 
@@ -1228,55 +1293,7 @@ export default function App() {
           // v1.18.0: 리비전 맥락 댓글 → 'revision' 알림 (revisionAction='comment').
           // 일반 댓글 알림 경로(isMentioned/isAssignee) 와 *분리* 해 중복 알림 방지.
           // 조건: revision_id 있음 + 그 리비전 notifyUserIds 에 나 포함 + 내가 작성자 아님.
-          if (me && newComment.revision_id && newComment.user_id !== me.id) {
-            const notiSettings = notiSettingsRef.current;
-            if (notiSettings.commentNotify !== false) {
-              import('@/stores/useRevisionStore').then(async ({ useRevisionStore }) => {
-                let rev = useRevisionStore.getState().revisions.find((r) => r.id === newComment.revision_id);
-                // 코덱스 P1 fix (3차, 2026-05-05): 리비전 store 가 비어있으면 (예: 다른 뷰에서
-                // 시작한 fresh 세션) 댓글 알림이 silent drop 되던 문제. lazy load 후 재시도.
-                if (!rev) {
-                  await useRevisionStore.getState().loadRevisions();
-                  rev = useRevisionStore.getState().revisions.find((r) => r.id === newComment.revision_id);
-                  if (!rev) return;
-                }
-                const revisionNotifyIds = Array.isArray(rev.notifyUserIds) ? rev.notifyUserIds : [];
-                const mentionedNames = Array.isArray(newComment.mentions) ? newComment.mentions : [];
-                const mentionedUserIds = useAuthStore.getState().users
-                  .filter((user) => mentionedNames.includes(user.name))
-                  .map((user) => user.id);
-                const targets = new Set([...revisionNotifyIds, ...mentionedUserIds]);
-                const isMentioned = mentionedNames.includes(me.name);
-                if (!targets.has(me.id)) return;
-                // dedupe — 같은 댓글이 broadcast/realtime 두 경로로 들어와도 한 번만.
-                // 코덱스 P1 fix (2026-05-05): commentId 포함. 같은 사용자가 같은 리비전에
-                // 짧은 시간 내 여러 댓글 작성 시 두 번째부터 dedupe 충돌로 알림 손실되던 문제.
-                const dedupeKey = `revcomment:${newComment.id ?? ''}:${newComment.revision_id}`;
-                if (!dedupeNotification(dedupeKey)) return;
-                // 씬 매칭 — comment_panel.css 카드 라우팅 위해 sceneId/sceneName 도 같이 채움.
-                const sceneByUuid = newComment.scene_uuid
-                  ? useDataStore.getState().findSceneByUuid(newComment.scene_uuid)
-                  : null;
-                const body = newComment.text
-                  ? (newComment.text.length > 60 ? newComment.text.slice(0, 60) + '...' : newComment.text)
-                  : `${newComment.user_name || '누군가'}님 댓글`;
-                dispatchNotification({
-                  type: 'revision',
-                  title: `${isMentioned ? '리비전 댓글 멘션' : '리비전 댓글'} — ${sceneByUuid?.sceneId || newComment.scene_id || ''}`,
-                  body,
-                  metadata: {
-                    // 코덱스 P2 fix (8차, 2026-05-05): sceneByUuid 가 stale 캐시 등으로 null 일 때
-                    // newComment.scene_uuid 폴백 — 라우팅이 sceneId/sceneName 의존이라 누락 시 알림 클릭이 동작 안 함.
-                    sceneId: sceneByUuid?.id ?? newComment.scene_uuid,
-                    sceneName: sceneByUuid?.sceneId,
-                    commentSceneId: newComment.scene_id,
-                    commentPartId: newComment.part_id,
-                    revisionId: newComment.revision_id,
-                    revisionAction: 'comment',
-                  } as Record<string, unknown>,
-                }, notiSettings);
-              }).catch(() => { /* 무시 */ });
-            }
+          if (dispatchRevisionCommentNotification(newComment)) {
             // 리비전 맥락 댓글은 일반 댓글 알림 경로 스킵.
             // 코덱스 P2 fix (2026-05-10): early return *전* 캐시 무효화. 안 그러면 리비전 댓글이
             //   캐시에 stale 한 상태로 남아 일반 댓글 뷰에서 누락됨 (broadcast 가 늦거나 끊긴 케이스).
@@ -1902,6 +1919,7 @@ export default function App() {
           commentId: commentCid,
           parentCommentId: commentParent,
           partId: commentPartId,
+          revisionId: commentRevisionId,
         } = data.payload as {
           sceneId?: string;
           userName?: string;
@@ -1911,8 +1929,24 @@ export default function App() {
           commentId?: string | null;
           parentCommentId?: string | null;
           partId?: string | null;
+          revisionId?: string | null;
         };
         const me = useAuthStore.getState().currentUser;
+        if (commentRevisionId) {
+          dispatchRevisionCommentNotification({
+            id: commentCid,
+            scene_id: commentSceneNumber,
+            part_id: commentPartId,
+            user_name: commentUserName,
+            user_id: commentUserId,
+            text: commentText,
+            mentions: commentMentions,
+            revision_id: commentRevisionId,
+          });
+          invalidatePartCache();
+          window.dispatchEvent(new Event('bflow:comments-invalidated'));
+          return;
+        }
         if (me && commentUserId && commentUserId !== me.id && commentSceneNumber) {
           const dedupeKey = `comment:${commentUserId}:${commentSceneNumber}:${commentCid ?? ''}`;
           if (!dedupeNotification(dedupeKey)) { /* 이미 Realtime으로 처리됨 */ }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1240,8 +1240,14 @@ export default function App() {
                   rev = useRevisionStore.getState().revisions.find((r) => r.id === newComment.revision_id);
                   if (!rev) return;
                 }
-                const targets = Array.isArray(rev.notifyUserIds) ? rev.notifyUserIds : [];
-                if (!targets.includes(me.id)) return;
+                const revisionNotifyIds = Array.isArray(rev.notifyUserIds) ? rev.notifyUserIds : [];
+                const mentionedNames = Array.isArray(newComment.mentions) ? newComment.mentions : [];
+                const mentionedUserIds = useAuthStore.getState().users
+                  .filter((user) => mentionedNames.includes(user.name))
+                  .map((user) => user.id);
+                const targets = new Set([...revisionNotifyIds, ...mentionedUserIds]);
+                const isMentioned = mentionedNames.includes(me.name);
+                if (!targets.has(me.id)) return;
                 // dedupe — 같은 댓글이 broadcast/realtime 두 경로로 들어와도 한 번만.
                 // 코덱스 P1 fix (2026-05-05): commentId 포함. 같은 사용자가 같은 리비전에
                 // 짧은 시간 내 여러 댓글 작성 시 두 번째부터 dedupe 충돌로 알림 손실되던 문제.
@@ -1256,7 +1262,7 @@ export default function App() {
                   : `${newComment.user_name || '누군가'}님 댓글`;
                 dispatchNotification({
                   type: 'revision',
-                  title: `리비전 댓글 — ${sceneByUuid?.sceneId || newComment.scene_id || ''}`,
+                  title: `${isMentioned ? '리비전 댓글 멘션' : '리비전 댓글'} — ${sceneByUuid?.sceneId || newComment.scene_id || ''}`,
                   body,
                   metadata: {
                     // 코덱스 P2 fix (8차, 2026-05-05): sceneByUuid 가 stale 캐시 등으로 null 일 때

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,13 @@ import { setFeedbackLastSeenAt, setAssignmentLastSeenAt, getCommentReactionLastS
 import { buildReactionNotificationTitle } from '@/utils/commentReactionEmojiFormat';
 import { applyTheme, getPreset, getLightColors, deriveThemeFromAccent, sanitizeCustomHex, hexToRgb, DEFAULT_THEME_ID } from '@/themes';
 import { applyPreferencesToDOM, FONT_COLOR_PRESETS, applyTextColors } from '@/utils/typography';
-import { DEFAULT_STAR_NEST_SETTINGS, normalizeBackgroundArt, normalizeStarNestSettings } from '@/utils/starNestSettings';
+import {
+  DEFAULT_STAR_NEST_SETTINGS,
+  normalizeBackgroundArt,
+  normalizeDashboardStarNestBlurPx,
+  normalizeDashboardStarNestOpacity,
+  normalizeStarNestSettings,
+} from '@/utils/starNestSettings';
 import { WelcomeToast } from '@/components/WelcomeToast';
 import { UpdateCenterModal } from '@/components/update/UpdateCenterModal';
 import { getGreeting, isFirstLogin, markFirstLoginShown } from '@/utils/greetings';
@@ -401,6 +407,8 @@ export default function App() {
             starNest: legacyStarNest,
             loginStarNest: normalizeStarNestSettings(p.loginStarNest ?? legacyStarNest),
             dashboardStarNest: normalizeStarNestSettings(p.dashboardStarNest ?? legacyStarNest),
+            dashboardStarNestOpacity: normalizeDashboardStarNestOpacity(p.dashboardStarNestOpacity),
+            dashboardStarNestBlurPx: normalizeDashboardStarNestBlurPx(p.dashboardStarNestBlurPx),
           });
         }
 

--- a/src/components/auth/LoginScreen.tsx
+++ b/src/components/auth/LoginScreen.tsx
@@ -348,7 +348,7 @@ function LoginBackgroundArt() {
       <StarNestBackground
         enabled={plexusSettings.loginEnabled}
         fixed={false}
-        settings={plexusSettings.starNest}
+        settings={plexusSettings.loginStarNest ?? plexusSettings.starNest}
       />
     );
   }

--- a/src/components/common/CompactIconLabel.tsx
+++ b/src/components/common/CompactIconLabel.tsx
@@ -6,6 +6,9 @@ interface CompactIconLabelProps {
   label: string;
   className?: string;
   textClassName?: string;
+  iconClassName?: string;
+  iconPosition?: 'before' | 'after';
+  displayMode?: 'both' | 'text' | 'icon';
 }
 
 export function CompactIconLabel({
@@ -13,23 +16,42 @@ export function CompactIconLabel({
   label,
   className,
   textClassName,
+  iconClassName,
+  iconPosition = 'before',
+  displayMode = 'both',
 }: CompactIconLabelProps) {
+  const showIcon = displayMode !== 'text';
+  const showText = displayMode !== 'icon';
+  const iconNode = (
+    <span
+      data-compact-label-icon
+      aria-hidden="true"
+      className={cn('inline-flex shrink-0 items-center justify-center', iconClassName)}
+    >
+      {icon}
+    </span>
+  );
+  const textNode = (
+    <span
+      data-compact-label-text
+      className={cn('min-w-0 whitespace-nowrap', textClassName)}
+    >
+      {label}
+    </span>
+  );
+
   return (
     <span
       data-compact-icon-label
+      data-icon-position={iconPosition}
+      data-display-mode={displayMode}
       aria-label={label}
       title={label}
       className={cn('inline-flex min-w-0 items-center justify-center gap-1.5', className)}
     >
-      <span aria-hidden="true" className="inline-flex shrink-0 items-center justify-center">
-        {icon}
-      </span>
-      <span
-        data-compact-label-text
-        className={cn('min-w-0 whitespace-nowrap', textClassName)}
-      >
-        {label}
-      </span>
+      {iconPosition === 'before' && showIcon ? iconNode : null}
+      {showText ? textNode : null}
+      {iconPosition === 'after' && showIcon ? iconNode : null}
     </span>
   );
 }

--- a/src/components/effects/StarNestBackground.tsx
+++ b/src/components/effects/StarNestBackground.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { type CSSProperties, useEffect, useRef } from 'react';
 import { useAppStore } from '@/stores/useAppStore';
 import { DEFAULT_STAR_NEST_SETTINGS, normalizeStarNestSettings, type StarNestSettings } from '@/utils/starNestSettings';
 import { cn } from '@/utils/cn';
@@ -140,11 +140,13 @@ export function StarNestBackground({
   className,
   fixed = true,
   settings: settingsOverride,
+  style,
 }: {
   enabled?: boolean;
   className?: string;
   fixed?: boolean;
   settings?: Partial<StarNestSettings> | null;
+  style?: CSSProperties;
 }) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const rafRef = useRef(0);
@@ -275,7 +277,7 @@ export function StarNestBackground({
     <canvas
       ref={canvasRef}
       className={cn(fixed ? 'fixed inset-0 pointer-events-none' : 'absolute inset-0 pointer-events-none', className)}
-      style={{ width: '100%', height: '100%' }}
+      style={{ width: '100%', height: '100%', ...style }}
       aria-hidden="true"
     />
   );

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -36,7 +36,7 @@ export function Header({ onRefresh }: HeaderProps) {
     : '동기화 대기 중';
 
   return (
-    <header className="h-14 bg-bg-card border-b border-bg-border flex items-center justify-between px-6">
+    <header className="relative z-30 h-14 shrink-0 bg-bg-card border-b border-bg-border flex items-center justify-between px-6">
       {/* 왼쪽: 현재 뷰 제목 */}
       <h1 className="text-lg font-semibold">{headerTitle}</h1>
 

--- a/src/components/scenes/AttachmentImageLightbox.tsx
+++ b/src/components/scenes/AttachmentImageLightbox.tsx
@@ -87,18 +87,23 @@ export function AttachmentImageLightbox({
   useEffect(() => {
     if (!manageKeyboard) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
+      const claimKey = () => {
         e.preventDefault();
+        e.stopPropagation();
+        e.stopImmediatePropagation();
+      };
+      if (e.key === 'Escape') {
+        claimKey();
         closeLightbox();
         return;
       }
       if (e.key === 'ArrowLeft') {
-        e.preventDefault();
+        claimKey();
         lightboxStep(-1);
         return;
       }
       if (e.key === 'ArrowRight') {
-        e.preventDefault();
+        claimKey();
         lightboxStep(1);
       }
     };

--- a/src/components/scenes/AttachmentImageLightbox.tsx
+++ b/src/components/scenes/AttachmentImageLightbox.tsx
@@ -1,0 +1,272 @@
+import { useCallback, useEffect, useRef, useState, type MouseEvent } from 'react';
+import { createPortal } from 'react-dom';
+import { ChevronLeft, ChevronRight, X } from 'lucide-react';
+import { cn } from '@/utils/cn';
+import { formatCommentTime } from '@/utils/formatTime';
+import { ImageContextMenu, type ContextAction } from './ImageContextMenu';
+import { copyImageToClipboard, copyImageUrl, downloadImage } from '@/utils/imageActions';
+
+export interface AttachmentImageLightboxEntry {
+  url: string;
+  userName: string;
+  commentText: string;
+  createdAt: string;
+  commentId: string;
+}
+
+export interface AttachmentImageLightboxState {
+  entries: AttachmentImageLightboxEntry[];
+  index: number;
+}
+
+interface AttachmentImageLightboxProps {
+  lightbox: AttachmentImageLightboxState;
+  setLightbox: (
+    next: AttachmentImageLightboxState | null
+      | ((prev: AttachmentImageLightboxState | null) => AttachmentImageLightboxState | null)
+  ) => void;
+  closeLightbox: () => void;
+  lightboxStep: (dir: 1 | -1) => void;
+  sceneLabel?: string;
+  ariaLabel?: string;
+  fileNamePrefix?: string;
+  manageKeyboard?: boolean;
+}
+
+function sanitizeFileName(value: string): string {
+  return value.trim().replace(/[\\/:*?"<>|]+/g, '_').replace(/\s+/g, '_').slice(0, 80);
+}
+
+function inferImageExtension(url: string): string {
+  const dataMime = url.match(/^data:image\/([a-z0-9.+-]+);/i)?.[1];
+  if (dataMime) return dataMime === 'jpeg' ? 'jpg' : dataMime;
+  try {
+    const pathname = new URL(url).pathname;
+    const ext = pathname.match(/\.([a-z0-9]+)$/i)?.[1]?.toLowerCase();
+    if (ext && ['png', 'jpg', 'jpeg', 'webp', 'gif'].includes(ext)) {
+      return ext === 'jpeg' ? 'jpg' : ext;
+    }
+  } catch {
+    /* fallback below */
+  }
+  return 'png';
+}
+
+function buildDownloadFileName(
+  entry: AttachmentImageLightboxEntry,
+  index: number,
+  sceneLabel?: string,
+  fileNamePrefix?: string,
+): string {
+  const date = entry.createdAt ? entry.createdAt.slice(0, 10) : '';
+  const base = [
+    fileNamePrefix || sceneLabel || 'bflow-image',
+    entry.userName,
+    date,
+    String(index + 1).padStart(2, '0'),
+  ].filter(Boolean).join('_');
+  return `${sanitizeFileName(base) || 'bflow-image'}.${inferImageExtension(entry.url)}`;
+}
+
+export function AttachmentImageLightbox({
+  lightbox,
+  setLightbox,
+  closeLightbox,
+  lightboxStep,
+  sceneLabel,
+  ariaLabel = '이미지 확대 보기',
+  fileNamePrefix,
+  manageKeyboard = true,
+}: AttachmentImageLightboxProps) {
+  const stageRef = useRef<HTMLDivElement>(null);
+  const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number } | null>(null);
+  const current = lightbox.entries[lightbox.index];
+  const totalCount = lightbox.entries.length;
+  const showNav = totalCount > 1;
+
+  useEffect(() => {
+    if (!manageKeyboard) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        closeLightbox();
+        return;
+      }
+      if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        lightboxStep(-1);
+        return;
+      }
+      if (e.key === 'ArrowRight') {
+        e.preventDefault();
+        lightboxStep(1);
+      }
+    };
+    window.addEventListener('keydown', onKey, true);
+    return () => window.removeEventListener('keydown', onKey, true);
+  }, [closeLightbox, lightboxStep, manageKeyboard]);
+
+  const openContextMenu = useCallback((e: MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const rect = stageRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    setCtxMenu({
+      x: e.clientX - rect.left,
+      y: e.clientY - rect.top,
+    });
+  }, []);
+
+  const handleContextAction = useCallback((action: ContextAction) => {
+    if (!current) return;
+    const fileName = buildDownloadFileName(current, lightbox.index, sceneLabel, fileNamePrefix);
+    if (action === 'download') void downloadImage(current.url, fileName);
+    if (action === 'copy') void copyImageToClipboard(current.url);
+    if (action === 'copy-url') void copyImageUrl(current.url);
+  }, [current, fileNamePrefix, lightbox.index, sceneLabel]);
+
+  if (typeof document === 'undefined' || !current) return null;
+
+  return createPortal(
+    <div
+      className="comment-lightbox-backdrop cursor-zoom-out"
+      onClick={closeLightbox}
+      role="dialog"
+      aria-modal="true"
+      aria-label={ariaLabel}
+    >
+      <div
+        className="relative w-full h-full flex flex-col cursor-default"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex-shrink-0 flex items-center justify-between gap-3 px-6 pt-4 pb-2">
+          <div className="flex items-center gap-2 text-[12px] text-white/80 flex-wrap min-w-0">
+            {sceneLabel && (
+              <>
+                <span className="px-2 py-1 rounded bg-white/10 font-medium">{sceneLabel}</span>
+                <span className="text-white/40">·</span>
+              </>
+            )}
+            <span className="tabular-nums text-white/70">{lightbox.index + 1} / {totalCount}</span>
+          </div>
+          <button
+            type="button"
+            onClick={closeLightbox}
+            className="w-10 h-10 rounded-full bg-white/10 hover:bg-white/20 text-white flex items-center justify-center transition-colors cursor-pointer flex-shrink-0"
+            title="닫기 (ESC)"
+            aria-label="닫기"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        <div ref={stageRef} className="flex-1 relative flex items-center justify-center px-6 min-h-0">
+          {showNav && (
+            <button
+              type="button"
+              onClick={() => lightboxStep(-1)}
+              className="absolute left-4 top-1/2 -translate-y-1/2 z-10 w-12 h-12 rounded-full bg-white/10 hover:bg-white/25 text-white flex items-center justify-center transition-colors cursor-pointer"
+              title="이전 이미지 (←)"
+              aria-label="이전 이미지"
+            >
+              <ChevronLeft size={26} />
+            </button>
+          )}
+
+          <img
+            src={current.url}
+            alt={`${current.userName}의 이미지 ${lightbox.index + 1}/${totalCount}`}
+            className="comment-lightbox-image"
+            key={`${lightbox.index}-${current.url}`}
+            onContextMenu={openContextMenu}
+          />
+
+          {showNav && (
+            <button
+              type="button"
+              onClick={() => lightboxStep(1)}
+              className="absolute right-4 top-1/2 -translate-y-1/2 z-10 w-12 h-12 rounded-full bg-white/10 hover:bg-white/25 text-white flex items-center justify-center transition-colors cursor-pointer"
+              title="다음 이미지 (→)"
+              aria-label="다음 이미지"
+            >
+              <ChevronRight size={26} />
+            </button>
+          )}
+
+          {ctxMenu && (
+            <ImageContextMenu
+              open
+              x={ctxMenu.x}
+              y={ctxMenu.y}
+              containerWidth={stageRef.current?.clientWidth ?? 0}
+              containerHeight={stageRef.current?.clientHeight ?? 0}
+              actions={['download', 'copy', 'copy-url']}
+              onAction={handleContextAction}
+              onClose={() => setCtxMenu(null)}
+            />
+          )}
+        </div>
+
+        <div className="flex-shrink-0 px-6 pt-3 pb-2 max-w-3xl mx-auto w-full">
+          <div className="flex items-baseline gap-2 text-[12.5px] mb-1">
+            <span className="font-semibold text-white">{current.userName}</span>
+            <span className="text-white/50 text-[11px]">{formatCommentTime(current.createdAt)}</span>
+          </div>
+          {current.commentText && (
+            <p className="text-[13.5px] text-white/95 leading-relaxed whitespace-pre-wrap break-words max-h-24 overflow-y-auto comment-lightbox-thumb-strip">
+              {current.commentText}
+            </p>
+          )}
+        </div>
+
+        {showNav && (
+          <div
+            className="flex-shrink-0 px-6 py-3"
+            style={{ background: 'linear-gradient(to top, rgba(0,0,0,0.7), rgba(0,0,0,0.2))' }}
+          >
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-[11px] text-white/60 font-medium">이미지 {totalCount}장</span>
+              <span className="text-[11px] text-white/60">
+                <span className="px-1.5 py-0.5 rounded bg-white/10 mr-1">←</span>
+                <span className="px-1.5 py-0.5 rounded bg-white/10">→</span>
+                <span className="ml-2">키보드 이동</span>
+                <span className="mx-2 text-white/30">·</span>
+                <span className="px-1.5 py-0.5 rounded bg-white/10">ESC</span>
+                <span className="ml-1">닫기</span>
+              </span>
+            </div>
+            <div className="flex gap-2 overflow-x-auto pb-1 comment-lightbox-thumb-strip">
+              {lightbox.entries.map((entry, i) => {
+                const isActive = i === lightbox.index;
+                return (
+                  <button
+                    key={`${i}-${entry.commentId}-${entry.url}`}
+                    type="button"
+                    onClick={() => setLightbox((prev) => prev ? { ...prev, index: i } : prev)}
+                    onContextMenu={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      setLightbox((prev) => prev ? { ...prev, index: i } : prev);
+                      openContextMenu(e);
+                    }}
+                    className={cn(
+                      'flex-shrink-0 rounded-md overflow-hidden transition-all cursor-pointer',
+                      isActive ? 'comment-lightbox-thumb-active' : 'opacity-60 hover:opacity-100',
+                    )}
+                    style={{ width: 72, height: 72 }}
+                    aria-label={`${i + 1}번 이미지로 이동 (${entry.userName})`}
+                    aria-current={isActive ? 'true' : undefined}
+                    title={`${entry.userName}: ${entry.commentText.slice(0, 30)}`}
+                  >
+                    <img src={entry.url} alt="" className="w-full h-full object-cover" loading="lazy" />
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/scenes/CommentPanel.tsx
+++ b/src/components/scenes/CommentPanel.tsx
@@ -41,6 +41,7 @@ import {
   parseRevisionSlashCommand,
   type RevisionSlashContext,
 } from '@/utils/revisionSlashCommand';
+import { AttachmentImageLightbox } from './AttachmentImageLightbox';
 import { toast as sonnerToast } from 'sonner';
 import '@/styles/comment-panel.css';
 
@@ -1993,12 +1994,14 @@ export function CommentPanel({ sceneKey, secondarySceneKey, sceneThreadKey, onCo
 
       {/* v1.24.1: 라이트박스를 portal 로 body 직속 렌더 → 사이드바/모달 위에 항상 노출 */}
       {lightbox && (
-        <CommentLightboxPortal
+        <AttachmentImageLightbox
           lightbox={lightbox}
           setLightbox={setLightbox}
           closeLightbox={closeLightbox}
           lightboxStep={lightboxStep}
           sceneLabel={sceneLabel}
+          ariaLabel="댓글 이미지 확대 보기"
+          manageKeyboard={false}
         />
       )}
     </div>

--- a/src/components/scenes/CommentPanel.tsx
+++ b/src/components/scenes/CommentPanel.tsx
@@ -755,9 +755,21 @@ export function CommentPanel({ sceneKey, secondarySceneKey, sceneThreadKey, onCo
   const addAttachedImageFromBlob = useCallback((file: File | Blob) => {
     const id = crypto.randomUUID();
     const previewUrl = URL.createObjectURL(file);
-    setAttachedImages(prev => [...prev, { id, previewUrl, uploading: true }]);
+    setAttachedImages(prev => {
+      if (!quickRevisionActive) return [...prev, { id, previewUrl, uploading: true }];
+
+      prev.forEach((item) => {
+        try { URL.revokeObjectURL(item.previewUrl); } catch { /* ignore */ }
+        if (item.uploadedUrl) {
+          storageService.deleteImage(item.uploadedUrl).catch(err => {
+            console.warn('[빠른 리비전 첨부 교체] 이전 업로드 객체 정리 실패:', err);
+          });
+        }
+      });
+      return [{ id, previewUrl, uploading: true }];
+    });
     void uploadAttachedImage(id, file);
-  }, [uploadAttachedImage]);
+  }, [quickRevisionActive, uploadAttachedImage]);
 
   const removeAttachedImage = (id: string) => {
     setAttachedImages(prev => {
@@ -782,7 +794,7 @@ export function CommentPanel({ sceneKey, secondarySceneKey, sceneThreadKey, onCo
     const imageItems = items.filter(it => it.type.startsWith('image/'));
     if (imageItems.length === 0) return;
     e.preventDefault();
-    imageItems.forEach(it => {
+    (quickRevisionActive ? imageItems.slice(0, 1) : imageItems).forEach(it => {
       const f = it.getAsFile();
       if (f) addAttachedImageFromBlob(f);
     });
@@ -807,12 +819,12 @@ export function CommentPanel({ sceneKey, secondarySceneKey, sceneThreadKey, onCo
     dragCounter.current = 0;
     setDraggingOver(false);
     const files = Array.from(e.dataTransfer.files || []).filter(f => f.type.startsWith('image/'));
-    files.forEach(addAttachedImageFromBlob);
+    (quickRevisionActive ? files.slice(0, 1) : files).forEach(addAttachedImageFromBlob);
   };
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files || []).filter(f => f.type.startsWith('image/'));
-    files.forEach(addAttachedImageFromBlob);
+    (quickRevisionActive ? files.slice(0, 1) : files).forEach(addAttachedImageFromBlob);
     e.target.value = '';
   };
 
@@ -822,7 +834,6 @@ export function CommentPanel({ sceneKey, secondarySceneKey, sceneThreadKey, onCo
   const canSubmit = quickRevisionActive
     ? !submitting
       && !hasUploadingImage
-      && !quickRevisionHasAttachments
       && quickRevisionDescription.length > 0
       && quickRevisionNotifyIds.length > 0
     : !submitting
@@ -833,10 +844,14 @@ export function CommentPanel({ sceneKey, secondarySceneKey, sceneThreadKey, onCo
     if (!canSubmit || !currentUser) return;
     if (quickRevisionActive && quickRevision) {
       setSubmitting(true);
+      const prevAttached = attachedImages;
+      const revisionImageUrl = uploadedImageUrls[0];
+      const unusedUploadedImageUrls = uploadedImageUrls.slice(1);
       try {
         await createRevision({
           sceneKey: quickRevision.sceneKey,
           description: quickRevisionDescription,
+          imageUrl: revisionImageUrl,
           department: quickRevision.department,
           lookupDepartment: quickRevision.department,
           requesterId: currentUser.id,
@@ -845,9 +860,19 @@ export function CommentPanel({ sceneKey, secondarySceneKey, sceneThreadKey, onCo
         });
         setInput('');
         inputValueRef.current = '';
+        setAttachedImages([]);
+        attachedImagesRef.current = [];
         setQuickRevisionPickerOpen(false);
         setShowMentions(false);
         setReplyTarget(null);
+        prevAttached.forEach((item) => {
+          try { URL.revokeObjectURL(item.previewUrl); } catch { /* ignore */ }
+        });
+        unusedUploadedImageUrls.forEach((url) => {
+          storageService.deleteImage(url).catch(err => {
+            console.warn('[빠른 리비전 등록] 미사용 업로드 객체 정리 실패:', err);
+          });
+        });
         const targetNames = quickRevisionSelectedUsers.map((user) => user.name).join(', ');
         sonnerToast.success('리비전을 등록했습니다', {
           description: targetNames ? `${targetNames}에게 알림을 보냈습니다.` : undefined,
@@ -1783,8 +1808,8 @@ export function CommentPanel({ sceneKey, secondarySceneKey, sceneThreadKey, onCo
                 </div>
 
                 {quickRevisionHasAttachments && (
-                  <div className="rounded-lg border border-status-none/30 bg-status-none/10 px-2.5 py-2 text-[11px] text-status-none">
-                    빠른 리비전은 텍스트만 등록합니다. 이미지는 리비전 탭의 정식 등록 폼에서 첨부해 주세요.
+                  <div className="rounded-lg border border-accent/30 bg-accent/10 px-2.5 py-2 text-[11px] text-accent-sub">
+                    첨부 이미지가 리비전 이미지로 함께 등록됩니다.
                   </div>
                 )}
 
@@ -1920,12 +1945,10 @@ export function CommentPanel({ sceneKey, secondarySceneKey, sceneThreadKey, onCo
           <div className="flex items-center justify-between mt-1.5 pt-1.5 border-t border-bg-border/40 shrink-0">
             <button
               onClick={() => {
-                if (quickRevisionActive) return;
                 fileInputRef.current?.click();
               }}
-              disabled={quickRevisionActive}
-              className="w-7 h-7 rounded-md flex items-center justify-center text-text-secondary hover:bg-bg-card hover:text-text-primary disabled:opacity-35 disabled:cursor-not-allowed transition-colors cursor-pointer"
-              title={quickRevisionActive ? '빠른 리비전은 텍스트만 지원합니다' : '이미지 첨부'}
+              className="w-7 h-7 rounded-md flex items-center justify-center text-text-secondary hover:bg-bg-card hover:text-text-primary transition-colors cursor-pointer"
+              title="이미지 첨부"
             >
               <Paperclip size={14} />
             </button>
@@ -1935,9 +1958,7 @@ export function CommentPanel({ sceneKey, secondarySceneKey, sceneThreadKey, onCo
               className="w-7 h-7 rounded-md flex items-center justify-center bg-accent hover:bg-accent-sub text-white disabled:opacity-30 disabled:cursor-not-allowed transition-colors cursor-pointer"
               title={
                 quickRevisionActive
-                  ? quickRevisionHasAttachments
-                    ? '이미지는 리비전 탭에서 첨부해 주세요'
-                    : quickRevisionNotifyIds.length === 0
+                  ? quickRevisionNotifyIds.length === 0
                       ? '알람 보낼 담당자를 선택해 주세요'
                       : '리비전 등록 (Enter)'
                   : hasUploadingImage ? '이미지 업로드 중...' : '전송 (Enter)'
@@ -1964,7 +1985,7 @@ export function CommentPanel({ sceneKey, secondarySceneKey, sceneThreadKey, onCo
               이미지를 여기에 놓으세요
             </div>
             <div className="text-[11px] text-text-secondary">
-              여러 장을 한 번에 첨부할 수 있어요
+              {quickRevisionActive ? '빠른 리비전 이미지로 첨부됩니다' : '여러 장을 한 번에 첨부할 수 있어요'}
             </div>
           </div>
         </div>

--- a/src/components/scenes/CommentPanel.tsx
+++ b/src/components/scenes/CommentPanel.tsx
@@ -848,6 +848,8 @@ export function CommentPanel({ sceneKey, secondarySceneKey, sceneThreadKey, onCo
       const prevAttached = attachedImages;
       const revisionImageUrl = uploadedImageUrls[0];
       const unusedUploadedImageUrls = uploadedImageUrls.slice(1);
+      setAttachedImages([]);
+      attachedImagesRef.current = [];
       try {
         await createRevision({
           sceneKey: quickRevision.sceneKey,
@@ -861,8 +863,6 @@ export function CommentPanel({ sceneKey, secondarySceneKey, sceneThreadKey, onCo
         });
         setInput('');
         inputValueRef.current = '';
-        setAttachedImages([]);
-        attachedImagesRef.current = [];
         setQuickRevisionPickerOpen(false);
         setShowMentions(false);
         setReplyTarget(null);
@@ -881,6 +881,32 @@ export function CommentPanel({ sceneKey, secondarySceneKey, sceneThreadKey, onCo
         });
       } catch (err) {
         console.error('[리비전 빠른 등록 실패]', err);
+        if (!mountedRef.current) {
+          prevAttached.forEach((item) => {
+            try { URL.revokeObjectURL(item.previewUrl); } catch { /* ignore */ }
+            if (item.uploadedUrl) {
+              storageService.deleteImage(item.uploadedUrl).catch(err2 => {
+                console.warn('[리비전 빠른 등록 실패 + unmount] storage 정리 실패:', err2);
+              });
+            }
+          });
+          return;
+        }
+
+        const userStartedNew = attachedImagesRef.current.length > 0;
+        if (userStartedNew) {
+          prevAttached.forEach((item) => {
+            try { URL.revokeObjectURL(item.previewUrl); } catch { /* ignore */ }
+            if (item.uploadedUrl) {
+              storageService.deleteImage(item.uploadedUrl).catch(err2 => {
+                console.warn('[리비전 빠른 등록 실패 롤백] 버려진 업로드 객체 정리 실패:', err2);
+              });
+            }
+          });
+        } else {
+          setAttachedImages(prevAttached);
+          attachedImagesRef.current = prevAttached;
+        }
         sonnerToast.error('리비전 등록 실패', {
           description: err instanceof Error ? err.message : '잠시 후 다시 시도해 주세요.',
         });

--- a/src/components/scenes/ImageContextMenu.tsx
+++ b/src/components/scenes/ImageContextMenu.tsx
@@ -17,12 +17,14 @@ interface ImageContextMenuProps {
   y: number;
   containerWidth: number;
   containerHeight: number;
+  actions?: ContextAction[];
   onAction: (action: ContextAction) => void;
   onClose: () => void;
 }
 
 const MENU_W = 220;
-const MENU_H = 200;
+const MENU_ITEM_H = 40;
+const MENU_PADDING_H = 12;
 
 export function ImageContextMenu({
   open,
@@ -30,10 +32,13 @@ export function ImageContextMenu({
   y,
   containerWidth,
   containerHeight,
+  actions,
   onAction,
   onClose,
 }: ImageContextMenuProps) {
   const ref = useRef<HTMLDivElement>(null);
+  const enabledActions = actions ?? ['download', 'copy', 'copy-url', 'annotate'];
+  const showAnnotate = enabledActions.includes('annotate');
 
   useEffect(() => {
     if (!open) return;
@@ -66,8 +71,9 @@ export function ImageContextMenu({
   if (!open) return null;
 
   // 경계 보정 — 메뉴가 컨테이너 밖으로 벗어나지 않게
+  const menuHeight = enabledActions.length * MENU_ITEM_H + MENU_PADDING_H + (showAnnotate ? 5 : 0);
   const left = Math.max(4, Math.min(x, containerWidth - MENU_W - 4));
-  const top = Math.max(4, Math.min(y, containerHeight - MENU_H - 4));
+  const top = Math.max(4, Math.min(y, containerHeight - menuHeight - 4));
 
   const Item = ({
     icon: Icon,
@@ -106,11 +112,21 @@ export function ImageContextMenu({
       onClick={(e) => e.stopPropagation()}
       onContextMenu={(e) => e.preventDefault()}
     >
-      <Item icon={Download} label="다운로드" action="download" shortcut="Ctrl+S" />
-      <Item icon={Copy} label="이미지 복사" action="copy" shortcut="Ctrl+C" />
-      <Item icon={LinkIcon} label="이미지 URL 복사" action="copy-url" />
-      <div className="h-px bg-bg-border/50 my-1" />
-      <Item icon={Edit3} label="주석 새 버전으로 그리기" action="annotate" />
+      {enabledActions.includes('download') && (
+        <Item icon={Download} label="다운로드" action="download" shortcut="Ctrl+S" />
+      )}
+      {enabledActions.includes('copy') && (
+        <Item icon={Copy} label="이미지 복사" action="copy" shortcut="Ctrl+C" />
+      )}
+      {enabledActions.includes('copy-url') && (
+        <Item icon={LinkIcon} label="이미지 URL 복사" action="copy-url" />
+      )}
+      {showAnnotate && (
+        <>
+          <div className="h-px bg-bg-border/50 my-1" />
+          <Item icon={Edit3} label="주석 새 버전으로 그리기" action="annotate" />
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/scenes/RevisionCommentThread.tsx
+++ b/src/components/scenes/RevisionCommentThread.tsx
@@ -13,8 +13,9 @@
  *   - 입력 placeholder: "re# 댓글 남기기..." (italic 금지 — placeholder 자체는 브라우저 기본 처리)
  */
 
-import { useCallback, useEffect, useState } from 'react';
-import { ArrowUp } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { ChangeEvent, ClipboardEvent } from 'react';
+import { ArrowUp, Paperclip, X } from 'lucide-react';
 import { useAuthStore } from '@/stores/useAuthStore';
 import { useRevisionStore } from '@/stores/useRevisionStore';
 import {
@@ -24,6 +25,8 @@ import {
 } from '@/services/commentService';
 import { revisionNoToLabel } from '@/constants/revision';
 import { formatCommentTime } from '@/utils/formatTime';
+import * as storageService from '@/services/storageService';
+import { resizeBlob } from '@/utils/imageUtils';
 
 interface Props {
   revisionId: string;
@@ -37,6 +40,19 @@ interface Props {
    * (이슈: 2026-05-04, RevisionPanel 의 buildSceneKey 결과를 그대로 전달하던 v1.18.0 버그).
    */
   sceneKey: string;
+}
+
+interface AttachedImage {
+  id: string;
+  previewUrl: string;
+  uploadedUrl?: string;
+  uploading: boolean;
+  error?: string;
+}
+
+function parseSceneKey(sceneKey: string): { sheetName: string; sceneId: string } {
+  const idx = sceneKey.lastIndexOf(':');
+  return { sheetName: sceneKey.substring(0, idx), sceneId: sceneKey.substring(idx + 1) };
 }
 
 // 사용자 ID 해시 → 일관된 아바타 색 (RevisionRecipientPicker 와 동일 팔레트)
@@ -58,11 +74,34 @@ export function RevisionCommentThread({ revisionId, sceneKey }: Props) {
   const { currentUser } = useAuthStore();
   const revision = useRevisionStore(s => s.revisions.find(r => r.id === revisionId));
   const revisionLabel = revision ? revisionNoToLabel(revision.revisionNo) : 're?';
+  const { sheetName, sceneId } = useMemo(() => parseSceneKey(sceneKey), [sceneKey]);
 
   const [allComments, setAllComments] = useState<SceneComment[]>([]);
   const [draft, setDraft] = useState('');
   const [expanded, setExpanded] = useState(true);
   const [submitting, setSubmitting] = useState(false);
+  const [attachedImages, setAttachedImages] = useState<AttachedImage[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const attachedImagesRef = useRef<AttachedImage[]>([]);
+  const draftRef = useRef('');
+  const mountedRef = useRef(true);
+
+  useEffect(() => { attachedImagesRef.current = attachedImages; }, [attachedImages]);
+  useEffect(() => { draftRef.current = draft; }, [draft]);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      attachedImagesRef.current.forEach((item) => {
+        try { URL.revokeObjectURL(item.previewUrl); } catch { /* ignore */ }
+        if (item.uploadedUrl) {
+          storageService.deleteImage(item.uploadedUrl).catch(err => {
+            console.warn('[리비전 댓글 첨부 unmount] draft Storage 정리 실패:', err);
+          });
+        }
+      });
+    };
+  }, []);
 
   // 이 리비전 맥락 댓글만 필터 (시간순)
   const comments = allComments
@@ -102,8 +141,91 @@ export function RevisionCommentThread({ revisionId, sceneKey }: Props) {
     return () => window.removeEventListener('bflow:expand-revision', onExpand);
   }, [revisionId]);
 
+  const uploadAttachedImage = useCallback(async (id: string, file: File | Blob) => {
+    try {
+      const base64 = await resizeBlob(file, 800, 0.8);
+      const result = await storageService.uploadImage(sheetName, sceneId, 'comment', base64);
+      if (!result.ok || !result.url) throw new Error(result.error || '업로드 실패');
+
+      const url = result.url;
+      if (!mountedRef.current) {
+        storageService.deleteImage(url).catch(err => {
+          console.warn('[리비전 댓글 첨부 unmount race] 정리 실패:', err);
+        });
+        return;
+      }
+
+      setAttachedImages(prev => {
+        const exists = prev.some(item => item.id === id);
+        if (!exists) {
+          storageService.deleteImage(url).catch(err => {
+            console.warn('[리비전 댓글 첨부 race] 제거 후 도착한 업로드 객체 정리 실패:', err);
+          });
+          return prev;
+        }
+        return prev.map(item =>
+          item.id === id ? { ...item, uploadedUrl: url, uploading: false } : item
+        );
+      });
+    } catch (err) {
+      console.error('[리비전 댓글 이미지 업로드 실패]', err);
+      if (!mountedRef.current) return;
+      const message = err instanceof Error ? err.message : String(err);
+      setAttachedImages(prev => prev.map(item =>
+        item.id === id ? { ...item, uploading: false, error: message } : item
+      ));
+    }
+  }, [sceneId, sheetName]);
+
+  const addAttachedImageFromBlob = useCallback((file: File | Blob) => {
+    const id = crypto.randomUUID();
+    const previewUrl = URL.createObjectURL(file);
+    setAttachedImages(prev => [...prev, { id, previewUrl, uploading: true }]);
+    void uploadAttachedImage(id, file);
+  }, [uploadAttachedImage]);
+
+  const removeAttachedImage = useCallback((id: string) => {
+    setAttachedImages(prev => {
+      const target = prev.find(item => item.id === id);
+      if (target?.previewUrl) {
+        try { URL.revokeObjectURL(target.previewUrl); } catch { /* ignore */ }
+      }
+      if (target?.uploadedUrl) {
+        storageService.deleteImage(target.uploadedUrl).catch(err => {
+          console.warn('[리비전 댓글 첨부 제거] Storage 삭제 실패:', err);
+        });
+      }
+      return prev.filter(item => item.id !== id);
+    });
+  }, []);
+
+  const handlePaste = useCallback((e: ClipboardEvent<HTMLElement>) => {
+    const imageItems = Array.from(e.clipboardData?.items || [])
+      .filter(item => item.type.startsWith('image/'));
+    if (imageItems.length === 0) return;
+
+    e.preventDefault();
+    imageItems.forEach((item) => {
+      const file = item.getAsFile();
+      if (file) addAttachedImageFromBlob(file);
+    });
+  }, [addAttachedImageFromBlob]);
+
+  const handleFileChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files || []).filter(file => file.type.startsWith('image/'));
+    files.forEach(addAttachedImageFromBlob);
+    e.target.value = '';
+  }, [addAttachedImageFromBlob]);
+
+  const hasUploadingImage = attachedImages.some(item => item.uploading);
+  const uploadedImageUrls = attachedImages.map(item => item.uploadedUrl).filter((url): url is string => !!url);
+  const canSend = Boolean(currentUser)
+    && !submitting
+    && !hasUploadingImage
+    && (draft.trim().length > 0 || uploadedImageUrls.length > 0);
+
   async function send() {
-    if (!draft.trim() || !currentUser || submitting) return;
+    if (!canSend || !currentUser) return;
     setSubmitting(true);
 
     const newComment: SceneComment = {
@@ -112,7 +234,7 @@ export function RevisionCommentThread({ revisionId, sceneKey }: Props) {
       userName: currentUser.name,
       text: draft.trim(),
       mentions: [],
-      images: [],
+      images: uploadedImageUrls,
       createdAt: new Date().toISOString(),
       // v1.18.0 핵심: 이 댓글은 해당 리비전 맥락에 속함.
       // commentService.addComment → supabase:add-comment IPC → addComment(... revisionId)
@@ -123,15 +245,50 @@ export function RevisionCommentThread({ revisionId, sceneKey }: Props) {
     // 낙관적 UI
     setAllComments(prev => [...prev, newComment]);
     const prevDraft = draft;
+    const prevAttached = attachedImages;
     setDraft('');
+    draftRef.current = '';
+    setAttachedImages([]);
+    attachedImagesRef.current = [];
 
     try {
       await addComment(sceneKey, newComment);
+      prevAttached.forEach((item) => {
+        try { URL.revokeObjectURL(item.previewUrl); } catch { /* ignore */ }
+      });
     } catch (err) {
       console.error('[리비전 댓글 스레드] 전송 실패:', err);
+
+      if (!mountedRef.current) {
+        prevAttached.forEach((item) => {
+          try { URL.revokeObjectURL(item.previewUrl); } catch { /* ignore */ }
+          if (item.uploadedUrl) {
+            storageService.deleteImage(item.uploadedUrl).catch(err2 => {
+              console.warn('[리비전 댓글 전송 실패 + unmount] storage 정리 실패:', err2);
+            });
+          }
+        });
+        return;
+      }
+
       // 롤백
       setAllComments(prev => prev.filter(c => c.id !== newComment.id));
-      setDraft(prevDraft);
+      const userStartedNewDraft = draftRef.current.length > 0 || attachedImagesRef.current.length > 0;
+      if (userStartedNewDraft) {
+        prevAttached.forEach((item) => {
+          try { URL.revokeObjectURL(item.previewUrl); } catch { /* ignore */ }
+          if (item.uploadedUrl) {
+            storageService.deleteImage(item.uploadedUrl).catch(err2 => {
+              console.warn('[리비전 댓글 전송 실패 롤백] 버려진 업로드 객체 정리 실패:', err2);
+            });
+          }
+        });
+      } else {
+        setDraft(prevDraft);
+        draftRef.current = prevDraft;
+        setAttachedImages(prevAttached);
+        attachedImagesRef.current = prevAttached;
+      }
     } finally {
       setSubmitting(false);
     }
@@ -170,30 +327,83 @@ export function RevisionCommentThread({ revisionId, sceneKey }: Props) {
           >
             {currentUser.name.charAt(0)}
           </span>
-          <div className="flex-1 flex gap-2">
-            <input
-              type="text"
-              value={draft}
-              onChange={e => setDraft(e.target.value)}
-              onKeyDown={e => {
-                if (e.key === 'Enter' && !e.shiftKey) {
-                  e.preventDefault();
-                  send();
-                }
-              }}
-              placeholder={`${revisionLabel} 댓글 남기기...`}
-              className="flex-1 px-3 py-1.5 bg-bg-primary/80 border border-bg-border/60 rounded text-[12px] text-text-primary placeholder:text-text-secondary/50 focus:outline-none focus:border-accent/60"
-            />
-            <button
-              type="button"
-              onClick={send}
-              disabled={!draft.trim() || submitting}
-              className="px-3 py-1.5 text-[11px] font-bold rounded-md bg-accent text-white hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer transition-opacity inline-flex items-center gap-1"
-              title="댓글 전송 (Enter)"
-            >
-              <ArrowUp size={11} strokeWidth={3} />
-              전송
-            </button>
+          <div className="flex-1 min-w-0 space-y-2" onPaste={handlePaste}>
+            {attachedImages.length > 0 && (
+              <div className="flex gap-2 overflow-x-auto pb-0.5">
+                {attachedImages.map((image) => (
+                  <div key={image.id} className="relative flex-shrink-0">
+                    <img
+                      src={image.previewUrl}
+                      alt=""
+                      className="w-14 h-14 rounded-md object-cover border border-bg-border/60"
+                    />
+                    {image.uploading && (
+                      <div className="absolute inset-0 rounded-md bg-black/45 flex items-center justify-center">
+                        <div className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                      </div>
+                    )}
+                    {image.error && (
+                      <div
+                        className="absolute inset-0 rounded-md bg-red-500/45 flex items-center justify-center"
+                        title={`업로드 실패: ${image.error}`}
+                      >
+                        <X size={16} className="text-white" />
+                      </div>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => removeAttachedImage(image.id)}
+                      className="absolute -top-1.5 -right-1.5 w-5 h-5 rounded-full bg-red-500 text-white flex items-center justify-center hover:scale-105 transition-transform cursor-pointer"
+                      style={{ border: '2px solid rgb(var(--color-bg-card))' }}
+                      title="첨부 제거"
+                    >
+                      <X size={11} strokeWidth={3} />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+            <div className="flex gap-2">
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                multiple
+                hidden
+                onChange={handleFileChange}
+              />
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                className="w-8 h-8 rounded-md border border-bg-border/60 bg-bg-primary/70 text-text-secondary hover:text-text-primary hover:border-accent/50 hover:bg-bg-primary transition-colors inline-flex items-center justify-center cursor-pointer"
+                title="이미지 첨부"
+              >
+                <Paperclip size={13} />
+              </button>
+              <input
+                type="text"
+                value={draft}
+                onChange={e => setDraft(e.target.value)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter' && !e.shiftKey) {
+                    e.preventDefault();
+                    send();
+                  }
+                }}
+                placeholder={`${revisionLabel} 댓글 남기기... (Ctrl+V)`}
+                className="flex-1 min-w-0 px-3 py-1.5 bg-bg-primary/80 border border-bg-border/60 rounded text-[12px] text-text-primary placeholder:text-text-secondary/50 focus:outline-none focus:border-accent/60"
+              />
+              <button
+                type="button"
+                onClick={send}
+                disabled={!canSend}
+                className="px-3 py-1.5 text-[11px] font-bold rounded-md bg-accent text-white hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer transition-opacity inline-flex items-center gap-1"
+                title={hasUploadingImage ? '이미지 업로드 중...' : '댓글 전송 (Enter)'}
+              >
+                <ArrowUp size={11} strokeWidth={3} />
+                전송
+              </button>
+            </div>
           </div>
         </div>
       )}
@@ -229,9 +439,32 @@ function CommentBubble({ comment, isMe }: { comment: SceneComment; isMe: boolean
           {formatCommentTime(comment.createdAt)}
         </span>
       </div>
-      <div className="text-[12px] text-text-primary whitespace-pre-wrap leading-relaxed">
-        {comment.text}
-      </div>
+      {comment.text && (
+        <div className="text-[12px] text-text-primary whitespace-pre-wrap leading-relaxed">
+          {comment.text}
+        </div>
+      )}
+      {(comment.images?.length ?? 0) > 0 && (
+        <div className={`mt-2 grid gap-1.5 ${comment.images!.length === 1 ? 'grid-cols-1' : 'grid-cols-2'}`}>
+          {comment.images!.map((url, index) => (
+            <a
+              key={`${url}-${index}`}
+              href={url}
+              target="_blank"
+              rel="noreferrer"
+              className="block rounded-md overflow-hidden border border-bg-border/60 bg-bg-secondary/40"
+              title="이미지 열기"
+            >
+              <img
+                src={url}
+                alt=""
+                className="w-full max-h-32 object-cover"
+                loading="lazy"
+              />
+            </a>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/scenes/RevisionCommentThread.tsx
+++ b/src/components/scenes/RevisionCommentThread.tsx
@@ -31,6 +31,11 @@ import * as storageService from '@/services/storageService';
 import { resizeBlob } from '@/utils/imageUtils';
 import { sendMentionWebhook } from '@/services/slackWebhookService';
 import { PathLinkifiedText } from '@/components/common/PathLinkifiedText';
+import {
+  AttachmentImageLightbox,
+  type AttachmentImageLightboxEntry,
+  type AttachmentImageLightboxState,
+} from './AttachmentImageLightbox';
 
 interface Props {
   revisionId: string;
@@ -89,6 +94,7 @@ export function RevisionCommentThread({ revisionId, sceneKey }: Props) {
   const [showMentions, setShowMentions] = useState(false);
   const [mentionFilter, setMentionFilter] = useState('');
   const [mentionIndex, setMentionIndex] = useState(0);
+  const [lightbox, setLightbox] = useState<AttachmentImageLightboxState | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const mentionDropdownRef = useRef<HTMLDivElement>(null);
@@ -124,6 +130,38 @@ export function RevisionCommentThread({ revisionId, sceneKey }: Props) {
   const comments = allComments
     .filter(c => c.revisionId === revisionId)
     .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+
+  const openLightbox = useCallback((clickedUrl: string, clickedComment: SceneComment) => {
+    const entries: AttachmentImageLightboxEntry[] = [];
+    for (const c of comments) {
+      if (!c.images || c.images.length === 0) continue;
+      for (const url of c.images) {
+        entries.push({
+          url,
+          userName: c.userName,
+          commentText: c.text,
+          createdAt: c.createdAt,
+          commentId: c.id,
+        });
+      }
+    }
+    if (entries.length === 0) return;
+    let clickIdx = entries.findIndex(
+      (entry) => entry.commentId === clickedComment.id && entry.url === clickedUrl,
+    );
+    if (clickIdx < 0) clickIdx = entries.findIndex((entry) => entry.url === clickedUrl);
+    setLightbox({ entries, index: clickIdx < 0 ? 0 : clickIdx });
+  }, [comments]);
+
+  const closeLightbox = useCallback(() => setLightbox(null), []);
+  const lightboxStep = useCallback((dir: 1 | -1) => {
+    setLightbox((prev) => {
+      if (!prev) return prev;
+      const len = prev.entries.length;
+      if (len <= 1) return prev;
+      return { ...prev, index: (prev.index + dir + len) % len };
+    });
+  }, []);
 
   // 댓글 로드 — sceneKey 의 모든 댓글을 가져와서 revisionId 로 필터링
   const loadComments = useCallback(() => {
@@ -383,6 +421,7 @@ export function RevisionCommentThread({ revisionId, sceneKey }: Props) {
           comment={c}
           isMe={c.userId === currentUser?.id}
           users={users}
+          onImageClick={openLightbox}
           onMentionClick={(userName) => {
             setHighlightUserName(userName);
             setView('team');
@@ -523,6 +562,17 @@ export function RevisionCommentThread({ revisionId, sceneKey }: Props) {
           </div>
         </div>
       )}
+      {lightbox && (
+        <AttachmentImageLightbox
+          lightbox={lightbox}
+          setLightbox={setLightbox}
+          closeLightbox={closeLightbox}
+          lightboxStep={lightboxStep}
+          sceneLabel={`${revisionLabel} 댓글`}
+          ariaLabel="리비전 댓글 이미지 확대 보기"
+          fileNamePrefix={`${revisionLabel}-comment`}
+        />
+      )}
     </div>
   );
 }
@@ -533,11 +583,13 @@ function CommentBubble({
   comment,
   isMe,
   users,
+  onImageClick,
   onMentionClick,
 }: {
   comment: SceneComment;
   isMe: boolean;
   users: { name: string }[];
+  onImageClick: (url: string, comment: SceneComment) => void;
   onMentionClick: (userName: string) => void;
 }) {
   const renderMentionInSegment = (segment: string, baseIdx: number) => {
@@ -596,13 +648,12 @@ function CommentBubble({
       {(comment.images?.length ?? 0) > 0 && (
         <div className={`mt-2 grid gap-1.5 ${comment.images!.length === 1 ? 'grid-cols-1' : 'grid-cols-2'}`}>
           {comment.images!.map((url, index) => (
-            <a
+            <button
+              type="button"
               key={`${url}-${index}`}
-              href={url}
-              target="_blank"
-              rel="noreferrer"
-              className="block rounded-md overflow-hidden border border-bg-border/60 bg-bg-secondary/40"
-              title="이미지 열기"
+              onClick={() => onImageClick(url, comment)}
+              className="block rounded-md overflow-hidden border border-bg-border/60 bg-bg-secondary/40 cursor-zoom-in hover:opacity-90 transition-opacity"
+              title="이미지 확대"
             >
               <img
                 src={url}
@@ -610,7 +661,7 @@ function CommentBubble({
                 className="w-full max-h-32 object-cover"
                 loading="lazy"
               />
-            </a>
+            </button>
           ))}
         </div>
       )}

--- a/src/components/scenes/RevisionCommentThread.tsx
+++ b/src/components/scenes/RevisionCommentThread.tsx
@@ -17,9 +17,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ChangeEvent, ClipboardEvent } from 'react';
 import { ArrowUp, Paperclip, X } from 'lucide-react';
 import { useAuthStore } from '@/stores/useAuthStore';
+import { useAppStore } from '@/stores/useAppStore';
 import { useRevisionStore } from '@/stores/useRevisionStore';
 import {
   addComment,
+  extractMentions,
   getComments,
   type SceneComment,
 } from '@/services/commentService';
@@ -27,6 +29,8 @@ import { revisionNoToLabel } from '@/constants/revision';
 import { formatCommentTime } from '@/utils/formatTime';
 import * as storageService from '@/services/storageService';
 import { resizeBlob } from '@/utils/imageUtils';
+import { sendMentionWebhook } from '@/services/slackWebhookService';
+import { PathLinkifiedText } from '@/components/common/PathLinkifiedText';
 
 interface Props {
   revisionId: string;
@@ -71,7 +75,8 @@ function avatarColor(id: string): string {
 // ─── 메인 컴포넌트 ──────────────────────────────────────────────────────
 
 export function RevisionCommentThread({ revisionId, sceneKey }: Props) {
-  const { currentUser } = useAuthStore();
+  const { currentUser, users } = useAuthStore();
+  const { setView, setHighlightUserName } = useAppStore();
   const revision = useRevisionStore(s => s.revisions.find(r => r.id === revisionId));
   const revisionLabel = revision ? revisionNoToLabel(revision.revisionNo) : 're?';
   const { sheetName, sceneId } = useMemo(() => parseSceneKey(sceneKey), [sceneKey]);
@@ -81,13 +86,25 @@ export function RevisionCommentThread({ revisionId, sceneKey }: Props) {
   const [expanded, setExpanded] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [attachedImages, setAttachedImages] = useState<AttachedImage[]>([]);
+  const [showMentions, setShowMentions] = useState(false);
+  const [mentionFilter, setMentionFilter] = useState('');
+  const [mentionIndex, setMentionIndex] = useState(0);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const mentionDropdownRef = useRef<HTMLDivElement>(null);
   const attachedImagesRef = useRef<AttachedImage[]>([]);
   const draftRef = useRef('');
   const mountedRef = useRef(true);
 
   useEffect(() => { attachedImagesRef.current = attachedImages; }, [attachedImages]);
   useEffect(() => { draftRef.current = draft; }, [draft]);
+  useEffect(() => {
+    if (!showMentions) return;
+    const container = mentionDropdownRef.current;
+    if (!container) return;
+    const items = container.querySelectorAll('button');
+    items[mentionIndex]?.scrollIntoView({ block: 'nearest' });
+  }, [mentionIndex, showMentions]);
   useEffect(() => {
     mountedRef.current = true;
     return () => {
@@ -217,6 +234,36 @@ export function RevisionCommentThread({ revisionId, sceneKey }: Props) {
     e.target.value = '';
   }, [addAttachedImageFromBlob]);
 
+  const handleDraftChange = useCallback((text: string) => {
+    setDraft(text);
+    const lastAt = text.lastIndexOf('@');
+    if (lastAt >= 0) {
+      const afterAt = text.slice(lastAt + 1);
+      if (!afterAt.includes(' ') && afterAt.length < 20) {
+        setShowMentions(true);
+        setMentionFilter(afterAt.toLowerCase());
+        setMentionIndex(0);
+        return;
+      }
+    }
+    setShowMentions(false);
+  }, []);
+
+  const filteredUsers = useMemo(
+    () => users.filter(user => user.name.toLowerCase().includes(mentionFilter)),
+    [mentionFilter, users],
+  );
+
+  const insertMention = useCallback((userName: string) => {
+    const lastAt = draft.lastIndexOf('@');
+    const before = lastAt >= 0 ? draft.slice(0, lastAt) : `${draft} `;
+    const nextDraft = `${before}@${userName} `;
+    setDraft(nextDraft);
+    draftRef.current = nextDraft;
+    setShowMentions(false);
+    inputRef.current?.focus();
+  }, [draft]);
+
   const hasUploadingImage = attachedImages.some(item => item.uploading);
   const uploadedImageUrls = attachedImages.map(item => item.uploadedUrl).filter((url): url is string => !!url);
   const canSend = Boolean(currentUser)
@@ -233,7 +280,7 @@ export function RevisionCommentThread({ revisionId, sceneKey }: Props) {
       userId: currentUser.id,
       userName: currentUser.name,
       text: draft.trim(),
-      mentions: [],
+      mentions: extractMentions(draft, users.map(user => user.name)),
       images: uploadedImageUrls,
       createdAt: new Date().toISOString(),
       // v1.18.0 핵심: 이 댓글은 해당 리비전 맥락에 속함.
@@ -248,6 +295,7 @@ export function RevisionCommentThread({ revisionId, sceneKey }: Props) {
     const prevAttached = attachedImages;
     setDraft('');
     draftRef.current = '';
+    setShowMentions(false);
     setAttachedImages([]);
     attachedImagesRef.current = [];
 
@@ -256,6 +304,26 @@ export function RevisionCommentThread({ revisionId, sceneKey }: Props) {
       prevAttached.forEach((item) => {
         try { URL.revokeObjectURL(item.previewUrl); } catch { /* ignore */ }
       });
+
+      if (newComment.mentions.length > 0 && currentUser.slackId) {
+        const parts = sheetName.match(/^EP(\d+)_([A-Z])_/);
+        const epLabel = parts ? `EP.${parts[1].padStart(2, '0')}` : sheetName;
+        const partLabel = parts ? `${parts[2]}파트` : '';
+        for (const mentionedName of newComment.mentions) {
+          const target = users.find(user => user.name === mentionedName);
+          if (target?.slackId && target.slackId !== currentUser.slackId) {
+            sendMentionWebhook({
+              commentText: newComment.text,
+              episodeLabel: epLabel,
+              sceneId,
+              partLabel,
+              sheetName,
+              authorSlackId: currentUser.slackId,
+              targetSlackId: target.slackId,
+            });
+          }
+        }
+      }
     } catch (err) {
       console.error('[리비전 댓글 스레드] 전송 실패:', err);
 
@@ -314,6 +382,11 @@ export function RevisionCommentThread({ revisionId, sceneKey }: Props) {
           key={c.id}
           comment={c}
           isMe={c.userId === currentUser?.id}
+          users={users}
+          onMentionClick={(userName) => {
+            setHighlightUserName(userName);
+            setView('team');
+          }}
         />
       ))}
 
@@ -363,7 +436,27 @@ export function RevisionCommentThread({ revisionId, sceneKey }: Props) {
                 ))}
               </div>
             )}
-            <div className="flex gap-2">
+            <div className="relative flex gap-2">
+              {showMentions && filteredUsers.length > 0 && (
+                <div
+                  ref={mentionDropdownRef}
+                  className="absolute bottom-full left-10 right-24 mb-1 max-h-32 overflow-y-auto rounded-lg border border-bg-border bg-bg-card shadow-lg z-20"
+                >
+                  {filteredUsers.map((user, index) => (
+                    <button
+                      key={user.id}
+                      type="button"
+                      onClick={() => insertMention(user.name)}
+                      className={`w-full text-left px-3 py-1.5 text-xs text-text-primary transition-colors flex items-center gap-2 cursor-pointer ${
+                        index === mentionIndex ? 'bg-accent/15' : 'hover:bg-accent/10'
+                      }`}
+                    >
+                      <span className="text-accent text-[11px]">@</span>
+                      <span>{user.name}</span>
+                    </button>
+                  ))}
+                </div>
+              )}
               <input
                 ref={fileInputRef}
                 type="file"
@@ -381,10 +474,33 @@ export function RevisionCommentThread({ revisionId, sceneKey }: Props) {
                 <Paperclip size={13} />
               </button>
               <input
+                ref={inputRef}
                 type="text"
                 value={draft}
-                onChange={e => setDraft(e.target.value)}
+                onChange={e => handleDraftChange(e.target.value)}
                 onKeyDown={e => {
+                  if (showMentions && filteredUsers.length > 0) {
+                    if (e.key === 'ArrowDown') {
+                      e.preventDefault();
+                      setMentionIndex((prev) => (prev + 1) % filteredUsers.length);
+                      return;
+                    }
+                    if (e.key === 'ArrowUp') {
+                      e.preventDefault();
+                      setMentionIndex((prev) => (prev - 1 + filteredUsers.length) % filteredUsers.length);
+                      return;
+                    }
+                    if (e.key === 'Enter' || e.key === 'Tab') {
+                      e.preventDefault();
+                      insertMention(filteredUsers[mentionIndex].name);
+                      return;
+                    }
+                    if (e.key === 'Escape') {
+                      e.preventDefault();
+                      setShowMentions(false);
+                      return;
+                    }
+                  }
                   if (e.key === 'Enter' && !e.shiftKey) {
                     e.preventDefault();
                     send();
@@ -413,7 +529,40 @@ export function RevisionCommentThread({ revisionId, sceneKey }: Props) {
 
 // ─── 댓글 버블 ──────────────────────────────────────────────────────────
 
-function CommentBubble({ comment, isMe }: { comment: SceneComment; isMe: boolean }) {
+function CommentBubble({
+  comment,
+  isMe,
+  users,
+  onMentionClick,
+}: {
+  comment: SceneComment;
+  isMe: boolean;
+  users: { name: string }[];
+  onMentionClick: (userName: string) => void;
+}) {
+  const renderMentionInSegment = (segment: string, baseIdx: number) => {
+    const parts = segment.split(/(@\S+)/g);
+    return parts.map((part, index) => {
+      const key = `${baseIdx}-${index}`;
+      if (part.startsWith('@')) {
+        const name = part.slice(1);
+        if (users.some(user => user.name === name)) {
+          return (
+            <span
+              key={key}
+              className="text-accent font-bold bg-accent/10 rounded px-0.5 cursor-pointer hover:bg-accent/20 transition-colors"
+              onClick={() => onMentionClick(name)}
+              title={`${name} 팀원 보기`}
+            >
+              {part}
+            </span>
+          );
+        }
+      }
+      return <span key={key}>{part}</span>;
+    });
+  };
+
   return (
     <div
       className={`border rounded-lg px-3 py-2 ${
@@ -441,7 +590,7 @@ function CommentBubble({ comment, isMe }: { comment: SceneComment; isMe: boolean
       </div>
       {comment.text && (
         <div className="text-[12px] text-text-primary whitespace-pre-wrap leading-relaxed">
-          {comment.text}
+          <PathLinkifiedText text={comment.text} renderTextSegment={renderMentionInSegment} />
         </div>
       )}
       {(comment.images?.length ?? 0) > 0 && (

--- a/src/components/scenes/RevisionCornerFlag.tsx
+++ b/src/components/scenes/RevisionCornerFlag.tsx
@@ -1,0 +1,27 @@
+import { Check, MessageSquareWarning } from 'lucide-react';
+import { cn } from '@/utils/cn';
+
+interface RevisionCornerFlagProps {
+  count: number;
+  resolved?: boolean;
+  className?: string;
+}
+
+export function RevisionCornerFlag({ count, resolved = false, className }: RevisionCornerFlagProps) {
+  if (count <= 0) return null;
+
+  const label = `${resolved ? '완료된 리비전' : '미해결 리비전'} ${count}`;
+
+  return (
+    <span
+      className={cn('revision-corner-flag', resolved && 'revision-corner-flag-resolved', className)}
+      title={label}
+      aria-label={label}
+    >
+      <span className="revision-corner-flag-content">
+        {resolved ? <Check size={10} strokeWidth={2.6} /> : <MessageSquareWarning size={10} strokeWidth={2.4} />}
+        <span className="revision-corner-flag-count">{count}</span>
+      </span>
+    </span>
+  );
+}

--- a/src/components/scenes/RevisionPanel.tsx
+++ b/src/components/scenes/RevisionPanel.tsx
@@ -14,6 +14,7 @@ import { STATUS_CONFIG, revisionNoToLabel } from '@/constants/revision';
 import { elevatedGlassStyle, floatingGlassStyle } from '@/utils/glassStyles';
 import { RevisionRecipientPicker } from './RevisionRecipientPicker';
 import { RevisionCommentThread } from './RevisionCommentThread';
+import { AttachmentImageLightbox, type AttachmentImageLightboxState } from './AttachmentImageLightbox';
 import { calcDefaultRecipients } from '@/utils/revisionRecipients';
 import { PathLinkifiedText } from '@/components/common/PathLinkifiedText';
 
@@ -120,6 +121,7 @@ function RevisionCard({
 }) {
   const [showResolveNote, setShowResolveNote] = useState(false);
   const [resolveNote, setResolveNote] = useState('');
+  const [lightbox, setLightbox] = useState<AttachmentImageLightboxState | null>(null);
   const { currentUser, users: allUsers } = useAuthStore();
   const canDelete = !!(
     currentUser && onDelete &&
@@ -147,6 +149,27 @@ function RevisionCard({
     onStatusChange('resolved', resolveNote);
     setShowResolveNote(false);
     setResolveNote('');
+  };
+
+  const openRevisionImage = () => {
+    if (!revision.imageUrl) return;
+    setLightbox({
+      entries: [{
+        url: revision.imageUrl,
+        userName: revision.requesterName,
+        commentText: revision.description,
+        createdAt: revision.createdAt,
+        commentId: revision.id,
+      }],
+      index: 0,
+    });
+  };
+
+  const lightboxStep = (dir: 1 | -1) => {
+    setLightbox((prev) => {
+      if (!prev || prev.entries.length <= 1) return prev;
+      return { ...prev, index: (prev.index + dir + prev.entries.length) % prev.entries.length };
+    });
   };
 
   return (
@@ -203,12 +226,30 @@ function RevisionCard({
       {/* 이미지 썸네일 */}
       {revision.imageUrl && (
         <div className="mb-2">
-          <img
-            src={revision.imageUrl}
-            alt="첨부"
-            className="rounded-lg max-h-32 object-cover border border-bg-border/40 cursor-pointer hover:opacity-80 transition-opacity"
-          />
+          <button
+            type="button"
+            onClick={openRevisionImage}
+            className="block w-fit rounded-lg border border-bg-border/40 overflow-hidden cursor-zoom-in hover:opacity-85 transition-opacity"
+            title="이미지 확대"
+          >
+            <img
+              src={revision.imageUrl}
+              alt="첨부"
+              className="max-h-32 object-cover"
+            />
+          </button>
         </div>
+      )}
+      {lightbox && (
+        <AttachmentImageLightbox
+          lightbox={lightbox}
+          setLightbox={setLightbox}
+          closeLightbox={() => setLightbox(null)}
+          lightboxStep={lightboxStep}
+          sceneLabel={revisionNoToLabel(revision.revisionNo)}
+          ariaLabel="리비전 이미지 확대 보기"
+          fileNamePrefix={`${revisionNoToLabel(revision.revisionNo)}-revision`}
+        />
       )}
 
       {/* 해결 메모 입력 */}

--- a/src/components/scenes/SceneDetailModal.tsx
+++ b/src/components/scenes/SceneDetailModal.tsx
@@ -15,8 +15,8 @@ import {
   Film,
 } from 'lucide-react';
 import { cn } from '@/utils/cn';
-import { STAGES, DEPARTMENT_CONFIGS } from '@/types';
-import type { Scene, Stage, Department } from '@/types';
+import { DEPARTMENT_CONFIGS } from '@/types';
+import type { Scene, Stage, Department, ScenePhaseState } from '@/types';
 import { sceneProgress } from '@/utils/calcStats';
 import * as storageService from '@/services/storageService';
 import { AssigneeSelect, getUserColor } from '@/components/common/AssigneeSelect';
@@ -24,7 +24,10 @@ import { AssigneeMultiSelect } from '@/components/common/AssigneeMultiSelect';
 import { PathLinkifiedText } from '@/components/common/PathLinkifiedText';
 import { resizeBlob, pasteImageFromClipboard } from '@/utils/imageUtils';
 import { ImageModal } from './ImageModal';
+import { ScenePhaseToggle } from './ScenePhaseToggle';
+import { StageSegmentToggle } from './StageSegmentToggle';
 import { CommentPanelResizable } from './CommentPanelResizable';
+import type { CommentInlineEvent } from './CommentPanel';
 import { RevisionPanel } from './RevisionPanel';
 import { getComments } from '@/services/commentService';
 import { useSceneActivities } from '@/hooks/useSceneActivities';
@@ -36,6 +39,7 @@ import { buildSceneKey } from '@/services/revisionService';
 import { buildSceneThreadKeyFromRevisionKey } from '@/utils/commentThreadKey';
 import { formatStamp, formatTime } from '@/utils/formatTime';
 import { findLatestMemoActivity, type MemoAuthorMeta } from './memoAuthorMeta';
+import { describeActivity, deptPrefix } from './activityLabels';
 
 // ─── 타입 ──────────────────────────────────────────
 
@@ -53,6 +57,9 @@ interface SceneDetailModalProps {
   readOnlyGuideUrl?: string | null;
   onFieldUpdate: (sceneIndex: number, field: string, value: string) => void;
   onToggle: (sceneId: string, stage: Stage) => void;
+  onActPhaseStateClick?: (sheetName: string, sceneId: string, newState: ScenePhaseState) => void;
+  onActFeedbackRequest?: (sheetName: string, sceneId: string) => void;
+  onActRoundBump?: (sheetName: string, sceneId: string, kind: 'work' | 'feedback', delta: 1 | -1) => void;
   onClose: () => void;
   onNavigate?: (direction: 'prev' | 'next') => void;
   hasPrev?: boolean;
@@ -426,6 +433,9 @@ export function SceneDetailModal({
   readOnlyGuideUrl,
   onFieldUpdate,
   onToggle,
+  onActPhaseStateClick,
+  onActFeedbackRequest,
+  onActRoundBump,
   onClose,
   onNavigate,
   hasPrev = false,
@@ -438,11 +448,60 @@ export function SceneDetailModal({
 }: SceneDetailModalProps) {
   const [imageLoading, setImageLoading] = useState<string | null>(null);
   const [showImageModal, setShowImageModal] = useState(false);
-  const sceneActivities = useSceneActivities([scene.id], 50);
+  const sceneActivities = useSceneActivities([scene.id], 200);
   const memoAuthorMeta = useMemo(
     () => findLatestMemoActivity(sceneActivities, scene.id),
     [sceneActivities, scene.id],
   );
+  const inlineEvents: CommentInlineEvent[] = useMemo(() => {
+    const BIG_EVENT_TYPES = new Set([
+      'memo_update',
+      'image_upload_storyboard', 'image_upload_guide',
+      'image_annotate_storyboard', 'image_annotate_guide',
+      'scene_add',
+      'revision_add', 'revision_in_progress', 'revision_resolve', 'revision_delete',
+    ]);
+
+    const events: CommentInlineEvent[] = sceneActivities
+      .filter((a) => BIG_EVENT_TYPES.has(a.actionType))
+      .map<CommentInlineEvent>((a) => {
+        const visual = describeActivity(a);
+        const revisionTone =
+          a.actionType === 'revision_add'
+            ? 'revision_add'
+            : a.actionType === 'revision_in_progress'
+              ? 'revision_in_progress'
+              : a.actionType === 'revision_resolve'
+                ? 'revision_resolve'
+                : undefined;
+        const revisionLabel =
+          a.actionType === 'revision_add'
+            ? '등록'
+            : a.actionType === 'revision_in_progress'
+              ? '진행'
+              : a.actionType === 'revision_resolve'
+                ? '완료'
+                : undefined;
+
+        return {
+          id: a.id,
+          at: a.createdAt,
+          text: `${a.userName} ${deptPrefix(a.department)}${visual.text}`,
+          tone: revisionTone,
+          label: revisionLabel,
+        };
+      });
+
+    if (scene.completedAt && scene.completedBy) {
+      events.push({
+        id: `completed:${department}:${scene.id ?? 'na'}`,
+        at: scene.completedAt,
+        text: `${scene.completedBy} ${deptPrefix(department)}모든 단계 완료`,
+      });
+    }
+
+    return events;
+  }, [department, scene.completedAt, scene.completedBy, scene.id, sceneActivities]);
   // 코덱스 P2 fix (5차, 2026-05-05): 알림 라우팅 시 initialTab='revisions' 면 리비전 패널 자동 펼침.
   const [showRevisions, setShowRevisions] = useState(initialTab === 'revisions');
   // 코덱스 P2 fix (6차, 2026-05-05): 모달 인스턴스가 재사용되어 initialTab prop 이 나중에 바뀌면
@@ -894,31 +953,25 @@ export function SceneDetailModal({
                   <h3 className="text-xs font-semibold text-text-secondary mb-3 px-4">
                     진행 단계
                   </h3>
-                  <div className="flex rounded-lg bg-bg-primary/75 p-1.5 gap-1.5 mx-4 border border-bg-border/50">
-                    {STAGES.map((stage, i) => {
-                      const isDone = scene[stage];
-                      const isCurrent = isDone && (i === STAGES.length - 1 || !scene[STAGES[i + 1]]);
-
-                      return (
-                        <button
-                          key={stage}
-                          onClick={() => onToggle(scene.sceneId, stage)}
-                          className={cn(
-                            'flex-1 py-2.5 rounded-md text-sm font-medium transition-all cursor-pointer',
-                            !isDone && 'text-text-secondary hover:text-text-primary hover:bg-bg-border/25',
-                          )}
-                          style={
-                            isDone
-                              ? isCurrent
-                                ? { backgroundColor: deptConfig.color, color: '#fff', fontWeight: 600, boxShadow: `0 2px 8px ${deptConfig.color}4D` }
-                                : { backgroundColor: `${deptConfig.color}18`, color: deptConfig.color }
-                              : undefined
-                          }
-                        >
-                          {deptConfig.stageLabels[stage]}
-                        </button>
-                      );
-                    })}
+                  <div className="mx-4">
+                    {department === 'acting' && onActPhaseStateClick && onActFeedbackRequest && onActRoundBump ? (
+                      <ScenePhaseToggle
+                        scene={scene}
+                        iconDisplay="always"
+                        onStateClick={(next) => onActPhaseStateClick(sheetName, scene.sceneId, next)}
+                        onRequestFeedback={() => onActFeedbackRequest(sheetName, scene.sceneId)}
+                        onRoundBump={(kind, delta) => onActRoundBump(sheetName, scene.sceneId, kind, delta)}
+                      />
+                    ) : (
+                      <StageSegmentToggle
+                        scene={scene}
+                        department={department}
+                        iconDisplay="always"
+                        className="bg-bg-primary/75 p-1.5 gap-1.5 border-bg-border/50"
+                        segmentClassName="py-2.5 text-sm"
+                        onToggle={(stage) => onToggle(scene.sceneId, stage)}
+                      />
+                    )}
                   </div>
                 </section>
 
@@ -1137,6 +1190,7 @@ export function SceneDetailModal({
             counterpartSheetName={counterpartSheetName}
             counterpartSceneNo={counterpartSceneNo}
             onCountChange={setCommentCount}
+            inlineEvents={inlineEvents}
             focusCommentId={focusCommentId}
             sceneLabel={`${sheetName.replace(/_/g, ' ').replace(/^EP0?/, 'EP')}${scene.sceneId ? ` #${scene.sceneId}` : ''}`}
             quickRevision={{

--- a/src/components/scenes/ScenePhaseToggle.tsx
+++ b/src/components/scenes/ScenePhaseToggle.tsx
@@ -19,6 +19,7 @@ import type { Scene, ScenePhaseState } from '@/types';
 import { SCENE_PHASES, SCENE_PHASE_LABELS_SHORT, SCENE_PHASE_COLORS } from '@/types';
 import { CompactIconLabel } from '@/components/common/CompactIconLabel';
 import { cn } from '@/utils/cn';
+import { useStageLabelDisplayMode } from './useStageLabelDisplayMode';
 
 export interface ScenePhaseToggleProps {
   scene: Scene;
@@ -32,6 +33,8 @@ export interface ScenePhaseToggleProps {
   disabled?: boolean;
   /** 컴팩트 모드 (시트 셀 안에서 사용 시) */
   compact?: boolean;
+  /** 아이콘 노출 방식. 좁은 카드/시트는 텍스트를 우선한다. */
+  iconDisplay?: 'always' | 'wide' | 'never' | 'auto';
 }
 
 const PHASE_ICON_BY_STATE: Record<ScenePhaseState, ReactNode> = {
@@ -48,6 +51,7 @@ export function ScenePhaseToggle({
   onRoundBump,
   disabled = false,
   compact = false,
+  iconDisplay = 'auto',
 }: ScenePhaseToggleProps) {
   const activeState: ScenePhaseState = scene.sceneState ?? 'wait';
   // v1.25.7: 작업중일 때만 차수 헤더 노출. 피드백/대기/완료는 차수 숨김.
@@ -57,6 +61,13 @@ export function ScenePhaseToggle({
   // 자기 색의 알파(0x20 ≈ 0.125) 로 살짝 채워 시각 진행도 표현.
   const activeIndex = SCENE_PHASES.indexOf(activeState);
   const pointerHandledRef = useRef(false);
+  const { modeOf, setNode } = useStageLabelDisplayMode(SCENE_PHASE_LABELS_SHORT, compact, iconDisplay === 'auto');
+  const phaseIconClassName =
+    (compact && iconDisplay !== 'auto') || iconDisplay === 'never'
+      ? 'hidden'
+      : iconDisplay === 'wide'
+        ? 'hidden 2xl:inline-flex'
+        : undefined;
 
   const handleChipClick = useCallback(
     (target: ScenePhaseState) => {
@@ -113,7 +124,7 @@ export function ScenePhaseToggle({
         </div>
       )}
 
-      {/* 칩 4개 — 라벨만, 균등 분할 */}
+      {/* 칩 4개 — 텍스트 우선, 아이콘은 뒤쪽에 배치해 좁은 칸에서 라벨을 먼저 보존한다. */}
       <div
         className={cn(
           'flex w-full rounded-lg bg-bg-primary/70 border border-bg-border/40',
@@ -129,6 +140,7 @@ export function ScenePhaseToggle({
           return (
             <div
               key={state}
+              ref={setNode(state)}
               data-continuity-stage-segment
               role="radio"
               aria-checked={isActive}
@@ -182,7 +194,16 @@ export function ScenePhaseToggle({
                 icon={PHASE_ICON_BY_STATE[state]}
                 label={SCENE_PHASE_LABELS_SHORT[state]}
                 className="w-full"
-                textClassName="truncate"
+                textClassName="leading-none"
+                iconClassName={phaseIconClassName}
+                iconPosition="after"
+                displayMode={
+                  iconDisplay === 'auto'
+                    ? modeOf(state)
+                    : iconDisplay === 'never'
+                      ? 'text'
+                      : 'both'
+                }
               />
             </div>
           );

--- a/src/components/scenes/SceneSheetView.tsx
+++ b/src/components/scenes/SceneSheetView.tsx
@@ -410,6 +410,7 @@ export function SceneSheetView({
     SINGLE_SHEET_FILL_COLUMNS,
   );
   const sheetWidth = fittedSheet.totalWidth;
+  const sheetOverflowsViewport = tableViewportWidth > 0 && sheetWidth > tableViewportWidth + 1;
   const displayWidthOf = useCallback(
     (key: SingleSheetColumnKey) => fittedSheet.widths[key],
     [fittedSheet],
@@ -660,7 +661,10 @@ export function SceneSheetView({
       <div
         ref={tableRef}
         tabIndex={0}
-        className="overflow-y-auto overflow-x-hidden rounded-lg border border-bg-border focus:outline-none"
+        className={cn(
+          'overflow-y-auto rounded-lg border border-bg-border focus:outline-none',
+          sheetOverflowsViewport ? 'overflow-x-auto' : 'overflow-x-hidden',
+        )}
         onKeyDown={handleTableKeyDown}
         onMouseUp={() => setIsDragging(false)}
         style={{ userSelect: isDragging ? 'none' : undefined }}

--- a/src/components/scenes/SceneSheetView.tsx
+++ b/src/components/scenes/SceneSheetView.tsx
@@ -1,23 +1,28 @@
 import { useState, useRef, useEffect, useMemo, useCallback, Fragment } from 'react';
 import { createPortal } from 'react-dom';
 import { motion } from 'framer-motion';
-import { MessageCircle, Trash2 } from 'lucide-react';
+import { Trash2 } from 'lucide-react';
 import { STAGES, DEPARTMENT_CONFIGS } from '@/types';
 import type { Scene, Stage, Department, ScenePhaseState } from '@/types';
 import type { SceneGroupMode } from '@/stores/useAppStore';
 import { useAppStore } from '@/stores/useAppStore';
+import { useDataStore } from '@/stores/useDataStore';
+import { useRevisionStore } from '@/stores/useRevisionStore';
+import { buildSceneKey } from '@/services/revisionService';
 import { isFullyDone } from '@/utils/calcStats';
 import { cn } from '@/utils/cn';
 import { HighlightText } from '@/components/common/HighlightText';
-import { CompactIconLabel } from '@/components/common/CompactIconLabel';
 import { AssigneeSelect } from '@/components/common/AssigneeSelect';
 import { AssigneeMultiSelect, AssigneeChipList } from '@/components/common/AssigneeMultiSelect';
 import {
   ResizableHeaderCell,
+  useFittedSheetColumnWidths,
   useResizableSheetColumns,
   type SheetColumnDefinition,
 } from './SheetColumnResize';
 import { ScenePhaseToggle } from './ScenePhaseToggle';
+import { StageSegmentToggle } from './StageSegmentToggle';
+import { SheetAlertBadges } from './SheetAlertBadges';
 
 // ─── Props ───────────────────────────────────────────────────
 
@@ -52,6 +57,7 @@ function cellKey(row: number, col: number) { return `${row}:${col}`; }
 
 type SingleSheetColumnKey =
   | 'scene'
+  | 'alerts'
   | 'memo'
   | 'storyboard'
   | 'guide'
@@ -64,7 +70,8 @@ type SingleSheetColumnKey =
 
 const SINGLE_SHEET_COLUMNS: Array<SheetColumnDefinition<SingleSheetColumnKey>> = [
   { key: 'scene', defaultWidth: 96, minWidth: 76, maxWidth: 180 },
-  { key: 'memo', defaultWidth: 300, minWidth: 80, maxWidth: 620 },
+  { key: 'alerts', defaultWidth: 58, minWidth: 44, maxWidth: 84 },
+  { key: 'memo', defaultWidth: 300, minWidth: 80, maxWidth: 1200 },
   { key: 'storyboard', defaultWidth: 82, minWidth: 52, maxWidth: 150 },
   { key: 'guide', defaultWidth: 82, minWidth: 52, maxWidth: 150 },
   { key: 'assignee', defaultWidth: 120, minWidth: 76, maxWidth: 240 },
@@ -74,6 +81,7 @@ const SINGLE_SHEET_COLUMNS: Array<SheetColumnDefinition<SingleSheetColumnKey>> =
   { key: 'png', defaultWidth: 58, minWidth: 36, maxWidth: 112 },
   { key: 'actions', defaultWidth: 40, minWidth: 32, maxWidth: 72 },
 ];
+const SINGLE_SHEET_FILL_COLUMNS: SingleSheetColumnKey[] = ['memo'];
 
 const STAGE_SHORT_LABELS: Record<Stage, string> = {
   lo: 'LO',
@@ -321,11 +329,9 @@ export function SceneSheetView({
 }: SceneSheetViewProps) {
   const deptConfig = DEPARTMENT_CONFIGS[department];
   const completionTintEnabled = useAppStore((s) => s.completionTintEnabled);
-  const stagePointerHandledRef = useRef(false);
   const useActingPhaseControls = department === 'acting' && !!onActPhaseStateClick && !!onActFeedbackRequest && !!onActRoundBump;
   const {
     widthOf,
-    totalWidth,
     startResize,
   } = useResizableSheetColumns(`bflow_scene_sheet_columns_${department}_v1`, SINGLE_SHEET_COLUMNS);
 
@@ -377,6 +383,61 @@ export function SceneSheetView({
   const [initialEditChar, setInitialEditChar] = useState<string | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   const tableRef = useRef<HTMLDivElement>(null);
+  const [tableViewportWidth, setTableViewportWidth] = useState(0);
+
+  useEffect(() => {
+    const node = tableRef.current;
+    if (!node) return;
+
+    const updateWidth = () => {
+      setTableViewportWidth(Math.floor(node.clientWidth));
+    };
+    updateWidth();
+
+    const observer = new ResizeObserver(updateWidth);
+    observer.observe(node);
+    window.addEventListener('resize', updateWidth);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', updateWidth);
+    };
+  }, []);
+
+  const fittedSheet = useFittedSheetColumnWidths(
+    SINGLE_SHEET_COLUMNS,
+    widthOf,
+    tableViewportWidth,
+    SINGLE_SHEET_FILL_COLUMNS,
+  );
+  const sheetWidth = fittedSheet.totalWidth;
+  const displayWidthOf = useCallback(
+    (key: SingleSheetColumnKey) => fittedSheet.widths[key],
+    [fittedSheet],
+  );
+
+  const revisions = useRevisionStore((s) => s.revisions);
+  const getOpenCount = useRevisionStore((s) => s.getOpenCount);
+  const episodes = useDataStore((s) => s.episodes);
+  const revisionCountBySceneId = useMemo(() => {
+    if (!sheetName) return new Map<string, number>();
+    let siblings: string[] = [];
+    for (const ep of episodes) {
+      const part = ep.parts.find((p) => p.sheetName === sheetName);
+      if (part) {
+        siblings = part.scenes.map((s) => s.sceneId);
+        break;
+      }
+    }
+    const map = new Map<string, number>();
+    for (const scene of displayScenes) {
+      const sceneId = scene.sceneId || '';
+      if (!sceneId) continue;
+      const sceneKey = buildSceneKey(sheetName, sceneId, { siblingSceneIds: siblings });
+      const openCount = getOpenCount(sceneKey);
+      if (openCount > 0) map.set(sceneId, openCount);
+    }
+    return map;
+  }, [displayScenes, episodes, getOpenCount, revisions, sheetName]);
 
   const maxRow = Math.max(0, displayScenes.length - 1);
   const maxCol = EDITABLE_FIELDS.length - 1;
@@ -599,18 +660,18 @@ export function SceneSheetView({
       <div
         ref={tableRef}
         tabIndex={0}
-        className="overflow-auto rounded-lg border border-bg-border focus:outline-none"
+        className="overflow-y-auto overflow-x-hidden rounded-lg border border-bg-border focus:outline-none"
         onKeyDown={handleTableKeyDown}
         onMouseUp={() => setIsDragging(false)}
         style={{ userSelect: isDragging ? 'none' : undefined }}
       >
         <table
           className="text-sm border-collapse"
-          style={{ tableLayout: 'fixed', width: totalWidth }}
+          style={{ tableLayout: 'fixed', width: sheetWidth }}
         >
           <colgroup>
             {SINGLE_SHEET_COLUMNS.map((column) => (
-              <col key={column.key} style={{ width: widthOf(column.key) }} />
+              <col key={column.key} style={{ width: displayWidthOf(column.key) }} />
             ))}
           </colgroup>
           {/* ── 헤더 ── */}
@@ -618,11 +679,12 @@ export function SceneSheetView({
             <tr className="bg-bg-card border-b border-bg-border">
               {/* 한솔 결정 (1-B): 레이아웃 별 보기 시 별도 컬럼 대신 행 위에 그룹 헤더 행을 삽입.
                   컬럼 수가 일반 모드와 동일하게 유지된다. */}
-              <ResizableHeaderCell columnKey="scene" width={widthOf('scene')} onResizeStart={startResize} shortLabel="씬">씬번호</ResizableHeaderCell>
-              <ResizableHeaderCell columnKey="memo" width={widthOf('memo')} onResizeStart={startResize} shortLabel="메모">메모</ResizableHeaderCell>
-              <ResizableHeaderCell columnKey="storyboard" width={widthOf('storyboard')} onResizeStart={startResize} align="center" shortLabel="SB">스토리보드</ResizableHeaderCell>
-              <ResizableHeaderCell columnKey="guide" width={widthOf('guide')} onResizeStart={startResize} align="center" shortLabel="Guide">가이드</ResizableHeaderCell>
-              <ResizableHeaderCell columnKey="assignee" width={widthOf('assignee')} onResizeStart={startResize} shortLabel="담">담당자</ResizableHeaderCell>
+              <ResizableHeaderCell columnKey="scene" width={displayWidthOf('scene')} onResizeStart={startResize} shortLabel="씬">씬번호</ResizableHeaderCell>
+              <ResizableHeaderCell columnKey="alerts" width={displayWidthOf('alerts')} onResizeStart={startResize} align="center" className="px-1" />
+              <ResizableHeaderCell columnKey="memo" width={displayWidthOf('memo')} onResizeStart={startResize} shortLabel="메모">메모</ResizableHeaderCell>
+              <ResizableHeaderCell columnKey="storyboard" width={displayWidthOf('storyboard')} onResizeStart={startResize} align="center" shortLabel="SB">스토리보드</ResizableHeaderCell>
+              <ResizableHeaderCell columnKey="guide" width={displayWidthOf('guide')} onResizeStart={startResize} align="center" shortLabel="Guide">가이드</ResizableHeaderCell>
+              <ResizableHeaderCell columnKey="assignee" width={displayWidthOf('assignee')} onResizeStart={startResize} shortLabel="담">담당자</ResizableHeaderCell>
               {useActingPhaseControls ? (
                 <th
                   colSpan={4}
@@ -636,7 +698,7 @@ export function SceneSheetView({
                   <ResizableHeaderCell
                     key={s}
                     columnKey={s}
-                    width={widthOf(s)}
+                    width={displayWidthOf(s)}
                     onResizeStart={startResize}
                     align="center"
                     className="px-1 text-[11px]"
@@ -647,7 +709,7 @@ export function SceneSheetView({
                   </ResizableHeaderCell>
                 ))
               )}
-              <ResizableHeaderCell columnKey="actions" width={widthOf('actions')} onResizeStart={startResize} align="center" className="px-1" />
+              <ResizableHeaderCell columnKey="actions" width={displayWidthOf('actions')} onResizeStart={startResize} align="center" className="px-1" />
             </tr>
           </thead>
 
@@ -662,6 +724,10 @@ export function SceneSheetView({
               const groupSize = meta?.groupSize ?? 1;
               const layoutKey = meta?.layoutKey ?? '';
               const isLayoutMode = sceneGroupMode === 'layout';
+              const commentKey = `${sheetName}:${scene.no}`;
+              const commentCount = commentCounts[commentKey] ?? 0;
+              const isUnreadComment = commentUnreadByKey?.[commentKey] ?? false;
+              const openRevCount = revisionCountBySceneId.get(scene.sceneId) ?? 0;
 
               return (
                 <Fragment key={`${scene.sceneId}-${idx}`}>
@@ -693,6 +759,7 @@ export function SceneSheetView({
                       searchQuery && 'bg-accent/5 border-l-2 border-l-accent/60',
                       highlightSceneId && scene.sceneId === highlightSceneId && 'scene-row-highlighted',
                       completionTintEnabled && isFullyDone(scene) && 'scene-completion-tint-row',
+                      openRevCount > 0 && 'sheet-row-revision-open',
                       isLayoutMode && !isLastInGroup && 'scene-row-group-mid',
                       isLayoutMode && isLastInGroup && 'scene-row-group-last',
                     )}
@@ -703,11 +770,10 @@ export function SceneSheetView({
                     }}
                     onDoubleClick={() => onOpenDetail(idx)}
                   >
-                  {/* 씬번호 + 레이아웃 뱃지 + 댓글 뱃지.
-                      한솔 결정 (5번): 1+3 합본 효과 — 텍스트 네온 펄스 + wrap 회전 보더. */}
+                  {/* 씬번호 */}
                   <td className="px-2 py-1.5 font-mono text-xs">
-                    <span className="flex items-center gap-2">
-                      <span className="scene-num-glow-wrap">
+                    <div className="flex min-w-0 items-center gap-1.5">
+                      <span className="scene-num-glow-wrap min-w-0">
                         <span className="scene-num-glow-text">
                           <HighlightText text={scene.sceneId || '-'} query={searchQuery} />
                         </span>
@@ -717,29 +783,14 @@ export function SceneSheetView({
                           L#{scene.layoutId}
                         </span>
                       )}
-                      {(() => {
-                        const commentKey = `${sheetName}:${scene.no}`;
-                        const cc = commentCounts[commentKey];
-                        const isUnread = commentUnreadByKey?.[commentKey] ?? false;
-                        return cc > 0 ? (
-                          <span
-                            className={cn(
-                              'compact-label-container inline-flex min-w-0 shrink items-center gap-0.5 rounded-full border px-1 py-px transition-colors',
-                              isUnread
-                                ? 'comment-unread-badge border-accent/25 bg-accent/20 text-accent'
-                                : 'border-bg-border/40 bg-text-secondary/10 text-text-secondary/55',
-                            )}
-                            title={`${isUnread ? '새 댓글' : '확인한 댓글'} ${cc}개`}
-                          >
-                            <CompactIconLabel
-                              icon={<MessageCircle size={9} fill="currentColor" />}
-                              label={`${cc}개`}
-                              textClassName="text-[10px] font-bold"
-                            />
-                          </span>
-                        ) : null;
-                      })()}
-                    </span>
+                    </div>
+                  </td>
+                  <td className="px-1 py-1.5">
+                    <SheetAlertBadges
+                      revisionCount={openRevCount}
+                      commentCount={commentCount}
+                      hasUnreadComments={isUnreadComment}
+                    />
                   </td>
 
                   {/* 메모 (인라인 편집) */}
@@ -781,7 +832,7 @@ export function SceneSheetView({
                     onStopEditing={handleStopEditing}
                   />
 
-                  {/* 진행상황: ACT 단독은 새 액팅 단계, 그 외는 기존 BG 스테이지 체크박스 */}
+                  {/* 진행상황: ACT/BG 모두 같은 segmented track 구조로 표시 */}
                   {useActingPhaseControls ? (
                     <td colSpan={4} className="px-1 py-1.5">
                       <div onClick={(e) => e.stopPropagation()}>
@@ -795,40 +846,15 @@ export function SceneSheetView({
                       </div>
                     </td>
                   ) : (
-                    STAGES.map((stage) => (
-                      <td key={stage} className="px-1 py-1.5 text-center">
-                        <button
-                          type="button"
-                          onPointerDown={(e) => {
-                            if (e.button !== 0) return;
-                            e.preventDefault();
-                            e.stopPropagation();
-                            stagePointerHandledRef.current = true;
-                            onToggle(scene.sceneId, stage);
-                            window.setTimeout(() => {
-                              stagePointerHandledRef.current = false;
-                            }, 600);
-                          }}
-                          onClick={(e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                            if (stagePointerHandledRef.current) {
-                              stagePointerHandledRef.current = false;
-                              return;
-                            }
-                            onToggle(scene.sceneId, stage);
-                          }}
-                          className="w-5 h-5 rounded flex items-center justify-center text-xs transition-all mx-auto"
-                          style={
-                            scene[stage]
-                              ? { backgroundColor: deptConfig.stageColors[stage], color: 'rgb(var(--color-bg-primary))' }
-                              : { border: '1px solid #2D3041' }
-                          }
-                        >
-                          {scene[stage] ? '✓' : ''}
-                        </button>
-                      </td>
-                    ))
+                    <td colSpan={4} className="px-1 py-1.5">
+                      <StageSegmentToggle
+                        scene={scene}
+                        department={department}
+                        compact
+                        iconDisplay="never"
+                        onToggle={(stage) => onToggle(scene.sceneId, stage)}
+                      />
+                    </td>
                   )}
 
                   {/* 삭제 */}

--- a/src/components/scenes/SheetAlertBadges.tsx
+++ b/src/components/scenes/SheetAlertBadges.tsx
@@ -1,0 +1,53 @@
+import { MessageCircle, MessageSquareWarning } from 'lucide-react';
+import { cn } from '@/utils/cn';
+
+interface SheetAlertBadgesProps {
+  revisionCount?: number;
+  commentCount?: number;
+  hasUnreadComments?: boolean;
+}
+
+export function SheetAlertBadges({
+  revisionCount = 0,
+  commentCount = 0,
+  hasUnreadComments = false,
+}: SheetAlertBadgesProps) {
+  if (revisionCount <= 0 && commentCount <= 0) return null;
+
+  return (
+    <div className="flex items-center justify-center gap-1">
+      {revisionCount > 0 && (
+        <span
+          className="relative inline-flex h-6 w-6 items-center justify-center rounded-md border border-accent/25 bg-accent/15 text-accent"
+          title={`미해결 리비전 ${revisionCount}`}
+          aria-label={`미해결 리비전 ${revisionCount}`}
+        >
+          <MessageSquareWarning size={12} strokeWidth={2.4} />
+          <span className="absolute -right-1 -top-1 min-w-3.5 rounded-full bg-accent px-0.5 text-center text-[9px] font-black leading-3.5 text-white">
+            {revisionCount}
+          </span>
+        </span>
+      )}
+      {commentCount > 0 && (
+        <span
+          className={cn(
+            'relative inline-flex h-6 w-6 items-center justify-center rounded-md border',
+            hasUnreadComments
+              ? 'comment-unread-badge border-accent/25 bg-accent/20 text-accent'
+              : 'border-bg-border/45 bg-text-secondary/10 text-text-secondary/60',
+          )}
+          title={`${hasUnreadComments ? '새 댓글' : '확인한 댓글'} ${commentCount}`}
+          aria-label={`${hasUnreadComments ? '새 댓글' : '확인한 댓글'} ${commentCount}`}
+        >
+          <MessageCircle size={12} fill="currentColor" />
+          <span className={cn(
+            'absolute -right-1 -top-1 min-w-3.5 rounded-full px-0.5 text-center text-[9px] font-black leading-3.5',
+            hasUnreadComments ? 'bg-accent text-white' : 'bg-bg-border text-text-primary',
+          )}>
+            {commentCount}
+          </span>
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/scenes/SheetColumnResize.tsx
+++ b/src/components/scenes/SheetColumnResize.tsx
@@ -12,6 +12,94 @@ function clampWidth(width: number, min: number, max?: number) {
   return Math.max(min, Math.min(max ?? 720, width));
 }
 
+function sumWidths<K extends string>(columns: Array<SheetColumnDefinition<K>>, widths: Record<K, number>) {
+  return columns.reduce((sum, column) => sum + widths[column.key], 0);
+}
+
+function shrinkColumns<K extends string>(
+  widths: Record<K, number>,
+  columnsByKey: Map<K, SheetColumnDefinition<K>>,
+  keys: K[],
+  overflow: number,
+) {
+  let remaining = overflow;
+  let guard = 0;
+
+  while (remaining > 0.5 && guard < 12) {
+    guard += 1;
+    const shrinkable = keys.filter((key) => {
+      const minWidth = columnsByKey.get(key)?.minWidth ?? 0;
+      return widths[key] > minWidth + 0.5;
+    });
+
+    if (shrinkable.length === 0) break;
+
+    const share = remaining / shrinkable.length;
+    let consumed = 0;
+    for (const key of shrinkable) {
+      const minWidth = columnsByKey.get(key)?.minWidth ?? 0;
+      const delta = Math.min(share, widths[key] - minWidth);
+      widths[key] -= delta;
+      consumed += delta;
+    }
+
+    if (consumed <= 0.01) break;
+    remaining -= consumed;
+  }
+
+  return remaining;
+}
+
+export function fitSheetColumnWidths<K extends string>(
+  columns: Array<SheetColumnDefinition<K>>,
+  widths: Record<K, number>,
+  viewportWidth: number,
+  fillColumnKeys: K[],
+) {
+  const next = { ...widths };
+  const columnsByKey = new Map(columns.map((column) => [column.key, column]));
+  const baseTotal = sumWidths(columns, next);
+  const minTotal = columns.reduce((sum, column) => sum + column.minWidth, 0);
+  const targetWidth = viewportWidth > 0 ? Math.max(viewportWidth, minTotal) : baseTotal;
+  const fillKeys = fillColumnKeys.filter((key) => columnsByKey.has(key));
+
+  if (baseTotal < targetWidth && fillKeys.length > 0) {
+    const share = (targetWidth - baseTotal) / fillKeys.length;
+    for (const key of fillKeys) {
+      next[key] += share;
+    }
+  } else if (baseTotal > targetWidth) {
+    const overflow = baseTotal - targetWidth;
+    const remaining = shrinkColumns(next, columnsByKey, fillKeys, overflow);
+    if (remaining > 0.5) {
+      const fallbackKeys = columns
+        .map((column) => column.key)
+        .filter((key) => !fillKeys.includes(key));
+      shrinkColumns(next, columnsByKey, fallbackKeys, remaining);
+    }
+  }
+
+  return {
+    widths: next,
+    totalWidth: sumWidths(columns, next),
+  };
+}
+
+export function useFittedSheetColumnWidths<K extends string>(
+  columns: Array<SheetColumnDefinition<K>>,
+  widthOf: (key: K) => number,
+  viewportWidth: number,
+  fillColumnKeys: K[],
+) {
+  return useMemo(() => {
+    const baseWidths = Object.fromEntries(
+      columns.map((column) => [column.key, widthOf(column.key)]),
+    ) as Record<K, number>;
+
+    return fitSheetColumnWidths(columns, baseWidths, viewportWidth, fillColumnKeys);
+  }, [columns, fillColumnKeys, viewportWidth, widthOf]);
+}
+
 function readStoredWidths<K extends string>(
   storageKey: string,
   columns: Array<SheetColumnDefinition<K>>,
@@ -59,14 +147,14 @@ export function useResizableSheetColumns<K extends string>(
     }
   }, [storageKey]);
 
-  const startResize = useCallback((key: K, event: ReactPointerEvent) => {
+  const startResize = useCallback((key: K, event: ReactPointerEvent, visualStartWidth?: number) => {
     const column = columnByKey.get(key);
     if (!column) return;
 
     event.preventDefault();
     event.stopPropagation();
     const startX = event.clientX;
-    const startWidth = widthOf(key);
+    const startWidth = visualStartWidth ?? widthOf(key);
     let latest = startWidth;
 
     document.documentElement.classList.add('is-resizing', 'is-sheet-column-resizing');
@@ -92,29 +180,103 @@ export function useResizableSheetColumns<K extends string>(
     document.addEventListener('pointerup', onUp, { once: true });
   }, [columnByKey, persist, widthOf]);
 
-  return { widthOf, totalWidth, startResize };
+  const startBoundaryResize = useCallback((
+    leftKey: K,
+    rightKey: K,
+    event: ReactPointerEvent,
+    leftVisualStartWidth?: number,
+    rightVisualStartWidth?: number,
+  ) => {
+    const leftColumn = columnByKey.get(leftKey);
+    const rightColumn = columnByKey.get(rightKey);
+    if (!leftColumn || !rightColumn) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    const startX = event.clientX;
+    const leftStartWidth = leftVisualStartWidth ?? widthOf(leftKey);
+    const rightStartWidth = rightVisualStartWidth ?? widthOf(rightKey);
+    const pairWidth = leftStartWidth + rightStartWidth;
+    const leftMax = leftColumn.maxWidth ?? 720;
+    const rightMax = rightColumn.maxWidth ?? 720;
+    const minLeft = Math.max(leftColumn.minWidth, pairWidth - rightMax);
+    const maxLeft = Math.min(leftMax, pairWidth - rightColumn.minWidth);
+    const min = Math.min(minLeft, maxLeft);
+    const max = Math.max(minLeft, maxLeft);
+    let latestLeft = leftStartWidth;
+    let latestRight = rightStartWidth;
+
+    document.documentElement.classList.add('is-resizing', 'is-sheet-column-resizing');
+
+    const onMove = (moveEvent: PointerEvent) => {
+      const nextLeft = Math.max(min, Math.min(max, leftStartWidth + moveEvent.clientX - startX));
+      const nextRight = pairWidth - nextLeft;
+      latestLeft = nextLeft;
+      latestRight = nextRight;
+      setWidths((prev) => ({ ...prev, [leftKey]: nextLeft, [rightKey]: nextRight }));
+    };
+
+    const onUp = () => {
+      document.removeEventListener('pointermove', onMove);
+      document.removeEventListener('pointerup', onUp);
+      document.documentElement.classList.remove('is-resizing', 'is-sheet-column-resizing');
+      setWidths((prev) => {
+        const next = { ...prev, [leftKey]: latestLeft, [rightKey]: latestRight };
+        persist(next);
+        return next;
+      });
+    };
+
+    document.addEventListener('pointermove', onMove);
+    document.addEventListener('pointerup', onUp, { once: true });
+  }, [columnByKey, persist, widthOf]);
+
+  return { widthOf, totalWidth, startResize, startBoundaryResize };
 }
 
 export function ResizableHeaderCell<K extends string>({
   columnKey,
   width,
+  leftBoundaryColumnKey,
+  leftBoundaryWidth,
+  rightBoundaryColumnKey,
+  rightBoundaryWidth,
   shortLabel,
   className,
   style,
   align = 'left',
   onResizeStart,
+  onBoundaryResizeStart,
   children,
 }: {
   columnKey: K;
   width: number;
+  leftBoundaryColumnKey?: K;
+  leftBoundaryWidth?: number;
+  rightBoundaryColumnKey?: K;
+  rightBoundaryWidth?: number;
   shortLabel?: string;
   className?: string;
   style?: CSSProperties;
   align?: 'left' | 'center';
-  onResizeStart: (key: K, event: ReactPointerEvent) => void;
+  onResizeStart: (key: K, event: ReactPointerEvent, visualStartWidth?: number) => void;
+  onBoundaryResizeStart?: (
+    leftKey: K,
+    rightKey: K,
+    event: ReactPointerEvent,
+    leftVisualStartWidth?: number,
+    rightVisualStartWidth?: number,
+  ) => void;
   children?: ReactNode;
 }) {
   const fullLabel = typeof children === 'string' ? children : undefined;
+  const handleRightResize = (event: ReactPointerEvent) => {
+    if (rightBoundaryColumnKey && onBoundaryResizeStart) {
+      onBoundaryResizeStart(columnKey, rightBoundaryColumnKey, event, width, rightBoundaryWidth);
+      return;
+    }
+    onResizeStart(columnKey, event, width);
+  };
 
   return (
     <th
@@ -130,12 +292,24 @@ export function ResizableHeaderCell<K extends string>({
         <span data-sheet-header-full-label>{children}</span>
         {shortLabel && <span data-sheet-header-short-label>{shortLabel}</span>}
       </span>
+      {leftBoundaryColumnKey && onBoundaryResizeStart && (
+        <span
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="컬럼 경계 너비 조절"
+          className="sheet-column-resizer sheet-column-resizer-left"
+          onPointerDown={(event) =>
+            onBoundaryResizeStart(leftBoundaryColumnKey, columnKey, event, leftBoundaryWidth, width)
+          }
+          onClick={(event) => event.stopPropagation()}
+        />
+      )}
       <span
         role="separator"
         aria-orientation="vertical"
-        aria-label="컬럼 너비 조절"
+        aria-label={rightBoundaryColumnKey ? '컬럼 경계 너비 조절' : '컬럼 너비 조절'}
         className="sheet-column-resizer"
-        onPointerDown={(event) => onResizeStart(columnKey, event)}
+        onPointerDown={handleRightResize}
         onClick={(event) => event.stopPropagation()}
       />
     </th>

--- a/src/components/scenes/StageSegmentToggle.tsx
+++ b/src/components/scenes/StageSegmentToggle.tsx
@@ -1,0 +1,131 @@
+import { useRef } from 'react';
+import { CheckCircle2, CheckSquare, Clock, PlayCircle } from 'lucide-react';
+import { STAGES, DEPARTMENT_CONFIGS } from '@/types';
+import type { Department, Scene, Stage } from '@/types';
+import { CompactIconLabel } from '@/components/common/CompactIconLabel';
+import { cn } from '@/utils/cn';
+import { useStageLabelDisplayMode } from './useStageLabelDisplayMode';
+
+export function stageIcon(stage: Stage, size = 12) {
+  if (stage === 'lo') return <Clock size={size} strokeWidth={2.4} />;
+  if (stage === 'done') return <PlayCircle size={size} strokeWidth={2.4} />;
+  if (stage === 'review') return <CheckSquare size={size} strokeWidth={2.4} />;
+  return <CheckCircle2 size={size} strokeWidth={2.4} />;
+}
+
+interface StageSegmentToggleProps {
+  scene: Scene;
+  department: Department;
+  onToggle: (stage: Stage) => void;
+  compact?: boolean;
+  iconDisplay?: 'always' | 'wide' | 'never' | 'auto';
+  className?: string;
+  segmentClassName?: string | ((stage: Stage) => string | undefined);
+  dataContinuityTarget?: string;
+}
+
+export function StageSegmentToggle({
+  scene,
+  department,
+  onToggle,
+  compact = false,
+  iconDisplay = 'auto',
+  className,
+  segmentClassName,
+  dataContinuityTarget,
+}: StageSegmentToggleProps) {
+  const cfg = DEPARTMENT_CONFIGS[department];
+  const pointerHandledRef = useRef(false);
+  const { modeOf, setNode } = useStageLabelDisplayMode(cfg.stageLabels, compact, iconDisplay === 'auto');
+  const iconClassName =
+    iconDisplay === 'never'
+      ? 'hidden'
+      : iconDisplay === 'wide'
+        ? 'hidden 2xl:inline-flex'
+        : undefined;
+
+  return (
+    <div
+      className={cn(
+        'flex w-full rounded-lg bg-bg-primary/70 border border-bg-border/40',
+        compact ? 'p-0.5 gap-0.5' : 'p-1 gap-0.5',
+        className,
+      )}
+      data-continuity-source={dataContinuityTarget}
+    >
+      {STAGES.map((stage, i) => {
+        const isDone = scene[stage];
+        const isCurrent = isDone && (i === STAGES.length - 1 || !scene[STAGES[i + 1]]);
+        const extraClassName =
+          typeof segmentClassName === 'function' ? segmentClassName(stage) : segmentClassName;
+
+        return (
+          <button
+            type="button"
+            key={stage}
+            ref={setNode(stage)}
+            data-continuity-stage-segment
+            onPointerDown={(e) => {
+              if (e.button !== 0) return;
+              e.preventDefault();
+              e.stopPropagation();
+              pointerHandledRef.current = true;
+              onToggle(stage);
+              window.setTimeout(() => {
+                pointerHandledRef.current = false;
+              }, 600);
+            }}
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              if (pointerHandledRef.current) {
+                pointerHandledRef.current = false;
+                return;
+              }
+              onToggle(stage);
+            }}
+            className={cn(
+              'compact-label-container flex-1 min-w-0 inline-flex items-center justify-center rounded-md font-medium transition-all cursor-pointer',
+              'focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/60',
+              compact ? 'px-1 py-1 text-[10px]' : 'px-1.5 py-2 text-[11px]',
+              !isDone && 'text-text-secondary/60 hover:text-text-primary hover:bg-bg-border/25',
+              extraClassName,
+            )}
+            style={
+              isDone
+                ? isCurrent
+                  ? {
+                      backgroundColor: cfg.color,
+                      color: '#fff',
+                      fontWeight: 700,
+                      boxShadow: `0 2px 8px ${cfg.color}40`,
+                    }
+                  : {
+                      backgroundColor: `${cfg.color}20`,
+                      color: cfg.color,
+                    }
+                : undefined
+            }
+            title={cfg.stageLabels[stage]}
+          >
+            <CompactIconLabel
+              icon={stageIcon(stage, 12)}
+              label={cfg.stageLabels[stage]}
+              className="w-full"
+              textClassName="leading-none"
+              iconClassName={iconClassName}
+              iconPosition="after"
+              displayMode={
+                iconDisplay === 'auto'
+                  ? modeOf(stage)
+                  : iconDisplay === 'never'
+                    ? 'text'
+                    : 'both'
+              }
+            />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/scenes/UnifiedSceneCard.tsx
+++ b/src/components/scenes/UnifiedSceneCard.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { motion } from 'framer-motion';
-import { Check, CheckCircle2, Clock, MessageCircle, MessageSquareWarning, PlayCircle, Trash2 } from 'lucide-react';
+import { MessageCircle, Trash2 } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import { isFullyDone, sceneProgress } from '@/utils/calcStats';
 import { STAGES, DEPARTMENT_CONFIGS } from '@/types';
@@ -18,13 +18,8 @@ import { useAppStore } from '@/stores/useAppStore';
 import { buildSceneKey } from '@/services/revisionService';
 import { LengthIcon } from './LengthIcon';
 import { SceneContextMenu } from './SceneContextMenu';
-
-function stageIcon(stage: Stage, size = 12) {
-  if (stage === 'lo') return <Clock size={size} strokeWidth={2.4} />;
-  if (stage === 'done') return <PlayCircle size={size} strokeWidth={2.4} />;
-  if (stage === 'review') return <MessageSquareWarning size={size} strokeWidth={2.4} />;
-  return <CheckCircle2 size={size} strokeWidth={2.4} />;
-}
+import { StageSegmentToggle, stageIcon } from './StageSegmentToggle';
+import { RevisionCornerFlag } from './RevisionCornerFlag';
 
 // 씬 UUID에 대한 현재 일괄 작업 상태(pending / failed)를 조회
 function getPendingState(
@@ -276,16 +271,16 @@ export function UnifiedSceneCard({
     >
         {isHighlighted && <div className="scene-highlight-bg" />}
 
-        {/* v1.18.0: 좌측 액센트 막대 — 미해결 리비전 있는 카드 표시 (mockup 시안 1) */}
-        {openRevCount > 0 && (
-          <span
-            aria-hidden
-            className="absolute left-0 top-0 bottom-0 w-1 bg-accent rounded-l-xl pointer-events-none"
-          />
-        )}
+        <RevisionCornerFlag
+          count={openRevCount > 0 ? openRevCount : resolvedRevCount}
+          resolved={openRevCount <= 0 && resolvedRevCount > 0}
+        />
 
         {isSelected && (
-          <div className="absolute top-2.5 right-2.5 z-20 w-5 h-5 rounded-full bg-accent flex items-center justify-center shadow-sm shadow-accent/30">
+          <div className={cn(
+            'absolute right-2.5 z-20 w-5 h-5 rounded-full bg-accent flex items-center justify-center shadow-sm shadow-accent/30',
+            openRevCount > 0 || resolvedRevCount > 0 ? 'top-9' : 'top-2.5',
+          )}>
             <svg width="10" height="10" viewBox="0 0 12 12" fill="none"><path d="M2 6l3 3 5-5" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/></svg>
           </div>
         )}
@@ -306,26 +301,6 @@ export function UnifiedSceneCard({
             )}
           </div>
           <div className="flex items-center gap-1.5">
-            {/* v1.18.0: 리비전 시각 표시 — 미해결 우선, 없으면 완료 카운트.
-                isSelected 시 우측 상단의 체크 아이콘과 겹치지 않도록 헤더 인라인 배치 (좌측 막대도 함께 노출). */}
-            {openRevCount > 0 ? (
-              <span
-                className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-md text-[10px] font-bold bg-accent text-white"
-                style={{ boxShadow: '0 0 14px rgb(var(--color-accent) / 0.55)' }}
-                title={`미해결 리비전 ${openRevCount}건`}
-              >
-                <MessageSquareWarning className="w-2.5 h-2.5" strokeWidth={2.4} />
-                {openRevCount}
-              </span>
-            ) : resolvedRevCount > 0 ? (
-              <span
-                className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-md text-[10px] font-medium bg-bg-card border border-bg-border/40 text-text-secondary/70"
-                title={`완료된 리비전 ${resolvedRevCount}건`}
-              >
-                <Check className="w-2.5 h-2.5" strokeWidth={2.5} />
-                {resolvedRevCount}
-              </span>
-            ) : null}
             {/* Codex P2 6차(2026-04-23): 정확한 total 은 ScenesView 가 commentIdsByKey 로 계산해
                 `totalCommentCount` 로 전달. 없으면 Math.max 로 fallback (대부분 BG·ACT 동일값). */}
             {(() => {
@@ -339,11 +314,11 @@ export function UnifiedSceneCard({
                       ? 'comment-unread-badge border-accent/25 bg-accent/15 text-accent shadow-[0_0_10px_rgba(108,92,231,0.16)]'
                       : 'border-bg-border/45 bg-text-secondary/10 text-text-secondary/60',
                   )}
-                  title={`${hasUnreadComments ? '새 댓글' : '확인한 댓글'} ${displayCount}개`}
+                  title={`${hasUnreadComments ? '새 댓글' : '확인한 댓글'} ${displayCount}`}
                 >
                   <CompactIconLabel
                     icon={<MessageCircle size={10} fill="currentColor" />}
-                    label={`${displayCount}개`}
+                    label={`${displayCount}`}
                     textClassName="text-[10px] font-bold"
                   />
                 </span>
@@ -484,7 +459,6 @@ function DeptSection({
   const cfg = DEPARTMENT_CONFIGS[dept];
   const completionTintEnabled = useAppStore((s) => s.completionTintEnabled);
   const isDeptDone = !!scene && isFullyDone(scene);
-  const stagePointerHandledRef = useRef(false);
 
   // stage-toggle 작업에서 이 씬의 targetStage 셀에만 pending/failed 스타일 적용
   const stageCellPendingClass = (stage: Stage): string => {
@@ -512,7 +486,13 @@ function DeptSection({
               data-continuity-stage-segment
               className="compact-label-container flex-1 min-w-0 text-center py-1.5 text-[11px] font-medium text-text-secondary/30 rounded-md"
             >
-              <CompactIconLabel icon={stageIcon(stage, 12)} label={cfg.stageLabels[stage]} className="w-full" />
+              <CompactIconLabel
+                icon={stageIcon(stage, 12)}
+                label={cfg.stageLabels[stage]}
+                className="w-full"
+                iconClassName="hidden 2xl:inline-flex"
+                iconPosition="after"
+              />
             </div>
           ))}
         </div>
@@ -561,57 +541,13 @@ function DeptSection({
           />
         </div>
       ) : (
-        <div
-          className="flex rounded-lg bg-bg-primary/70 border border-bg-border/40 p-1 gap-0.5"
-          data-continuity-source={dept === 'bg' ? 'bg-stage' : 'act-stage'}
-        >
-          {STAGES.map((stage, i) => {
-            const isDone = scene[stage];
-            const isCurrent = isDone && (i === STAGES.length - 1 || !scene[STAGES[i + 1]]);
-
-            return (
-              <button
-                type="button"
-                key={stage}
-                data-continuity-stage-segment
-                onPointerDown={(e) => {
-                  if (e.button !== 0) return;
-                  e.preventDefault();
-                  e.stopPropagation();
-                  stagePointerHandledRef.current = true;
-                  onToggle(sheetName, sceneId, stage);
-                  window.setTimeout(() => {
-                    stagePointerHandledRef.current = false;
-                  }, 600);
-                }}
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  if (stagePointerHandledRef.current) {
-                    stagePointerHandledRef.current = false;
-                    return;
-                  }
-                  onToggle(sheetName, sceneId, stage);
-                }}
-                className={cn(
-                  'compact-label-container flex-1 min-w-0 text-center py-2 text-[11px] font-medium rounded-md transition-all cursor-pointer',
-                  !isDone && 'text-text-secondary/60 hover:text-text-primary hover:bg-bg-border/25',
-                  stageCellPendingClass(stage),
-                )}
-                style={
-                  isDone
-                    ? isCurrent
-                      ? { backgroundColor: cfg.color, color: '#fff', fontWeight: 700, boxShadow: `0 2px 8px ${cfg.color}40` }
-                      : { backgroundColor: `${cfg.color}20`, color: cfg.color }
-                    : undefined
-                }
-                title={cfg.stageLabels[stage]}
-              >
-                <CompactIconLabel icon={stageIcon(stage, 12)} label={cfg.stageLabels[stage]} className="w-full" />
-              </button>
-            );
-          })}
-        </div>
+        <StageSegmentToggle
+          scene={scene}
+          department={dept}
+          onToggle={(stage) => onToggle(sheetName, sceneId, stage)}
+          segmentClassName={stageCellPendingClass}
+          dataContinuityTarget={dept === 'bg' ? 'bg-stage' : 'act-stage'}
+        />
       )}
     </div>
   );

--- a/src/components/scenes/UnifiedSceneDetailModal.tsx
+++ b/src/components/scenes/UnifiedSceneDetailModal.tsx
@@ -15,9 +15,10 @@ import {
   Pin,
 } from 'lucide-react';
 import { cn } from '@/utils/cn';
-import { STAGES, DEPARTMENT_CONFIGS } from '@/types';
+import { DEPARTMENT_CONFIGS } from '@/types';
 import type { MergedScene, Scene, Stage, Department, ScenePhaseState } from '@/types';
 import { ScenePhaseToggle } from './ScenePhaseToggle';
+import { StageSegmentToggle } from './StageSegmentToggle';
 import { sceneProgress } from '@/utils/calcStats';
 import { AssigneeMultiSelect, AssigneeChipList } from '@/components/common/AssigneeMultiSelect';
 import { PathLinkifiedText } from '@/components/common/PathLinkifiedText';
@@ -1242,41 +1243,22 @@ function DeptSection({
           <div data-continuity-target="act-stage">
             <ScenePhaseToggle
               scene={scene}
+              iconDisplay="always"
               onStateClick={(next) => onActPhaseStateClick(sheetName, sceneId, next)}
               onRequestFeedback={() => onActFeedbackRequest(sheetName, sceneId)}
               onRoundBump={(kind, delta) => onActRoundBump(sheetName, sceneId, kind, delta)}
             />
           </div>
         ) : (
-          <div
-            className="flex rounded-lg bg-black/[0.06] dark:bg-white/[0.04] p-1 gap-1"
-            data-continuity-target={dept === 'bg' ? 'bg-stage' : 'act-stage'}
-          >
-            {STAGES.map((stage, i) => {
-              const done = scene[stage];
-              const isCurrent = done && (i === STAGES.length - 1 || !scene[STAGES[i + 1]]);
-              return (
-                <button
-                  key={stage}
-                  data-continuity-stage-segment
-                  onClick={() => onToggle(sheetName, sceneId, stage)}
-                  className={cn(
-                    'flex-1 text-center py-2 text-xs font-medium rounded-md transition-all cursor-pointer',
-                    !done && 'text-text-secondary/60 hover:text-text-primary hover:bg-black/5 dark:hover:bg-white/5',
-                  )}
-                  style={
-                    done
-                      ? isCurrent
-                        ? { backgroundColor: cfg.color, color: '#fff', fontWeight: 700, boxShadow: `0 2px 8px ${cfg.color}40` }
-                        : { backgroundColor: `${cfg.color}20`, color: cfg.color }
-                      : undefined
-                  }
-                >
-                  {cfg.stageLabels[stage]}
-                </button>
-              );
-            })}
-          </div>
+          <StageSegmentToggle
+            scene={scene}
+            department={dept}
+            iconDisplay="always"
+            className="bg-black/[0.06] dark:bg-white/[0.04] border-transparent"
+            segmentClassName="py-2 text-xs"
+            dataContinuityTarget={dept === 'bg' ? 'bg-stage' : 'act-stage'}
+            onToggle={(stage) => onToggle(sheetName, sceneId, stage)}
+          />
         )}
       </div>
 

--- a/src/components/scenes/UnifiedSceneSheetView.tsx
+++ b/src/components/scenes/UnifiedSceneSheetView.tsx
@@ -475,6 +475,7 @@ export function UnifiedSceneSheetView({
     UNIFIED_SHEET_FILL_COLUMNS,
   );
   const sheetWidth = fittedSheet.totalWidth;
+  const sheetOverflowsViewport = tableViewportWidth > 0 && sheetWidth > tableViewportWidth + 1;
   const displayWidthOf = useCallback(
     (key: UnifiedSheetColumnKey) => fittedSheet.widths[key],
     [fittedSheet],
@@ -785,7 +786,10 @@ export function UnifiedSceneSheetView({
       <div
         ref={tableRef}
         tabIndex={0}
-        className="overflow-y-auto overflow-x-hidden rounded-lg border border-bg-border focus:outline-none"
+        className={cn(
+          'overflow-y-auto rounded-lg border border-bg-border focus:outline-none',
+          sheetOverflowsViewport ? 'overflow-x-auto' : 'overflow-x-hidden',
+        )}
         onKeyDown={handleTableKeyDown}
         onMouseUp={() => setIsDragging(false)}
         style={{ userSelect: isDragging ? 'none' : undefined }}

--- a/src/components/scenes/UnifiedSceneSheetView.tsx
+++ b/src/components/scenes/UnifiedSceneSheetView.tsx
@@ -1,11 +1,10 @@
 import { useState, useRef, useEffect, useMemo, useCallback, Fragment } from 'react';
 import { createPortal } from 'react-dom';
 import { motion } from 'framer-motion';
-import { MessageCircle, Trash2 } from 'lucide-react';
+import { Trash2 } from 'lucide-react';
 import { STAGES, DEPARTMENT_CONFIGS } from '@/types';
 import type { MergedScene, Stage, Scene, ScenePhaseState } from '@/types';
 import { ScenePhaseToggle } from './ScenePhaseToggle';
-import { CompactIconLabel } from '@/components/common/CompactIconLabel';
 import type { SceneGroupMode } from '@/stores/useAppStore';
 import { isFullyDone } from '@/utils/calcStats';
 import { cn } from '@/utils/cn';
@@ -21,10 +20,13 @@ import { LengthIcon } from './LengthIcon';
 import { SceneContextMenu } from './SceneContextMenu';
 import {
   ResizableHeaderCell,
+  useFittedSheetColumnWidths,
   useResizableSheetColumns,
   type SheetColumnDefinition,
 } from './SheetColumnResize';
 import { useAppStore } from '@/stores/useAppStore';
+import { StageSegmentToggle } from './StageSegmentToggle';
+import { SheetAlertBadges } from './SheetAlertBadges';
 
 // ─── Props ───────────────────────────────────────────────────
 
@@ -65,6 +67,7 @@ function cellKey(row: number, col: number) { return `${row}:${col}`; }
 
 type UnifiedSheetColumnKey =
   | 'scene'
+  | 'alerts'
   | 'bgMemo'
   | 'actMemo'
   | 'storyboard'
@@ -83,8 +86,9 @@ type UnifiedSheetColumnKey =
 
 const UNIFIED_SHEET_COLUMNS: Array<SheetColumnDefinition<UnifiedSheetColumnKey>> = [
   { key: 'scene', defaultWidth: 104, minWidth: 78, maxWidth: 180 },
-  { key: 'bgMemo', defaultWidth: 220, minWidth: 72, maxWidth: 520 },
-  { key: 'actMemo', defaultWidth: 220, minWidth: 72, maxWidth: 520 },
+  { key: 'alerts', defaultWidth: 58, minWidth: 44, maxWidth: 84 },
+  { key: 'bgMemo', defaultWidth: 220, minWidth: 72, maxWidth: 900 },
+  { key: 'actMemo', defaultWidth: 220, minWidth: 72, maxWidth: 900 },
   { key: 'storyboard', defaultWidth: 64, minWidth: 48, maxWidth: 140 },
   { key: 'guide', defaultWidth: 64, minWidth: 48, maxWidth: 140 },
   { key: 'bgAssignee', defaultWidth: 112, minWidth: 72, maxWidth: 220 },
@@ -99,6 +103,7 @@ const UNIFIED_SHEET_COLUMNS: Array<SheetColumnDefinition<UnifiedSheetColumnKey>>
   { key: 'actDone', defaultWidth: 56, minWidth: 36, maxWidth: 112 },
   { key: 'actions', defaultWidth: 40, minWidth: 32, maxWidth: 72 },
 ];
+const UNIFIED_SHEET_FILL_COLUMNS: UnifiedSheetColumnKey[] = ['bgMemo', 'actMemo'];
 
 const BG_STAGE_SHORT_LABELS: Record<Stage, string> = {
   lo: 'LO',
@@ -358,11 +363,10 @@ export function UnifiedSceneSheetView({
   const bgCfg = DEPARTMENT_CONFIGS.bg;
   const actCfg = DEPARTMENT_CONFIGS.acting;
   const completionTintEnabled = useAppStore((s) => s.completionTintEnabled);
-  const stagePointerHandledRef = useRef(false);
   const {
     widthOf,
-    totalWidth,
     startResize,
+    startBoundaryResize,
   } = useResizableSheetColumns('bflow_unified_scene_sheet_columns_v1', UNIFIED_SHEET_COLUMNS);
 
   // 레이아웃 그루핑
@@ -444,6 +448,37 @@ export function UnifiedSceneSheetView({
   const [initialEditChar, setInitialEditChar] = useState<string | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   const tableRef = useRef<HTMLDivElement>(null);
+  const [tableViewportWidth, setTableViewportWidth] = useState(0);
+
+  useEffect(() => {
+    const node = tableRef.current;
+    if (!node) return;
+
+    const updateWidth = () => {
+      setTableViewportWidth(Math.floor(node.clientWidth));
+    };
+    updateWidth();
+
+    const observer = new ResizeObserver(updateWidth);
+    observer.observe(node);
+    window.addEventListener('resize', updateWidth);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', updateWidth);
+    };
+  }, []);
+
+  const fittedSheet = useFittedSheetColumnWidths(
+    UNIFIED_SHEET_COLUMNS,
+    widthOf,
+    tableViewportWidth,
+    UNIFIED_SHEET_FILL_COLUMNS,
+  );
+  const sheetWidth = fittedSheet.totalWidth;
+  const displayWidthOf = useCallback(
+    (key: UnifiedSheetColumnKey) => fittedSheet.widths[key],
+    [fittedSheet],
+  );
 
   // ── v1.16.0: 우클릭 컨텍스트 메뉴 상태 ──
   const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number; merged: MergedScene } | null>(null);
@@ -750,18 +785,18 @@ export function UnifiedSceneSheetView({
       <div
         ref={tableRef}
         tabIndex={0}
-        className="overflow-auto rounded-lg border border-bg-border focus:outline-none"
+        className="overflow-y-auto overflow-x-hidden rounded-lg border border-bg-border focus:outline-none"
         onKeyDown={handleTableKeyDown}
         onMouseUp={() => setIsDragging(false)}
         style={{ userSelect: isDragging ? 'none' : undefined }}
       >
         <table
           className="text-sm border-collapse"
-          style={{ tableLayout: 'fixed', width: totalWidth }}
+          style={{ tableLayout: 'fixed', width: sheetWidth }}
         >
           <colgroup>
             {UNIFIED_SHEET_COLUMNS.map((column) => (
-              <col key={column.key} style={{ width: widthOf(column.key) }} />
+              <col key={column.key} style={{ width: displayWidthOf(column.key) }} />
             ))}
           </colgroup>
           {/* ── 헤더 ── */}
@@ -771,7 +806,7 @@ export function UnifiedSceneSheetView({
                 여기만 19칸이 되어 sticky 2단 헤더 정렬이 깨졌음. 한솔 결정 1-B 에 따라 컬럼 수는
                 일반 모드와 동일하므로 별도 분기 불필요. */}
             <tr className="bg-bg-card border-b border-bg-border/50">
-              <th colSpan={5} />
+              <th colSpan={6} />
               <th colSpan={5} className="py-1 text-center">
                 <span className="inline-flex items-center gap-1 text-[10px] text-text-secondary/60">
                   <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: bgCfg.color }} />
@@ -790,13 +825,36 @@ export function UnifiedSceneSheetView({
               {/* 한솔 결정 (1-B): 레이아웃 별 보기 시 별도 컬럼 대신 행 위에 그룹 헤더 행을 삽입.
                   sceneGroupMode === 'layout' 컬럼 분기 제거 — 컬럼 수가 일반 모드와 동일하게 유지된다.
                   v1.16.0: 메모 컬럼을 BG/ACT 두 개로 분리 (한솔 결정 B2). */}
-              <ResizableHeaderCell columnKey="scene" width={widthOf('scene')} onResizeStart={startResize} shortLabel="씬">씬번호</ResizableHeaderCell>
-              <ResizableHeaderCell columnKey="bgMemo" width={widthOf('bgMemo')} onResizeStart={startResize} style={{ color: bgCfg.color }} shortLabel="BG">BG 메모</ResizableHeaderCell>
-              <ResizableHeaderCell columnKey="actMemo" width={widthOf('actMemo')} onResizeStart={startResize} style={{ color: actCfg.color }} shortLabel="ACT">ACT 메모</ResizableHeaderCell>
-              <ResizableHeaderCell columnKey="storyboard" width={widthOf('storyboard')} onResizeStart={startResize} align="center" shortLabel="SB">스토리보드</ResizableHeaderCell>
-              <ResizableHeaderCell columnKey="guide" width={widthOf('guide')} onResizeStart={startResize} align="center" shortLabel="Guide">가이드</ResizableHeaderCell>
+              <ResizableHeaderCell columnKey="scene" width={displayWidthOf('scene')} onResizeStart={startResize} shortLabel="씬">씬번호</ResizableHeaderCell>
+              <ResizableHeaderCell columnKey="alerts" width={displayWidthOf('alerts')} onResizeStart={startResize} align="center" className="px-1" />
+              <ResizableHeaderCell
+                columnKey="bgMemo"
+                width={displayWidthOf('bgMemo')}
+                rightBoundaryColumnKey="actMemo"
+                rightBoundaryWidth={displayWidthOf('actMemo')}
+                onResizeStart={startResize}
+                onBoundaryResizeStart={startBoundaryResize}
+                style={{ color: bgCfg.color }}
+                shortLabel="BG"
+              >
+                BG 메모
+              </ResizableHeaderCell>
+              <ResizableHeaderCell
+                columnKey="actMemo"
+                width={displayWidthOf('actMemo')}
+                leftBoundaryColumnKey="bgMemo"
+                leftBoundaryWidth={displayWidthOf('bgMemo')}
+                onResizeStart={startResize}
+                onBoundaryResizeStart={startBoundaryResize}
+                style={{ color: actCfg.color }}
+                shortLabel="ACT"
+              >
+                ACT 메모
+              </ResizableHeaderCell>
+              <ResizableHeaderCell columnKey="storyboard" width={displayWidthOf('storyboard')} onResizeStart={startResize} align="center" shortLabel="SB">스토리보드</ResizableHeaderCell>
+              <ResizableHeaderCell columnKey="guide" width={displayWidthOf('guide')} onResizeStart={startResize} align="center" shortLabel="Guide">가이드</ResizableHeaderCell>
               {/* BG 담당 + 스테이지 */}
-              <ResizableHeaderCell columnKey="bgAssignee" width={widthOf('bgAssignee')} onResizeStart={startResize} style={{ color: bgCfg.color }} shortLabel="BG담">
+              <ResizableHeaderCell columnKey="bgAssignee" width={displayWidthOf('bgAssignee')} onResizeStart={startResize} style={{ color: bgCfg.color }} shortLabel="BG담">
                 BG담당
               </ResizableHeaderCell>
               {STAGES.map((s) => {
@@ -805,7 +863,7 @@ export function UnifiedSceneSheetView({
                   <ResizableHeaderCell
                     key={`bg-${s}`}
                     columnKey={key}
-                    width={widthOf(key)}
+                    width={displayWidthOf(key)}
                     onResizeStart={startResize}
                     align="center"
                     className="px-1 text-[11px]"
@@ -817,7 +875,7 @@ export function UnifiedSceneSheetView({
                 );
               })}
               {/* ACT 담당 + 스테이지 */}
-              <ResizableHeaderCell columnKey="actAssignee" width={widthOf('actAssignee')} onResizeStart={startResize} style={{ color: actCfg.color }} shortLabel="ACT담">
+              <ResizableHeaderCell columnKey="actAssignee" width={displayWidthOf('actAssignee')} onResizeStart={startResize} style={{ color: actCfg.color }} shortLabel="ACT담">
                 ACT담당
               </ResizableHeaderCell>
               {/* v1.25.2~: 액팅 새 토글 핸들러가 전달되면 ACT 단계 4셀을 ScenePhaseToggle 1셀로 통합 */}
@@ -842,7 +900,7 @@ export function UnifiedSceneSheetView({
                     <ResizableHeaderCell
                       key={`act-${s}`}
                       columnKey={key}
-                      width={widthOf(key)}
+                      width={displayWidthOf(key)}
                       onResizeStart={startResize}
                       align="center"
                       className="px-1 text-[11px]"
@@ -854,7 +912,7 @@ export function UnifiedSceneSheetView({
                   );
                 })
               )}
-              <ResizableHeaderCell columnKey="actions" width={widthOf('actions')} onResizeStart={startResize} align="center" className="px-1" />
+              <ResizableHeaderCell columnKey="actions" width={displayWidthOf('actions')} onResizeStart={startResize} align="center" className="px-1" />
             </tr>
           </thead>
 
@@ -952,18 +1010,9 @@ export function UnifiedSceneSheetView({
                     }}
                   >
 
-                  {/* 씬번호 + 레이아웃 뱃지 + 댓글 뱃지.
-                      한솔 결정 (5번): 1+3 합본 효과 — 텍스트 네온 펄스 + wrap 회전 보더.
-                      v1.16.0: 길이 변경 라벨 LD/SD 칩 (씬번호 앞).
-                      v1.18.0: 미해결 리비전 좌측 막대(셀 안 absolute) + 씬번호 옆 mini 카운트 배지. */}
-                  <td className="px-2 py-1.5 font-mono text-xs relative" style={{ overflow: 'visible', whiteSpace: 'nowrap' }}>
-                    {openRevCount > 0 && (
-                      <span
-                        aria-hidden
-                        className="absolute left-0 top-0 bottom-0 w-[3px] bg-accent pointer-events-none"
-                      />
-                    )}
-                    <span className="flex items-center gap-2">
+                  {/* 씬번호 */}
+                  <td className="px-2 py-1.5 font-mono text-xs relative" style={{ overflow: 'visible' }}>
+                    <div className="flex min-w-0 items-center gap-1.5">
                       {lengthChange && (
                         <span
                           className={`length-symbol-sheet ${lengthChange === 'LD' ? 'up' : 'down'}`}
@@ -972,42 +1021,24 @@ export function UnifiedSceneSheetView({
                           <LengthIcon kind={lengthChange} size="sm" />
                         </span>
                       )}
-                      <span className="scene-num-glow-wrap">
+                      <span className="scene-num-glow-wrap min-w-0">
                         <span className="scene-num-glow-text">
                           <HighlightText text={sceneId || primary.sceneId || '-'} query={searchQuery} />
                         </span>
                       </span>
-                      {openRevCount > 0 && (
-                        <span
-                          className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md text-[10px] font-bold bg-accent text-white"
-                          title={`미해결 리비전 ${openRevCount}건`}
-                        >
-                          {openRevCount}
-                        </span>
-                      )}
                       {primary.layoutId && (
                         <span className="text-[11px] italic font-medium text-accent flex-shrink-0">
                           L#{primary.layoutId}
                         </span>
                       )}
-                      {commentBadgeCounts.total > 0 && (
-                        <span
-                          className={cn(
-                            'compact-label-container inline-flex min-w-0 shrink items-center gap-0.5 rounded-full border px-1 py-px transition-colors',
-                            hasUnreadComments
-                              ? 'comment-unread-badge border-accent/25 bg-accent/20 text-accent'
-                              : 'border-bg-border/40 bg-text-secondary/10 text-text-secondary/55',
-                          )}
-                          title={`${hasUnreadComments ? '새 댓글' : '확인한 댓글'} ${commentBadgeCounts.total}개`}
-                        >
-                          <CompactIconLabel
-                            icon={<MessageCircle size={9} fill="currentColor" />}
-                            label={`${commentBadgeCounts.total}개`}
-                            textClassName="text-[10px] font-bold"
-                          />
-                        </span>
-                      )}
-                    </span>
+                    </div>
+                  </td>
+                  <td className="px-1 py-1.5">
+                    <SheetAlertBadges
+                      revisionCount={openRevCount}
+                      commentCount={commentBadgeCounts.total}
+                      hasUnreadComments={hasUnreadComments}
+                    />
                   </td>
 
                   {/* BG 메모 (인라인 편집, 한솔 결정 B2) */}
@@ -1074,45 +1105,20 @@ export function UnifiedSceneSheetView({
                     <td className="px-2 py-1.5 text-xs text-text-secondary/20">—</td>
                   )}
 
-                  {/* BG 스테이지 체크박스 */}
-                  {STAGES.map((stage) => (
-                    <td key={`bg-${stage}`} className="px-1 py-1.5 text-center">
-                      {bgScene && bgSheetName ? (
-                        <button
-                          type="button"
-                          onPointerDown={(e) => {
-                            if (e.button !== 0) return;
-                            e.preventDefault();
-                            e.stopPropagation();
-                            stagePointerHandledRef.current = true;
-                            onToggle(bgSheetName, bgScene.sceneId, stage);
-                            window.setTimeout(() => {
-                              stagePointerHandledRef.current = false;
-                            }, 600);
-                          }}
-                          onClick={(e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                            if (stagePointerHandledRef.current) {
-                              stagePointerHandledRef.current = false;
-                              return;
-                            }
-                            onToggle(bgSheetName, bgScene.sceneId, stage);
-                          }}
-                          className="w-5 h-5 rounded flex items-center justify-center text-xs transition-all mx-auto cursor-pointer"
-                          style={
-                            bgScene[stage]
-                              ? { backgroundColor: bgCfg.stageColors[stage], color: 'rgb(var(--color-bg-primary))' }
-                              : { border: '1px solid #2D3041' }
-                          }
-                        >
-                          {bgScene[stage] ? '✓' : ''}
-                        </button>
-                      ) : (
-                        <span className="text-text-secondary/20 text-xs">—</span>
-                      )}
-                    </td>
-                  ))}
+                  {/* BG 스테이지 — ACT 단계와 같은 segmented track 구조 */}
+                  <td colSpan={4} className="px-1 py-1.5">
+                    {bgScene && bgSheetName ? (
+                      <StageSegmentToggle
+                        scene={bgScene}
+                        department="bg"
+                        compact
+                        iconDisplay="never"
+                        onToggle={(stage) => onToggle(bgSheetName, bgScene.sceneId, stage)}
+                      />
+                    ) : (
+                      <span className="text-text-secondary/20 text-xs">—</span>
+                    )}
+                  </td>
 
                   {/* ACT 담당자 (인라인 편집) — v1.16.0 col index 2→3 (메모 분리로 시프트) */}
                   {actScene ? (
@@ -1152,44 +1158,19 @@ export function UnifiedSceneSheetView({
                       )}
                     </td>
                   ) : (
-                    STAGES.map((stage) => (
-                      <td key={`act-${stage}`} className="px-1 py-1.5 text-center">
-                        {actScene && actSheetName ? (
-                          <button
-                            type="button"
-                            onPointerDown={(e) => {
-                              if (e.button !== 0) return;
-                              e.preventDefault();
-                              e.stopPropagation();
-                              stagePointerHandledRef.current = true;
-                              onToggle(actSheetName, actScene.sceneId, stage);
-                              window.setTimeout(() => {
-                                stagePointerHandledRef.current = false;
-                              }, 600);
-                            }}
-                            onClick={(e) => {
-                              e.preventDefault();
-                              e.stopPropagation();
-                              if (stagePointerHandledRef.current) {
-                                stagePointerHandledRef.current = false;
-                                return;
-                              }
-                              onToggle(actSheetName, actScene.sceneId, stage);
-                            }}
-                            className="w-5 h-5 rounded flex items-center justify-center text-xs transition-all mx-auto cursor-pointer"
-                            style={
-                              actScene[stage]
-                                ? { backgroundColor: actCfg.stageColors[stage], color: 'rgb(var(--color-bg-primary))' }
-                                : { border: '1px solid #2D3041' }
-                            }
-                          >
-                            {actScene[stage] ? '✓' : ''}
-                          </button>
-                        ) : (
-                          <span className="text-text-secondary/20 text-xs">—</span>
-                        )}
-                      </td>
-                    ))
+                    <td colSpan={4} className="px-1 py-1.5">
+                      {actScene && actSheetName ? (
+                        <StageSegmentToggle
+                          scene={actScene}
+                          department="acting"
+                          compact
+                          iconDisplay="never"
+                          onToggle={(stage) => onToggle(actSheetName, actScene.sceneId, stage)}
+                        />
+                      ) : (
+                        <span className="text-text-secondary/20 text-xs">—</span>
+                      )}
+                    </td>
                   )}
 
                   {/* 삭제 */}

--- a/src/components/scenes/useStageLabelDisplayMode.ts
+++ b/src/components/scenes/useStageLabelDisplayMode.ts
@@ -1,0 +1,62 @@
+import { useEffect, useRef, useState } from 'react';
+
+type LabelMode = 'text' | 'icon';
+
+function estimateLabelWidth(label: string, compact: boolean) {
+  const fontSize = compact ? 10 : 11;
+  const horizontalPadding = compact ? 18 : 22;
+  const glyphCount = Array.from(label).length;
+  return Math.ceil(glyphCount * fontSize + horizontalPadding);
+}
+
+export function useStageLabelDisplayMode<K extends string>(
+  labels: Record<K, string>,
+  compact: boolean,
+  enabled: boolean,
+) {
+  const [modes, setModes] = useState<Record<string, LabelMode>>({});
+  const nodesRef = useRef(new Map<K, HTMLElement>());
+
+  useEffect(() => {
+    if (!enabled) {
+      setModes({});
+      return;
+    }
+
+    const measure = () => {
+      const next: Record<string, LabelMode> = {};
+      for (const [key, node] of nodesRef.current.entries()) {
+        const label = labels[key];
+        if (!label) continue;
+        const availableWidth = node.getBoundingClientRect().width;
+        next[key] = availableWidth > 0 && availableWidth < estimateLabelWidth(label, compact)
+          ? 'icon'
+          : 'text';
+      }
+      setModes(next);
+    };
+
+    const observers: ResizeObserver[] = [];
+    for (const node of nodesRef.current.values()) {
+      const observer = new ResizeObserver(measure);
+      observer.observe(node);
+      observers.push(observer);
+    }
+
+    measure();
+    window.addEventListener('resize', measure);
+    return () => {
+      window.removeEventListener('resize', measure);
+      observers.forEach((observer) => observer.disconnect());
+    };
+  }, [compact, enabled, labels]);
+
+  const setNode = (key: K) => (node: HTMLElement | null) => {
+    if (node) nodesRef.current.set(key, node);
+    else nodesRef.current.delete(key);
+  };
+
+  const modeOf = (key: K): LabelMode => modes[key] ?? 'text';
+
+  return { modeOf, setNode };
+}

--- a/src/components/settings/EffectsSection.tsx
+++ b/src/components/settings/EffectsSection.tsx
@@ -7,11 +7,15 @@ import { cn } from '@/utils/cn';
 import { StarNestBackground } from '@/components/effects/StarNestBackground';
 import {
   DEFAULT_BACKGROUND_ART,
+  DEFAULT_DASHBOARD_STAR_NEST_BLUR_PX,
+  DEFAULT_DASHBOARD_STAR_NEST_OPACITY,
   DEFAULT_STAR_NEST_SETTINGS,
   STAR_NEST_TONE_PRESETS,
   applyStarNestTonePreset,
   getThemeSyncedStarNestSettings,
   normalizeBackgroundArt,
+  normalizeDashboardStarNestBlurPx,
+  normalizeDashboardStarNestOpacity,
   normalizeStarNestSettings,
   type BackgroundArt,
   type StarNestSettings,
@@ -38,6 +42,8 @@ const DEFAULTS = {
   starNest: DEFAULT_STAR_NEST_SETTINGS,
   loginStarNest: DEFAULT_STAR_NEST_SETTINGS,
   dashboardStarNest: DEFAULT_STAR_NEST_SETTINGS,
+  dashboardStarNestOpacity: DEFAULT_DASHBOARD_STAR_NEST_OPACITY,
+  dashboardStarNestBlurPx: DEFAULT_DASHBOARD_STAR_NEST_BLUR_PX,
 };
 
 /* ── 미니 플렉서스 프리뷰 (마우스 반응 + 부드러운 파티클 증감) ── */
@@ -261,14 +267,34 @@ function MiniPlexusPreview({ particleCount, enabled, speed, mouseRadius, mouseFo
   );
 }
 
-function MiniStarNestPreview({ enabled, settings }: { enabled: boolean; settings: StarNestSettings }) {
+function MiniStarNestPreview({
+  enabled,
+  settings,
+  opacity = 1,
+  blurPx = 0,
+}: {
+  enabled: boolean;
+  settings: StarNestSettings;
+  opacity?: number;
+  blurPx?: number;
+}) {
   return (
     <div
       className="relative rounded-lg overflow-hidden border border-bg-border/30 my-2.5"
       style={{ width: '100%', aspectRatio: `${PREVIEW_W}/${PREVIEW_H}`, background: 'rgb(var(--color-bg-primary) / 0.6)' }}
     >
       {enabled ? (
-        <StarNestBackground enabled fixed={false} settings={settings} />
+        <StarNestBackground
+          enabled
+          fixed={false}
+          settings={settings}
+          style={{
+            opacity,
+            filter: blurPx > 0 ? `blur(${blurPx}px)` : undefined,
+            transform: blurPx > 0 ? 'scale(1.03)' : undefined,
+            willChange: 'opacity, filter',
+          }}
+        />
       ) : (
         <div className="absolute inset-0 flex items-center justify-center bg-bg-border/20">
           <span className="text-xs text-text-secondary/40 font-medium">OFF</span>
@@ -493,6 +519,10 @@ export function EffectsSection() {
   const usesStarNest = loginBackgroundArt === 'starnest' || dashboardBackgroundArt === 'starnest';
   const usesPlexus = loginBackgroundArt !== 'starnest' || dashboardBackgroundArt !== 'starnest';
   const starNest = normalizeStarNestSettings(plexusSettings.starNest);
+  const loginStarNest = normalizeStarNestSettings(plexusSettings.loginStarNest ?? starNest);
+  const dashboardStarNest = normalizeStarNestSettings(plexusSettings.dashboardStarNest ?? starNest);
+  const dashboardStarNestOpacity = normalizeDashboardStarNestOpacity(plexusSettings.dashboardStarNestOpacity);
+  const dashboardStarNestBlurPx = normalizeDashboardStarNestBlurPx(plexusSettings.dashboardStarNestBlurPx);
 
   const update = useCallback((partial: Partial<typeof DEFAULTS>) => {
     const legacy = normalizeStarNestSettings(partial.starNest ?? plexusSettings.starNest);
@@ -505,6 +535,8 @@ export function EffectsSection() {
       starNest: legacy,
       loginStarNest: normalizeStarNestSettings(partial.loginStarNest ?? plexusSettings.loginStarNest ?? legacy),
       dashboardStarNest: normalizeStarNestSettings(partial.dashboardStarNest ?? plexusSettings.dashboardStarNest ?? legacy),
+      dashboardStarNestOpacity: normalizeDashboardStarNestOpacity(partial.dashboardStarNestOpacity ?? plexusSettings.dashboardStarNestOpacity),
+      dashboardStarNestBlurPx: normalizeDashboardStarNestBlurPx(partial.dashboardStarNestBlurPx ?? plexusSettings.dashboardStarNestBlurPx),
     };
     setPlexusSettings(next);
     persistPlexus(next);
@@ -677,7 +709,7 @@ export function EffectsSection() {
         </div>
 
         {loginBackgroundArt === 'starnest' ? (
-          <MiniStarNestPreview enabled={plexusSettings.loginEnabled} settings={starNest} />
+          <MiniStarNestPreview enabled={plexusSettings.loginEnabled} settings={loginStarNest} />
         ) : (
           <MiniPlexusPreview
             particleCount={plexusSettings.loginParticleCount}
@@ -722,7 +754,12 @@ export function EffectsSection() {
         </div>
 
         {dashboardBackgroundArt === 'starnest' ? (
-          <MiniStarNestPreview enabled={plexusSettings.dashboardEnabled} settings={starNest} />
+          <MiniStarNestPreview
+            enabled={plexusSettings.dashboardEnabled}
+            settings={dashboardStarNest}
+            opacity={dashboardStarNestOpacity}
+            blurPx={dashboardStarNestBlurPx}
+          />
         ) : (
           <MiniPlexusPreview
             particleCount={plexusSettings.dashboardParticleCount}
@@ -733,6 +770,22 @@ export function EffectsSection() {
             glowIntensity={plexusSettings.glowIntensity}
             connectionDist={plexusSettings.connectionDist}
           />
+        )}
+
+        {plexusSettings.dashboardEnabled && dashboardBackgroundArt === 'starnest' && (
+          <div className="flex flex-col gap-2.5 pl-1">
+            <Slider
+              label="불투명도" value={dashboardStarNestOpacity}
+              min={0.2} max={1} step={0.05} defaultVal={DEFAULTS.dashboardStarNestOpacity}
+              precision={2}
+              onChange={(v) => update({ dashboardStarNestOpacity: v })}
+            />
+            <Slider
+              label="블러" value={dashboardStarNestBlurPx}
+              min={0} max={20} step={1} defaultVal={DEFAULTS.dashboardStarNestBlurPx}
+              onChange={(v) => update({ dashboardStarNestBlurPx: v })}
+            />
+          </div>
         )}
 
         {plexusSettings.dashboardEnabled && dashboardBackgroundArt !== 'starnest' && (

--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,8 @@
   --font-family: 'Pretendard Variable', Pretendard, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --text-line-height: 1.55;
   --text-letter-spacing: 0em;
+  --bflow-cursor-default: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'%3E%3Cpath d='M6 4 L23 18 L15.5 19.1 L19.4 27 L15.8 28.7 L12 20.9 L6.8 26.4 Z' fill='%23F7F8FF' stroke='%230B0F1D' stroke-width='1.8' stroke-linejoin='round'/%3E%3Cpath d='M8.8 7.4 L18.5 15.6 L13.9 16.3 L16.5 21.7' fill='none' stroke='%23A29BFE' stroke-width='1.2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E") 6 4, auto;
+  --bflow-cursor-pointer: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'%3E%3Cpath d='M6 4 L23 18 L15.5 19.1 L19.4 27 L15.8 28.7 L12 20.9 L6.8 26.4 Z' fill='%23F7F8FF' stroke='%230B0F1D' stroke-width='1.8' stroke-linejoin='round'/%3E%3Cpath d='M8.8 7.4 L18.5 15.6 L13.9 16.3 L16.5 21.7' fill='none' stroke='%236C5CE7' stroke-width='1.2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E") 6 4, pointer;
 }
 
 /* v1.20.0: 글꼴 family / 줄간격 / 자간 — applyFontFamily/applySpacing이 CSS 변수 갱신 */
@@ -24,6 +26,54 @@
     letter-spacing: var(--text-letter-spacing);
   }
 }
+
+html,
+body,
+#root {
+  cursor: var(--bflow-cursor-default);
+}
+
+a[href],
+button:not(:disabled),
+[role="button"]:not([aria-disabled="true"]),
+summary,
+.cursor-pointer:not(.cursor-not-allowed) {
+  cursor: var(--bflow-cursor-pointer) !important;
+}
+
+.cursor-default {
+  cursor: var(--bflow-cursor-default) !important;
+}
+
+input,
+textarea,
+[contenteditable="true"],
+.cursor-text {
+  cursor: text !important;
+}
+
+button:disabled,
+[disabled],
+[aria-disabled="true"],
+.cursor-not-allowed {
+  cursor: not-allowed !important;
+}
+
+.cursor-col-resize,
+.sheet-column-resizer,
+.is-sheet-column-resizing,
+.is-sheet-column-resizing * {
+  cursor: col-resize !important;
+}
+
+.cursor-ew-resize { cursor: ew-resize !important; }
+.cursor-row-resize { cursor: row-resize !important; }
+.cursor-move { cursor: move !important; }
+.cursor-grab { cursor: grab !important; }
+.cursor-grabbing { cursor: grabbing !important; }
+.cursor-zoom-in { cursor: zoom-in !important; }
+.cursor-zoom-out { cursor: zoom-out !important; }
+.cursor-crosshair { cursor: crosshair !important; }
 
 /* v1.20.0: 숫자 자릿수 고정 — 사용자 옵션 없이 항상 적용
    대상: 위젯·표·진행률·시간·날짜 등 숫자 영역.
@@ -333,19 +383,32 @@ body.theme-ready *::after {
   max-width: 100%;
 }
 
+[data-compact-label-icon] {
+  display: inline-flex;
+  max-width: 1.25rem;
+  overflow: hidden;
+  opacity: 1;
+  transition: max-width 160ms ease, opacity 120ms ease, margin-inline 160ms ease;
+}
+
 [data-compact-label-text] {
   display: inline-block;
   max-width: 12rem;
   overflow: hidden;
   opacity: 1;
-  transition: max-width 160ms ease, opacity 120ms ease, margin-inline-start 160ms ease;
+  transition: max-width 160ms ease, opacity 120ms ease, margin-inline 160ms ease;
 }
 
 @media (max-width: 1040px) {
-  .compact-label-container [data-compact-label-text] {
+  .compact-label-container [data-compact-icon-label]:not([data-display-mode="icon"]) [data-compact-label-icon] {
     max-width: 0;
     opacity: 0;
+    margin-inline-end: -0.375rem;
+  }
+
+  .compact-label-container [data-compact-icon-label]:not([data-display-mode="icon"])[data-icon-position="after"] [data-compact-label-icon] {
     margin-inline-start: -0.375rem;
+    margin-inline-end: 0;
   }
 
   [data-episode-filter-label] {
@@ -358,6 +421,7 @@ body.theme-ready *::after {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  [data-compact-label-icon],
   [data-compact-label-text] {
     transition: none;
   }
@@ -429,6 +493,11 @@ body.theme-ready *::after {
   border-radius: 999px;
 }
 
+.sheet-column-resizer-left {
+  right: auto;
+  left: -4px;
+}
+
 .sheet-column-resizer::after {
   content: "";
   position: absolute;
@@ -448,6 +517,49 @@ body.theme-ready *::after {
 
 .is-sheet-column-resizing {
   cursor: col-resize;
+}
+
+.revision-corner-flag {
+  position: absolute;
+  top: -1px;
+  right: -1px;
+  z-index: 18;
+  width: 42px;
+  height: 42px;
+  pointer-events: none;
+  color: #fff;
+}
+
+.revision-corner-flag::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-style: solid;
+  border-width: 0 42px 42px 0;
+  border-color: transparent rgb(var(--color-accent) / 0.9) transparent transparent;
+  filter: drop-shadow(0 0 10px rgb(var(--color-accent) / 0.42));
+}
+
+.revision-corner-flag-resolved::before {
+  border-color: transparent rgb(var(--color-text-secondary) / 0.56) transparent transparent;
+  filter: none;
+}
+
+.revision-corner-flag-content {
+  position: absolute;
+  top: 5px;
+  right: 4px;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 9px;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.revision-corner-flag-count {
+  min-width: 8px;
+  text-align: center;
 }
 
 /* ─── 스크롤바 (테마 반응형, 다크 UI 통일) ─── */

--- a/src/index.css
+++ b/src/index.css
@@ -334,11 +334,14 @@ body.theme-ready *::after {
 }
 
 [data-compact-label-icon] {
-  display: inline-flex;
   max-width: 1.25rem;
   overflow: hidden;
   opacity: 1;
   transition: max-width 160ms ease, opacity 120ms ease, margin-inline 160ms ease;
+}
+
+[data-compact-label-icon]:not(.hidden) {
+  display: inline-flex;
 }
 
 [data-compact-label-text] {

--- a/src/index.css
+++ b/src/index.css
@@ -14,8 +14,6 @@
   --font-family: 'Pretendard Variable', Pretendard, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --text-line-height: 1.55;
   --text-letter-spacing: 0em;
-  --bflow-cursor-default: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'%3E%3Cpath d='M6 4 L23 18 L15.5 19.1 L19.4 27 L15.8 28.7 L12 20.9 L6.8 26.4 Z' fill='%23F7F8FF' stroke='%230B0F1D' stroke-width='1.8' stroke-linejoin='round'/%3E%3Cpath d='M8.8 7.4 L18.5 15.6 L13.9 16.3 L16.5 21.7' fill='none' stroke='%23A29BFE' stroke-width='1.2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E") 6 4, auto;
-  --bflow-cursor-pointer: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'%3E%3Cpath d='M6 4 L23 18 L15.5 19.1 L19.4 27 L15.8 28.7 L12 20.9 L6.8 26.4 Z' fill='%23F7F8FF' stroke='%230B0F1D' stroke-width='1.8' stroke-linejoin='round'/%3E%3Cpath d='M8.8 7.4 L18.5 15.6 L13.9 16.3 L16.5 21.7' fill='none' stroke='%236C5CE7' stroke-width='1.2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E") 6 4, pointer;
 }
 
 /* v1.20.0: 글꼴 family / 줄간격 / 자간 — applyFontFamily/applySpacing이 CSS 변수 갱신 */
@@ -26,54 +24,6 @@
     letter-spacing: var(--text-letter-spacing);
   }
 }
-
-html,
-body,
-#root {
-  cursor: var(--bflow-cursor-default);
-}
-
-a[href],
-button:not(:disabled),
-[role="button"]:not([aria-disabled="true"]),
-summary,
-.cursor-pointer:not(.cursor-not-allowed) {
-  cursor: var(--bflow-cursor-pointer) !important;
-}
-
-.cursor-default {
-  cursor: var(--bflow-cursor-default) !important;
-}
-
-input,
-textarea,
-[contenteditable="true"],
-.cursor-text {
-  cursor: text !important;
-}
-
-button:disabled,
-[disabled],
-[aria-disabled="true"],
-.cursor-not-allowed {
-  cursor: not-allowed !important;
-}
-
-.cursor-col-resize,
-.sheet-column-resizer,
-.is-sheet-column-resizing,
-.is-sheet-column-resizing * {
-  cursor: col-resize !important;
-}
-
-.cursor-ew-resize { cursor: ew-resize !important; }
-.cursor-row-resize { cursor: row-resize !important; }
-.cursor-move { cursor: move !important; }
-.cursor-grab { cursor: grab !important; }
-.cursor-grabbing { cursor: grabbing !important; }
-.cursor-zoom-in { cursor: zoom-in !important; }
-.cursor-zoom-out { cursor: zoom-out !important; }
-.cursor-crosshair { cursor: crosshair !important; }
 
 /* v1.20.0: 숫자 자릿수 고정 — 사용자 옵션 없이 항상 적용
    대상: 위젯·표·진행률·시간·날짜 등 숫자 영역.

--- a/src/services/commentReadStateService.ts
+++ b/src/services/commentReadStateService.ts
@@ -125,10 +125,16 @@ function isCommentReadStateSchemaUnavailableError(err: unknown): boolean {
   const message = err instanceof Error ? err.message : String(err ?? '');
   const lower = message.toLowerCase();
 
-  return lower.includes('upsert_comment_read_state')
-    || lower.includes('comment_read_states')
-    || lower.includes('schema cache')
-    || lower.includes('could not find the function');
+  const missingReadStateFunction = lower.includes('upsert_comment_read_state')
+    && lower.includes('could not find the function');
+  const missingReadStateTable = lower.includes('comment_read_states')
+    && (
+      lower.includes('could not find the table')
+      || lower.includes('relation "comment_read_states" does not exist')
+      || lower.includes("relation 'comment_read_states' does not exist")
+    );
+
+  return missingReadStateFunction || missingReadStateTable;
 }
 
 function disablePersistenceForSession(err: unknown): void {

--- a/src/services/commentReadStateService.ts
+++ b/src/services/commentReadStateService.ts
@@ -50,6 +50,8 @@ const pendingWrites = new Map<string, PendingWrite>();
 
 let persistenceOverride: CommentReadStatePersistence | null = null;
 let pendingVersionSequence = 0;
+let persistenceDisabledForSession = false;
+let schemaUnavailableWarningLogged = false;
 
 async function getDefaultPersistence(): Promise<CommentReadStatePersistence> {
   if (typeof window === 'undefined') {
@@ -110,6 +112,32 @@ function clearPendingTimer(pending: PendingWrite): void {
   if (!pending.timer) return;
   clearTimeout(pending.timer);
   pending.timer = null;
+}
+
+function clearAllPendingWrites(): void {
+  for (const pending of pendingWrites.values()) {
+    clearPendingTimer(pending);
+  }
+  pendingWrites.clear();
+}
+
+function isCommentReadStateSchemaUnavailableError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err ?? '');
+  const lower = message.toLowerCase();
+
+  return lower.includes('upsert_comment_read_state')
+    || lower.includes('comment_read_states')
+    || lower.includes('schema cache')
+    || lower.includes('could not find the function');
+}
+
+function disablePersistenceForSession(err: unknown): void {
+  persistenceDisabledForSession = true;
+  clearAllPendingWrites();
+
+  if (schemaUnavailableWarningLogged) return;
+  schemaUnavailableWarningLogged = true;
+  console.warn('[댓글 읽음] Supabase 읽음 상태 스키마가 아직 준비되지 않아 이번 실행에서는 로컬 캐시만 사용합니다:', err);
 }
 
 function scheduleRetry(pending: PendingWrite): void {
@@ -183,6 +211,8 @@ function queuePendingWrite(input: MarkSceneThreadReadInput): void {
 }
 
 async function saveReadState(input: MarkSceneThreadReadInput): Promise<void> {
+  if (persistenceDisabledForSession) return;
+
   const persistence = await getPersistence();
   await persistence.upsert(input.userId, input.sceneThreadKey, input.readAt);
 }
@@ -198,6 +228,11 @@ async function flushPendingWrite(
     await saveReadState(attempted);
     completePendingWriteAfterSuccessfulSave(attempted);
   } catch (err) {
+    if (isCommentReadStateSchemaUnavailableError(err)) {
+      disablePersistenceForSession(err);
+      return;
+    }
+
     console.warn('[댓글 읽음] Supabase 저장 실패:', err);
 
     const current = pendingWrites.get(key);
@@ -294,20 +329,32 @@ export function primeCommentReadStateForUser(userId: string, state: Record<strin
 export async function getCommentReadStateForUser(userId: string): Promise<Record<string, string>> {
   if (!userId) return {};
 
-  try {
-    await flushPendingWritesForUser(userId);
-  } catch (err) {
-    console.warn('[댓글 읽음] 대기 중인 저장 반영 실패:', err);
+  if (!persistenceDisabledForSession) {
+    try {
+      await flushPendingWritesForUser(userId);
+    } catch (err) {
+      if (isCommentReadStateSchemaUnavailableError(err)) {
+        disablePersistenceForSession(err);
+      } else {
+        console.warn('[댓글 읽음] 대기 중인 저장 반영 실패:', err);
+      }
+    }
   }
 
-  try {
-    const persistence = await getPersistence();
-    const rows = await persistence.read(userId);
-    for (const row of rows) {
-      applyReadStateToCache(userId, row.sceneThreadKey, row.lastReadAt);
+  if (!persistenceDisabledForSession) {
+    try {
+      const persistence = await getPersistence();
+      const rows = await persistence.read(userId);
+      for (const row of rows) {
+        applyReadStateToCache(userId, row.sceneThreadKey, row.lastReadAt);
+      }
+    } catch (err) {
+      if (isCommentReadStateSchemaUnavailableError(err)) {
+        disablePersistenceForSession(err);
+      } else {
+        console.warn('[댓글 읽음] Supabase 상태 로드 실패, 캐시를 사용합니다:', err);
+      }
     }
-  } catch (err) {
-    console.warn('[댓글 읽음] Supabase 상태 로드 실패, 캐시를 사용합니다:', err);
   }
 
   return { ...(cacheByUser.get(userId) ?? {}) };
@@ -336,6 +383,11 @@ export async function markSceneThreadReadForUser(input: MarkSceneThreadReadInput
     await saveReadState(normalizedInput);
     completePendingWriteAfterSuccessfulSave(normalizedInput);
   } catch (err) {
+    if (isCommentReadStateSchemaUnavailableError(err)) {
+      disablePersistenceForSession(err);
+      return;
+    }
+
     console.warn('[댓글 읽음] Supabase 저장 실패, 재시도 예약:', err);
     queuePendingWrite(normalizedInput);
   }
@@ -384,13 +436,15 @@ export function __hasCommentReadStatePersistenceOverrideForTests(): boolean {
   return !!persistenceOverride;
 }
 
+export function __isCommentReadStatePersistenceDisabledForTests(): boolean {
+  return persistenceDisabledForSession;
+}
+
 export function __resetCommentReadStateServiceForTests(): void {
   cacheByUser.clear();
   persistenceOverride = null;
   pendingVersionSequence = 0;
-
-  for (const pending of pendingWrites.values()) {
-    clearPendingTimer(pending);
-  }
-  pendingWrites.clear();
+  persistenceDisabledForSession = false;
+  schemaUnavailableWarningLogged = false;
+  clearAllPendingWrites();
 }

--- a/src/services/settingsService.ts
+++ b/src/services/settingsService.ts
@@ -126,6 +126,8 @@ export interface UserPreferences {
     starNest?: Partial<StarNestSettings>;
     loginStarNest?: Partial<StarNestSettings>;
     dashboardStarNest?: Partial<StarNestSettings>;
+    dashboardStarNestOpacity?: number;
+    dashboardStarNestBlurPx?: number;
   };
 
   // Phase 8-4: 스플래시 건너뛰기

--- a/src/stores/useAppStore.ts
+++ b/src/stores/useAppStore.ts
@@ -4,6 +4,8 @@ import type { ThemeColors } from '@/themes';
 import type { VacationConfig, VacationStatus, VacationLogEntry } from '@/types/vacation';
 import {
   DEFAULT_BACKGROUND_ART,
+  DEFAULT_DASHBOARD_STAR_NEST_BLUR_PX,
+  DEFAULT_DASHBOARD_STAR_NEST_OPACITY,
   DEFAULT_STAR_NEST_SETTINGS,
   type BackgroundArt,
   type StarNestSettings,
@@ -162,6 +164,8 @@ interface AppState {
     starNest: StarNestSettings;
     loginStarNest: StarNestSettings;
     dashboardStarNest: StarNestSettings;
+    dashboardStarNestOpacity: number;
+    dashboardStarNestBlurPx: number;
   };
   setPlexusSettings: (settings: Partial<AppState['plexusSettings']>) => void;
 
@@ -305,6 +309,8 @@ export const useAppStore = create<AppState>((set) => ({
     starNest: DEFAULT_STAR_NEST_SETTINGS,
     loginStarNest: DEFAULT_STAR_NEST_SETTINGS,
     dashboardStarNest: DEFAULT_STAR_NEST_SETTINGS,
+    dashboardStarNestOpacity: DEFAULT_DASHBOARD_STAR_NEST_OPACITY,
+    dashboardStarNestBlurPx: DEFAULT_DASHBOARD_STAR_NEST_BLUR_PX,
   },
   setPlexusSettings: (partial) => set((s) => ({
     plexusSettings: { ...s.plexusSettings, ...partial },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,7 +27,7 @@ export const DEPARTMENT_CONFIGS: Record<Department, DepartmentConfig> = {
     id: 'acting',
     label: '액팅',
     shortLabel: 'ACT',
-    stageLabels: { lo: '1원화', done: '2원화', review: '동화', png: '최종' },
+    stageLabels: { lo: '대기', done: '작업중', review: '피드백', png: '완료' },
     stageColors: { lo: '#F5BEB3', done: '#EDA293', review: '#E58A76', png: '#E17055' },
     color: '#E17055',
   },

--- a/src/utils/starNestSettings.ts
+++ b/src/utils/starNestSettings.ts
@@ -22,6 +22,8 @@ export interface StarNestSettings {
 }
 
 export const DEFAULT_BACKGROUND_ART: BackgroundArt = 'plexus';
+export const DEFAULT_DASHBOARD_STAR_NEST_OPACITY = 1;
+export const DEFAULT_DASHBOARD_STAR_NEST_BLUR_PX = 0;
 
 export const DEFAULT_STAR_NEST_SETTINGS: StarNestSettings = {
   directionMode: 'mouse',
@@ -142,6 +144,14 @@ export function normalizeStarNestSettings(settings?: Partial<StarNestSettings> |
     iterations: Math.round(clamp(settings?.iterations, 10, 22, DEFAULT_STAR_NEST_SETTINGS.iterations)),
     quality: Math.round(clamp(settings?.quality, 8, 20, DEFAULT_STAR_NEST_SETTINGS.quality)),
   };
+}
+
+export function normalizeDashboardStarNestOpacity(value: unknown): number {
+  return clamp(value, 0.2, 1, DEFAULT_DASHBOARD_STAR_NEST_OPACITY);
+}
+
+export function normalizeDashboardStarNestBlurPx(value: unknown): number {
+  return clamp(value, 0, 20, DEFAULT_DASHBOARD_STAR_NEST_BLUR_PX);
 }
 
 export function applyStarNestTonePreset(

--- a/src/views/CompositingView.tsx
+++ b/src/views/CompositingView.tsx
@@ -21,7 +21,11 @@ import {
   filterRevisionsBySearch,
   sortRevisions,
 } from './compositing/utils';
-import { buildFeedbackHubStats, buildFeedbackHubTree } from './compositing/feedbackHubUtils';
+import {
+  buildFeedbackHubPartCollapseKey,
+  buildFeedbackHubStats,
+  buildFeedbackHubTree,
+} from './compositing/feedbackHubUtils';
 import type { SceneInfo, SceneGroup, SortMode } from './compositing/utils';
 import { FeedbackTreeSection, EpisodeFilter } from './compositing/SceneGroupSection';
 import { DetailPanel } from './compositing/RevisionDetailPanel';
@@ -58,7 +62,8 @@ export default function CompositingView({
   const [statusFilter, setStatusFilter] = useState<'all' | RevisionStatus>('all');
   const [myTasksOnly, setMyTasksOnly] = useState(false);
   const [expandedScenes, setExpandedScenes] = useState<Set<string>>(new Set());
-  const [autoExpandedOnce, setAutoExpandedOnce] = useState(false);
+  const [expandedFeedbackEpisodes, setExpandedFeedbackEpisodes] = useState<Set<number>>(new Set());
+  const [expandedFeedbackParts, setExpandedFeedbackParts] = useState<Set<string>>(new Set());
   const [selectedRevisionId, setSelectedRevisionId] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [sortMode, setSortMode] = useState<SortMode>('recent');
@@ -377,14 +382,6 @@ export default function CompositingView({
   }, [sceneGroups.length, visibleRevisions, effectiveCommentCountByRev, currentUser?.name]);
 
   useEffect(() => {
-    if (autoExpandedOnce || sceneGroups.length === 0) return;
-    const openGroups = sceneGroups.filter((group) => group.openCount > 0);
-    const groupsToOpen = openGroups.length > 0 ? openGroups : sceneGroups.slice(0, 8);
-    setExpandedScenes(new Set(groupsToOpen.map((group) => group.sceneKey)));
-    setAutoExpandedOnce(true);
-  }, [autoExpandedOnce, sceneGroups]);
-
-  useEffect(() => {
     if (!selectedRevisionId) return;
     if (visibleRevisions.some((revision) => revision.id === selectedRevisionId)) return;
     setSelectedRevisionId(null);
@@ -468,16 +465,55 @@ export default function CompositingView({
     });
   }, []);
 
+  const toggleFeedbackEpisode = useCallback((episodeNumber: number) => {
+    setExpandedFeedbackEpisodes(prev => {
+      const next = new Set(prev);
+      if (next.has(episodeNumber)) next.delete(episodeNumber);
+      else next.add(episodeNumber);
+      return next;
+    });
+  }, []);
+
+  const toggleFeedbackPart = useCallback((episodeNumber: number, partId: string) => {
+    const partKey = buildFeedbackHubPartCollapseKey(episodeNumber, partId);
+    setExpandedFeedbackParts(prev => {
+      const next = new Set(prev);
+      if (next.has(partKey)) next.delete(partKey);
+      else next.add(partKey);
+      return next;
+    });
+  }, []);
+
+  const hasFeedbackTreeExpansion = useMemo(
+    () =>
+      feedbackTree.some((episodeTree) =>
+        expandedFeedbackEpisodes.has(episodeTree.episodeNumber)
+        || episodeTree.parts.some((partTree) =>
+          expandedFeedbackParts.has(buildFeedbackHubPartCollapseKey(episodeTree.episodeNumber, partTree.partId)),
+        ),
+      )
+      || sceneGroups.some((group) => expandedScenes.has(group.sceneKey)),
+    [expandedFeedbackEpisodes, expandedFeedbackParts, expandedScenes, feedbackTree, sceneGroups],
+  );
+
   // 모두 펼치기/접기
   const toggleAll = useCallback(() => {
-    if (expandedScenes.size > 0) {
+    if (hasFeedbackTreeExpansion) {
       setExpandedScenes(new Set());
+      setExpandedFeedbackEpisodes(new Set());
+      setExpandedFeedbackParts(new Set());
     } else {
-      const openGroups = sceneGroups.filter(g => g.openCount > 0);
-      const groupsToOpen = openGroups.length > 0 ? openGroups : sceneGroups;
-      setExpandedScenes(new Set(groupsToOpen.map(g => g.sceneKey)));
+      setExpandedFeedbackEpisodes(new Set(feedbackTree.map((episodeTree) => episodeTree.episodeNumber)));
+      setExpandedFeedbackParts(new Set(
+        feedbackTree.flatMap((episodeTree) =>
+          episodeTree.parts.map((partTree) =>
+            buildFeedbackHubPartCollapseKey(episodeTree.episodeNumber, partTree.partId),
+          ),
+        ),
+      ));
+      setExpandedScenes(new Set(sceneGroups.map(g => g.sceneKey)));
     }
-  }, [expandedScenes.size, sceneGroups]);
+  }, [feedbackTree, hasFeedbackTreeExpansion, sceneGroups]);
 
   // 리비전 선택
   const handleSelectRevision = useCallback((rev: CompRevision) => {
@@ -518,7 +554,7 @@ export default function CompositingView({
                 >
                   <CompactIconLabel
                     icon={<ListFilter size={12} strokeWidth={2.4} />}
-                    label={expandedScenes.size > 0 ? '모두 접기' : '모두 펼치기'}
+                    label={hasFeedbackTreeExpansion ? '모두 접기' : '모두 펼치기'}
                   />
                 </button>
               )}
@@ -645,10 +681,14 @@ export default function CompositingView({
           ) : groupMode === 'scene' ? (
             <FeedbackTreeSection
               episodeTrees={feedbackTree}
+              expandedEpisodes={expandedFeedbackEpisodes}
+              expandedParts={expandedFeedbackParts}
               expandedScenes={expandedScenes}
               selectedRevisionId={selectedRevisionId}
               commentCountByRev={effectiveCommentCountByRev}
               commentSeenByRev={effectiveCommentSeenByRev}
+              onToggleEpisode={toggleFeedbackEpisode}
+              onTogglePart={toggleFeedbackPart}
               onToggleScene={toggleScene}
               onSelectRevision={handleSelectRevision}
               onStatusChange={handleStatusChange}

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -31,6 +31,10 @@ import { DEPARTMENTS, DEPARTMENT_CONFIGS } from '@/types';
 import { cn } from '@/utils/cn';
 import { getPreset } from '@/themes';
 import { StarNestBackground } from '@/components/effects/StarNestBackground';
+import {
+  normalizeDashboardStarNestBlurPx,
+  normalizeDashboardStarNestOpacity,
+} from '@/utils/starNestSettings';
 
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
@@ -206,11 +210,19 @@ function DashboardBackgroundArt() {
   const plexusSettings = useAppStore((s) => s.plexusSettings);
   const backgroundArt = plexusSettings.dashboardBackgroundArt ?? plexusSettings.backgroundArt;
   if (backgroundArt === 'starnest') {
+    const opacity = normalizeDashboardStarNestOpacity(plexusSettings.dashboardStarNestOpacity);
+    const blurPx = normalizeDashboardStarNestBlurPx(plexusSettings.dashboardStarNestBlurPx);
     return (
       <StarNestBackground
         enabled={plexusSettings.dashboardEnabled}
         className="z-0"
-        settings={plexusSettings.starNest}
+        settings={plexusSettings.dashboardStarNest ?? plexusSettings.starNest}
+        style={{
+          opacity,
+          filter: blurPx > 0 ? `blur(${blurPx}px)` : undefined,
+          transform: blurPx > 0 ? 'scale(1.03)' : undefined,
+          willChange: 'opacity, filter',
+        }}
       />
     );
   }

--- a/src/views/ScenesView.tsx
+++ b/src/views/ScenesView.tsx
@@ -33,6 +33,8 @@ import { UnifiedSceneSheetView } from '@/components/scenes/UnifiedSceneSheetView
 import { ScenePhaseToggle } from '@/components/scenes/ScenePhaseToggle';
 import { LengthIcon } from '@/components/scenes/LengthIcon';
 import { UnifiedSceneDetailModal } from '@/components/scenes/UnifiedSceneDetailModal';
+import { StageSegmentToggle, stageIcon } from '@/components/scenes/StageSegmentToggle';
+import { RevisionCornerFlag } from '@/components/scenes/RevisionCornerFlag';
 import { BulkOperationStatus } from '@/components/scenes/BulkOperationStatus';
 import { useAuthStore } from '@/stores/useAuthStore';
 import { setCommentsSheetsMode, getCommentStoreForPart, invalidatePartCache } from '@/services/commentService';
@@ -50,13 +52,6 @@ import type { PartContextMenuTarget } from '@/utils/partMemoHelpers';
 import { usePartMemos } from '@/hooks/usePartMemos';
 import { useUnifiedScenes } from '@/hooks/useUnifiedScenes';
 import { loadPreferences, savePreferences, type UserPreferences } from '@/services/settingsService';
-
-function stageIcon(stage: Stage, size = 12) {
-  if (stage === 'lo') return <Clock size={size} strokeWidth={2.4} />;
-  if (stage === 'done') return <PlayCircle size={size} strokeWidth={2.4} />;
-  if (stage === 'review') return <CheckSquare size={size} strokeWidth={2.4} />;
-  return <CheckCircle2 size={size} strokeWidth={2.4} />;
-}
 
 function phaseIcon(phase: ScenePhaseState, size = 12) {
   if (phase === 'wait') return <Clock size={size} strokeWidth={2.4} />;
@@ -761,7 +756,6 @@ function SceneCard({ scene, sceneIndex, celebrating, department, isHighlighted, 
   const storyboardUrl = scene.storyboardUrl || fallbackStoryboardUrl || '';
   const guideUrl = scene.guideUrl || fallbackGuideUrl || '';
   const hasImages = !!(storyboardUrl || guideUrl);
-  const stagePointerHandledRef = useRef(false);
   const useActingPhaseControls = department === 'acting' && !!sheetName && !!onActPhaseStateClick && !!onActFeedbackRequest && !!onActRoundBump;
 
   const borderColor = pct >= 100 ? '#6C5CE7' : pct >= 50 ? '#A599F5' : pct > 0 ? '#E17055' : 'rgb(var(--color-bg-border))';
@@ -807,9 +801,14 @@ function SceneCard({ scene, sceneIndex, celebrating, department, isHighlighted, 
       {/* 하이라이트 배경 오버레이 */}
       {isHighlighted && <div className="scene-highlight-bg" />}
 
+      <RevisionCornerFlag count={revisionCount} />
+
       {/* 선택 체크마크 */}
       {isSelected && (
-        <div className="absolute top-1.5 right-1.5 z-20 w-5 h-5 rounded-full bg-accent flex items-center justify-center shadow-sm shadow-accent/30">
+        <div className={cn(
+          'absolute right-1.5 z-20 w-5 h-5 rounded-full bg-accent flex items-center justify-center shadow-sm shadow-accent/30',
+          revisionCount > 0 ? 'top-9' : 'top-1.5',
+        )}>
           <svg width="10" height="10" viewBox="0 0 12 12" fill="none"><path d="M2 6l3 3 5-5" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/></svg>
         </div>
       )}
@@ -838,20 +837,11 @@ function SceneCard({ scene, sceneIndex, celebrating, department, isHighlighted, 
                   ? 'comment-unread-badge border-accent/25 bg-accent/15 text-accent shadow-[0_0_10px_rgba(108,92,231,0.16)]'
                   : 'border-bg-border/45 bg-text-secondary/10 text-text-secondary/60',
               )}
-              title={`${hasUnreadComments ? '새 댓글' : '확인한 댓글'} ${commentCount}개`}
+              title={`${hasUnreadComments ? '새 댓글' : '확인한 댓글'} ${commentCount}`}
             >
               <CompactIconLabel
                 icon={<MessageCircle size={10} fill="currentColor" />}
-                label={`${commentCount}개`}
-                textClassName="text-[10px] font-bold leading-none"
-              />
-            </span>
-          )}
-          {revisionCount > 0 && (
-            <span className="compact-label-container flex min-w-0 shrink items-center gap-0.5 px-1.5 py-0.5 rounded-full" style={{ backgroundColor: 'rgba(108, 92, 231, 0.15)', color: '#A599F5' }} title={`리비전 ${revisionCount}건`}>
-              <CompactIconLabel
-                icon={<Film size={10} />}
-                label={`${revisionCount}건`}
+                label={`${commentCount}`}
                 textClassName="text-[10px] font-bold leading-none"
               />
             </span>
@@ -938,51 +928,11 @@ function SceneCard({ scene, sceneIndex, celebrating, department, isHighlighted, 
             />
           </div>
         ) : (
-          <div className="flex rounded-lg bg-bg-primary/70 border border-bg-border/40 p-1 gap-0.5">
-            {STAGES.map((stage, i) => {
-              const isDone = scene[stage];
-              const isCurrent = isDone && (i === STAGES.length - 1 || !scene[STAGES[i + 1]]);
-
-              return (
-                <button
-                  type="button"
-                  key={stage}
-                  onPointerDown={(e) => {
-                    if (e.button !== 0) return;
-                    e.preventDefault();
-                    e.stopPropagation();
-                    stagePointerHandledRef.current = true;
-                    onToggle(scene.sceneId, stage);
-                    window.setTimeout(() => {
-                      stagePointerHandledRef.current = false;
-                    }, 600);
-                  }}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    if (stagePointerHandledRef.current) {
-                      stagePointerHandledRef.current = false;
-                      return;
-                    }
-                    onToggle(scene.sceneId, stage);
-                  }}
-                  className={cn(
-                    'compact-label-container flex-1 min-w-0 text-center py-2 text-[11px] font-medium rounded-md transition-all cursor-pointer',
-                    !isDone && 'text-text-secondary/60 hover:text-text-primary hover:bg-bg-border/25',
-                  )}
-                  style={
-                    isDone
-                      ? isCurrent
-                        ? { backgroundColor: deptConfig.color, color: '#fff', fontWeight: 700, boxShadow: `0 2px 8px ${deptConfig.color}40` }
-                        : { backgroundColor: `${deptConfig.color}20`, color: deptConfig.color }
-                      : undefined
-                  }
-                >
-                  <CompactIconLabel icon={stageIcon(stage, 12)} label={deptConfig.stageLabels[stage]} className="w-full" />
-                </button>
-              );
-            })}
-          </div>
+          <StageSegmentToggle
+            scene={scene}
+            department={department}
+            onToggle={(stage) => onToggle(scene.sceneId, stage)}
+          />
         )}
         <Confetti active={celebrating} onComplete={onCelebrationEnd} />
       </div>
@@ -5090,7 +5040,13 @@ export function ScenesView() {
                         border: `1px solid ${DEPARTMENT_CONFIGS.bg.stageColors[stage]}40`,
                       }}
                     >
-                      <CompactIconLabel icon={stageIcon(stage, 12)} label={DEPARTMENT_CONFIGS.bg.stageLabels[stage]} className="w-full" />
+                      <CompactIconLabel
+                        icon={stageIcon(stage, 12)}
+                        label={DEPARTMENT_CONFIGS.bg.stageLabels[stage]}
+                        className="w-full"
+                        iconClassName="hidden 2xl:inline-flex"
+                        iconPosition="after"
+                      />
                     </button>
                   ))}
                 </div>
@@ -5112,7 +5068,13 @@ export function ScenesView() {
                         border: `1px solid ${SCENE_PHASE_COLORS[phase]}40`,
                       }}
                     >
-                      <CompactIconLabel icon={phaseIcon(phase, 12)} label={SCENE_PHASE_LABELS_SHORT[phase]} className="w-full" />
+                      <CompactIconLabel
+                        icon={phaseIcon(phase, 12)}
+                        label={SCENE_PHASE_LABELS_SHORT[phase]}
+                        className="w-full"
+                        iconClassName="hidden 2xl:inline-flex"
+                        iconPosition="after"
+                      />
                     </button>
                   ))}
                 </div>
@@ -5130,7 +5092,13 @@ export function ScenesView() {
                     border: `1px solid ${deptConfig.stageColors[stage]}40`,
                   }}
                 >
-                  <CompactIconLabel icon={stageIcon(stage, 12)} label={deptConfig.stageLabels[stage]} className="w-full" />
+                  <CompactIconLabel
+                    icon={stageIcon(stage, 12)}
+                    label={deptConfig.stageLabels[stage]}
+                    className="w-full"
+                    iconClassName="hidden 2xl:inline-flex"
+                    iconPosition="after"
+                  />
                 </button>
               ))
             )}
@@ -5402,6 +5370,9 @@ export function ScenesView() {
             readOnlyGuideUrl={bgImageForAct?.guide ?? null}
             onFieldUpdate={(idx, field, value) => handleFieldUpdateForSheet(detailSheetName, idx, field, value)}
             onToggle={(id, stage) => handleToggleForSheet(detailSheetName, id, stage)}
+            onActPhaseStateClick={handleActPhaseStateClick}
+            onActFeedbackRequest={handleActFeedbackRequest}
+            onActRoundBump={handleActRoundBump}
             onClose={() => { setDetailSceneIndex(null); setDetailContext(null); setModalRouting(null); }}
             initialTab={modalRouting?.initialTab}
             focusRevisionId={modalRouting?.focusRevisionId}

--- a/src/views/compositing/EpisodeGroupSection.tsx
+++ b/src/views/compositing/EpisodeGroupSection.tsx
@@ -88,11 +88,7 @@ export function EpisodeGroupSection({
     [sceneGroups, episodes],
   );
 
-  const [expandedEps, setExpandedEps] = useState<Set<number>>(() => {
-    // 첫 EP 자동 펼침
-    const first = episodeGroups[0]?.episodeNumber;
-    return first !== undefined ? new Set([first]) : new Set();
-  });
+  const [expandedEps, setExpandedEps] = useState<Set<number>>(() => new Set());
 
   const toggleEp = (epNum: number) => {
     setExpandedEps((prev) => {

--- a/src/views/compositing/RevisionDetailPanel.tsx
+++ b/src/views/compositing/RevisionDetailPanel.tsx
@@ -21,6 +21,10 @@ import { parsePathsFromText, parseSceneKey } from './utils';
 import type { SceneInfo } from './utils';
 import { SceneJumpButton } from './SceneJumpButton';
 import { RevisionCommentThread } from '@/components/scenes/RevisionCommentThread';
+import {
+  AttachmentImageLightbox,
+  type AttachmentImageLightboxState,
+} from '@/components/scenes/AttachmentImageLightbox';
 
 export function DetailPanel({
   revision,
@@ -35,6 +39,7 @@ export function DetailPanel({
 }) {
   const [showResolveNote, setShowResolveNote] = useState(false);
   const [resolveNote, setResolveNote] = useState('');
+  const [lightbox, setLightbox] = useState<AttachmentImageLightboxState | null>(null);
   const { description: descText, paths: detailPaths } = parsePathsFromText(revision.description);
   const allUsers = useAuthStore((s) => s.users);
   // v1.19.4: notifyUserIds 를 사용자 객체로 변환 (이름 + 컴포지터 라벨 표시)
@@ -57,6 +62,26 @@ export function DetailPanel({
   };
 
   const { sceneId } = parseSceneKey(revision.sceneKey);
+  const revisionLabel = revisionNoToLabel(revision.revisionNo);
+  const openRevisionImage = () => {
+    if (!revision.imageUrl) return;
+    setLightbox({
+      entries: [{
+        url: revision.imageUrl,
+        userName: revision.requesterName,
+        commentText: revision.description,
+        createdAt: revision.createdAt,
+        commentId: revision.id,
+      }],
+      index: 0,
+    });
+  };
+  const lightboxStep = (dir: 1 | -1) => {
+    setLightbox((prev) => {
+      if (!prev || prev.entries.length <= 1) return prev;
+      return { ...prev, index: (prev.index + dir + prev.entries.length) % prev.entries.length };
+    });
+  };
 
   return (
     <motion.div
@@ -87,7 +112,7 @@ export function DetailPanel({
           {/* re# 라벨 + 상태 뱃지 + 씬 점프 */}
           <div className="flex items-center gap-2 mb-5 flex-wrap">
             <span className="inline-flex items-center text-[11px] px-1.5 py-0.5 rounded bg-accent/15 text-accent-sub font-mono font-bold border border-accent/30">
-              {revisionNoToLabel(revision.revisionNo)}
+              {revisionLabel}
             </span>
             <span
               className="compact-label-container inline-flex min-w-0 shrink items-center gap-1 text-[11px] font-medium rounded-full px-2 py-0.5"
@@ -155,12 +180,30 @@ export function DetailPanel({
           {/* 이미지 */}
           {revision.imageUrl && (
             <div className="mb-5">
-              <img
-                src={revision.imageUrl}
-                alt="첨부"
-                className="rounded-xl max-h-48 w-full object-contain border border-bg-border/40"
-              />
+              <button
+                type="button"
+                onClick={openRevisionImage}
+                className="block w-full rounded-xl border border-bg-border/40 overflow-hidden cursor-zoom-in hover:opacity-85 transition-opacity"
+                title="이미지 확대"
+              >
+                <img
+                  src={revision.imageUrl}
+                  alt="첨부"
+                  className="max-h-48 w-full object-contain"
+                />
+              </button>
             </div>
+          )}
+          {lightbox && (
+            <AttachmentImageLightbox
+              lightbox={lightbox}
+              setLightbox={setLightbox}
+              closeLightbox={() => setLightbox(null)}
+              lightboxStep={lightboxStep}
+              sceneLabel={revisionLabel}
+              ariaLabel="리비전 이미지 확대 보기"
+              fileNamePrefix={`${revisionLabel}-revision`}
+            />
           )}
 
           {/* 알림 받는 사람 — v1.19.4 신규 */}

--- a/src/views/compositing/RevisionItem.tsx
+++ b/src/views/compositing/RevisionItem.tsx
@@ -1,6 +1,6 @@
 // ─── 리비전 아이템 (확장된 씬 내부) ──────────
 
-import { useMemo, useState } from 'react';
+import { useMemo, useState, type MouseEvent } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Bell, MessageSquarePlus, Undo2, UserRound } from 'lucide-react';
 import type { CompRevision, RevisionStatus } from '@/types';
@@ -11,6 +11,10 @@ import { useAuthStore } from '@/stores/useAuthStore';
 import { StatusDropdown } from './sharedComponents';
 import { parsePathsFromText } from './utils';
 import { RevisionCommentMarker } from './RevisionCommentMarker';
+import {
+  AttachmentImageLightbox,
+  type AttachmentImageLightboxState,
+} from '@/components/scenes/AttachmentImageLightbox';
 
 const STATUS_TINT: Record<RevisionStatus, { background: string; halo: string }> = {
   open: {
@@ -46,10 +50,12 @@ export function RevisionItem({
 }) {
   const [showResolveNote, setShowResolveNote] = useState(false);
   const [resolveNote, setResolveNote] = useState('');
+  const [lightbox, setLightbox] = useState<AttachmentImageLightboxState | null>(null);
   const isResolved = revision.status === 'resolved';
   const isInProgress = revision.status === 'in_progress';
   const statusCfg = STATUS_CONFIG[revision.status];
   const statusTint = STATUS_TINT[revision.status];
+  const revisionLabel = revisionNoToLabel(revision.revisionNo);
   const { description: descText, paths } = parsePathsFromText(revision.description);
   const allUsers = useAuthStore((s) => s.users);
   // v1.19.4: notifyUserIds → 사용자 이름 배열 (AvatarStack 용)
@@ -75,19 +81,42 @@ export function RevisionItem({
     setResolveNote('');
   };
 
+  const openRevisionImage = (e: MouseEvent) => {
+    e.stopPropagation();
+    if (!revision.imageUrl) return;
+    setLightbox({
+      entries: [{
+        url: revision.imageUrl,
+        userName: revision.requesterName,
+        commentText: revision.description,
+        createdAt: revision.createdAt,
+        commentId: revision.id,
+      }],
+      index: 0,
+    });
+  };
+
+  const lightboxStep = (dir: 1 | -1) => {
+    setLightbox((prev) => {
+      if (!prev || prev.entries.length <= 1) return prev;
+      return { ...prev, index: (prev.index + dir + prev.entries.length) % prev.entries.length };
+    });
+  };
+
   return (
-    <motion.div
-      layout
-      initial={{ opacity: 0, x: -8 }}
-      animate={{ opacity: 1, x: 0 }}
-      exit={{ opacity: 0, x: -8 }}
-      transition={{ duration: 0.2 }}
-      onClick={onSelect}
-      data-revision-status={revision.status}
-      className={`relative flex items-start gap-3 pl-10 pr-4 py-2.5 rounded-lg border border-bg-border/35 bg-bg-primary/20 transition-all duration-200 group cursor-pointer overflow-hidden ${
-        isSelected ? 'ring-1 ring-accent/25 bg-bg-border/10' : 'hover:bg-bg-border/10'
-      }`}
-    >
+    <>
+      <motion.div
+        layout
+        initial={{ opacity: 0, x: -8 }}
+        animate={{ opacity: 1, x: 0 }}
+        exit={{ opacity: 0, x: -8 }}
+        transition={{ duration: 0.2 }}
+        onClick={onSelect}
+        data-revision-status={revision.status}
+        className={`relative flex items-start gap-3 pl-10 pr-4 py-2.5 rounded-lg border border-bg-border/35 bg-bg-primary/20 transition-all duration-200 group cursor-pointer overflow-hidden ${
+          isSelected ? 'ring-1 ring-accent/25 bg-bg-border/10' : 'hover:bg-bg-border/10'
+        }`}
+      >
       <div
         className="pointer-events-none absolute inset-[1px] rounded-[7px]"
         style={{
@@ -114,13 +143,18 @@ export function RevisionItem({
 
       {/* 썸네일 영역 (이미지 있으면 표시, 없으면 placeholder) */}
       {revision.imageUrl ? (
-        <div className="relative z-[1] shrink-0 w-20 h-14 rounded overflow-hidden">
+        <button
+          type="button"
+          onClick={openRevisionImage}
+          className="relative z-[1] shrink-0 w-20 h-14 rounded overflow-hidden cursor-zoom-in hover:opacity-85 transition-opacity"
+          title="이미지 확대"
+        >
           <img
             src={revision.imageUrl}
             className={`w-full h-full object-cover ${isResolved ? 'opacity-60' : ''}`}
             alt=""
           />
-        </div>
+        </button>
       ) : (
         <div className="relative z-[1] shrink-0 w-20 h-14 rounded border border-dashed border-bg-border/40 flex items-center justify-center text-text-secondary/40">
           <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24">
@@ -140,7 +174,7 @@ export function RevisionItem({
               isResolved ? 'text-text-secondary/50' : 'text-accent-sub'
             }`}
           >
-            {revisionNoToLabel(revision.revisionNo)}
+            {revisionLabel}
           </span>
           <p
             className={`text-sm leading-relaxed ${
@@ -260,6 +294,18 @@ export function RevisionItem({
           <CompactIconLabel icon={<Undo2 size={11} />} label="되돌리기" />
         </button>
       )}
-    </motion.div>
+      </motion.div>
+      {lightbox && (
+        <AttachmentImageLightbox
+          lightbox={lightbox}
+          setLightbox={setLightbox}
+          closeLightbox={() => setLightbox(null)}
+          lightboxStep={lightboxStep}
+          sceneLabel={revisionLabel}
+          ariaLabel="리비전 이미지 확대 보기"
+          fileNamePrefix={`${revisionLabel}-revision`}
+        />
+      )}
+    </>
   );
 }

--- a/src/views/compositing/SceneGroupSection.tsx
+++ b/src/views/compositing/SceneGroupSection.tsx
@@ -10,7 +10,7 @@ import { RevisionItem } from './RevisionItem';
 import { AddRevisionForm } from './AddRevisionForm';
 import { SceneJumpButton } from './SceneJumpButton';
 import type { SceneGroup } from './utils';
-import type { FeedbackHubEpisodeTree } from './feedbackHubUtils';
+import { buildFeedbackHubPartCollapseKey, type FeedbackHubEpisodeTree } from './feedbackHubUtils';
 import { RevisionCommentMarker, summarizeRevisionComments } from './RevisionCommentMarker';
 import { CompactIconLabel } from '@/components/common/CompactIconLabel';
 
@@ -291,19 +291,27 @@ export function SceneRow({
 
 export function FeedbackTreeSection({
   episodeTrees,
+  expandedEpisodes,
+  expandedParts,
   expandedScenes,
   selectedRevisionId,
   commentCountByRev,
   commentSeenByRev,
+  onToggleEpisode,
+  onTogglePart,
   onToggleScene,
   onSelectRevision,
   onStatusChange,
 }: {
   episodeTrees: FeedbackHubEpisodeTree[];
+  expandedEpisodes: Set<number>;
+  expandedParts: Set<string>;
   expandedScenes: Set<string>;
   selectedRevisionId: string | null;
   commentCountByRev?: Map<string, number>;
   commentSeenByRev?: Map<string, boolean>;
+  onToggleEpisode: (episodeNumber: number) => void;
+  onTogglePart: (episodeNumber: number, partId: string) => void;
   onToggleScene: (sceneKey: string) => void;
   onSelectRevision: (rev: CompRevision) => void;
   onStatusChange: (revId: string, sceneKey: string, status: RevisionStatus, note?: string) => void;
@@ -311,6 +319,7 @@ export function FeedbackTreeSection({
   return (
     <div className="px-5 py-4 space-y-4">
       {episodeTrees.map((episodeTree) => {
+        const isEpisodeExpanded = expandedEpisodes.has(episodeTree.episodeNumber);
         const episodeCommentSummary = summarizeRevisionComments(
           episodeTree.parts.flatMap((partTree) =>
             partTree.scenes.flatMap((group) => group.revisions),
@@ -324,7 +333,22 @@ export function FeedbackTreeSection({
             key={episodeTree.episodeNumber}
             className="overflow-hidden rounded-xl border border-bg-border/55 bg-bg-card/55"
           >
-            <header className="px-4 py-3 flex items-center gap-3 border-b border-bg-border/35 bg-bg-primary/20">
+            <header
+              role="button"
+              tabIndex={0}
+              aria-expanded={isEpisodeExpanded}
+              onClick={() => onToggleEpisode(episodeTree.episodeNumber)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  onToggleEpisode(episodeTree.episodeNumber);
+                }
+              }}
+              className="px-4 py-3 flex items-center gap-3 border-b border-bg-border/35 bg-bg-primary/20 hover:bg-bg-primary/35 transition-colors cursor-pointer"
+            >
+              <span className="shrink-0 text-text-secondary/60">
+                {isEpisodeExpanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+              </span>
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-2">
                   <span className="text-sm font-bold text-text-primary">{episodeTree.episodeLabel}</span>
@@ -348,73 +372,112 @@ export function FeedbackTreeSection({
               )}
             </header>
 
-            <div className="divide-y divide-bg-border/30">
-            {episodeTree.parts.map((partTree) => {
-              const isPartResolved = partTree.totalRevisions > 0 && partTree.totalOpen === 0;
-              const partCommentSummary = summarizeRevisionComments(
-                partTree.scenes.flatMap((group) => group.revisions),
-                commentCountByRev,
-                commentSeenByRev,
-              );
+            <AnimatePresence initial={false}>
+              {isEpisodeExpanded && (
+                <motion.div
+                  initial={{ opacity: 0, height: 0 }}
+                  animate={{ opacity: 1, height: 'auto' }}
+                  exit={{ opacity: 0, height: 0 }}
+                  transition={{ duration: 0.2, ease: 'easeInOut' }}
+                  className="overflow-hidden"
+                >
+                  <div className="divide-y divide-bg-border/30">
+                  {episodeTree.parts.map((partTree) => {
+                    const partKey = buildFeedbackHubPartCollapseKey(episodeTree.episodeNumber, partTree.partId);
+                    const isPartExpanded = expandedParts.has(partKey);
+                    const isPartResolved = partTree.totalRevisions > 0 && partTree.totalOpen === 0;
+                    const partCommentSummary = summarizeRevisionComments(
+                      partTree.scenes.flatMap((group) => group.revisions),
+                      commentCountByRev,
+                      commentSeenByRev,
+                    );
 
-              return (
-                <section key={partTree.partId}>
-                  <div
-                    data-part-complete={isPartResolved ? 'true' : 'false'}
-                    className={`px-4 py-2.5 flex items-center gap-2 transition-colors ${
-                      isPartResolved ? 'bg-bg-primary/5' : 'bg-bg-primary/10'
-                    }`}
-                  >
-                    <span className={`h-1.5 w-1.5 rounded-full shrink-0 ${
-                      isPartResolved ? 'bg-text-secondary/25' : 'bg-accent-sub'
-                    }`} />
-                    <span className={`text-[12px] font-bold ${
-                      isPartResolved ? 'text-text-secondary/45' : 'text-text-primary'
-                    }`}>{partTree.partId} 파트</span>
-                    <span className={`text-[10px] ${
-                      isPartResolved ? 'text-text-secondary/35' : 'text-text-secondary/60'
-                    }`}>
-                      {partTree.scenes.length}씬 · {partTree.totalRevisions}개
-                    </span>
-                    <RevisionCommentMarker
-                      count={partCommentSummary.count}
-                      seen={partCommentSummary.seen}
-                      size="compact"
-                      className={isPartResolved ? 'opacity-60' : ''}
-                    />
-                    {isPartResolved ? (
-                      <span className="compact-label-container ml-auto inline-flex min-w-0 shrink text-[10px] font-bold rounded-full px-2 py-0.5 text-text-secondary/45 bg-bg-primary/35 border border-bg-border/25">
-                        <CompactIconLabel icon={<CheckCircle2 size={10} />} label="완료" />
-                      </span>
-                    ) : partTree.totalOpen > 0 ? (
-                      <span className="compact-label-container ml-auto inline-flex min-w-0 shrink text-[10px] font-bold text-accent-sub">
-                        <CompactIconLabel icon={<AlertTriangle size={10} />} label={`${partTree.totalOpen} 미해결`} />
-                      </span>
-                    ) : null}
-                  </div>
+                    return (
+                      <section key={partTree.partId}>
+                        <div
+                          role="button"
+                          tabIndex={0}
+                          aria-expanded={isPartExpanded}
+                          data-part-complete={isPartResolved ? 'true' : 'false'}
+                          onClick={() => onTogglePart(episodeTree.episodeNumber, partTree.partId)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                              e.preventDefault();
+                              onTogglePart(episodeTree.episodeNumber, partTree.partId);
+                            }
+                          }}
+                          className={`px-4 py-2.5 flex items-center gap-2 transition-colors cursor-pointer ${
+                            isPartResolved
+                              ? 'bg-bg-primary/5 hover:bg-bg-border/5'
+                              : 'bg-bg-primary/10 hover:bg-bg-border/10'
+                          }`}
+                        >
+                          <span className="shrink-0 text-text-secondary/55">
+                            {isPartExpanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+                          </span>
+                          <span className={`h-1.5 w-1.5 rounded-full shrink-0 ${
+                            isPartResolved ? 'bg-text-secondary/25' : 'bg-accent-sub'
+                          }`} />
+                          <span className={`text-[12px] font-bold ${
+                            isPartResolved ? 'text-text-secondary/45' : 'text-text-primary'
+                          }`}>{partTree.partId} 파트</span>
+                          <span className={`text-[10px] ${
+                            isPartResolved ? 'text-text-secondary/35' : 'text-text-secondary/60'
+                          }`}>
+                            {partTree.scenes.length}씬 · {partTree.totalRevisions}개
+                          </span>
+                          <RevisionCommentMarker
+                            count={partCommentSummary.count}
+                            seen={partCommentSummary.seen}
+                            size="compact"
+                            className={isPartResolved ? 'opacity-60' : ''}
+                          />
+                          {isPartResolved ? (
+                            <span className="compact-label-container ml-auto inline-flex min-w-0 shrink text-[10px] font-bold rounded-full px-2 py-0.5 text-text-secondary/45 bg-bg-primary/35 border border-bg-border/25">
+                              <CompactIconLabel icon={<CheckCircle2 size={10} />} label="완료" />
+                            </span>
+                          ) : partTree.totalOpen > 0 ? (
+                            <span className="compact-label-container ml-auto inline-flex min-w-0 shrink text-[10px] font-bold text-accent-sub">
+                              <CompactIconLabel icon={<AlertTriangle size={10} />} label={`${partTree.totalOpen} 미해결`} />
+                            </span>
+                          ) : null}
+                        </div>
 
-                  <div className={`ml-5 border-l ${
-                    isPartResolved ? 'border-bg-border/25' : 'border-bg-border/40'
-                  }`}>
-                    {partTree.scenes.map((group) => (
-                      <SceneRow
-                        key={group.sceneKey}
-                        group={group}
-                        expanded={expandedScenes.has(group.sceneKey)}
-                        selectedRevisionId={selectedRevisionId}
-                        commentCountByRev={commentCountByRev}
-                        commentSeenByRev={commentSeenByRev}
-                        pathMode="sceneOnly"
-                        onToggle={() => onToggleScene(group.sceneKey)}
-                        onSelectRevision={onSelectRevision}
-                        onStatusChange={onStatusChange}
-                      />
-                    ))}
+                        <AnimatePresence initial={false}>
+                          {isPartExpanded && (
+                            <motion.div
+                              initial={{ opacity: 0, height: 0 }}
+                              animate={{ opacity: 1, height: 'auto' }}
+                              exit={{ opacity: 0, height: 0 }}
+                              transition={{ duration: 0.18, ease: 'easeInOut' }}
+                              className={`ml-5 overflow-hidden border-l ${
+                                isPartResolved ? 'border-bg-border/25' : 'border-bg-border/40'
+                              }`}
+                            >
+                              {partTree.scenes.map((group) => (
+                                <SceneRow
+                                  key={group.sceneKey}
+                                  group={group}
+                                  expanded={expandedScenes.has(group.sceneKey)}
+                                  selectedRevisionId={selectedRevisionId}
+                                  commentCountByRev={commentCountByRev}
+                                  commentSeenByRev={commentSeenByRev}
+                                  pathMode="sceneOnly"
+                                  onToggle={() => onToggleScene(group.sceneKey)}
+                                  onSelectRevision={onSelectRevision}
+                                  onStatusChange={onStatusChange}
+                                />
+                              ))}
+                            </motion.div>
+                          )}
+                        </AnimatePresence>
+                      </section>
+                    );
+                  })}
                   </div>
-                </section>
-              );
-            })}
-            </div>
+                </motion.div>
+              )}
+            </AnimatePresence>
           </section>
         );
       })}

--- a/src/views/compositing/feedbackHubUtils.ts
+++ b/src/views/compositing/feedbackHubUtils.ts
@@ -3,6 +3,10 @@ import type { SceneGroup } from './utils';
 
 const STALLED_HOURS = 48;
 
+export function buildFeedbackHubPartCollapseKey(episodeNumber: number, partId: string): string {
+  return `${episodeNumber}::${partId}`;
+}
+
 export interface FeedbackHubPartTree {
   partId: string;
   scenes: SceneGroup[];

--- a/tests/commentReadStateSchema.test.ts
+++ b/tests/commentReadStateSchema.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs';
 
 const migration = readFileSync('DEVLOG/migrations/2026-05-30-comment-read-states.sql', 'utf8');
 const initSql = readFileSync('DEVLOG/supabase-init.sql', 'utf8');
+const electronSupabase = readFileSync('electron/supabase.ts', 'utf8');
 
 for (const [label, sql] of [
   ['migration', migration],
@@ -29,3 +30,11 @@ for (const [label, sql] of [
     assert.match(sql, /GRANT EXECUTE ON FUNCTION upsert_comment_read_state\s*\(\s*TEXT\s*,\s*TEXT\s*,\s*TIMESTAMPTZ\s*\)\s+TO anon,\s*authenticated/i);
   });
 }
+
+test('Electron falls back to table writes when the comment read-state RPC is missing', () => {
+  assert.match(electronSupabase, /isMissingCommentReadStateRpcError/);
+  assert.match(electronSupabase, /upsertCommentReadStateViaTable/);
+  assert.match(electronSupabase, /\.from\('comment_read_states'\)[\s\S]*\.insert/);
+  assert.match(electronSupabase, /\.from\('comment_read_states'\)[\s\S]*\.update/);
+  assert.match(electronSupabase, /\.lt\('last_read_at',\s*lastReadAt\)/);
+});

--- a/tests/commentReadStateService.test.ts
+++ b/tests/commentReadStateService.test.ts
@@ -6,6 +6,7 @@ import {
   __flushPendingCommentReadStateForTests,
   __getPendingCommentReadStateForTests,
   __hasCommentReadStatePersistenceOverrideForTests,
+  __isCommentReadStatePersistenceDisabledForTests,
   __resetCommentReadStateServiceForTests,
   __setCommentReadStatePersistenceForTests,
   getCommentReadStateForUser,
@@ -145,6 +146,39 @@ test('save failure keeps optimistic cache and queues pending write', async () =>
     assert.equal(state['EP05:A:a001'], '2026-05-29T10:00:00.000Z');
     assert.equal(pending?.readAt, '2026-05-29T10:00:00.000Z');
     assert.equal(pending?.hasTimer, true);
+  });
+});
+
+test('missing Supabase read-state schema keeps local cache without retry spam', async () => {
+  let upsertCalls = 0;
+  await withMutedWarnings(async () => {
+    installFakePersistence({
+      upsert: async () => {
+        upsertCalls += 1;
+        throw new Error(
+          "Error invoking remote method 'supabase:upsert-comment-read-state': Error: Could not find the function public.upsert_comment_read_state(p_last_read_at, p_scene_thread_key, p_user_id) in the schema cache",
+        );
+      },
+    });
+
+    await markSceneThreadReadForUser({
+      userId: 'me',
+      sceneThreadKey: 'EP05:A:a001',
+      readAt: '2026-05-29T10:00:00.000Z',
+    });
+
+    await markSceneThreadReadForUser({
+      userId: 'me',
+      sceneThreadKey: 'EP05:A:a001',
+      readAt: '2026-05-29T10:01:00.000Z',
+    });
+
+    const state = await getCommentReadStateForUser('me');
+
+    assert.equal(state['EP05:A:a001'], '2026-05-29T10:01:00.000Z');
+    assert.equal(upsertCalls, 1);
+    assert.equal(__isCommentReadStatePersistenceDisabledForTests(), true);
+    assert.equal(__getPendingCommentReadStateForTests('me', 'EP05:A:a001'), null);
   });
 });
 

--- a/tests/commentReadStateService.test.ts
+++ b/tests/commentReadStateService.test.ts
@@ -182,6 +182,32 @@ test('missing Supabase read-state schema keeps local cache without retry spam', 
   });
 });
 
+test('non-schema read-state failures keep retrying instead of disabling persistence', async () => {
+  let upsertCalls = 0;
+  await withMutedWarnings(async () => {
+    installFakePersistence({
+      upsert: async () => {
+        upsertCalls += 1;
+        throw new Error('permission denied for table comment_read_states');
+      },
+    });
+
+    await markSceneThreadReadForUser({
+      userId: 'me',
+      sceneThreadKey: 'EP05:A:a001',
+      readAt: '2026-05-29T10:00:00.000Z',
+    });
+
+    const state = await getCommentReadStateForUser('me');
+    const pending = __getPendingCommentReadStateForTests('me', 'EP05:A:a001');
+
+    assert.equal(state['EP05:A:a001'], '2026-05-29T10:00:00.000Z');
+    assert.equal(upsertCalls, 2);
+    assert.equal(__isCommentReadStatePersistenceDisabledForTests(), false);
+    assert.equal(pending?.readAt, '2026-05-29T10:00:00.000Z');
+  });
+});
+
 test('next get flushes pending write and deletes it on success', async () => {
   let shouldFail = true;
   const { upserts } = installFakePersistence({

--- a/tests/commentReadStateUiWiring.test.ts
+++ b/tests/commentReadStateUiWiring.test.ts
@@ -14,6 +14,11 @@ const feedbackHubPreviewApp = readFileSync('src/views/FeedbackHubPreviewApp.tsx'
 const indexCss = readFileSync('src/index.css', 'utf8');
 const electronBroadcast = readFileSync('electron/broadcast.ts', 'utf8');
 const electronSupabase = readFileSync('electron/supabase.ts', 'utf8');
+const attachmentImageLightbox = readFileSync('src/components/scenes/AttachmentImageLightbox.tsx', 'utf8');
+const imageContextMenu = readFileSync('src/components/scenes/ImageContextMenu.tsx', 'utf8');
+const revisionPanel = readFileSync('src/components/scenes/RevisionPanel.tsx', 'utf8');
+const revisionDetailPanel = readFileSync('src/views/compositing/RevisionDetailPanel.tsx', 'utf8');
+const revisionItem = readFileSync('src/views/compositing/RevisionItem.tsx', 'utf8');
 
 function getCommentPanelResizableUsage(source: string): string {
   const usage = source.match(/<CommentPanelResizable\b[\s\S]*?\/>/);
@@ -88,6 +93,22 @@ test('revision comment thread supports user mentions like the main comment panel
   assert.match(revisionCommentThread, /insertMention/);
   assert.match(revisionCommentThread, /PathLinkifiedText/);
   assert.match(revisionCommentThread, /sendMentionWebhook/);
+});
+
+test('comment and revision images share enlarge, copy, and download actions', () => {
+  assert.match(attachmentImageLightbox, /ImageContextMenu/);
+  assert.match(attachmentImageLightbox, /downloadImage/);
+  assert.match(attachmentImageLightbox, /copyImageToClipboard/);
+  assert.match(attachmentImageLightbox, /copyImageUrl/);
+  assert.match(attachmentImageLightbox, /actions=\{\['download', 'copy', 'copy-url'\]\}/);
+  assert.match(imageContextMenu, /actions\?: ContextAction\[\]/);
+  assert.match(commentPanel, /AttachmentImageLightbox/);
+  assert.match(revisionCommentThread, /AttachmentImageLightbox/);
+  assert.match(revisionCommentThread, /onImageClick/);
+  assert.doesNotMatch(revisionCommentThread, /href=\{url\}/);
+  assert.match(revisionPanel, /openRevisionImage/);
+  assert.match(revisionDetailPanel, /openRevisionImage/);
+  assert.match(revisionItem, /openRevisionImage/);
 });
 
 test('revision comment notifications include explicitly mentioned users', () => {

--- a/tests/commentReadStateUiWiring.test.ts
+++ b/tests/commentReadStateUiWiring.test.ts
@@ -69,6 +69,9 @@ test('Scene detail comment panels expose /re quick revision context', () => {
 
 test('quick revision can register a pasted attachment as the revision image', () => {
   assert.match(commentPanel, /imageUrl:\s*revisionImageUrl/);
+  assert.match(commentPanel, /const prevAttached = attachedImages;[\s\S]*setAttachedImages\(\[\]\);[\s\S]*attachedImagesRef\.current = \[\];[\s\S]*await createRevision\(\{/);
+  assert.match(commentPanel, /\[리비전 빠른 등록 실패 \+ unmount\]/);
+  assert.match(commentPanel, /setAttachedImages\(prevAttached\);[\s\S]*attachedImagesRef\.current = prevAttached/);
   assert.match(commentPanel, /첨부 이미지가 리비전 이미지로 함께 등록됩니다/);
   assert.match(commentPanel, /quickRevisionActive \? files\.slice\(0, 1\) : files/);
   assert.doesNotMatch(commentPanel, /빠른 리비전은 텍스트만 등록합니다/);

--- a/tests/commentReadStateUiWiring.test.ts
+++ b/tests/commentReadStateUiWiring.test.ts
@@ -58,6 +58,17 @@ test('Scene detail comment panels expose /re quick revision context', () => {
   assert.match(unifiedSceneDetailModal, /context: selectedDepartment === 'bg' \|\| selectedDepartment === 'acting' \? selectedDepartment : 'all'/);
 });
 
+test('single scene detail comment panel exposes the same activity inline events as unified detail', () => {
+  const usage = getCommentPanelResizableUsage(sceneDetailModal);
+
+  assert.match(sceneDetailModal, /import type \{ CommentInlineEvent \}/);
+  assert.match(sceneDetailModal, /const inlineEvents: CommentInlineEvent\[\]/);
+  assert.match(sceneDetailModal, /describeActivity\(a\)/);
+  assert.match(sceneDetailModal, /'revision_add', 'revision_in_progress', 'revision_resolve', 'revision_delete'/);
+  assert.match(usage, /inlineEvents=\{inlineEvents\}/);
+  assert.match(unifiedSceneDetailModal, /const inlineEvents: CommentInlineEvent\[\]/);
+});
+
 test('ScenesView maps legacy comment keys to canonical thread keys for read badges', () => {
   assert.match(scenesView, /buildSceneThreadKeyFromCommentKey/);
   assert.match(scenesView, /setCommentThreadKeyByCommentKey/);

--- a/tests/commentReadStateUiWiring.test.ts
+++ b/tests/commentReadStateUiWiring.test.ts
@@ -12,6 +12,8 @@ const scenesView = readFileSync('src/views/ScenesView.tsx', 'utf8');
 const compositingView = readFileSync('src/views/CompositingView.tsx', 'utf8');
 const feedbackHubPreviewApp = readFileSync('src/views/FeedbackHubPreviewApp.tsx', 'utf8');
 const indexCss = readFileSync('src/index.css', 'utf8');
+const electronBroadcast = readFileSync('electron/broadcast.ts', 'utf8');
+const electronSupabase = readFileSync('electron/supabase.ts', 'utf8');
 
 function getCommentPanelResizableUsage(source: string): string {
   const usage = source.match(/<CommentPanelResizable\b[\s\S]*?\/>/);
@@ -93,6 +95,16 @@ test('revision comment notifications include explicitly mentioned users', () => 
   assert.match(app, /const mentionedUserIds = useAuthStore\.getState\(\)\.users/);
   assert.match(app, /const targets = new Set\(\[\.\.\.revisionNotifyIds, \.\.\.mentionedUserIds\]\)/);
   assert.match(app, /리비전 댓글 멘션/);
+});
+
+test('revision comment broadcasts keep revision context and avoid general comment notification fallback', () => {
+  assert.match(electronBroadcast, /revisionId\?: string \| null/);
+  assert.match(electronBroadcast, /revisionId: revisionId \?\? null/);
+  assert.match(electronSupabase, /broadcastCommentAdded\(sceneId, userName, userId, text, mentions, commentId, safeParent, partUuid, revisionId\)/);
+  assert.match(app, /const dispatchRevisionCommentNotification = useCallback/);
+  assert.match(app, /revisionId: commentRevisionId/);
+  assert.match(app, /if \(commentRevisionId\) \{/);
+  assert.match(app, /window\.dispatchEvent\(new Event\('bflow:comments-invalidated'\)\)/);
 });
 
 test('single scene detail comment panel exposes the same activity inline events as unified detail', () => {

--- a/tests/commentReadStateUiWiring.test.ts
+++ b/tests/commentReadStateUiWiring.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs';
 
 const commentPanel = readFileSync('src/components/scenes/CommentPanel.tsx', 'utf8');
 const revisionCommentThread = readFileSync('src/components/scenes/RevisionCommentThread.tsx', 'utf8');
+const app = readFileSync('src/App.tsx', 'utf8');
 const resizable = readFileSync('src/components/scenes/CommentPanelResizable.tsx', 'utf8');
 const sceneDetailModal = readFileSync('src/components/scenes/SceneDetailModal.tsx', 'utf8');
 const unifiedSceneDetailModal = readFileSync('src/components/scenes/UnifiedSceneDetailModal.tsx', 'utf8');
@@ -75,6 +76,23 @@ test('revision comment thread supports image paste and file attachments', () => 
   assert.match(revisionCommentThread, /onPaste=\{handlePaste\}/);
   assert.match(revisionCommentThread, /images:\s*uploadedImageUrls/);
   assert.match(revisionCommentThread, /comment\.images/);
+});
+
+test('revision comment thread supports user mentions like the main comment panel', () => {
+  assert.match(revisionCommentThread, /extractMentions/);
+  assert.match(revisionCommentThread, /mentions:\s*extractMentions\(draft,\s*users\.map/);
+  assert.match(revisionCommentThread, /showMentions/);
+  assert.match(revisionCommentThread, /mentionFilter/);
+  assert.match(revisionCommentThread, /insertMention/);
+  assert.match(revisionCommentThread, /PathLinkifiedText/);
+  assert.match(revisionCommentThread, /sendMentionWebhook/);
+});
+
+test('revision comment notifications include explicitly mentioned users', () => {
+  assert.match(app, /const mentionedNames = Array\.isArray\(newComment\.mentions\) \? newComment\.mentions : \[\]/);
+  assert.match(app, /const mentionedUserIds = useAuthStore\.getState\(\)\.users/);
+  assert.match(app, /const targets = new Set\(\[\.\.\.revisionNotifyIds, \.\.\.mentionedUserIds\]\)/);
+  assert.match(app, /리비전 댓글 멘션/);
 });
 
 test('single scene detail comment panel exposes the same activity inline events as unified detail', () => {

--- a/tests/commentReadStateUiWiring.test.ts
+++ b/tests/commentReadStateUiWiring.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
 const commentPanel = readFileSync('src/components/scenes/CommentPanel.tsx', 'utf8');
+const revisionCommentThread = readFileSync('src/components/scenes/RevisionCommentThread.tsx', 'utf8');
 const resizable = readFileSync('src/components/scenes/CommentPanelResizable.tsx', 'utf8');
 const sceneDetailModal = readFileSync('src/components/scenes/SceneDetailModal.tsx', 'utf8');
 const unifiedSceneDetailModal = readFileSync('src/components/scenes/UnifiedSceneDetailModal.tsx', 'utf8');
@@ -56,6 +57,24 @@ test('Scene detail comment panels expose /re quick revision context', () => {
   assert.match(sceneDetailModal, /quickRevision=\{\{/);
   assert.match(sceneDetailModal, /context: department/);
   assert.match(unifiedSceneDetailModal, /context: selectedDepartment === 'bg' \|\| selectedDepartment === 'acting' \? selectedDepartment : 'all'/);
+});
+
+test('quick revision can register a pasted attachment as the revision image', () => {
+  assert.match(commentPanel, /imageUrl:\s*revisionImageUrl/);
+  assert.match(commentPanel, /첨부 이미지가 리비전 이미지로 함께 등록됩니다/);
+  assert.match(commentPanel, /quickRevisionActive \? files\.slice\(0, 1\) : files/);
+  assert.doesNotMatch(commentPanel, /빠른 리비전은 텍스트만 등록합니다/);
+  assert.doesNotMatch(commentPanel, /disabled=\{quickRevisionActive\}/);
+  assert.doesNotMatch(commentPanel, /&& !quickRevisionHasAttachments/);
+});
+
+test('revision comment thread supports image paste and file attachments', () => {
+  assert.match(revisionCommentThread, /attachedImages/);
+  assert.match(revisionCommentThread, /storageService\.uploadImage/);
+  assert.match(revisionCommentThread, /resizeBlob/);
+  assert.match(revisionCommentThread, /onPaste=\{handlePaste\}/);
+  assert.match(revisionCommentThread, /images:\s*uploadedImageUrls/);
+  assert.match(revisionCommentThread, /comment\.images/);
 });
 
 test('single scene detail comment panel exposes the same activity inline events as unified detail', () => {

--- a/tests/feedbackHubCollapseUi.test.ts
+++ b/tests/feedbackHubCollapseUi.test.ts
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+
+function read(...parts: string[]) {
+  return readFileSync(path.join(root, ...parts), 'utf8');
+}
+
+test('feedback hub main tree supports episode and part collapse from an all-collapsed entry state', () => {
+  const view = read('src/views/CompositingView.tsx');
+  const sceneTree = read('src/views/compositing/SceneGroupSection.tsx');
+  const episodeGroup = read('src/views/compositing/EpisodeGroupSection.tsx');
+  const utils = read('src/views/compositing/feedbackHubUtils.ts');
+
+  assert.match(utils, /export function buildFeedbackHubPartCollapseKey/);
+  assert.match(view, /const \[expandedScenes, setExpandedScenes\] = useState<Set<string>>\(new Set\(\)\)/);
+  assert.match(view, /const \[expandedFeedbackEpisodes, setExpandedFeedbackEpisodes\] = useState<Set<number>>\(new Set\(\)\)/);
+  assert.match(view, /const \[expandedFeedbackParts, setExpandedFeedbackParts\] = useState<Set<string>>\(new Set\(\)\)/);
+  assert.doesNotMatch(view, /autoExpandedOnce/);
+  assert.doesNotMatch(view, /setExpandedScenes\(new Set\(groupsToOpen/);
+  assert.match(view, /expandedEpisodes=\{expandedFeedbackEpisodes\}/);
+  assert.match(view, /expandedParts=\{expandedFeedbackParts\}/);
+  assert.match(view, /onToggleEpisode=\{toggleFeedbackEpisode\}/);
+  assert.match(view, /onTogglePart=\{toggleFeedbackPart\}/);
+  assert.match(view, /setExpandedFeedbackEpisodes\(new Set\(feedbackTree\.map/);
+  assert.match(view, /setExpandedFeedbackParts\(new Set\(/);
+
+  assert.match(sceneTree, /aria-expanded=\{isEpisodeExpanded\}/);
+  assert.match(sceneTree, /onToggleEpisode\(episodeTree\.episodeNumber\)/);
+  assert.match(sceneTree, /aria-expanded=\{isPartExpanded\}/);
+  assert.match(sceneTree, /onTogglePart\(episodeTree\.episodeNumber, partTree\.partId\)/);
+  assert.match(sceneTree, /buildFeedbackHubPartCollapseKey\(episodeTree\.episodeNumber, partTree\.partId\)/);
+  assert.match(sceneTree, /isEpisodeExpanded &&/);
+  assert.match(sceneTree, /isPartExpanded &&/);
+
+  assert.match(episodeGroup, /const \[expandedEps, setExpandedEps\] = useState<Set<number>>\(\(\) => new Set\(\)\)/);
+});

--- a/tests/responsiveCompactLabels.test.ts
+++ b/tests/responsiveCompactLabels.test.ts
@@ -154,13 +154,13 @@ test('compositing and shared dropdown controls use compact or bounded labels', (
   assert.match(dashboardBulkBar, /CompactIconLabel/);
 });
 
-test('Bflow cursor uses a custom app cursor while preserving precision cursors', () => {
+test('Bflow does not install a custom app cursor', () => {
   const css = read('src/index.css');
+  const main = read('src/main.tsx');
 
-  assert.match(css, /--bflow-cursor-default/);
-  assert.match(css, /--bflow-cursor-pointer/);
-  assert.match(css, /html,\s*body,\s*#root\s*\{[\s\S]*cursor:\s*var\(--bflow-cursor-default\)/);
-  assert.match(css, /button:not\(:disabled\)[\s\S]*cursor:\s*var\(--bflow-cursor-pointer\) !important/);
-  assert.match(css, /input,\s*textarea,[\s\S]*\.cursor-text\s*\{[\s\S]*cursor:\s*text !important/);
-  assert.match(css, /\.sheet-column-resizer,[\s\S]*\.is-sheet-column-resizing \*[\s\S]*cursor:\s*col-resize !important/);
+  assert.ok(!existsSync('src/components/common/BflowCursorLayer.tsx'));
+  assert.doesNotMatch(css, /--bflow-cursor-/);
+  assert.doesNotMatch(css, /bflow-custom-cursor-enabled/);
+  assert.doesNotMatch(css, /bflow-cursor-layer/);
+  assert.doesNotMatch(main, /BflowCursorLayer/);
 });

--- a/tests/responsiveCompactLabels.test.ts
+++ b/tests/responsiveCompactLabels.test.ts
@@ -12,7 +12,10 @@ test('CompactIconLabel exposes accessible icon and label hooks', () => {
   assert.match(source, /aria-label=\{label\}/);
   assert.match(source, /title=\{label\}/);
   assert.match(source, /data-compact-icon-label/);
+  assert.match(source, /data-compact-label-icon/);
   assert.match(source, /data-compact-label-text/);
+  assert.match(source, /data-icon-position=\{iconPosition\}/);
+  assert.match(source, /data-display-mode=\{displayMode\}/);
   assert.match(source, /aria-hidden="true"/);
 });
 
@@ -24,7 +27,8 @@ test('compact labels collapse at narrow viewport without self-sizing container t
   assert.doesNotMatch(css, /\[data-compact-icon-label\]\s*\{[^}]*container-type/);
   assert.doesNotMatch(component, /container-type/);
   assert.match(css, /@media\s*\(max-width:\s*1040px\)/);
-  assert.match(css, /@media\s*\(max-width:\s*1040px\)\s*\{[\s\S]*\.compact-label-container\s+\[data-compact-label-text\][\s\S]*max-width:\s*0/);
+  assert.match(css, /@media\s*\(max-width:\s*1040px\)\s*\{[\s\S]*\[data-compact-icon-label\]:not\(\[data-display-mode="icon"\]\)\s+\[data-compact-label-icon\][\s\S]*max-width:\s*0/);
+  assert.doesNotMatch(css, /@media\s*\(max-width:\s*1040px\)\s*\{[\s\S]*\.compact-label-container\s+\[data-compact-label-text\][\s\S]*max-width:\s*0/);
   assert.match(css, /data-sheet-header-short-label/);
   assert.match(css, /data-sheet-header-full-label/);
   assert.doesNotMatch(css, /writing-mode/);
@@ -41,9 +45,8 @@ test('target dense surfaces import and use CompactIconLabel', () => {
     'src/views/compositing/SceneJumpButton.tsx',
     'src/views/ScenesView.tsx',
     'src/components/scenes/ScenePhaseToggle.tsx',
-    'src/components/scenes/SceneSheetView.tsx',
+    'src/components/scenes/StageSegmentToggle.tsx',
     'src/components/scenes/UnifiedSceneCard.tsx',
-    'src/components/scenes/UnifiedSceneSheetView.tsx',
   ];
 
   for (const file of surfaces) {
@@ -63,6 +66,12 @@ test('ScenePhaseToggle maps every phase to a lucide icon label', () => {
   assert.match(source, /className="w-full"/);
 });
 
+test('acting department labels no longer expose deprecated animation stages', () => {
+  const source = read('src/types/index.ts');
+
+  assert.match(source, /stageLabels:\s*\{\s*lo:\s*'대기',\s*done:\s*'작업중',\s*review:\s*'피드백',\s*png:\s*'완료'\s*\}/);
+});
+
 test('sheet headers support full and short labels', () => {
   const resize = read('src/components/scenes/SheetColumnResize.tsx');
   const singleSheet = read('src/components/scenes/SceneSheetView.tsx');
@@ -72,10 +81,18 @@ test('sheet headers support full and short labels', () => {
   assert.match(resize, /data-sheet-header-full-label/);
   assert.match(resize, /data-sheet-header-short-label/);
   assert.match(resize, /title=\{fullLabel\}/);
+  assert.match(resize, /startBoundaryResize/);
+  assert.match(resize, /leftBoundaryColumnKey/);
+  assert.match(resize, /rightBoundaryColumnKey/);
+  assert.match(resize, /fitSheetColumnWidths/);
+  assert.match(resize, /useFittedSheetColumnWidths/);
 
   assert.match(singleSheet, /shortLabel="SB"/);
   assert.match(singleSheet, /shortLabel="Guide"/);
   assert.match(singleSheet, /shortLabel="씬"/);
+  assert.match(singleSheet, /columnKey="alerts"/);
+  assert.match(singleSheet, /SINGLE_SHEET_FILL_COLUMNS/);
+  assert.match(singleSheet, /overflow-y-auto overflow-x-hidden/);
   assert.match(singleSheet, /shortLabel="담"/);
   assert.match(singleSheet, /STAGE_SHORT_LABELS[\s\S]*lo:\s*'LO'/);
   assert.match(singleSheet, /STAGE_SHORT_LABELS[\s\S]*done:\s*'완'/);
@@ -83,22 +100,38 @@ test('sheet headers support full and short labels', () => {
   assert.match(singleSheet, /STAGE_SHORT_LABELS[\s\S]*png:\s*'PNG'/);
   assert.match(unifiedSheet, /shortLabel="BG"/);
   assert.match(unifiedSheet, /shortLabel="ACT"/);
+  assert.match(unifiedSheet, /columnKey="alerts"/);
+  assert.match(unifiedSheet, /UNIFIED_SHEET_FILL_COLUMNS/);
+  assert.match(unifiedSheet, /overflow-y-auto overflow-x-hidden/);
   assert.match(unifiedSheet, /BG_STAGE_SHORT_LABELS[\s\S]*lo:\s*'LO'/);
   assert.match(unifiedSheet, /BG_STAGE_SHORT_LABELS[\s\S]*review:\s*'검'/);
   assert.match(unifiedSheet, /ACT_STAGE_SHORT_LABELS[\s\S]*done:\s*'작'/);
   assert.match(unifiedSheet, /ACT_STAGE_SHORT_LABELS[\s\S]*review:\s*'피'/);
+  assert.match(unifiedSheet, /rightBoundaryColumnKey="actMemo"/);
+  assert.match(unifiedSheet, /leftBoundaryColumnKey="bgMemo"/);
 });
 
 test('bulk and card stage controls avoid forced ellipsis overflow', () => {
   const scenesView = read('src/views/ScenesView.tsx');
   const unifiedCard = read('src/components/scenes/UnifiedSceneCard.tsx');
+  const phaseToggle = read('src/components/scenes/ScenePhaseToggle.tsx');
+  const stageToggle = read('src/components/scenes/StageSegmentToggle.tsx');
+  const labelModeHook = read('src/components/scenes/useStageLabelDisplayMode.ts');
+  const revisionFlag = read('src/components/scenes/RevisionCornerFlag.tsx');
 
   assert.match(scenesView, /bflow-bulk-bar-pulse[\s\S]*max-w-\[calc\(100vw-2rem\)\][\s\S]*flex-wrap/);
   assert.match(scenesView, /compact-label-container[\s\S]*inline-flex[\s\S]*min-w-0[\s\S]*shrink/);
   assert.match(scenesView, /compact-label-container[\s\S]*flex[\s\S]*min-w-0[\s\S]*shrink/);
   assert.doesNotMatch(scenesView, /bflow-bulk-bar-pulse[\s\S]{0,3000}whitespace-nowrap disabled:opacity-50/);
-  assert.match(scenesView, /<CompactIconLabel icon=\{stageIcon\(stage, 12\)\}/);
-  assert.match(scenesView, /<CompactIconLabel icon=\{phaseIcon\(phase, 12\)\}/);
+  assert.match(scenesView, /StageSegmentToggle/);
+  assert.match(scenesView, /icon=\{stageIcon\(stage, 12\)\}[\s\S]*iconPosition="after"/);
+  assert.match(scenesView, /icon=\{phaseIcon\(phase, 12\)\}[\s\S]*iconPosition="after"/);
+  assert.match(phaseToggle, /iconDisplay = 'auto'/);
+  assert.match(stageToggle, /iconDisplay = 'auto'/);
+  assert.match(phaseToggle, /displayMode=\{[\s\S]*modeOf\(state\)/);
+  assert.match(stageToggle, /displayMode=\{[\s\S]*modeOf\(stage\)/);
+  assert.match(labelModeHook, /ResizeObserver/);
+  assert.match(revisionFlag, /revision-corner-flag/);
   assert.doesNotMatch(unifiedCard, /text-ellipsis/);
 });
 
@@ -119,4 +152,15 @@ test('compositing and shared dropdown controls use compact or bounded labels', (
   assert.match(dashboardBulkBar, /max-w-\[calc\(100vw-2rem\)\]/);
   assert.match(dashboardBulkBar, /overflow-x-auto/);
   assert.match(dashboardBulkBar, /CompactIconLabel/);
+});
+
+test('Bflow cursor uses a custom app cursor while preserving precision cursors', () => {
+  const css = read('src/index.css');
+
+  assert.match(css, /--bflow-cursor-default/);
+  assert.match(css, /--bflow-cursor-pointer/);
+  assert.match(css, /html,\s*body,\s*#root\s*\{[\s\S]*cursor:\s*var\(--bflow-cursor-default\)/);
+  assert.match(css, /button:not\(:disabled\)[\s\S]*cursor:\s*var\(--bflow-cursor-pointer\) !important/);
+  assert.match(css, /input,\s*textarea,[\s\S]*\.cursor-text\s*\{[\s\S]*cursor:\s*text !important/);
+  assert.match(css, /\.sheet-column-resizer,[\s\S]*\.is-sheet-column-resizing \*[\s\S]*cursor:\s*col-resize !important/);
 });

--- a/tests/responsiveCompactLabels.test.ts
+++ b/tests/responsiveCompactLabels.test.ts
@@ -92,7 +92,7 @@ test('sheet headers support full and short labels', () => {
   assert.match(singleSheet, /shortLabel="씬"/);
   assert.match(singleSheet, /columnKey="alerts"/);
   assert.match(singleSheet, /SINGLE_SHEET_FILL_COLUMNS/);
-  assert.match(singleSheet, /overflow-y-auto overflow-x-hidden/);
+  assert.match(singleSheet, /sheetOverflowsViewport \? 'overflow-x-auto' : 'overflow-x-hidden'/);
   assert.match(singleSheet, /shortLabel="담"/);
   assert.match(singleSheet, /STAGE_SHORT_LABELS[\s\S]*lo:\s*'LO'/);
   assert.match(singleSheet, /STAGE_SHORT_LABELS[\s\S]*done:\s*'완'/);
@@ -102,7 +102,7 @@ test('sheet headers support full and short labels', () => {
   assert.match(unifiedSheet, /shortLabel="ACT"/);
   assert.match(unifiedSheet, /columnKey="alerts"/);
   assert.match(unifiedSheet, /UNIFIED_SHEET_FILL_COLUMNS/);
-  assert.match(unifiedSheet, /overflow-y-auto overflow-x-hidden/);
+  assert.match(unifiedSheet, /sheetOverflowsViewport \? 'overflow-x-auto' : 'overflow-x-hidden'/);
   assert.match(unifiedSheet, /BG_STAGE_SHORT_LABELS[\s\S]*lo:\s*'LO'/);
   assert.match(unifiedSheet, /BG_STAGE_SHORT_LABELS[\s\S]*review:\s*'검'/);
   assert.match(unifiedSheet, /ACT_STAGE_SHORT_LABELS[\s\S]*done:\s*'작'/);

--- a/tests/responsiveCompactLabels.test.ts
+++ b/tests/responsiveCompactLabels.test.ts
@@ -34,6 +34,17 @@ test('compact labels collapse at narrow viewport without self-sizing container t
   assert.doesNotMatch(css, /writing-mode/);
 });
 
+test('compact label icon display rule preserves Tailwind hidden utilities', () => {
+  const css = read('src/index.css');
+  const scenesView = read('src/views/ScenesView.tsx');
+  const unifiedCard = read('src/components/scenes/UnifiedSceneCard.tsx');
+
+  assert.match(scenesView, /iconClassName="hidden 2xl:inline-flex"/);
+  assert.match(unifiedCard, /iconClassName="hidden 2xl:inline-flex"/);
+  assert.doesNotMatch(css, /\[data-compact-label-icon\]\s*\{[^}]*display:\s*inline-flex/);
+  assert.match(css, /\[data-compact-label-icon\]:not\(\.hidden\)\s*\{[\s\S]*display:\s*inline-flex/);
+});
+
 test('target dense surfaces import and use CompactIconLabel', () => {
   const surfaces = [
     'src/views/CompositingView.tsx',

--- a/tests/sceneCompletionUx.test.ts
+++ b/tests/sceneCompletionUx.test.ts
@@ -72,14 +72,17 @@ test('sheet percentage columns are removed and main columns are resizable', asyn
   assert.match(resize, /onPointerDown/);
 });
 
-test('sheet resize uses an exact table width so one column does not redistribute others', async () => {
+test('sheet resize fits the table to the visible area without browser horizontal scrolling', async () => {
   const singleSheet = await readRepoFile('src', 'components', 'scenes', 'SceneSheetView.tsx');
   const unifiedSheet = await readRepoFile('src', 'components', 'scenes', 'UnifiedSceneSheetView.tsx');
 
   for (const source of [singleSheet, unifiedSheet]) {
-    assert.match(source, /style=\{\{\s*tableLayout:\s*'fixed',\s*width:\s*totalWidth\s*\}\}/);
+    assert.match(source, /useFittedSheetColumnWidths/);
+    assert.match(source, /style=\{\{\s*tableLayout:\s*'fixed',\s*width:\s*sheetWidth\s*\}\}/);
+    assert.match(source, /overflow-y-auto overflow-x-hidden/);
     assert.doesNotMatch(source, /className="w-full text-sm border-collapse"/);
-    assert.doesNotMatch(source, /minWidth:\s*totalWidth/);
+    assert.doesNotMatch(source, /className="overflow-auto rounded-lg/);
+    assert.doesNotMatch(source, /minWidth:\s*sheetWidth/);
   }
 });
 
@@ -99,25 +102,26 @@ test('stage and phase controls commit on pointer down in card and sheet views', 
   const singleCard = await readRepoFile('src', 'views', 'ScenesView.tsx');
   const singleSheet = await readRepoFile('src', 'components', 'scenes', 'SceneSheetView.tsx');
   const unifiedSheet = await readRepoFile('src', 'components', 'scenes', 'UnifiedSceneSheetView.tsx');
+  const stageToggle = await readRepoFile('src', 'components', 'scenes', 'StageSegmentToggle.tsx');
 
   assert.match(phaseToggle, /handleChipPointerDown/);
   assert.match(phaseToggle, /pointerHandledRef/);
   assert.match(phaseToggle, /onPointerDown=\{\(e\) => handleChipPointerDown\(e, state\)\}/);
 
-  assert.match(unifiedCard, /onPointerDown=\{\(e\) => \{/);
-  assert.match(unifiedCard, /stagePointerHandledRef/);
+  assert.match(stageToggle, /onPointerDown=\{\(e\) => \{/);
+  assert.match(stageToggle, /pointerHandledRef/);
+  assert.match(stageToggle, /onToggle\(stage\)/);
+
+  assert.match(unifiedCard, /StageSegmentToggle/);
   assert.match(unifiedCard, /onToggle\(sheetName, sceneId, stage\)/);
 
-  assert.match(singleCard, /onPointerDown=\{\(e\) => \{/);
-  assert.match(singleCard, /stagePointerHandledRef/);
+  assert.match(singleCard, /StageSegmentToggle/);
   assert.match(singleCard, /onToggle\(scene\.sceneId, stage\)/);
 
-  assert.match(singleSheet, /onPointerDown=\{\(e\) => \{/);
-  assert.match(singleSheet, /stagePointerHandledRef/);
+  assert.match(singleSheet, /StageSegmentToggle/);
   assert.match(singleSheet, /onToggle\(scene\.sceneId, stage\)/);
 
-  assert.match(unifiedSheet, /onPointerDown=\{\(e\) => \{/);
-  assert.match(unifiedSheet, /stagePointerHandledRef/);
+  assert.match(unifiedSheet, /StageSegmentToggle/);
   assert.match(unifiedSheet, /onToggle\(bgSheetName, bgScene\.sceneId, stage\)/);
   assert.match(unifiedSheet, /onToggle\(actSheetName, actScene\.sceneId, stage\)/);
 });

--- a/tests/sceneCompletionUx.test.ts
+++ b/tests/sceneCompletionUx.test.ts
@@ -72,16 +72,19 @@ test('sheet percentage columns are removed and main columns are resizable', asyn
   assert.match(resize, /onPointerDown/);
 });
 
-test('sheet resize fits the table to the visible area without browser horizontal scrolling', async () => {
+test('sheet resize fits the table but restores horizontal access below minimum width', async () => {
   const singleSheet = await readRepoFile('src', 'components', 'scenes', 'SceneSheetView.tsx');
   const unifiedSheet = await readRepoFile('src', 'components', 'scenes', 'UnifiedSceneSheetView.tsx');
 
   for (const source of [singleSheet, unifiedSheet]) {
     assert.match(source, /useFittedSheetColumnWidths/);
     assert.match(source, /style=\{\{\s*tableLayout:\s*'fixed',\s*width:\s*sheetWidth\s*\}\}/);
-    assert.match(source, /overflow-y-auto overflow-x-hidden/);
+    assert.match(source, /const sheetOverflowsViewport = tableViewportWidth > 0 && sheetWidth > tableViewportWidth \+ 1;/);
+    assert.match(source, /sheetOverflowsViewport \? 'overflow-x-auto' : 'overflow-x-hidden'/);
+    assert.match(source, /'overflow-y-auto rounded-lg border border-bg-border focus:outline-none'/);
     assert.doesNotMatch(source, /className="w-full text-sm border-collapse"/);
     assert.doesNotMatch(source, /className="overflow-auto rounded-lg/);
+    assert.doesNotMatch(source, /overflow-y-auto overflow-x-hidden rounded-lg/);
     assert.doesNotMatch(source, /minWidth:\s*sheetWidth/);
   }
 });

--- a/tests/starNestSettings.test.ts
+++ b/tests/starNestSettings.test.ts
@@ -1,10 +1,15 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 
 import {
+  DEFAULT_DASHBOARD_STAR_NEST_BLUR_PX,
+  DEFAULT_DASHBOARD_STAR_NEST_OPACITY,
   DEFAULT_STAR_NEST_SETTINGS,
   applyStarNestTonePreset,
   getThemeSyncedStarNestSettings,
+  normalizeDashboardStarNestBlurPx,
+  normalizeDashboardStarNestOpacity,
   normalizeStarNestSettings,
 } from '../src/utils/starNestSettings.ts';
 
@@ -66,4 +71,37 @@ test('StarNest theme sync derives a valid palette from current theme colors', ()
   assert.ok(synced.colorShift >= -1 && synced.colorShift <= 1);
   assert.equal(synced.sparkleSpeed, 0.9);
   assert.equal(synced.brightness, 0.00145);
+});
+
+test('StarNest dashboard background cannot cover the app header menu', () => {
+  const header = readFileSync('src/components/layout/Header.tsx', 'utf-8');
+
+  assert.match(header, /<header className="[^"]*\brelative\b[^"]*\bz-\d+\b/);
+});
+
+test('dashboard StarNest backdrop controls clamp to safe presentation ranges', () => {
+  assert.equal(DEFAULT_DASHBOARD_STAR_NEST_OPACITY, 1);
+  assert.equal(DEFAULT_DASHBOARD_STAR_NEST_BLUR_PX, 0);
+  assert.equal(normalizeDashboardStarNestOpacity(-4), 0.2);
+  assert.equal(normalizeDashboardStarNestOpacity(4), 1);
+  assert.equal(normalizeDashboardStarNestOpacity('bad'), 1);
+  assert.equal(normalizeDashboardStarNestBlurPx(-4), 0);
+  assert.equal(normalizeDashboardStarNestBlurPx(44), 20);
+  assert.equal(normalizeDashboardStarNestBlurPx('bad'), 0);
+});
+
+test('dashboard StarNest backdrop controls are wired through settings and render only on the background layer', () => {
+  const settings = readFileSync('src/components/settings/EffectsSection.tsx', 'utf-8');
+  const dashboard = readFileSync('src/views/Dashboard.tsx', 'utf-8');
+  const appStore = readFileSync('src/stores/useAppStore.ts', 'utf-8');
+  const prefs = readFileSync('src/services/settingsService.ts', 'utf-8');
+
+  assert.match(appStore, /dashboardStarNestOpacity: number;/);
+  assert.match(appStore, /dashboardStarNestBlurPx: number;/);
+  assert.match(prefs, /dashboardStarNestOpacity\?: number;/);
+  assert.match(prefs, /dashboardStarNestBlurPx\?: number;/);
+  assert.match(settings, /label="불투명도" value=\{dashboardStarNestOpacity\}/);
+  assert.match(settings, /label="블러" value=\{dashboardStarNestBlurPx\}/);
+  assert.match(dashboard, /settings=\{plexusSettings\.dashboardStarNest \?\? plexusSettings\.starNest\}/);
+  assert.match(dashboard, /filter: blurPx > 0 \? `blur\(\$\{blurPx\}px\)` : undefined/);
 });


### PR DESCRIPTION
## 📋 업데이트 요약

- 시트 뷰에서 댓글과 리비전 알림이 씬 번호 옆에 아이콘만으로 정리되어, 표 안에서 글자가 세로로 밀리거나 잘리는 느낌을 줄였습니다.
- 시트 컬럼을 잡아 좌우로 움직일 때 엑셀/노션처럼 잡은 경계가 바로 움직이도록 조정했습니다.
- 카드 뷰의 단계 표기는 좁은 공간에서 텍스트가 먼저 보이고, 부족하면 아이콘만 남도록 정리했습니다.
- 리비전이 있는 카드에는 왼쪽 바 대신 코너 플래그 방식의 표시를 적용했습니다.
- 시트 뷰 좌우 조절 중 불필요한 가로 스크롤이 생기지 않게 했습니다.
- 피드백 허브는 처음 들어왔을 때 에피소드와 파트가 접힌 상태로 보이고, 필요한 묶음만 펼쳐서 볼 수 있습니다.
- 빠른 리비전과 리비전 댓글에서도 이미지를 붙여넣거나 첨부할 수 있게 했습니다.
- 피드백 허브와 씬 상세의 리비전 댓글에서도 사람을 태그할 수 있고, 태그된 사람에게 리비전 댓글 멘션 알림이 가도록 했습니다.
- 리비전 댓글 알림이 일반 댓글 알림과 겹쳐 뜨지 않도록 정리했습니다. 윈도우 알림도 리비전 알림으로 한 번만 뜹니다.
- 댓글 읽음 저장용 Supabase 스키마가 아직 반영되지 않은 환경에서도 콘솔에 저장 실패 알림이 반복해서 쌓이지 않도록 했습니다.
- 대시보드 배경이 StarNest일 때 설정에서 불투명도와 블러를 직접 조절할 수 있습니다.
- Claude Code에서도 같은 디자인 스킬을 찾을 수 있도록 스킬 파일을 함께 배치했습니다.

## 🔧 상세 기술 설명

- `src/components/scenes/StageSegmentToggle.tsx`, `CompactIconLabel.tsx`, `useStageLabelDisplayMode.ts`를 추가/정리해 카드·시트의 단계 라벨이 텍스트 우선에서 아이콘 단독 상태로 자연스럽게 축약되도록 했습니다.
- `src/components/scenes/SheetAlertBadges.tsx`와 `RevisionCornerFlag.tsx`를 추가해 시트 알림과 카드 리비전 표기를 독립 컴포넌트로 분리했습니다.
- `src/components/scenes/SheetColumnResize.tsx`에 경계 기반 리사이즈와 visible width fitting 로직을 추가해 컬럼 조절 시 오른쪽 빈 공간과 가로 스크롤 문제를 줄였습니다.
- `SceneDetailModal.tsx`, `UnifiedSceneDetailModal.tsx`, `ScenePhaseToggle.tsx`에서 액팅/배경 단계 표기를 최신 구조로 맞추고, 액팅 상세 모달에 남아 있던 구버전 단계 표기를 제거했습니다.
- `/re` 입력 시 단일 상세 모달 댓글창에서도 전체 상세 모달과 같은 활동 inline event가 붙도록 댓글 패널 wiring을 맞췄습니다.
- `CommentPanel.tsx`에서 `/re` 빠른 리비전의 이미지 첨부 제한을 해제하고, 업로드된 첫 이미지를 `createRevision({ imageUrl })`로 넘기도록 연결했습니다.
- `RevisionCommentThread.tsx`에 이미지 붙여넣기, 파일 첨부, 썸네일 미리보기, 업로드 실패 표시, 전송 실패 롤백, draft storage 정리 흐름을 추가했습니다.
- `RevisionCommentThread.tsx`에 일반 댓글창과 같은 `@` 멘션 자동완성, 멘션 추출 저장, 멘션 하이라이트/팀원 이동, Slack 멘션 웹훅 발송을 추가했습니다.
- `App.tsx`의 리비전 댓글 알림 분기를 공통 함수로 정리해 Realtime과 broadcast 어느 경로로 들어와도 리비전 알림으로 처리되도록 했습니다.
- `electron/broadcast.ts`, `electron/supabase.ts`에서 댓글 broadcast payload에 `revisionId`를 포함시켜 리비전 댓글이 일반 댓글 알림으로 잘못 분류되지 않게 했습니다.
- `App.tsx`의 리비전 댓글 알림 대상 계산에서 리비전 기본 알림 대상자뿐 아니라 댓글 본문에 직접 태그된 사용자도 알림 대상에 포함하도록 했습니다.
- `electron/supabase.ts`에서 `upsert_comment_read_state` RPC가 아직 schema cache에 없으면 `comment_read_states` 테이블 저장 경로를 fallback으로 시도하도록 했습니다.
- `commentReadStateService.ts`에서 읽음 상태 스키마 미반영 오류를 영구 재시도 대상에서 제외하고, 해당 실행 동안 로컬 캐시만 사용하도록 전환했습니다.
- `CompositingView.tsx`, `SceneGroupSection.tsx`, `EpisodeGroupSection.tsx`, `feedbackHubUtils.ts`에서 피드백 허브의 에피소드/파트 접힘 상태와 모두 펼치기/접기 동작을 정리했습니다.
- `StarNestBackground.tsx`, `EffectsSection.tsx`, `Dashboard.tsx`, `starNestSettings.ts`, `useAppStore.ts`, `settingsService.ts`에 대시보드 StarNest 전용 `opacity`/`blur` 설정 저장 및 렌더링 경로를 추가했습니다.
- `.agents/skills/design-taste-frontend/SKILL.md`와 `.claude/skills/design-taste-frontend/SKILL.md`를 추가해 Codex와 Claude Code 양쪽 discovery path에서 같은 스킬을 사용할 수 있게 했습니다.
- `package.json`과 `package-lock.json` 버전을 `1.35.0`으로 올렸습니다.

## 🚧 개발 난항

- 시트 컬럼 조절은 단순히 한 컬럼 width만 바꾸면 사용자가 잡은 경계가 아닌 반대편이 밀려 보였습니다. 그래서 좌우 한 쌍의 컬럼을 함께 조정하는 방식으로 바꿨습니다.
- 단계 표기는 텍스트와 아이콘이 함께 보이는 중간 상태가 가장 지저분해 보여, 폭이 부족할 때 바로 아이콘만 남도록 기준을 분리했습니다.
- 빠른 리비전은 기존 코드에서 이미지 첨부를 명시적으로 막고 있었고, 리비전 댓글은 첨부 UI 자체가 없었습니다. 일반 댓글의 업로드/정리 패턴을 좁게 가져와 저장소에 사용되지 않는 이미지가 남지 않도록 처리했습니다.
- 리비전 댓글은 `mentions: []`로 고정되어 있어 입력 UI뿐 아니라 저장 데이터와 알림 대상 계산까지 함께 보강해야 했습니다.
- 리비전 댓글은 Realtime 경로와 broadcast 경로가 동시에 존재했습니다. broadcast에 리비전 정보가 없으면 일반 댓글 알림과 리비전 알림이 겹칠 수 있어 payload와 앱 분기를 함께 정리했습니다.
- 댓글 읽음 상태는 마이그레이션 SQL은 있었지만 실제 Supabase schema cache에 함수/테이블이 없을 수 있어, 앱에서 영구 실패와 일시 실패를 구분해야 했습니다.
- 피드백 허브의 모두 펼치기/접기는 에피소드, 파트, 씬 접힘 상태가 서로 따로 움직여야 해서 별도 유틸 테스트로 상태 전환을 고정했습니다.
- StarNest 블러는 전체 대시보드에 걸면 위젯과 상단 메뉴까지 흐려지므로, 캔버스 배경 레이어에만 적용되도록 `style` 전달 경로를 열었습니다.
- 이번 변경은 UI 폴리싱, 설정 저장, mockup, 스킬 미러링, 피드백 허브, 이미지 첨부, 멘션 입력, 알림 라우팅이 함께 묶여 변경 범위가 넓습니다. 그래서 관련 UI 테스트와 빌드를 함께 돌려 회귀를 확인했습니다.

## ✅ 테스트 가이드

실사용자용:
- 설정 > 효과에서 대시보드 화면 배경 아트를 StarNest로 바꾼 뒤, 불투명도와 블러 슬라이더를 움직여 배경만 변하는지 확인합니다.
- 시트 뷰에서 컬럼 경계를 잡고 좌우로 움직였을 때 잡은 경계가 직관적으로 따라오는지 확인합니다.
- 카드 뷰와 시트 뷰에서 액팅/배경 단계가 좁은 영역에서도 글자 밀림 없이 보이는지 확인합니다.
- 리비전이 있는 카드의 코너 플래그와 시트 씬 번호 옆 알림 아이콘을 확인합니다.
- 피드백 허브에 들어갔을 때 에피소드가 접힌 상태로 시작하고, 에피소드와 파트를 각각 펼치고 접을 수 있는지 확인합니다.
- 댓글창에서 `/re`를 입력한 뒤 이미지를 붙여넣어 빠른 리비전 이미지로 함께 등록되는지 확인합니다.
- 리비전 카드 안 댓글창에서 이미지를 붙여넣거나 첨부한 뒤 댓글에 이미지가 보이는지 확인합니다.
- 리비전 카드 안 댓글창에서 `@`를 입력했을 때 사용자 후보가 뜨고, 선택한 이름이 댓글에 태그로 저장되는지 확인합니다.
- 앱이 백그라운드에 있을 때 리비전 알림 대상이 되거나 리비전 댓글에서 태그되면 윈도우 알림이 한 번만 뜨는지 확인합니다.

개발자용:
- `node --test tests\responsiveCompactLabels.test.ts tests\sceneCompletionUx.test.ts tests\commentReadStateUiWiring.test.ts tests\starNestSettings.test.ts tests\imageAnnotationRefresh.test.ts`
- `node --test tests\feedbackHubCollapseUi.test.ts tests\feedbackHubStats.test.ts tests\commentReadStateUiWiring.test.ts`
- `node --test tests\commentReadStateService.test.ts tests\commentReadStateSchema.test.ts`
- `node --test tests\commentReadStateUiWiring.test.ts`
- `npm run typecheck`
- `npm run build:vite`

