### PR TITLE
후속2: 상세모달 부서별 워크링크 인라인 + 우클릭 '연결'

### DIFF
--- a/src/components/scenes/SceneContextMenu.tsx
+++ b/src/components/scenes/SceneContextMenu.tsx
@@ -28,6 +28,8 @@ export interface SceneContextMenuProps {
       department: 'bg' | 'acting';
       folder?: SceneWorkLink;
       primaryFile?: SceneWorkLink;
+      /** 이 부서에 실제 씬이 존재하는지. 없으면 빈 슬롯 "연결"을 활성화하지 않는다 (클릭 먹통 방지). */
+      hasScene?: boolean;
     }>;
     onOpen: (link: SceneWorkLink) => void;
     /** 빈 슬롯에서 "연결" 클릭 시 폴더/파일 선택창을 열어 링크를 추가한다. */
@@ -94,6 +96,7 @@ export function SceneContextMenu({ x, y, current, onSelect, onClose, sceneLabel,
                 department={item.department}
                 folder={item.folder}
                 primaryFile={item.primaryFile}
+                hasScene={item.hasScene ?? true}
                 onOpen={(link) => {
                   workLinks.onOpen(link);
                   onClose();
@@ -156,12 +159,14 @@ function WorkLinkDepartmentMenu({
   department,
   folder,
   primaryFile,
+  hasScene,
   onOpen,
   onAdd,
 }: {
   department: 'bg' | 'acting';
   folder?: SceneWorkLink;
   primaryFile?: SceneWorkLink;
+  hasScene: boolean;
   onOpen: (link: SceneWorkLink) => void;
   onAdd?: (department: 'bg' | 'acting', linkKind: 'folder' | 'primary_file') => void;
 }) {
@@ -177,6 +182,7 @@ function WorkLinkDepartmentMenu({
         openLabel="작업 폴더 열기"
         addLabel="작업 폴더 연결"
         link={folder}
+        hasScene={hasScene}
         onOpen={onOpen}
         onAdd={onAdd}
       />
@@ -187,6 +193,7 @@ function WorkLinkDepartmentMenu({
         openLabel="작업 파일 열기"
         addLabel="대표 파일 연결"
         link={primaryFile}
+        hasScene={hasScene}
         onOpen={onOpen}
         onAdd={onAdd}
       />
@@ -201,6 +208,7 @@ function WorkLinkMenuItem({
   openLabel,
   addLabel,
   link,
+  hasScene,
   onOpen,
   onAdd,
 }: {
@@ -210,11 +218,13 @@ function WorkLinkMenuItem({
   openLabel: string;
   addLabel: string;
   link?: SceneWorkLink;
+  hasScene: boolean;
   onOpen: (link: SceneWorkLink) => void;
   onAdd?: (department: 'bg' | 'acting', linkKind: 'folder' | 'primary_file') => void;
 }) {
-  // 연결된 슬롯 = "열기", 빈 슬롯 = "연결" (선택창 열기). onAdd 미제공 시 빈 슬롯은 비활성.
-  const canAdd = !link && !!onAdd;
+  // 연결된 슬롯 = "열기", 빈 슬롯 = "연결" (선택창 열기).
+  // 부서 씬이 없으면(예: BG만 있는 병합 씬의 ACT) sceneUuid 가 없어 클릭 먹통 → 비활성.
+  const canAdd = !link && !!onAdd && hasScene;
   const interactive = !!link || canAdd;
   return (
     <button

--- a/src/components/scenes/SceneContextMenu.tsx
+++ b/src/components/scenes/SceneContextMenu.tsx
@@ -30,6 +30,8 @@ export interface SceneContextMenuProps {
       primaryFile?: SceneWorkLink;
     }>;
     onOpen: (link: SceneWorkLink) => void;
+    /** 빈 슬롯에서 "연결" 클릭 시 폴더/파일 선택창을 열어 링크를 추가한다. */
+    onAdd?: (department: 'bg' | 'acting', linkKind: 'folder' | 'primary_file') => void | Promise<void>;
   };
 }
 
@@ -96,6 +98,12 @@ export function SceneContextMenu({ x, y, current, onSelect, onClose, sceneLabel,
                   workLinks.onOpen(link);
                   onClose();
                 }}
+                onAdd={workLinks.onAdd
+                  ? (department, linkKind) => {
+                      void workLinks.onAdd?.(department, linkKind);
+                      onClose();
+                    }
+                  : undefined}
               />
             ))}
           </div>
@@ -149,11 +157,13 @@ function WorkLinkDepartmentMenu({
   folder,
   primaryFile,
   onOpen,
+  onAdd,
 }: {
   department: 'bg' | 'acting';
   folder?: SceneWorkLink;
   primaryFile?: SceneWorkLink;
   onOpen: (link: SceneWorkLink) => void;
+  onAdd?: (department: 'bg' | 'acting', linkKind: 'folder' | 'primary_file') => void;
 }) {
   const label = department === 'bg' ? '배경' : '액팅';
   const tone = department === 'bg' ? 'text-accent-sub' : 'text-[#F09A87]';
@@ -161,51 +171,70 @@ function WorkLinkDepartmentMenu({
     <div>
       <div className={`px-2.5 py-0.5 text-[10.5px] font-bold ${tone}`}>{label}</div>
       <WorkLinkMenuItem
+        department={department}
+        linkKind="folder"
         icon={<Folder size={13} aria-hidden />}
-        label="작업 폴더 열기"
+        openLabel="작업 폴더 열기"
+        addLabel="작업 폴더 연결"
         link={folder}
         onOpen={onOpen}
+        onAdd={onAdd}
       />
       <WorkLinkMenuItem
+        department={department}
+        linkKind="primary_file"
         icon={<File size={13} aria-hidden />}
-        label="작업 파일 열기"
+        openLabel="작업 파일 열기"
+        addLabel="대표 파일 연결"
         link={primaryFile}
         onOpen={onOpen}
+        onAdd={onAdd}
       />
     </div>
   );
 }
 
 function WorkLinkMenuItem({
+  department,
+  linkKind,
   icon,
-  label,
+  openLabel,
+  addLabel,
   link,
   onOpen,
+  onAdd,
 }: {
+  department: 'bg' | 'acting';
+  linkKind: 'folder' | 'primary_file';
   icon: React.ReactNode;
-  label: string;
+  openLabel: string;
+  addLabel: string;
   link?: SceneWorkLink;
   onOpen: (link: SceneWorkLink) => void;
+  onAdd?: (department: 'bg' | 'acting', linkKind: 'folder' | 'primary_file') => void;
 }) {
+  // 연결된 슬롯 = "열기", 빈 슬롯 = "연결" (선택창 열기). onAdd 미제공 시 빈 슬롯은 비활성.
+  const canAdd = !link && !!onAdd;
+  const interactive = !!link || canAdd;
   return (
     <button
       role="menuitem"
-      disabled={!link}
+      disabled={!interactive}
       onClick={(e) => {
-        if (!link) return;
+        if (!interactive) return;
         e.stopPropagation();
-        onOpen(link);
+        if (link) onOpen(link);
+        else onAdd?.(department, linkKind);
       }}
       className={[
         'w-full flex items-center gap-2.5 px-2.5 py-1.5 rounded-md text-[12px] text-left transition-colors',
-        link
+        interactive
           ? 'text-text-primary hover:bg-accent/10 hover:text-accent cursor-pointer'
           : 'text-text-secondary/35 cursor-not-allowed',
       ].join(' ')}
     >
       <span className="inline-flex w-[22px] justify-center flex-shrink-0">{icon}</span>
-      <span className="min-w-0 flex-1 truncate">{label}</span>
-      {!link && <span className="text-[10px] text-text-secondary/35">파일 탭에서 연결</span>}
+      <span className="min-w-0 flex-1 truncate">{link ? openLabel : addLabel}</span>
     </button>
   );
 }

--- a/src/components/scenes/SceneFilesTab.tsx
+++ b/src/components/scenes/SceneFilesTab.tsx
@@ -4,8 +4,7 @@ import { cn } from '@/utils/cn';
 import { formatStamp } from '@/utils/formatTime';
 import { getComments } from '@/services/commentService';
 import { getRevisions } from '@/services/revisionService';
-import { SceneWorkLinksPanel } from './SceneWorkLinksPanel';
-import type { Scene, CompRevision, SceneWorkLinkDepartment } from '@/types';
+import type { Scene, CompRevision } from '@/types';
 
 /**
  * 씬 상세 모달 — 파일 탭.
@@ -41,8 +40,6 @@ const SOURCE_META: Record<FileItem['source'], { label: string; tone: string; Ico
 
 export interface SceneFilesTabProps {
   bgScene: Scene | null;
-  actScene: Scene | null;
-  visibleDepartments: SceneWorkLinkDepartment[];
   primaryCommentKey: string;
   secondaryCommentKey?: string;
   /**
@@ -55,8 +52,6 @@ export interface SceneFilesTabProps {
 
 export function SceneFilesTab({
   bgScene,
-  actScene,
-  visibleDepartments,
   primaryCommentKey,
   secondaryCommentKey,
   revisionSceneKey,
@@ -152,12 +147,6 @@ export function SceneFilesTab({
 
   return (
     <div className="px-5 py-4">
-      <SceneWorkLinksPanel
-        bgScene={bgScene}
-        actScene={actScene}
-        visibleDepartments={visibleDepartments}
-      />
-
       <div className="mb-3 flex items-center justify-between">
         <span className="text-[11.5px] text-text-secondary">
           {loading ? '불러오는 중…' : `총 ${totalCount}개 파일`}

--- a/src/components/scenes/SceneSheetView.tsx
+++ b/src/components/scenes/SceneSheetView.tsx
@@ -12,6 +12,7 @@ import { useRevisionStore } from '@/stores/useRevisionStore';
 import { useSceneWorkLinkStore } from '@/stores/useSceneWorkLinkStore';
 import { buildSceneKey } from '@/services/revisionService';
 import { openWorkPath } from '@/services/sceneWorkLinkService';
+import { chooseAndLinkWorkPath } from '@/services/sceneWorkLinkActions';
 import { isFullyDone } from '@/utils/calcStats';
 import { cn } from '@/utils/cn';
 import { buildSingleSceneSelectionId } from '@/utils/sceneSelectionId';
@@ -760,6 +761,7 @@ export function SceneSheetView({
       department,
       folder: slots.folder,
       primaryFile: slots.primaryFile,
+      hasScene: !!scene?.id,
     }];
   }, [department, linkMap]);
   const handleOpenWorkLink = useCallback(async (link: SceneWorkLink) => {
@@ -768,6 +770,11 @@ export function SceneSheetView({
       toast.error(link.linkKind === 'folder' ? '이 PC에서 폴더를 찾을 수 없음' : '이 PC에서 파일을 찾을 수 없음');
     }
   }, []);
+  const getAddWorkLinkHandlerForScene = useCallback((scene: Scene) => {
+    return async (dept: 'bg' | 'acting', linkKind: 'folder' | 'primary_file') => {
+      await chooseAndLinkWorkPath({ sceneUuid: scene?.id, department: dept, linkKind, userId: presenceExcludeUserId });
+    };
+  }, [presenceExcludeUserId]);
   const handleSetLengthChange = useCallback(async (scene: Scene, value: 'LD' | 'SD' | null) => {
     if (!scene.id || lengthChangeInFlightRef.current.has(scene.id)) return;
     lengthChangeInFlightRef.current.add(scene.id);
@@ -1098,6 +1105,7 @@ export function SceneSheetView({
             episodeName,
             departments: getWorkLinkDepartmentsForScene(ctxMenu.scene),
             onOpen: handleOpenWorkLink,
+            onAdd: getAddWorkLinkHandlerForScene(ctxMenu.scene),
           }}
         />,
         document.body,

--- a/src/components/scenes/SceneWorkLinksPanel.tsx
+++ b/src/components/scenes/SceneWorkLinksPanel.tsx
@@ -110,32 +110,37 @@ export function SceneWorkLinksPanel({
   );
 }
 
-function DepartmentBlock({
+export function DepartmentBlock({
   department,
   scene,
   folder,
   primaryFile,
+  hideHeader = false,
 }: {
   department: SceneWorkLinkDepartment;
   scene: Scene | null;
   folder?: SceneWorkLink;
   primaryFile?: SceneWorkLink;
+  /** 상세 모달 부서 섹션처럼 이미 부서명이 보이는 곳에서는 자체 부서 헤더를 숨긴다. */
+  hideHeader?: boolean;
 }) {
   const meta = DEPT_META[department];
   return (
-    <div className="px-3.5 py-3">
-      <div className="mb-2 flex items-center gap-2">
-        <span
-          className="inline-flex h-5 min-w-9 items-center justify-center rounded px-1.5 text-[10px] font-bold"
-          style={{
-            color: meta.tone,
-            backgroundColor: `color-mix(in oklab, ${meta.tone} 15%, transparent)`,
-          }}
-        >
-          {meta.shortLabel}
-        </span>
-        <span className="text-[11.5px] font-medium text-text-primary">{meta.label}</span>
-      </div>
+    <div className={hideHeader ? undefined : 'px-3.5 py-3'}>
+      {!hideHeader && (
+        <div className="mb-2 flex items-center gap-2">
+          <span
+            className="inline-flex h-5 min-w-9 items-center justify-center rounded px-1.5 text-[10px] font-bold"
+            style={{
+              color: meta.tone,
+              backgroundColor: `color-mix(in oklab, ${meta.tone} 15%, transparent)`,
+            }}
+          >
+            {meta.shortLabel}
+          </span>
+          <span className="text-[11.5px] font-medium text-text-primary">{meta.label}</span>
+        </div>
+      )}
 
       <div className="grid gap-2 md:grid-cols-2">
         <WorkLinkRow department={department} scene={scene} linkKind="folder" link={folder} />

--- a/src/components/scenes/SceneWorkLinksPanel.tsx
+++ b/src/components/scenes/SceneWorkLinksPanel.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import {
   AlertTriangle,
   Clipboard,
@@ -172,6 +173,10 @@ function WorkLinkRow({
   const upsertLink = useSceneWorkLinkStore((state) => state.upsertLink);
   const deleteLink = useSceneWorkLinkStore((state) => state.deleteLink);
   const [menuOpen, setMenuOpen] = useState(false);
+  // P2-A: 드롭다운 메뉴를 body 로 portal — 인라인 상세 모달의 overflow-hidden 부서 섹션에서 잘리지 않게.
+  const menuTriggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [menuPos, setMenuPos] = useState<{ top: number; left: number } | null>(null);
   const [pasteOpen, setPasteOpen] = useState(false);
   const [draftPath, setDraftPath] = useState('');
   const [saving, setSaving] = useState(false);
@@ -201,6 +206,52 @@ function WorkLinkRow({
     });
     return () => { cancelled = true; };
   }, [link?.path]);
+
+  // P2-A: 포털 메뉴 위치 계산 — 트리거 버튼 rect 기준 우측 정렬로 아래에 띄우고,
+  // 화면 하단을 넘치면 위로 뒤집는다. 스크롤/리사이즈 시 재계산, 바깥 클릭/Esc 로 닫음.
+  const MENU_WIDTH = 160;
+  const MENU_HEIGHT = 84;
+  useLayoutEffect(() => {
+    if (!menuOpen) {
+      setMenuPos(null);
+      return;
+    }
+    const compute = () => {
+      const trigger = menuTriggerRef.current;
+      if (!trigger) return;
+      const rect = trigger.getBoundingClientRect();
+      const left = Math.max(8, Math.min(rect.right - MENU_WIDTH, window.innerWidth - MENU_WIDTH - 8));
+      const openUp = rect.bottom + 4 + MENU_HEIGHT > window.innerHeight;
+      const top = openUp ? rect.top - 4 - MENU_HEIGHT : rect.bottom + 4;
+      setMenuPos({ top: Math.max(8, top), left });
+    };
+    compute();
+    const handleScroll = () => compute();
+    window.addEventListener('scroll', handleScroll, true);
+    window.addEventListener('resize', handleScroll);
+    return () => {
+      window.removeEventListener('scroll', handleScroll, true);
+      window.removeEventListener('resize', handleScroll);
+    };
+  }, [menuOpen]);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handleDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (menuRef.current?.contains(target) || menuTriggerRef.current?.contains(target)) return;
+      setMenuOpen(false);
+    };
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setMenuOpen(false);
+    };
+    document.addEventListener('mousedown', handleDown);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleDown);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [menuOpen]);
 
   const savePath = async (nextPath: string) => {
     const trimmed = nextPath.trim();
@@ -313,6 +364,7 @@ function WorkLinkRow({
                 </button>
               )}
               <button
+                ref={menuTriggerRef}
                 type="button"
                 onClick={() => setMenuOpen((value) => !value)}
                 disabled={!canEdit || saving}
@@ -339,8 +391,12 @@ function WorkLinkRow({
                 </button>
               )}
 
-              {menuOpen && (
-                <div className="absolute right-0 top-8 z-30 w-40 overflow-hidden rounded-md border border-bg-border bg-bg-card shadow-xl">
+              {menuOpen && menuPos && createPortal(
+                <div
+                  ref={menuRef}
+                  style={{ position: 'fixed', top: menuPos.top, left: menuPos.left, width: MENU_WIDTH, zIndex: 9999 }}
+                  className="overflow-hidden rounded-md border border-bg-border bg-bg-card shadow-xl"
+                >
                   <button
                     type="button"
                     onClick={handleChoose}
@@ -357,7 +413,8 @@ function WorkLinkRow({
                     <Clipboard size={13} aria-hidden />
                     경로 붙여넣기
                   </button>
-                </div>
+                </div>,
+                document.body,
               )}
             </div>
           </div>

--- a/src/components/scenes/SceneWorkLinksPanel.tsx
+++ b/src/components/scenes/SceneWorkLinksPanel.tsx
@@ -22,6 +22,7 @@ import {
   openWorkPath,
   pathExists as checkPathExists,
 } from '@/services/sceneWorkLinkService';
+import { saveWorkLinkPathGuarded } from '@/services/sceneWorkLinkActions';
 import { cn } from '@/utils/cn';
 import {
   getUniqueSceneUuids,
@@ -170,7 +171,6 @@ function WorkLinkRow({
   link?: SceneWorkLink;
 }) {
   const currentUser = useAuthStore((state) => state.currentUser);
-  const upsertLink = useSceneWorkLinkStore((state) => state.upsertLink);
   const deleteLink = useSceneWorkLinkStore((state) => state.deleteLink);
   const [menuOpen, setMenuOpen] = useState(false);
   // P2-A: 드롭다운 메뉴를 body 로 portal — 인라인 상세 모달의 overflow-hidden 부서 섹션에서 잘리지 않게.
@@ -258,19 +258,21 @@ function WorkLinkRow({
     if (!scene?.id || !trimmed) return;
     setSaving(true);
     try {
-      await upsertLink({
+      // 공용 가드 경유 — 지금 빈 슬롯으로 보일 때('연결')만 로딩 레이스 대비 재확인.
+      // 이미 링크가 보이는 '변경'(link truthy)은 사용자가 아는 상태라 confirm 스킵.
+      // upsert/toast/에러 처리는 가드 안에서 수행.
+      const saved = await saveWorkLinkPathGuarded({
         sceneUuid: scene.id,
         department,
         linkKind,
         path: trimmed,
         userId: currentUser?.id ?? null,
+        confirmIfExists: !link,
       });
-      setPasteOpen(false);
-      setMenuOpen(false);
-      toast.success(link ? '작업 링크를 변경했습니다' : '작업 링크를 연결했습니다');
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      toast.error(`작업 링크 저장 실패: ${message}`);
+      if (saved) {
+        setPasteOpen(false);
+        setMenuOpen(false);
+      }
     } finally {
       setSaving(false);
     }

--- a/src/components/scenes/SceneWorkLinksPanel.tsx
+++ b/src/components/scenes/SceneWorkLinksPanel.tsx
@@ -116,6 +116,7 @@ export function DepartmentBlock({
   folder,
   primaryFile,
   hideHeader = false,
+  singleColumn = false,
 }: {
   department: SceneWorkLinkDepartment;
   scene: Scene | null;
@@ -123,6 +124,12 @@ export function DepartmentBlock({
   primaryFile?: SceneWorkLink;
   /** 상세 모달 부서 섹션처럼 이미 부서명이 보이는 곳에서는 자체 부서 헤더를 숨긴다. */
   hideHeader?: boolean;
+  /**
+   * 좁은 컨테이너(상세 모달 2칼럼 부서 섹션)에서는 folder/file 를 세로 단일 칼럼으로 스택.
+   * md: 반응형은 뷰포트 기준이라 좁은 모달 칼럼에서도 2칼럼이 적용돼 글자가 뭉개지므로,
+   * 인라인 컨텍스트에선 명시적으로 1칼럼 강제.
+   */
+  singleColumn?: boolean;
 }) {
   const meta = DEPT_META[department];
   return (
@@ -142,7 +149,7 @@ export function DepartmentBlock({
         </div>
       )}
 
-      <div className="grid gap-2 md:grid-cols-2">
+      <div className={cn('grid gap-2', !singleColumn && 'md:grid-cols-2')}>
         <WorkLinkRow department={department} scene={scene} linkKind="folder" link={folder} />
         <WorkLinkRow department={department} scene={scene} linkKind="primary_file" link={primaryFile} />
       </div>

--- a/src/components/scenes/UnifiedSceneCard.tsx
+++ b/src/components/scenes/UnifiedSceneCard.tsx
@@ -275,6 +275,7 @@ export function UnifiedSceneCard({
         department,
         folder: slots.folder,
         primaryFile: slots.primaryFile,
+        hasScene: !!scene?.id,
       };
     });
   }, [actScene, bgScene, linkMap, selectedDepartment]);

--- a/src/components/scenes/UnifiedSceneCard.tsx
+++ b/src/components/scenes/UnifiedSceneCard.tsx
@@ -22,6 +22,7 @@ import { useAuthStore } from '@/stores/useAuthStore';
 import { useSceneWorkLinkStore } from '@/stores/useSceneWorkLinkStore';
 import { buildSceneKey } from '@/services/revisionService';
 import { openWorkPath } from '@/services/sceneWorkLinkService';
+import { chooseAndLinkWorkPath } from '@/services/sceneWorkLinkActions';
 import { getSceneWorkLinkSlots } from '@/utils/sceneWorkLinks';
 import { LengthIcon } from './LengthIcon';
 import { SceneContextMenu } from './SceneContextMenu';
@@ -115,6 +116,7 @@ export function UnifiedSceneCard({
   const completionTintEnabled = useAppStore((s) => s.completionTintEnabled);
   const selectedDepartment = useAppStore((s) => s.selectedDepartment);
   const users = useAuthStore((s) => s.users);
+  const currentUser = useAuthStore((s) => s.currentUser);
   const userNames = useMemo(() => users.map((u) => u.name), [users]);
   const linkMap = useSceneWorkLinkStore((s) => s.linkMap);
   // 실시간 편집 프레즌스 — 카드 전체 링은 BG/ACT 유니온으로(어느 부서든 편집 중이면 글로우).
@@ -281,6 +283,10 @@ export function UnifiedSceneCard({
     if (!result.ok) {
       toast.error(link.linkKind === 'folder' ? '이 PC에서 폴더를 찾을 수 없음' : '이 PC에서 파일을 찾을 수 없음');
     }
+  };
+  const handleAddWorkLink = async (department: 'bg' | 'acting', linkKind: 'folder' | 'primary_file') => {
+    const scene = department === 'bg' ? bgScene : actScene;
+    await chooseAndLinkWorkPath({ sceneUuid: scene?.id, department, linkKind, userId: currentUser?.id });
   };
 
   return (
@@ -491,6 +497,7 @@ export function UnifiedSceneCard({
               episodeName,
               departments: workLinkDepartments,
               onOpen: handleOpenWorkLink,
+              onAdd: handleAddWorkLink,
             }}
           />,
           document.body,

--- a/src/components/scenes/UnifiedSceneDetailModal.tsx
+++ b/src/components/scenes/UnifiedSceneDetailModal.tsx
@@ -35,7 +35,7 @@ import { SceneFilesTab } from './SceneFilesTab';
 import { DepartmentBlock } from './SceneWorkLinksPanel';
 import { SceneHistoryTab } from './SceneHistoryTab';
 import { useSceneWorkLinkStore } from '@/stores/useSceneWorkLinkStore';
-import { getSceneWorkLinkSlots } from '@/utils/sceneWorkLinks';
+import { getSceneWorkLinkSlots, getUniqueSceneUuids } from '@/utils/sceneWorkLinks';
 import { useSceneActivities } from '@/hooks/useSceneActivities';
 import { describeActivity, deptPrefix } from './activityLabels';
 import { useRevisionStore } from '@/stores/useRevisionStore';
@@ -274,6 +274,22 @@ export function UnifiedSceneDetailModal({
     : '';
   const sceneThreadKey = revisionSceneKey ? buildSceneThreadKeyFromRevisionKey(revisionSceneKey) : '';
   const openRevCount = useRevisionStore((s) => revisionSceneKey ? s.getOpenCount(revisionSceneKey) : 0);
+
+  // 작업 링크 로드 — 모달이 현재 보이는 파트 밖 씬(도킹 참조 등)으로 열리면 ScenesView 의 배치 로드에
+  // 그 씬이 없어 linkMap 이 비어있다. 그대로 두면 기존 DB 링크가 "연결된 경로 없음" 으로 보여
+  // '연결' 시 못 본 링크를 덮어쓸 위험이 있으므로, 모달 열릴 때 해당 씬 링크를 한 번 로드한다.
+  // (부서별 DeptSection 이 아닌 모달 본체에서 한 번만 — 중복 로드 방지.)
+  const loadForSceneUuids = useSceneWorkLinkStore((s) => s.loadForSceneUuids);
+  const workLinkSceneUuidKey = useMemo(
+    () => getUniqueSceneUuids([bgScene, actScene]).join('|'),
+    [bgScene, actScene],
+  );
+  useEffect(() => {
+    if (!workLinkSceneUuidKey) return;
+    void loadForSceneUuids(workLinkSceneUuidKey.split('|').filter(Boolean)).catch((err) => {
+      console.warn('[UnifiedSceneDetailModal] 작업 링크 로드 실패', err);
+    });
+  }, [loadForSceneUuids, workLinkSceneUuidKey]);
 
   // UI state — v1.18.0: initialTab 으로 외부에서 시작 탭 지정 가능 (알림 클릭 시 'revisions' 등)
   const [tab, setTab] = useState<TabKey>(initialTab ?? 'detail');

--- a/src/components/scenes/UnifiedSceneDetailModal.tsx
+++ b/src/components/scenes/UnifiedSceneDetailModal.tsx
@@ -32,7 +32,10 @@ import { CommentPanelResizable } from './CommentPanelResizable';
 import { RevisionPanel } from './RevisionPanel';
 import { EntityHashContextMenu } from './EntityHashContextMenu';
 import { SceneFilesTab } from './SceneFilesTab';
+import { DepartmentBlock } from './SceneWorkLinksPanel';
 import { SceneHistoryTab } from './SceneHistoryTab';
+import { useSceneWorkLinkStore } from '@/stores/useSceneWorkLinkStore';
+import { getSceneWorkLinkSlots } from '@/utils/sceneWorkLinks';
 import { useSceneActivities } from '@/hooks/useSceneActivities';
 import { describeActivity, deptPrefix } from './activityLabels';
 import { useRevisionStore } from '@/stores/useRevisionStore';
@@ -271,11 +274,6 @@ export function UnifiedSceneDetailModal({
     : '';
   const sceneThreadKey = revisionSceneKey ? buildSceneThreadKeyFromRevisionKey(revisionSceneKey) : '';
   const openRevCount = useRevisionStore((s) => revisionSceneKey ? s.getOpenCount(revisionSceneKey) : 0);
-  const visibleWorkLinkDepartments = selectedDepartment === 'bg'
-    ? ['bg'] as const
-    : selectedDepartment === 'acting'
-      ? ['acting'] as const
-      : ['bg', 'acting'] as const;
 
   // UI state — v1.18.0: initialTab 으로 외부에서 시작 탭 지정 가능 (알림 클릭 시 'revisions' 등)
   const [tab, setTab] = useState<TabKey>(initialTab ?? 'detail');
@@ -1043,8 +1041,6 @@ export function UnifiedSceneDetailModal({
                     {tab === 'files' && revisionSceneKey && (
                       <SceneFilesTab
                         bgScene={bgScene}
-                        actScene={actScene}
-                        visibleDepartments={[...visibleWorkLinkDepartments]}
                         primaryCommentKey={primaryCommentKey}
                         secondaryCommentKey={secondaryCommentKey || undefined}
                         revisionSceneKey={revisionSceneKey}
@@ -1375,6 +1371,8 @@ function DeptSection({
 }) {
   const cfg = DEPARTMENT_CONFIGS[dept];
   const visualColor = deptVisualColor(dept);
+  const workLinkMap = useSceneWorkLinkStore((s) => s.linkMap);
+  const workLinkSlots = getSceneWorkLinkSlots(workLinkMap, scene?.id, dept);
   const canUseAssigneeProgressStack = hasMultiAssigneeProgress(scene) && (
     dept === 'acting'
       ? Boolean(onAssigneeActPhaseStateClick && onAssigneeActFeedbackRequest && onAssigneeActRoundBump)
@@ -1495,6 +1493,18 @@ function DeptSection({
         onHashClick={onHashClick}
         onHashContextMenu={onHashContextMenu}
       />
+
+      {/* 제작 파일 연동 — 부서 섹션 안에 인라인. 헤더는 위 부서 라벨과 중복이라 숨김. */}
+      <div className="border-t border-bg-border/40 pt-3">
+        <span className="mb-2 block text-xs text-text-secondary">작업 링크</span>
+        <DepartmentBlock
+          department={dept}
+          scene={scene}
+          folder={workLinkSlots.folder}
+          primaryFile={workLinkSlots.primaryFile}
+          hideHeader
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/scenes/UnifiedSceneDetailModal.tsx
+++ b/src/components/scenes/UnifiedSceneDetailModal.tsx
@@ -1503,6 +1503,7 @@ function DeptSection({
           folder={workLinkSlots.folder}
           primaryFile={workLinkSlots.primaryFile}
           hideHeader
+          singleColumn
         />
       </div>
     </div>

--- a/src/components/scenes/UnifiedSceneSheetView.tsx
+++ b/src/components/scenes/UnifiedSceneSheetView.tsx
@@ -20,6 +20,7 @@ import { useRevisionStore } from '@/stores/useRevisionStore';
 import { useSceneWorkLinkStore } from '@/stores/useSceneWorkLinkStore';
 import { buildSceneKey } from '@/services/revisionService';
 import { openWorkPath } from '@/services/sceneWorkLinkService';
+import { chooseAndLinkWorkPath } from '@/services/sceneWorkLinkActions';
 import { getSceneWorkLinkSlots } from '@/utils/sceneWorkLinks';
 import { LengthIcon } from './LengthIcon';
 import { SceneContextMenu } from './SceneContextMenu';
@@ -907,6 +908,12 @@ export function UnifiedSceneSheetView({
       toast.error(link.linkKind === 'folder' ? '이 PC에서 폴더를 찾을 수 없음' : '이 PC에서 파일을 찾을 수 없음');
     }
   }, []);
+  const getAddWorkLinkHandlerForMerged = useCallback((merged: MergedScene) => {
+    return async (department: 'bg' | 'acting', linkKind: 'folder' | 'primary_file') => {
+      const scene = department === 'bg' ? merged.bgScene : merged.actScene;
+      await chooseAndLinkWorkPath({ sceneUuid: scene?.id, department, linkKind, userId: presenceExcludeUserId });
+    };
+  }, [presenceExcludeUserId]);
 
   return (
     <motion.div
@@ -1430,6 +1437,7 @@ export function UnifiedSceneSheetView({
             episodeName: getEpisodeNameForMerged(ctxMenu.merged),
             departments: getWorkLinkDepartmentsForMerged(ctxMenu.merged),
             onOpen: handleOpenWorkLink,
+            onAdd: getAddWorkLinkHandlerForMerged(ctxMenu.merged),
           }}
         />,
         document.body,

--- a/src/components/scenes/UnifiedSceneSheetView.tsx
+++ b/src/components/scenes/UnifiedSceneSheetView.tsx
@@ -899,6 +899,7 @@ export function UnifiedSceneSheetView({
         department,
         folder: slots.folder,
         primaryFile: slots.primaryFile,
+        hasScene: !!scene?.id,
       };
     });
   }, [linkMap, selectedDepartment]);

--- a/src/components/scenes/UnifiedSceneSheetView.tsx
+++ b/src/components/scenes/UnifiedSceneSheetView.tsx
@@ -908,12 +908,14 @@ export function UnifiedSceneSheetView({
       toast.error(link.linkKind === 'folder' ? '이 PC에서 폴더를 찾을 수 없음' : '이 PC에서 파일을 찾을 수 없음');
     }
   }, []);
+  // 워크링크 작성자 id — 값은 현재 사용자 id 로, presenceExcludeUserId 와 동일하지만 의미(작성자)를 명확히.
+  const currentUserId = presenceExcludeUserId;
   const getAddWorkLinkHandlerForMerged = useCallback((merged: MergedScene) => {
     return async (department: 'bg' | 'acting', linkKind: 'folder' | 'primary_file') => {
       const scene = department === 'bg' ? merged.bgScene : merged.actScene;
-      await chooseAndLinkWorkPath({ sceneUuid: scene?.id, department, linkKind, userId: presenceExcludeUserId });
+      await chooseAndLinkWorkPath({ sceneUuid: scene?.id, department, linkKind, userId: currentUserId });
     };
-  }, [presenceExcludeUserId]);
+  }, [currentUserId]);
 
   return (
     <motion.div

--- a/src/services/sceneWorkLinkActions.ts
+++ b/src/services/sceneWorkLinkActions.ts
@@ -6,15 +6,74 @@ import { getSceneWorkLinkSlots } from '@/utils/sceneWorkLinks';
 import type { SceneWorkLinkDepartment } from '@/types';
 
 /**
+ * 작업 링크 경로 저장 공용 코어 — 모든 upsert 진입점(컨텍스트 메뉴 + 인라인 WorkLinkRow)이
+ * 이 함수 하나를 거쳐 스테일 슬롯 덮어쓰기로부터 보호된다.
+ *
+ * silent overwrite 방어: 그리드/시트/모달을 막 연 직후 링크 로드가 끝나기 전에는 실제 저장된
+ * 링크가 있어도 빈 슬롯으로 보여 "연결" 이 활성이다. 그래서 `confirmIfExists` 일 때 upsert 전에
+ * 그 씬 링크를 최신화(loadForSceneUuids)하고, 최신 linkMap 에 이미 링크가 있으면 확인을 받는다.
+ *
+ * @param confirmIfExists 빈 줄 알았던 슬롯('연결')에만 true. 이미 링크가 보이는 '변경' 은
+ *                        사용자가 경로를 아는 상태라 false 로 두어 확인을 건너뛴다.
+ * @returns 실제로 저장했으면 true, 씬/경로 없음·사용자 취소·실패면 false.
+ */
+export async function saveWorkLinkPathGuarded(opts: {
+  sceneUuid: string | null | undefined;
+  department: SceneWorkLinkDepartment;
+  linkKind: 'folder' | 'primary_file';
+  path: string;
+  userId?: string | null;
+  confirmIfExists: boolean;
+}): Promise<boolean> {
+  const { sceneUuid, department, linkKind, userId, confirmIfExists } = opts;
+  const path = opts.path.trim();
+  if (!sceneUuid || !path) return false;
+
+  let existingPath: string | undefined;
+  if (confirmIfExists) {
+    // 저장 전 그 씬 링크를 최신화 — 로딩 레이스로 빈 줄 알았던 슬롯에 실은 링크가 있을 수 있다.
+    // best-effort: 실패하면 그냥 (이전과 동일하게) 새 링크로 진행.
+    try {
+      await useSceneWorkLinkStore.getState().loadForSceneUuids([sceneUuid]);
+    } catch (err) {
+      console.warn('[sceneWorkLinkActions] 저장 전 링크 로드 실패', err);
+    }
+
+    // 최신 linkMap 에서 이 슬롯 재확인 — 이미 링크가 있으면 덮어쓰기 전 확인.
+    const slots = getSceneWorkLinkSlots(useSceneWorkLinkStore.getState().linkMap, sceneUuid, department);
+    existingPath = (linkKind === 'folder' ? slots.folder : slots.primaryFile)?.path || undefined;
+    if (existingPath) {
+      const ok = await ConfirmDialog.show({
+        message: `이미 연결된 경로가 있어요:\n${existingPath}\n새 경로로 바꿀까요?`,
+        confirmLabel: '바꾸기',
+        tone: 'danger',
+      });
+      if (!ok) return false;
+    }
+  }
+
+  try {
+    await useSceneWorkLinkStore.getState().upsertLink({
+      sceneUuid,
+      department,
+      linkKind,
+      path,
+      userId: userId ?? null,
+    });
+    toast.success(existingPath ? '작업 링크를 변경했습니다' : '작업 링크를 연결했습니다');
+    return true;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    toast.error(`작업 링크 저장 실패: ${message}`);
+    return false;
+  }
+}
+
+/**
  * 우클릭 메뉴 등에서 빈 작업 링크 슬롯을 "연결" 할 때 공용으로 쓰는 핸들러.
  *
- * 폴더/파일 선택창을 띄우고, 사용자가 경로를 고르면 낙관적 업데이트로 저장한다.
+ * 폴더/파일 선택창을 띄우고, 사용자가 경로를 고르면 가드를 거쳐 저장한다.
  * (카드/시트/레거시 그리드 여러 곳이 동일 동작을 공유하도록 한 곳에 둠 — DRY)
- *
- * silent overwrite 방어: 그리드/시트를 막 연 직후 링크 로드가 끝나기 전에는 실제 저장된
- * 링크가 있어도 빈 슬롯으로 보여 "연결" 이 활성이다. 그래서 upsert 전에 그 씬 링크를
- * 최신화(loadForSceneUuids)하고, 최신 linkMap 에 이미 링크가 있으면 확인을 받는다.
- * 이 핸들러를 쓰는 모든 진입점이 한 번에 안전해진다.
  *
  * @returns 실제로 연결에 성공하면 true, 씬 없음·사용자 취소면 false.
  */
@@ -31,39 +90,6 @@ export async function chooseAndLinkWorkPath(input: {
   const path = selected?.trim();
   if (!path) return false;
 
-  // 저장 전 그 씬 링크를 최신화 — 로딩 레이스로 빈 줄 알았던 슬롯에 실은 링크가 있을 수 있다.
-  // best-effort: 실패하면 그냥 (이전과 동일하게) 새 링크로 진행.
-  try {
-    await useSceneWorkLinkStore.getState().loadForSceneUuids([sceneUuid]);
-  } catch (err) {
-    console.warn('[sceneWorkLinkActions] 저장 전 링크 로드 실패', err);
-  }
-
-  // 최신 linkMap 에서 이 슬롯 재확인 — 이미 링크가 있으면 덮어쓰기 전 확인.
-  const slots = getSceneWorkLinkSlots(useSceneWorkLinkStore.getState().linkMap, sceneUuid, department);
-  const existing = linkKind === 'folder' ? slots.folder : slots.primaryFile;
-  if (existing?.path) {
-    const ok = await ConfirmDialog.show({
-      message: `이미 연결된 경로가 있어요:\n${existing.path}\n새 경로로 바꿀까요?`,
-      confirmLabel: '바꾸기',
-      tone: 'danger',
-    });
-    if (!ok) return false;
-  }
-
-  try {
-    await useSceneWorkLinkStore.getState().upsertLink({
-      sceneUuid,
-      department,
-      linkKind,
-      path,
-      userId: userId ?? null,
-    });
-    toast.success(existing?.path ? '작업 링크를 변경했습니다' : '작업 링크를 연결했습니다');
-    return true;
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    toast.error(`작업 링크 저장 실패: ${message}`);
-    return false;
-  }
+  // 컨텍스트 메뉴의 '연결' 은 빈 슬롯 가정 진입점이라 항상 가드(로딩 레이스 대비).
+  return saveWorkLinkPathGuarded({ sceneUuid, department, linkKind, path, userId, confirmIfExists: true });
 }

--- a/src/services/sceneWorkLinkActions.ts
+++ b/src/services/sceneWorkLinkActions.ts
@@ -1,0 +1,42 @@
+import { toast } from 'sonner';
+import { chooseWorkFile, chooseWorkFolder } from '@/services/sceneWorkLinkService';
+import { useSceneWorkLinkStore } from '@/stores/useSceneWorkLinkStore';
+import type { SceneWorkLinkDepartment } from '@/types';
+
+/**
+ * 우클릭 메뉴 등에서 빈 작업 링크 슬롯을 "연결" 할 때 공용으로 쓰는 핸들러.
+ *
+ * 폴더/파일 선택창을 띄우고, 사용자가 경로를 고르면 낙관적 업데이트로 저장한다.
+ * (카드/시트/레거시 그리드 3곳이 동일 동작을 공유하도록 한 곳에 둠 — DRY)
+ *
+ * @returns 실제로 연결에 성공하면 true, 씬 없음·사용자 취소면 false.
+ */
+export async function chooseAndLinkWorkPath(input: {
+  sceneUuid: string | null | undefined;
+  department: SceneWorkLinkDepartment;
+  linkKind: 'folder' | 'primary_file';
+  userId?: string | null;
+}): Promise<boolean> {
+  const { sceneUuid, department, linkKind, userId } = input;
+  if (!sceneUuid) return false;
+
+  const selected = linkKind === 'folder' ? await chooseWorkFolder() : await chooseWorkFile();
+  const path = selected?.trim();
+  if (!path) return false;
+
+  try {
+    await useSceneWorkLinkStore.getState().upsertLink({
+      sceneUuid,
+      department,
+      linkKind,
+      path,
+      userId: userId ?? null,
+    });
+    toast.success('작업 링크를 연결했습니다');
+    return true;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    toast.error(`작업 링크 저장 실패: ${message}`);
+    return false;
+  }
+}

--- a/src/services/sceneWorkLinkActions.ts
+++ b/src/services/sceneWorkLinkActions.ts
@@ -1,13 +1,20 @@
 import { toast } from 'sonner';
+import { ConfirmDialog } from '@/components/common/ConfirmDialog';
 import { chooseWorkFile, chooseWorkFolder } from '@/services/sceneWorkLinkService';
 import { useSceneWorkLinkStore } from '@/stores/useSceneWorkLinkStore';
+import { getSceneWorkLinkSlots } from '@/utils/sceneWorkLinks';
 import type { SceneWorkLinkDepartment } from '@/types';
 
 /**
  * 우클릭 메뉴 등에서 빈 작업 링크 슬롯을 "연결" 할 때 공용으로 쓰는 핸들러.
  *
  * 폴더/파일 선택창을 띄우고, 사용자가 경로를 고르면 낙관적 업데이트로 저장한다.
- * (카드/시트/레거시 그리드 3곳이 동일 동작을 공유하도록 한 곳에 둠 — DRY)
+ * (카드/시트/레거시 그리드 여러 곳이 동일 동작을 공유하도록 한 곳에 둠 — DRY)
+ *
+ * silent overwrite 방어: 그리드/시트를 막 연 직후 링크 로드가 끝나기 전에는 실제 저장된
+ * 링크가 있어도 빈 슬롯으로 보여 "연결" 이 활성이다. 그래서 upsert 전에 그 씬 링크를
+ * 최신화(loadForSceneUuids)하고, 최신 linkMap 에 이미 링크가 있으면 확인을 받는다.
+ * 이 핸들러를 쓰는 모든 진입점이 한 번에 안전해진다.
  *
  * @returns 실제로 연결에 성공하면 true, 씬 없음·사용자 취소면 false.
  */
@@ -24,6 +31,26 @@ export async function chooseAndLinkWorkPath(input: {
   const path = selected?.trim();
   if (!path) return false;
 
+  // 저장 전 그 씬 링크를 최신화 — 로딩 레이스로 빈 줄 알았던 슬롯에 실은 링크가 있을 수 있다.
+  // best-effort: 실패하면 그냥 (이전과 동일하게) 새 링크로 진행.
+  try {
+    await useSceneWorkLinkStore.getState().loadForSceneUuids([sceneUuid]);
+  } catch (err) {
+    console.warn('[sceneWorkLinkActions] 저장 전 링크 로드 실패', err);
+  }
+
+  // 최신 linkMap 에서 이 슬롯 재확인 — 이미 링크가 있으면 덮어쓰기 전 확인.
+  const slots = getSceneWorkLinkSlots(useSceneWorkLinkStore.getState().linkMap, sceneUuid, department);
+  const existing = linkKind === 'folder' ? slots.folder : slots.primaryFile;
+  if (existing?.path) {
+    const ok = await ConfirmDialog.show({
+      message: `이미 연결된 경로가 있어요:\n${existing.path}\n새 경로로 바꿀까요?`,
+      confirmLabel: '바꾸기',
+      tone: 'danger',
+    });
+    if (!ok) return false;
+  }
+
   try {
     await useSceneWorkLinkStore.getState().upsertLink({
       sceneUuid,
@@ -32,7 +59,7 @@ export async function chooseAndLinkWorkPath(input: {
       path,
       userId: userId ?? null,
     });
-    toast.success('작업 링크를 연결했습니다');
+    toast.success(existing?.path ? '작업 링크를 변경했습니다' : '작업 링크를 연결했습니다');
     return true;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/src/views/ScenesView.tsx
+++ b/src/views/ScenesView.tsx
@@ -979,7 +979,8 @@ function SceneCard({ scene, sceneIndex, celebrating, department, isHighlighted, 
     department,
     folder: workLinkSlots.folder,
     primaryFile: workLinkSlots.primaryFile,
-  }], [department, workLinkSlots.folder, workLinkSlots.primaryFile]);
+    hasScene: !!scene.id,
+  }], [department, workLinkSlots.folder, workLinkSlots.primaryFile, scene.id]);
   const handleOpenWorkLink = useCallback(async (link: SceneWorkLink) => {
     const result = await openWorkPath(link.path);
     if (!result.ok) {

--- a/src/views/ScenesView.tsx
+++ b/src/views/ScenesView.tsx
@@ -61,6 +61,7 @@ import { resolveReferenceMergedScene } from '@/utils/sceneReference';
 import { navigateToHashTarget } from '@/utils/hashNavigation';
 import type { HashTarget } from '@/utils/hashEntity';
 import { chooseWorkFile, openWorkPath } from '@/services/sceneWorkLinkService';
+import { chooseAndLinkWorkPath } from '@/services/sceneWorkLinkActions';
 import { loadPreferences, savePreferences, type UserPreferences } from '@/services/settingsService';
 import {
   persistLengthChangeAtomic,
@@ -960,6 +961,7 @@ function SceneCard({ scene, sceneIndex, celebrating, department, isHighlighted, 
   const episodes = useDataStore((s) => s.episodes);
   const episodeTitles = useDataStore((s) => s.episodeTitles);
   const linkMap = useSceneWorkLinkStore((s) => s.linkMap);
+  const cardUserId = useAuthStore((s) => s.currentUser?.id ?? null);
   const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number } | null>(null);
   const lengthChangeInFlightRef = useRef(false);
 
@@ -984,6 +986,9 @@ function SceneCard({ scene, sceneIndex, celebrating, department, isHighlighted, 
       sonnerToast.error(link.linkKind === 'folder' ? '이 PC에서 폴더를 찾을 수 없음' : '이 PC에서 파일을 찾을 수 없음');
     }
   }, []);
+  const handleAddWorkLink = useCallback(async (dept: 'bg' | 'acting', linkKind: 'folder' | 'primary_file') => {
+    await chooseAndLinkWorkPath({ sceneUuid: scene.id, department: dept, linkKind, userId: cardUserId });
+  }, [scene.id, cardUserId]);
   const handleSetLengthChange = useCallback(async (value: 'LD' | 'SD' | null) => {
     if (!scene.id || lengthChangeInFlightRef.current) return;
     lengthChangeInFlightRef.current = true;
@@ -1219,6 +1224,7 @@ function SceneCard({ scene, sceneIndex, celebrating, department, isHighlighted, 
             episodeName,
             departments: workLinkDepartments,
             onOpen: handleOpenWorkLink,
+            onAdd: handleAddWorkLink,
           }}
         />,
         document.body,


### PR DESCRIPTION
## 📋 업데이트 요약

작업 파일 연동을 더 편하게 만들었어요.

- 씬 **상세 창**을 열면 배경(BG)·액팅(ACT) **각 칸 바로 밑에서** 폴더·파일 경로를 연결할 수 있어요. (예전엔 '파일' 탭까지 들어가야 했어요)
- 씬을 **우클릭**했을 때 아직 경로가 안 걸려 있으면 **바로 '연결'**해서 폴더/파일을 지정할 수 있어요. (예전엔 '열기'만 됐어요)

## 🔧 상세 기술 설명 (개발자용)

프레즌스 후속 수정 2/2 (작업 링크 UX).

- **모달 인라인**: `SceneWorkLinksPanel`의 `DepartmentBlock`을 export + `hideHeader`/`singleColumn` prop 추가 → `UnifiedSceneDetailModal`의 부서 `DeptSection` 메모 아래에 인라인(좁은 모달 칼럼용 단일 칼럼). `SceneFilesTab`의 패널은 **제거(이동, 중복 아님)**. 레거시 `SceneDetailModal`은 기존 2칼럼 유지(기본값 보존).
- **우클릭 연결**: `SceneContextMenu`의 빈 슬롯을 비활성 대신 **활성 '연결'**(작업 폴더 연결 / 대표 파일 연결)로. `onAdd` prop 추가. 공용 핸들러 `chooseAndLinkWorkPath`(신규 `src/services/sceneWorkLinkActions.ts` — 스토어↔서비스 순환 import 회피). 카드·시트·레거시 **3개 호출처** 배선(중복 없이 공용 핸들러 위임).

## 🧪 테스트 가이드

- `npm run typecheck` / `npm run test:presence`(23) / `npm run build:vite` → 통과
- **시각 검증(미리보기 확인)**: 상세 모달 BG/ACT 인라인 워크링크(단일 칼럼, 한 줄 깔끔), 우클릭 빈 슬롯 '연결' 활성

🤖 Generated with [Claude Code](https://claude.com/claude-code)
