### PR TITLE
후속1: 프레즌스 개별뷰 표시 + 부서 구분 + 이름 줄바꿈 수정

### DIFF
--- a/src/components/common/AssigneeMultiSelect.tsx
+++ b/src/components/common/AssigneeMultiSelect.tsx
@@ -272,7 +272,7 @@ export function AssigneeChip({
   const fs = size === 'sm' ? 11 : 12;
   return (
     <span
-      className="inline-flex items-center gap-1 rounded-full px-2 font-medium tabular-nums"
+      className="inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded-full px-2 font-medium tabular-nums"
       style={{
         background: `${color}1f`,
         color,

--- a/src/components/scenes/SceneSheetView.tsx
+++ b/src/components/scenes/SceneSheetView.tsx
@@ -33,6 +33,10 @@ import { getSceneWorkLinkSlots } from '@/utils/sceneWorkLinks';
 import { loadPreferences, savePreferences } from '@/services/settingsService';
 import { SceneContextMenu } from './SceneContextMenu';
 import { SceneWorkLinkBadges } from './SceneWorkLinkBadges';
+import { EditingNameLabels } from './EditingNameLabels';
+import { useEditingPresenceStore } from '@/stores/useEditingPresenceStore';
+import { editingBeamRowClassName, selectEditorsForScenes } from '@/utils/editingPresence';
+import { useAuthStore } from '@/stores/useAuthStore';
 import {
   persistLengthChangeIndependent,
   saveLengthChangeField,
@@ -508,6 +512,10 @@ export function SceneSheetView({
   const episodes = useDataStore((s) => s.episodes);
   const episodeTitles = useDataStore((s) => s.episodeTitles);
   const linkMap = useSceneWorkLinkStore((s) => s.linkMap);
+  // 실시간 편집 프레즌스 — 스냅샷과 현재 사용자 id를 한 번만 구독하고,
+  // 행별 편집자는 순수 선택자로 계산(rules-of-hooks 준수: map 안에서 훅 호출 금지).
+  const presenceByScene = useEditingPresenceStore((s) => s.byScene);
+  const presenceExcludeUserId = useAuthStore((s) => s.currentUser?.id ?? null);
   const revisionCountBySceneId = useMemo(() => {
     if (!sheetName) return new Map<string, number>();
     let siblings: string[] = [];
@@ -894,6 +902,8 @@ export function SceneSheetView({
               const commentCount = commentCounts[commentKey] ?? 0;
               const isUnreadComment = commentUnreadByKey?.[commentKey] ?? false;
               const openRevCount = revisionCountBySceneId.get(scene.sceneId) ?? 0;
+              // 실시간 편집 프레즌스 — 이 행 씬 파일을 지금 열어둔 다른 팀원(자기 제외)
+              const editingUsers = selectEditorsForScenes(presenceByScene, [scene.id], presenceExcludeUserId);
 
               return (
                 <Fragment key={selectionId}>
@@ -928,6 +938,8 @@ export function SceneSheetView({
                       openRevCount > 0 && 'sheet-row-revision-open',
                       isLayoutMode && !isLastInGroup && 'scene-row-group-mid',
                       isLayoutMode && isLastInGroup && 'scene-row-group-last',
+                      // 실시간 편집 프레즌스 — 행 무지개 테두리(<tr> box-shadow 링, div wrapper 없음)
+                      editingBeamRowClassName(editingUsers),
                     )}
                     onClick={(e) => {
                       if ((e.ctrlKey || e.metaKey) && onCtrlClick) {
@@ -961,6 +973,8 @@ export function SceneSheetView({
                           L#{scene.layoutId}
                         </span>
                       )}
+                      {/* 실시간 편집 프레즌스 — 이름칩(최대 2 + +N) */}
+                      <EditingNameLabels editors={editingUsers} max={2} className="flex-shrink-0" />
                     </div>
                   </td>
                   <td className="px-1 py-1.5">

--- a/src/components/scenes/UnifiedSceneCard.tsx
+++ b/src/components/scenes/UnifiedSceneCard.tsx
@@ -539,7 +539,7 @@ function DeptSection({
   const completionTintEnabled = useAppStore((s) => s.completionTintEnabled);
   const isDeptDone = !!scene && isFullyDone(scene);
   // 실시간 편집 프레즌스 — 이 부서 씬을 지금 열어둔 다른 팀원(자기 제외).
-  // DeptSection 은 bg/act 정확히 2번만 호출되므로 여기서 훅 호출은 rules-of-hooks 안전.
+  // 훅은 early return 앞에서 무조건 top-level 로 호출하므로 rules-of-hooks 안전.
   const deptEditors = useSceneEditingPresence([scene?.id]);
 
   // stage-toggle 작업에서 이 씬의 targetStage 셀에만 pending/failed 스타일 적용

--- a/src/components/scenes/UnifiedSceneCard.tsx
+++ b/src/components/scenes/UnifiedSceneCard.tsx
@@ -117,8 +117,9 @@ export function UnifiedSceneCard({
   const users = useAuthStore((s) => s.users);
   const userNames = useMemo(() => users.map((u) => u.name), [users]);
   const linkMap = useSceneWorkLinkStore((s) => s.linkMap);
-  // 실시간 편집 프레즌스 — 이 씬 파일을 지금 열어둔 다른 팀원(자기 제외)
-  const editingUsers = useSceneEditingPresence([bgScene?.id, actScene?.id]);
+  // 실시간 편집 프레즌스 — 카드 전체 링은 BG/ACT 유니온으로(어느 부서든 편집 중이면 글로우).
+  // 이름표는 부서별로 DeptSection 안에서 개별 표시(위치로 어느 부서인지 구분).
+  const unionEditors = useSceneEditingPresence([bgScene?.id, actScene?.id]);
   const episodeName = useDataStore((s) => {
     const sheetName = bgSheetName ?? actSheetName;
     if (!sheetName) return undefined;
@@ -298,8 +299,8 @@ export function UnifiedSceneCard({
         isHighlighted && 'scene-highlight',
         isSelected && 'scene-card-selected',
         cardWholePendingClass,
-        // 실시간 편집 프레즌스 — 회전 무지개 테두리(래퍼 없이 클래스만)
-        editingBeamClassName(editingUsers),
+        // 실시간 편집 프레즌스 — 회전 무지개 테두리(래퍼 없이 클래스만, BG/ACT 유니온)
+        editingBeamClassName(unionEditors),
       )}
       style={{
         overflow: 'visible',
@@ -315,12 +316,6 @@ export function UnifiedSceneCard({
       } : {})}
     >
         {isHighlighted && <div className="scene-highlight-bg" />}
-
-        {/* 실시간 편집 프레즌스 — 무지개 이름표(좌상단, 링크 배지와 겹치지 않게) */}
-        <EditingNameLabels
-          editors={editingUsers}
-          className="absolute -top-3 left-3 z-20"
-        />
 
         <SceneWorkLinkBadges
           bgSceneUuid={bgScene?.id}
@@ -543,6 +538,9 @@ function DeptSection({
   const cfg = DEPARTMENT_CONFIGS[dept];
   const completionTintEnabled = useAppStore((s) => s.completionTintEnabled);
   const isDeptDone = !!scene && isFullyDone(scene);
+  // 실시간 편집 프레즌스 — 이 부서 씬을 지금 열어둔 다른 팀원(자기 제외).
+  // DeptSection 은 bg/act 정확히 2번만 호출되므로 여기서 훅 호출은 rules-of-hooks 안전.
+  const deptEditors = useSceneEditingPresence([scene?.id]);
 
   // stage-toggle 작업에서 이 씬의 targetStage 셀에만 pending/failed 스타일 적용
   const stageCellPendingClass = (stage: Stage): string => {
@@ -587,17 +585,19 @@ function DeptSection({
   return (
     <div className="group/dept">
       <div className="flex items-center justify-between mb-1.5">
-        <div className="flex items-center gap-1.5">
+        <div className="flex min-w-0 items-center gap-1.5">
           <span className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: cfg.color }} />
-          <span className="text-xs font-semibold" style={{ color: cfg.color }}>{cfg.shortLabel}</span>
+          <span className="text-xs font-semibold shrink-0" style={{ color: cfg.color }}>{cfg.shortLabel}</span>
           {completionTintEnabled && isDeptDone && (
-            <span className="scene-completion-dept-done rounded-full px-1.5 py-0.5 text-[9px] font-semibold leading-none">
+            <span className="scene-completion-dept-done shrink-0 whitespace-nowrap rounded-full px-1.5 py-0.5 text-[9px] font-semibold leading-none">
               완료
             </span>
           )}
+          {/* 실시간 편집 프레즌스 — 이 부서 이름표(위치로 BG/ACT 구분) */}
+          <EditingNameLabels editors={deptEditors} className="min-w-0 shrink" />
         </div>
-        <div className="flex items-center gap-1.5">
-          <span className="min-w-0 text-xs text-text-secondary">
+        <div className="flex shrink-0 items-center gap-1.5">
+          <span className="whitespace-nowrap text-xs text-text-secondary">
             {searchQuery ? (
               <HighlightText text={scene.assignee || '-'} query={searchQuery} />
             ) : scene.assignee ? (

--- a/src/views/ScenesView.tsx
+++ b/src/views/ScenesView.tsx
@@ -901,6 +901,9 @@ import {
 } from '@/utils/bulkOperations';
 import { ContextMenu, useContextMenu } from '@/components/ui/ContextMenu';
 import { cn } from '@/utils/cn';
+import { EditingNameLabels } from '@/components/scenes/EditingNameLabels';
+import { useSceneEditingPresence } from '@/stores/useEditingPresenceStore';
+import { editingBeamClassName } from '@/utils/editingPresence';
 import { Confetti } from '@/components/ui/Confetti';
 import { SceneDetailModal } from '@/components/scenes/SceneDetailModal';
 import { GlassDropdown } from '@/components/common/GlassDropdown';
@@ -946,6 +949,8 @@ interface SceneCardProps {
 function SceneCard({ scene, sceneIndex, celebrating, department, isHighlighted, isSelected, searchQuery, commentCount = 0, hasUnreadComments = false, revisionCount = 0, selectionId, sheetName, fallbackStoryboardUrl, fallbackGuideUrl, onToggle, onActPhaseStateClick, onActFeedbackRequest, onActRoundBump, onAssigneeStageToggle, onAssigneeActPhaseStateClick, onAssigneeActFeedbackRequest, onAssigneeActRoundBump, onDelete, onOpenDetail, onCelebrationEnd, onCtrlClick, onShiftClick }: SceneCardProps) {
   const deptConfig = DEPARTMENT_CONFIGS[department];
   const completionTintEnabled = useAppStore((s) => s.completionTintEnabled);
+  // 실시간 편집 프레즌스 — 이 씬 파일을 지금 열어둔 다른 팀원(자기 제외). 단일 부서라 부서 모호성 없음.
+  const editingUsers = useSceneEditingPresence([scene?.id]);
   const pct = sceneProgress(scene);
   const isComplete = isFullyDone(scene);
   const storyboardUrl = scene.storyboardUrl || fallbackStoryboardUrl || '';
@@ -1022,6 +1027,8 @@ function SceneCard({ scene, sceneIndex, celebrating, department, isHighlighted, 
         completionTintEnabled && isComplete && 'scene-completion-tint-card',
         isHighlighted && 'scene-highlight',
         isSelected && 'scene-card-selected',
+        // 실시간 편집 프레즌스 — 회전 무지개 테두리(래퍼 없이 클래스만)
+        editingBeamClassName(editingUsers),
       )}
       style={{
         overflow: 'visible',
@@ -1038,6 +1045,12 @@ function SceneCard({ scene, sceneIndex, celebrating, department, isHighlighted, 
     >
       {/* 하이라이트 배경 오버레이 */}
       {isHighlighted && <div className="scene-highlight-bg" />}
+
+      {/* 실시간 편집 프레즌스 — 무지개 이름표(좌상단, 링크 배지와 겹치지 않게) */}
+      <EditingNameLabels
+        editors={editingUsers}
+        className="absolute -top-3 left-3 z-20"
+      />
 
       <SceneWorkLinkBadges
         bgSceneUuid={department === 'bg' ? scene.id : null}


### PR DESCRIPTION
## 📋 업데이트 요약

씬 화면의 '지금 누가 작업 중' 표시를 더 정확하게 다듬었어요.

- 전에는 **'전체' 탭에서만** 보이고 'BG'·'ACT' 개별 탭에선 안 떴는데, 이제 **개별 탭에서도** 떠요.
- '전체' 탭에서 **배경(BG)을 만지는지 액팅(ACT)을 만지는지** 이름이 해당 줄 옆에 떠서 바로 구분돼요.
- 담당자 이름('강선영' 등)이나 '완료' 글자가 세로로 잘려 두 줄로 나오던 것도 **한 줄로** 고쳤어요.

## 🔧 상세 기술 설명 (개발자용)

프레즌스 후속 수정 1/2 (카드/리스트).

- **개별 부서 뷰 버그 fix**: 개별 BG/ACT 탭은 레거시 컴포넌트(`ScenesView` 내 로컬 `SceneCard`, `SceneSheetView`)를 써서 프레즌스가 아예 없었음 → `useSceneEditingPresence([scene.id])`(단일 부서) + `editingBeamClassName`/`editingBeamRowClassName` + `EditingNameLabels` 추가.
- **부서 구분(통합 카드)**: `UnifiedSceneCard`의 카드 링은 union(`[bgScene?.id, actScene?.id]`) 유지, 이름표는 `DeptSection`으로 이동해 **부서별 `[scene?.id]`**로 표시 → BG/ACT 어느 파일 작업인지 구분. (통합 시트는 union 칩 유지 — 고정 컬럼 제약)
- **이름 세로 줄바꿈 fix**: 근본 원인 `AssigneeChip`(`AssigneeMultiSelect.tsx`)에 `whitespace-nowrap shrink-0` 추가(칩 내부 줄바꿈 방지). 다중 담당자 간 `flex-wrap`은 유지. `DeptSection` 헤더도 `min-w-0`/`shrink-0`/`완료` pill `nowrap` 보강.

## 🧪 테스트 가이드

- `npm run typecheck` / `npm run test:presence`(23) / `npm run build:vite` → 통과
- **시각 검증(미리보기, 실제 프레즌스 주입 확인)**: 전체 탭 부서별 이름표(a001=ACT 강선영 / a002=BG 김민수 / a003=ACT 2명 경고), ACT 개별 탭 표시, 담당자 이름 한 줄 — 모두 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
