### PR TITLE
PR5: 프레즌스 최종 리뷰 반영 — 스냅샷 replay 레이스 가드

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1442,12 +1442,17 @@ export default function App() {
 
   // 실시간 편집 프레즌스: 메인이 병합한 스냅샷을 받아 스토어에 반영.
   useEffect(() => {
-    const off = window.electronAPI?.onSupabasePresence?.((snap) =>
-      useEditingPresenceStore.getState().applyPresenceSnapshot(snap as EditingPresenceSnapshot));
+    // 마운트 replay가 도착하기 전에 실시간 이벤트가 먼저 오면, 더 오래된 replay로 덮지 않는다.
+    // (스토어 empty 체크로는 'leave 로 방금 비워짐'과 '아직 미수신'을 구분 못 해 유령이 되살아날 수 있음)
+    let liveEventSeen = false;
+    const off = window.electronAPI?.onSupabasePresence?.((snap) => {
+      liveEventSeen = true;
+      useEditingPresenceStore.getState().applyPresenceSnapshot(snap as EditingPresenceSnapshot);
+    });
     // 마운트 시 현재 스냅샷 replay — 리로드/새 창이 마지막 sync 이후 구독해도 현재 편집자를 즉시 반영.
-    // 단, 이미 실시간 이벤트가 들어와 스토어가 채워졌다면 stale replay로 덮지 않는다.
+    // 단, 그 사이 실시간 이벤트를 한 번이라도 받았다면(=더 최신) replay 는 적용하지 않는다.
     window.electronAPI?.getPresenceSnapshot?.().then((snap) => {
-      if (Object.keys(useEditingPresenceStore.getState().byScene).length === 0) {
+      if (!liveEventSeen) {
         useEditingPresenceStore.getState().applyPresenceSnapshot((snap ?? {}) as EditingPresenceSnapshot);
       }
     }).catch(() => { /* ignore */ });


### PR DESCRIPTION
## 📋 업데이트 요약

'지금 누가 작업 중' 표시가 아주 드물게 남던 잔상을 없앤 마무리 손질이에요. 누가 파일을 막 닫은 그 찰나에 창을 새로 열면 이미 닫은 사람이 잠깐 '작업 중'으로 보일 수 있었는데, 이제 그런 유령 표시가 안 뜨게 다듬었어요. 화면에 보이는 변화는 없고 정확도만 좋아진 정리입니다.

## 🔧 상세 기술 설명 (개발자용)

최종 통합 리뷰의 Minor 1건 반영(스펙 '유령 잔상 없음').

- `src/App.tsx` 프레즌스 구독 effect: 마운트 시 `getPresenceSnapshot()` replay를 **스토어 empty 체크**가 아니라 **'실시간 이벤트 수신 여부(liveEventSeen) 플래그'**로 가드. empty 체크는 '아직 미수신'과 'leave로 방금 비워짐'을 구분 못 해, replay가 in-flight인 사이 live `leave`가 스토어를 비우면 stale replay가 유령 편집자를 되살릴 수 있었음. 이제 live 이벤트를 한 번이라도 받았으면 replay를 적용하지 않음(live가 더 최신).

나머지 Minor 2건(모달 배너 탭 배치·Supabase presence key 미설정)은 동작 선택/문서 차이로 별도 follow-up.

## 🧪 테스트 가이드

- `npm run typecheck` / `npm run build:vite` → 통과
🤖 Generated with [Claude Code](https://claude.com/claude-code)