### PR TITLE
[계획] 배플레이그라운드 아케이드·포인트 제도 설계 확정 (스펙/구현계획/목업)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,9 +53,9 @@ Phase 9: Supabase 마이그레이션  ██████░░░░ M-0, M-2 �
 - [x] 화면·마우스 뒤로가기와 작은 화면용 하단 주문 조작부
 - [x] 배한솔 관리자용 뉴스·가격 충격·추세·거래 정지 이벤트
 - [x] 실사용 피드백 반영: 양방향 빠른주문, 휠·드래그·핀치 차트, 장 전체·업종·종목별 시세 움직임
-- [ ] 실제 사용 피드백을 반영한 포인트·게임 점수 정책 확정
+- [ ] 실제 사용 피드백을 반영한 포인트·게임 점수 정책 확정 → **설계 완료, 한솔 리뷰 대기**: `docs/superpowers/specs/2026-07-13-baeplayground-arcade-points-design.md`
 - [ ] 정식 운영용 종목 정보 편집·시장 정책 확정
-- [ ] 게임 실행과 서버 저장
+- [ ] 게임 실행과 서버 저장 → **구현 계획 완료 (PR A~D, v1.84~1.87)**: `docs/superpowers/plans/2026-07-13-baeplayground-arcade-points.md` · 인터랙션 목업: `docs/superpowers/mockups/2026-07-13-baeplayground-arcade-mockup.html`
 
 ---
 

--- a/docs/superpowers/mockups/2026-07-13-baeplayground-arcade-mockup.html
+++ b/docs/superpowers/mockups/2026-07-13-baeplayground-arcade-mockup.html
@@ -1,0 +1,959 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>배플레이그라운드 아케이드 · 포인트 인터랙션 목업</title>
+<style>
+  :root {
+    color-scheme: dark;
+    --bg: #0f1117;
+    --panel: #1a1d27;
+    --panel-2: #202431;
+    --stage: rgba(18, 21, 29, .87);
+    --line: #2d3041;
+    --text: #e8e8ee;
+    --muted: #8b8da3;
+    --accent: #6c5ce7;
+    --lavender: #a29bfe;
+    --mint: #45e0b5;
+    --green: #00b894;
+    --blue: #74b9ff;
+    --yellow: #fdcb6e;
+    --danger: #ff7675;
+    --mono: ui-monospace, Consolas, 'Cascadia Mono', monospace;
+  }
+  * { box-sizing: border-box; }
+  html { background: var(--bg); }
+  body {
+    margin: 0; color: var(--text); min-height: 100vh;
+    font: 14px/1.6 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+    background:
+      radial-gradient(circle at 11% -6%, rgba(108, 92, 231, .18), transparent 31rem),
+      radial-gradient(circle at 94% 4%, rgba(0, 184, 148, .10), transparent 28rem),
+      var(--bg);
+  }
+  button { font: inherit; color: inherit; cursor: pointer; }
+  button:focus-visible { outline: 3px solid var(--lavender); outline-offset: 3px; }
+
+  /* ── 앱 헤더 목업 (우상단 포인트 배지) ─────────────────── */
+  .app-header {
+    position: sticky; top: 0; z-index: 50;
+    display: flex; align-items: center; justify-content: space-between;
+    height: 56px; padding: 0 18px;
+    border-bottom: 1px solid var(--line);
+    background: rgba(15, 17, 23, .92); backdrop-filter: blur(8px);
+  }
+  .app-header h1 { margin: 0; font-size: 14px; font-weight: 700; }
+  .app-header h1 small { color: var(--muted); font-weight: 500; margin-left: 8px; }
+  .header-right { display: flex; align-items: center; gap: 10px; }
+  .header-icon {
+    display: grid; place-items: center; width: 34px; height: 34px;
+    border: 1px solid var(--line); border-radius: 9px; background: var(--panel);
+    color: var(--muted); font-size: 15px;
+  }
+  .points-badge {
+    position: relative; display: flex; align-items: center; gap: 8px;
+    min-height: 34px; padding: 0 12px;
+    border: 1px solid rgba(162, 155, 254, .28); border-radius: 9px;
+    background: rgba(108, 92, 231, .13);
+    transition: transform .18s ease;
+  }
+  .points-badge.pulse { transform: scale(1.06); }
+  .points-badge .coin {
+    width: 16px; height: 16px; border-radius: 50%;
+    background: radial-gradient(circle at 35% 30%, #ffe29a, var(--yellow) 60%, #c9962f);
+    box-shadow: 0 0 8px rgba(253, 203, 110, .5);
+  }
+  .points-badge strong { font: 700 13px var(--mono); font-variant-numeric: tabular-nums; }
+  .points-badge span.unit { color: var(--lavender); font-size: 12px; }
+  .points-float {
+    position: absolute; right: 6px; top: -4px; pointer-events: none;
+    color: var(--mint); font: 700 12px var(--mono);
+    animation: floatUp 1.2s ease forwards;
+  }
+  @keyframes floatUp {
+    from { opacity: 0; transform: translateY(4px); }
+    18% { opacity: 1; }
+    to { opacity: 0; transform: translateY(-22px); }
+  }
+  .avatar {
+    display: flex; align-items: center; gap: 8px; padding: 0 10px; height: 34px;
+    border: 1px solid var(--line); border-radius: 9px; background: var(--panel); font-size: 13px;
+  }
+  .avatar i {
+    display: grid; place-items: center; width: 20px; height: 20px; border-radius: 50%;
+    background: var(--accent); font-style: normal; font-size: 11px; font-weight: 700;
+  }
+
+  /* ── 공통 레이아웃 ────────────────────────────────────── */
+  .wrap { max-width: 1060px; margin: 0 auto; padding: 26px 18px 80px; }
+  .note {
+    border: 1px solid rgba(162, 155, 254, .25); border-radius: 14px;
+    background: rgba(108, 92, 231, .08); padding: 14px 18px; margin-bottom: 26px;
+  }
+  .note b { color: var(--lavender); }
+  .note code { font-family: var(--mono); font-size: 12px; color: var(--mint); }
+  section.block { margin: 34px 0; }
+  section.block > header { display: flex; align-items: baseline; gap: 12px; margin-bottom: 14px; }
+  section.block > header h2 { margin: 0; font-size: 18px; letter-spacing: -.02em; }
+  section.block > header p { margin: 0; color: var(--muted); font-size: 13px; }
+  .demo-chip-row { display: flex; flex-wrap: wrap; gap: 8px; }
+  .demo-chip {
+    min-height: 44px; padding: 0 14px; border-radius: 10px;
+    border: 1px solid var(--line); background: var(--panel);
+    transition: border-color .15s ease;
+  }
+  .demo-chip:hover { border-color: rgba(162, 155, 254, .6); }
+  .demo-chip b { color: var(--mint); font-family: var(--mono); }
+  .demo-chip.capped b { color: var(--muted); }
+
+  /* ── 게임 스테이지 셸 (계획의 ArcadeStageChrome) ───────── */
+  .stage-shell {
+    display: grid; grid-template-columns: minmax(250px, .72fr) minmax(0, 1.28fr);
+    gap: 18px; padding: 20px; border: 1px solid var(--line); border-radius: 17px;
+    background: radial-gradient(circle at 78% 12%, rgba(var(--tone), .12), transparent 42%), var(--panel);
+  }
+  .stage-shell.tone-mint { --tone: 69, 224, 181; --toneSolid: #45e0b5; }
+  .stage-shell.tone-lavender { --tone: 162, 155, 254; --toneSolid: #a29bfe; }
+  .stage-info small.tag {
+    color: var(--toneSolid); font: 700 11px/1 var(--mono); letter-spacing: .15em;
+  }
+  .stage-info h3 { margin: 10px 0 6px; font-size: clamp(34px, 5vw, 52px); line-height: .9; letter-spacing: -.05em; }
+  .stage-info p.meta { margin: 0 0 14px; color: var(--muted); }
+  .hud { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin: 12px 0; }
+  .hud .cell {
+    border: 1px solid var(--line); border-radius: 10px; padding: 8px 11px; background: rgba(15,17,23,.5);
+  }
+  .hud .cell small { display: block; color: var(--muted); font-size: 11px; }
+  .hud .cell b { font: 700 16px var(--mono); font-variant-numeric: tabular-nums; }
+  .hud .cell.wide { grid-column: 1 / -1; }
+  .grade-track { height: 7px; border-radius: 99px; background: rgba(45,48,65,.9); overflow: hidden; margin-top: 6px; }
+  .grade-track i { display: block; height: 100%; width: 0%; border-radius: 99px;
+    background: linear-gradient(90deg, var(--accent), var(--toneSolid)); transition: width .3s ease; }
+  .reward-chips { display: flex; flex-wrap: wrap; gap: 6px; margin: 10px 0; }
+  .reward-chips span {
+    border: 1px solid var(--line); border-radius: 8px; padding: 3px 8px;
+    color: var(--muted); font: 600 11px var(--mono);
+  }
+  .reward-chips span.hit { color: var(--toneSolid); border-color: rgba(var(--tone), .5); }
+  .key-hints { color: var(--muted); font-size: 12px; margin-top: 8px; }
+  .key-hints kbd {
+    font-family: var(--mono); font-size: 11px; padding: 1px 6px; border-radius: 6px;
+    border: 1px solid var(--line); border-bottom-width: 2px; background: var(--panel-2); color: var(--text);
+  }
+  .stage-box {
+    position: relative; display: grid; place-items: center; min-height: 460px;
+    border: 1px solid var(--line); border-radius: 15px; background: var(--stage);
+    box-shadow: inset 0 0 50px rgba(0,0,0,.25); overflow: hidden;
+  }
+  .stage-box canvas { display: block; border-radius: 8px; }
+  .stage-overlay {
+    position: absolute; inset: 0; display: grid; place-items: center;
+    background: rgba(13, 15, 21, .78); backdrop-filter: blur(3px); text-align: center; padding: 20px;
+  }
+  .stage-overlay .card { max-width: 340px; }
+  .stage-overlay h4 { margin: 0 0 6px; font-size: 21px; }
+  .stage-overlay p { margin: 0 0 14px; color: var(--muted); font-size: 13px; }
+  .btn-primary {
+    min-height: 44px; padding: 0 18px; border: 0; border-radius: 11px; font-weight: 700;
+    background: linear-gradient(135deg, var(--accent), #8c7cf4); color: #fff;
+  }
+  .btn-primary:disabled { opacity: .45; cursor: not-allowed; }
+  .btn-ghost {
+    min-height: 44px; padding: 0 16px; border-radius: 11px;
+    border: 1px solid var(--line); background: rgba(26,29,39,.85);
+  }
+  .fee-note { display: block; margin-top: 10px; color: var(--muted); font-size: 12px; }
+  .fee-note b { color: var(--yellow); font-family: var(--mono); }
+  .countdown { font: 800 84px var(--mono); color: var(--toneSolid); animation: pop .68s ease infinite; }
+  @keyframes pop { from { transform: scale(1.25); opacity: .4; } 30% { transform: scale(1); opacity: 1; } }
+  .live-status { position: absolute; left: 12px; bottom: 10px; color: var(--muted); font-size: 11px; }
+
+  /* 결과 오버레이 */
+  .result-grade { font: 800 15px var(--mono); letter-spacing: .3em; color: var(--toneSolid); }
+  .result-score { font: 800 44px var(--mono); margin: 4px 0 2px; }
+  .result-gauge { width: 240px; height: 9px; margin: 12px auto; border-radius: 99px; background: rgba(45,48,65,.9); overflow: hidden; }
+  .result-gauge i { display: block; height: 100%; width: 0%; background: linear-gradient(90deg, var(--accent), var(--toneSolid)); transition: width .56s cubic-bezier(.2,.9,.3,1); }
+  .result-reward { font: 700 20px var(--mono); color: var(--mint); min-height: 28px; }
+  .result-reward.capped { color: var(--muted); font-size: 13px; font-weight: 600; }
+  .best-banner {
+    display: inline-block; margin: 8px 0; padding: 5px 14px; border-radius: 99px;
+    background: rgba(253, 203, 110, .14); border: 1px solid rgba(253, 203, 110, .45);
+    color: var(--yellow); font-weight: 700; font-size: 13px;
+    animation: bannerIn .4s cubic-bezier(.2,1.4,.4,1) both;
+  }
+  @keyframes bannerIn { from { transform: scale(.6); opacity: 0; } }
+  .result-achievements { display: grid; gap: 6px; margin: 10px 0 14px; }
+  .ach-card {
+    display: flex; align-items: center; gap: 10px; text-align: left;
+    border: 1px solid rgba(69, 224, 181, .35); border-radius: 10px; padding: 8px 12px;
+    background: rgba(0, 184, 148, .08); animation: achIn .35s ease both;
+  }
+  @keyframes achIn { from { transform: translateY(8px); opacity: 0; } }
+  .ach-card .medal { font-size: 20px; }
+  .ach-card b { display: block; font-size: 13px; }
+  .ach-card small { color: var(--muted); }
+  .ach-card .bonus { margin-left: auto; color: var(--mint); font: 700 13px var(--mono); }
+  .result-actions { display: flex; gap: 8px; justify-content: center; }
+
+  /* ── 도전과제 목록 ────────────────────────────────────── */
+  .ach-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(230px, 1fr)); gap: 10px; }
+  .ach-tile { display: flex; gap: 11px; border: 1px solid var(--line); border-radius: 12px; padding: 12px; background: var(--panel); }
+  .ach-tile.locked { opacity: .55; }
+  .ach-tile .medal { font-size: 22px; }
+  .ach-tile b { display: block; font-size: 13px; }
+  .ach-tile small { color: var(--muted); display: block; }
+  .ach-tile .bonus { margin-left: auto; align-self: center; color: var(--mint); font: 700 12px var(--mono); white-space: nowrap; }
+  .ach-tile.locked .bonus { color: var(--muted); }
+
+  /* ── 랭킹 + 슬랙 ─────────────────────────────────────── */
+  .rank-slack { display: grid; grid-template-columns: 1.2fr .8fr; gap: 16px; }
+  .rank-panel, .slack-panel { border: 1px solid var(--line); border-radius: 15px; background: var(--panel); padding: 16px; }
+  .tabs { display: flex; gap: 6px; margin-bottom: 12px; flex-wrap: wrap; }
+  .tabs button {
+    min-height: 34px; padding: 0 13px; border-radius: 9px; font-size: 13px;
+    border: 1px solid var(--line); background: transparent; color: var(--muted);
+  }
+  .tabs button[aria-selected="true"] { background: rgba(108,92,231,.16); border-color: rgba(162,155,254,.4); color: var(--text); font-weight: 700; }
+  .tabs .spacer { flex: 1; }
+  table.rank { width: 100%; border-collapse: collapse; font-size: 13px; }
+  table.rank th { text-align: left; color: var(--muted); font-weight: 600; font-size: 11px; padding: 4px 8px; border-bottom: 1px solid var(--line); }
+  table.rank td { padding: 8px; border-bottom: 1px solid rgba(45,48,65,.5); font-variant-numeric: tabular-nums; }
+  table.rank td.num { font-family: var(--mono); }
+  table.rank tr.me td { background: rgba(108,92,231,.10); }
+  table.rank tr.me td:first-child { border-left: 2px solid var(--accent); }
+  .slack-msg { border: 1px solid var(--line); border-radius: 12px; background: #14171f; padding: 12px 14px; }
+  .slack-msg .from { display: flex; gap: 8px; align-items: center; margin-bottom: 8px; }
+  .slack-msg .from i { width: 26px; height: 26px; border-radius: 7px; background: var(--accent); display: grid; place-items: center; font-style: normal; }
+  .slack-msg .from b { font-size: 13px; }
+  .slack-msg .from small { color: var(--muted); }
+  .slack-msg .body { border-left: 3px solid var(--yellow); padding-left: 10px; font-size: 13px; }
+  .slack-msg .body b { color: var(--yellow); }
+  .slack-toggle { display: flex; align-items: center; gap: 10px; margin-top: 12px; color: var(--muted); font-size: 12px; }
+  .switch { position: relative; width: 40px; height: 22px; border-radius: 99px; border: 1px solid var(--line); background: var(--panel-2); }
+  .switch[aria-checked="true"] { background: rgba(0,184,148,.35); border-color: var(--green); }
+  .switch i { position: absolute; top: 2px; left: 2px; width: 16px; height: 16px; border-radius: 50%; background: var(--muted); transition: transform .18s ease, background .18s ease; }
+  .switch[aria-checked="true"] i { transform: translateX(18px); background: var(--mint); }
+
+  /* 토스트 */
+  .toasts { position: fixed; right: 18px; bottom: 18px; display: grid; gap: 8px; z-index: 90; }
+  .toast {
+    display: flex; align-items: center; gap: 10px; min-width: 240px; max-width: 320px;
+    border: 1px solid rgba(69,224,181,.4); border-radius: 12px; padding: 10px 14px;
+    background: rgba(20, 24, 32, .96); box-shadow: 0 12px 30px rgba(0,0,0,.4);
+    animation: achIn .3s ease both;
+  }
+  .toast.earn { border-color: rgba(162,155,254,.4); }
+  .toast b { font-size: 13px; }
+  .toast small { color: var(--muted); display: block; }
+  .toast .pts { margin-left: auto; color: var(--mint); font: 700 13px var(--mono); }
+
+  @media (max-width: 860px) {
+    .stage-shell { grid-template-columns: 1fr; }
+    .rank-slack { grid-template-columns: 1fr; }
+    .stage-box { min-height: 380px; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .points-float, .countdown, .best-banner, .ach-card, .toast { animation: none !important; }
+    .result-gauge i, .grade-track i, .points-badge { transition: none !important; }
+  }
+</style>
+</head>
+<body>
+
+<header class="app-header" aria-label="B flow 메인 헤더 목업">
+  <h1>B flow <small>메인 화면 헤더 — 우상단에 포인트 배지가 상시 노출</small></h1>
+  <div class="header-right">
+    <span class="header-icon" title="알림(기존)">🔔</span>
+    <button type="button" class="points-badge" id="pointsBadge" aria-label="보유 포인트, 배플레이그라운드 열기">
+      <span class="coin" aria-hidden="true"></span>
+      <strong id="pointsValue">12,500</strong><span class="unit">P</span>
+    </button>
+    <span class="avatar"><i>배</i> 배한솔</span>
+  </div>
+</header>
+
+<div class="wrap">
+  <div class="note">
+    <b>이 페이지는 실제로 조작되는 인터랙션 목업입니다.</b> 스네이크와 테트리스를 직접 플레이해 보면
+    입장료 차감 → 플레이 → 등급 보상 → 도전과제 → 랭킹/슬랙까지 계획된 전체 루프가 어떻게 느껴질지 확인할 수 있어요.
+    수치·규칙의 정본은 <code>docs/superpowers/plans/2026-07-13-baeplayground-arcade-points.md</code> 입니다.
+    (목업 한정: 테트리스 회전은 간이 킥 — 실제 구현은 SRS 표준 킥 테이블을 사용)
+  </div>
+
+  <!-- ① 활동 적립 -->
+  <section class="block" aria-labelledby="s1">
+    <header><h2 id="s1">① 업무 활동으로 포인트 적립</h2><p>씬 완료·댓글·리테이크·출석 시 우상단 배지가 반응해요 (버튼으로 시뮬레이션)</p></header>
+    <div class="demo-chip-row">
+      <button type="button" class="demo-chip" data-earn="5" data-label="씬 단계 완료">씬 단계 체크 <b>+5P</b></button>
+      <button type="button" class="demo-chip" data-earn="10" data-label="ACT 씬 완료">액팅 씬 완료 <b>+10P</b></button>
+      <button type="button" class="demo-chip" data-earn="5" data-label="댓글 작성">댓글 작성 <b>+5P</b></button>
+      <button type="button" class="demo-chip" data-earn="30" data-label="리테이크 수정 완료">리테이크 수정 완료 <b>+30P</b></button>
+      <button type="button" class="demo-chip" data-earn="20" data-label="오늘 첫 출석" data-once="daily">매일 첫 로그인 <b>+20P</b></button>
+    </div>
+  </section>
+
+  <!-- ② 스네이크 -->
+  <section class="block" aria-labelledby="s2">
+    <header><h2 id="s2">② 스네이크</h2><p>화살표/WASD 이동 · P 일시정지 · 5번째 사과마다 골든(+2)</p></header>
+    <div class="stage-shell tone-lavender" id="snakeShell">
+      <div class="stage-info">
+        <small class="tag">SNAKE · ONE MORE RUN</small>
+        <h3>SNAKE</h3>
+        <p class="meta">score = 최종 길이 · 시작 160ms/틱, 사과당 −4ms (하한 80ms)</p>
+        <div class="hud">
+          <div class="cell"><small>길이</small><b id="snakeLen">4</b></div>
+          <div class="cell"><small>골든 사과</small><b id="snakeGolden">0</b></div>
+          <div class="cell"><small>내 최고</small><b id="snakeBest">34</b></div>
+          <div class="cell"><small>오늘 보상</small><b id="snakeRewardCount">0/5</b></div>
+          <div class="cell wide"><small id="snakeNextGradeLabel">다음 등급(BRONZE 15)까지 11</small>
+            <div class="grade-track"><i id="snakeGradeFill"></i></div></div>
+        </div>
+        <div class="reward-chips" id="snakeChips">
+          <span data-min="15">B 15 → +8P</span><span data-min="25">S 25 → +18P</span>
+          <span data-min="40">G 40 → +30P</span><span data-min="55">P 55 → +45P</span>
+        </div>
+        <p class="key-hints"><kbd>←→↑↓</kbd>/<kbd>WASD</kbd> 이동 · <kbd>P</kbd> 일시정지 · 뒤로가기는 종료 확인</p>
+      </div>
+      <div class="stage-box" id="snakeBox">
+        <canvas id="snakeCanvas" width="378" height="378" aria-label="스네이크 게임 보드"></canvas>
+        <div class="live-status" aria-live="polite" id="snakeStatus">대기 중</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ③ 테트리스 -->
+  <section class="block" aria-labelledby="s3">
+    <header><h2 id="s3">③ 테트리스</h2><p>←→ 이동(DAS 160/ARR 40) · ↓ 소프트 · Space 하드 · Z/X 회전 · C 홀드</p></header>
+    <div class="stage-shell tone-mint" id="tetrisShell">
+      <div class="stage-info">
+        <small class="tag">TETRIS · QUICK RUN</small>
+        <h3>TETRIS</h3>
+        <p class="meta">1/2/3/4줄 = 100/300/500/800 × 레벨 · 콤보 +50×n×레벨 · 10라인마다 레벨업</p>
+        <div class="hud">
+          <div class="cell"><small>점수</small><b id="tScore">0</b></div>
+          <div class="cell"><small>레벨 · 라인</small><b><span id="tLevel">1</span> · <span id="tLines">0</span></b></div>
+          <div class="cell"><small>내 최고</small><b id="tBest">18,420</b></div>
+          <div class="cell"><small>오늘 보상</small><b id="tRewardCount">0/5</b></div>
+          <div class="cell wide"><small id="tNextGradeLabel">다음 등급(BRONZE 3,000)까지 3,000</small>
+            <div class="grade-track"><i id="tGradeFill"></i></div></div>
+        </div>
+        <div class="reward-chips" id="tChips">
+          <span data-min="3000">B 3,000 → +12P</span><span data-min="10000">S 10,000 → +30P</span>
+          <span data-min="25000">G 25,000 → +55P</span><span data-min="50000">P 50,000 → +80P</span>
+        </div>
+        <p class="key-hints"><kbd>←→</kbd> 이동 · <kbd>↓</kbd> 소프트 · <kbd>Space</kbd> 하드 · <kbd>Z</kbd>/<kbd>X</kbd> 회전 · <kbd>C</kbd> 홀드 · <kbd>P</kbd> 일시정지</p>
+      </div>
+      <div class="stage-box" id="tetrisBox">
+        <canvas id="tetrisCanvas" width="420" height="440" aria-label="테트리스 게임 보드"></canvas>
+        <div class="live-status" aria-live="polite" id="tetrisStatus">대기 중</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ④ 도전과제 -->
+  <section class="block" aria-labelledby="s4">
+    <header><h2 id="s4">④ 도전과제</h2><p>해금 시 보너스 포인트 + 토스트 · 게임 결과 화면에도 표시</p></header>
+    <div class="ach-grid" id="achGrid"></div>
+  </section>
+
+  <!-- ⑤ 랭킹 + 슬랙 -->
+  <section class="block" aria-labelledby="s5">
+    <header><h2 id="s5">⑤ 게임별 랭킹 · 신기록 슬랙 알림</h2><p>신기록을 세우면 랭킹이 갱신되고, 설정이 켜져 있으면 슬랙 미리보기가 채워져요</p></header>
+    <div class="rank-slack">
+      <div class="rank-panel">
+        <div class="tabs" role="tablist" aria-label="랭킹 게임 선택">
+          <button type="button" role="tab" aria-selected="true" data-game-tab="snake">스네이크</button>
+          <button type="button" role="tab" aria-selected="false" data-game-tab="tetris">테트리스</button>
+          <span class="spacer"></span>
+          <button type="button" role="tab" aria-selected="true" data-period-tab="all">전체</button>
+          <button type="button" role="tab" aria-selected="false" data-period-tab="week">이번 주</button>
+        </div>
+        <table class="rank" aria-label="랭킹 표">
+          <thead><tr><th style="width:44px">순위</th><th>이름</th><th style="width:110px" id="rankScoreHead">길이</th><th style="width:100px">달성일</th></tr></thead>
+          <tbody id="rankBody"></tbody>
+        </table>
+      </div>
+      <div class="slack-panel">
+        <p style="margin:0 0 10px; color:var(--muted); font-size:12px;">#studio-jbbj 채널 미리보기</p>
+        <div class="slack-msg">
+          <div class="from"><i>🎮</i><div><b>배플레이그라운드</b> <small>워크플로</small></div></div>
+          <div class="body" id="slackBody">
+            <b>아직 새 기록이 없어요</b><br />
+            <span style="color:var(--muted)">신기록이 나오면 이 자리에 실제 발송될 메시지가 표시됩니다.</span>
+          </div>
+        </div>
+        <div class="slack-toggle">
+          <button type="button" class="switch" role="switch" aria-checked="true" id="slackSwitch"><i></i></button>
+          신기록 슬랙 알림 (관리자 설정 · 기본 꺼짐, 목업에선 켜둠)
+        </div>
+      </div>
+    </div>
+  </section>
+</div>
+
+<div class="toasts" id="toasts" aria-live="polite"></div>
+
+<script>
+'use strict';
+/* ══════════ 공통: 지갑·보상·도전과제 (목업 시뮬레이션) ══════════ */
+const BALANCE = {
+  snake: { fee: 10, grades: [['bronze',15,8],['silver',25,18],['gold',40,30],['platinum',55,45]] },
+  tetris:{ fee: 15, grades: [['bronze',3000,12],['silver',10000,30],['gold',25000,55],['platinum',50000,80]] },
+  rewardCap: 5,
+};
+const ACHIEVEMENTS = [
+  { id:'arcade-first-run', medal:'🎫', name:'첫 판', desc:'아케이드 게임 첫 완주', bonus:10 },
+  { id:'arcade-runs-50', medal:'🪑', name:'단골 손님', desc:'누적 50판 플레이', bonus:30 },
+  { id:'arcade-earned-5k', medal:'🐷', name:'티끌 모아', desc:'적립 누적 5,000P', bonus:50 },
+  { id:'attend-7', medal:'📅', name:'개근상', desc:'7일 연속 출석', bonus:50 },
+  { id:'snake-30', medal:'🐍', name:'몸집 불리기', desc:'스네이크 길이 30', bonus:15 },
+  { id:'snake-55', medal:'🐉', name:'전설의 뱀', desc:'스네이크 길이 55', bonus:40 },
+  { id:'snake-golden-5', medal:'🍎', name:'황금 미식가', desc:'한 판에 골든 사과 5개', bonus:20 },
+  { id:'tetris-tetris', medal:'🧱', name:'테트리스!', desc:'한 번에 4줄 클리어', bonus:20 },
+  { id:'tetris-level-10', medal:'🚀', name:'고속 낙하', desc:'레벨 10 도달', bonus:30 },
+  { id:'tetris-30k', medal:'🏆', name:'3만 클럽', desc:'단판 30,000점', bonus:40 },
+];
+const state = {
+  points: 12500, dailyDone: new Set(), unlocked: new Set(), totalRuns: 0,
+  best: { snake: 34, tetris: 18420 }, rewards: { snake: 0, tetris: 0 },
+  slackOn: true,
+};
+const fmt = (n) => n.toLocaleString('ko-KR');
+const $ = (id) => document.getElementById(id);
+
+const badge = $('pointsBadge');
+function setPoints(next, delta, label) {
+  state.points = next;
+  $('pointsValue').textContent = fmt(next);
+  if (!delta) return;
+  badge.classList.remove('pulse'); void badge.offsetWidth; badge.classList.add('pulse');
+  setTimeout(() => badge.classList.remove('pulse'), 220);
+  const float = document.createElement('span');
+  float.className = 'points-float';
+  float.textContent = (delta > 0 ? '+' : '') + fmt(delta) + 'P';
+  if (delta < 0) float.style.color = 'var(--danger)';
+  badge.appendChild(float);
+  setTimeout(() => float.remove(), 1200);
+  if (label) toast(delta > 0 ? 'earn' : 'spend', label, (delta > 0 ? '+' : '') + fmt(delta) + 'P');
+}
+function toast(kind, title, pts, sub) {
+  const box = $('toasts');
+  const el = document.createElement('div');
+  el.className = 'toast ' + (kind === 'ach' ? '' : 'earn');
+  el.innerHTML = `<span style="font-size:18px">${kind === 'ach' ? '🏅' : kind === 'spend' ? '🎟️' : '✨'}</span>
+    <div><b>${title}</b>${sub ? `<small>${sub}</small>` : ''}</div><span class="pts">${pts ?? ''}</span>`;
+  box.appendChild(el);
+  setTimeout(() => el.remove(), 3400);
+}
+document.querySelectorAll('.demo-chip').forEach((btn) => {
+  btn.addEventListener('click', () => {
+    if (btn.dataset.once && state.dailyDone.has(btn.dataset.once)) {
+      toast('earn', '오늘은 이미 받았어요', '+0P', '내일 다시 지급돼요 (멱등 키)');
+      btn.classList.add('capped');
+      return;
+    }
+    if (btn.dataset.once) { state.dailyDone.add(btn.dataset.once); btn.classList.add('capped'); }
+    setPoints(state.points + Number(btn.dataset.earn), Number(btn.dataset.earn), btn.dataset.label);
+  });
+});
+badge.addEventListener('click', () => toast('earn', '실제 앱에서는 배플레이그라운드로 이동해요', '→'));
+
+function gradeFor(game, score) {
+  let hit = null;
+  for (const [g, min, reward] of BALANCE[game].grades) if (score >= min) hit = { grade: g, reward };
+  return hit ?? { grade: 'none', reward: 0 };
+}
+function unlockAchievements(ids) {
+  const fresh = ids.filter((id) => !state.unlocked.has(id));
+  fresh.forEach((id) => state.unlocked.add(id));
+  renderAchievements();
+  return fresh.map((id) => ACHIEVEMENTS.find((a) => a.id === id));
+}
+function renderAchievements() {
+  $('achGrid').innerHTML = ACHIEVEMENTS.map((a) => `
+    <div class="ach-tile ${state.unlocked.has(a.id) ? '' : 'locked'}">
+      <span class="medal">${state.unlocked.has(a.id) ? a.medal : '🔒'}</span>
+      <div><b>${a.name}</b><small>${a.desc}</small></div>
+      <span class="bonus">+${a.bonus}P</span>
+    </div>`).join('');
+}
+renderAchievements();
+
+/* ══════════ 랭킹 + 슬랙 ══════════ */
+const leaderboards = {
+  snake: { all: [['배한솔',34,'7/12'],['민지',29,'7/11'],['도윤',22,'7/10']], week: [['배한솔',34,'7/12'],['민지',26,'7/12']] },
+  tetris:{ all: [['배한솔',18420,'7/9'],['민지',12040,'7/8'],['유진',8130,'7/7']], week: [['민지',12040,'7/12'],['배한솔',9800,'7/11']] },
+};
+let rankGame = 'snake', rankPeriod = 'all';
+function renderRank() {
+  $('rankScoreHead').textContent = rankGame === 'snake' ? '길이' : '점수';
+  const rows = [...leaderboards[rankGame][rankPeriod]].sort((a, b) => b[1] - a[1]).slice(0, 5);
+  while (rows.length < 5) rows.push(null);
+  $('rankBody').innerHTML = rows.map((row, i) => row
+    ? `<tr class="${row[0] === '배한솔' ? 'me' : ''}"><td class="num">${String(i + 1).padStart(2, '0')}</td>
+       <td>${row[0]}${row[0] === '배한솔' ? ' · 나' : ''}</td><td class="num">${fmt(row[1])}</td><td>${row[2]}</td></tr>`
+    : `<tr><td class="num">${String(i + 1).padStart(2, '0')}</td><td style="color:var(--muted)">—</td><td class="num" style="color:var(--muted)">—</td><td style="color:var(--muted)">—</td></tr>`
+  ).join('');
+}
+document.querySelectorAll('[data-game-tab]').forEach((b) => b.addEventListener('click', () => {
+  rankGame = b.dataset.gameTab;
+  document.querySelectorAll('[data-game-tab]').forEach((x) => x.setAttribute('aria-selected', String(x === b)));
+  renderRank();
+}));
+document.querySelectorAll('[data-period-tab]').forEach((b) => b.addEventListener('click', () => {
+  rankPeriod = b.dataset.periodTab;
+  document.querySelectorAll('[data-period-tab]').forEach((x) => x.setAttribute('aria-selected', String(x === b)));
+  renderRank();
+}));
+renderRank();
+$('slackSwitch').addEventListener('click', () => {
+  state.slackOn = !state.slackOn;
+  $('slackSwitch').setAttribute('aria-checked', String(state.slackOn));
+});
+function announceRecord(gameKo, score, prev, unit) {
+  leaderboards[rankGame === 'snake' ? rankGame : rankGame] // no-op guard
+  if (!state.slackOn) return;
+  $('slackBody').innerHTML = `<b>${gameKo} 신기록! 🏆</b><br />
+    배한솔 — ${fmt(score)}${unit} ${prev ? `(이전 기록 ${fmt(prev)}${unit})` : '(첫 기록)'}<br />
+    <span style="color:var(--muted)">payload: { title, detail, player } → 슬랙 워크플로 트리거</span>`;
+}
+
+/* ══════════ 스테이지 셸 공통 (ready/countdown/running/paused/result) ══════════ */
+let activeGame = null; // 동시에 한 게임만
+function makeChrome(box, tone, opts) {
+  const overlay = document.createElement('div');
+  overlay.className = 'stage-overlay';
+  box.appendChild(overlay);
+  const chrome = {
+    phase: 'ready',
+    show(html) { overlay.innerHTML = `<div class="card">${html}</div>`; overlay.style.display = 'grid'; },
+    hide() { overlay.style.display = 'none'; },
+    ready() {
+      chrome.phase = 'ready';
+      const capped = state.rewards[opts.id] >= BALANCE.rewardCap;
+      const poor = state.points < BALANCE[opts.id].fee;
+      chrome.show(`
+        <h4>${opts.title}</h4>
+        <p>${opts.rules}</p>
+        <button type="button" class="btn-primary" id="${opts.id}Start" ${poor ? 'disabled' : ''}>
+          ${BALANCE[opts.id].fee}P 내고 시작</button>
+        <span class="fee-note">오늘 보상 가능 <b>${BALANCE.rewardCap - state.rewards[opts.id]}/${BALANCE.rewardCap}</b>
+        ${capped ? ' · 기록/랭킹만 반영돼요' : ''} ${poor ? '<br />포인트가 부족해요 — 활동으로 적립해 보세요' : ''}</span>`);
+      overlay.querySelector('#' + opts.id + 'Start')?.addEventListener('click', () => {
+        if (activeGame && activeGame !== opts.id && opts.pauseOthers) opts.pauseOthers();
+        activeGame = opts.id;
+        setPoints(state.points - BALANCE[opts.id].fee, -BALANCE[opts.id].fee, opts.title + ' 입장료');
+        chrome.countdown();
+      });
+      opts.status('대기 중');
+    },
+    countdown() {
+      chrome.phase = 'countdown';
+      let n = 3;
+      const tick = () => {
+        if (n === 0) { chrome.hide(); chrome.phase = 'running'; opts.begin(); return; }
+        chrome.show(`<div class="countdown">${n}</div>`);
+        opts.status(n + '초 뒤 시작');
+        n -= 1; chrome.timer = setTimeout(tick, 700);
+      };
+      tick();
+    },
+    paused() {
+      chrome.phase = 'paused';
+      chrome.show(`<h4>일시정지</h4><p>창을 벗어나도 자동으로 멈춰요</p>
+        <div class="result-actions">
+          <button type="button" class="btn-primary" data-resume>계속하기</button>
+          <button type="button" class="btn-ghost" data-quit>나가기</button>
+        </div>
+        <span class="fee-note">나가면 입장료는 돌려받지 못해요</span>`);
+      overlay.querySelector('[data-resume]').addEventListener('click', () => { chrome.hide(); chrome.phase = 'running'; opts.resume(); });
+      overlay.querySelector('[data-quit]').addEventListener('click', () => { opts.abort(); chrome.ready(); });
+      opts.status('일시정지');
+    },
+    result(run) {
+      chrome.phase = 'result';
+      const { grade, reward } = gradeFor(opts.id, run.score);
+      const capped = grade !== 'none' && state.rewards[opts.id] >= BALANCE.rewardCap;
+      const paid = capped ? 0 : reward;
+      if (grade !== 'none' && !capped) state.rewards[opts.id] += 1;
+      state.totalRuns += 1;
+      const isBest = run.score > state.best[opts.id];
+      const prevBest = state.best[opts.id];
+      if (isBest) {
+        state.best[opts.id] = run.score;
+        const lb = leaderboards[opts.id];
+        const stamp = '오늘';
+        const mine = lb.all.find((r) => r[0] === '배한솔');
+        if (mine) { mine[1] = run.score; mine[2] = stamp; } else lb.all.push(['배한솔', run.score, stamp]);
+        const mineW = lb.week.find((r) => r[0] === '배한솔');
+        if (mineW) { mineW[1] = Math.max(mineW[1], run.score); mineW[2] = stamp; } else lb.week.push(['배한솔', run.score, stamp]);
+        renderRank();
+        announceRecord(opts.title, run.score, prevBest, opts.unit);
+      }
+      const fresh = unlockAchievements(opts.evaluate(run));
+      if (state.totalRuns >= 1) fresh.push(...unlockAchievements(['arcade-first-run']));
+      let bonus = 0;
+      fresh.forEach((a) => { bonus += a.bonus; toast('ach', '도전과제 달성! ' + a.name, '+' + a.bonus + 'P', a.desc); });
+      const gradePct = { none: 8, bronze: 30, silver: 55, gold: 80, platinum: 100 }[grade];
+      chrome.show(`
+        <div class="result-grade">${grade === 'none' ? 'NO GRADE' : grade.toUpperCase()}</div>
+        <div class="result-score">${fmt(run.score)}<small style="font-size:15px;color:var(--muted)"> ${opts.unit}</small></div>
+        <div class="result-gauge"><i id="${opts.id}Gauge"></i></div>
+        ${isBest ? '<span class="best-banner">🏆 신기록!</span><br />' : ''}
+        <div class="result-reward ${paid === 0 ? 'capped' : ''}" id="${opts.id}Reward">${
+          grade === 'none' ? '등급 미달 — 보상 없음'
+          : capped ? '오늘 보상 한도에 도달했어요 (5/5)' : '+0P'}</div>
+        ${fresh.length ? `<div class="result-achievements">${fresh.map((a) =>
+          `<div class="ach-card"><span class="medal">${a.medal}</span><div><b>${a.name}</b><small>${a.desc}</small></div><span class="bonus">+${a.bonus}P</span></div>`).join('')}</div>` : ''}
+        <div class="result-actions">
+          <button type="button" class="btn-primary" data-replay>다시 하기 (${BALANCE[opts.id].fee}P)</button>
+          <button type="button" class="btn-ghost" data-exit>로비로</button>
+        </div>`);
+      requestAnimationFrame(() => requestAnimationFrame(() => {
+        const g = overlay.querySelector('#' + opts.id + 'Gauge');
+        if (g) g.style.width = gradePct + '%';
+      }));
+      if (paid > 0) {
+        let shown = 0;
+        const el = () => overlay.querySelector('#' + opts.id + 'Reward');
+        const step = Math.max(1, Math.round(paid / 24));
+        const iv = setInterval(() => {
+          shown = Math.min(paid, shown + step);
+          if (el()) el().textContent = '+' + shown + 'P';
+          if (shown >= paid) clearInterval(iv);
+        }, 20);
+        setPoints(state.points + paid + bonus, paid + bonus, opts.title + ' 보상' + (bonus ? ' + 도전과제' : ''));
+      } else if (bonus > 0) {
+        setPoints(state.points + bonus, bonus, '도전과제 보너스');
+      }
+      $(opts.id === 'snake' ? 'snakeRewardCount' : 'tRewardCount').textContent = state.rewards[opts.id] + '/5';
+      $(opts.id === 'snake' ? 'snakeBest' : 'tBest').textContent = fmt(state.best[opts.id]);
+      overlay.querySelector('[data-replay]').addEventListener('click', () => chrome.ready());
+      overlay.querySelector('[data-exit]').addEventListener('click', () => chrome.ready());
+      opts.status('게임 오버 — 등급 ' + grade.toUpperCase());
+    },
+  };
+  return chrome;
+}
+
+/* ══════════ 스네이크 ══════════ */
+(function snakeGame() {
+  const cv = $('snakeCanvas'), ctx = cv.getContext('2d');
+  const N = 21, CELL = cv.width / N;
+  let s = null, raf = 0, acc = 0, last = 0;
+  const chrome = makeChrome($('snakeBox'), 'lavender', {
+    id: 'snake', title: '스네이크', unit: '',
+    rules: '사과를 먹고 몸을 키우세요. 5번째 사과마다 골든(+2). 벽과 몸에 부딪히면 끝!',
+    status: (t) => { $('snakeStatus').textContent = t; },
+    begin() { s = fresh(); acc = 0; last = 0; loop(); $('snakeStatus').textContent = '진행 중'; },
+    resume() { last = 0; loop(); $('snakeStatus').textContent = '진행 중'; },
+    abort() { cancelAnimationFrame(raf); s = null; },
+    pauseOthers: () => window.__pauseTetris?.(),
+    evaluate: (run) => [
+      run.score >= 30 && 'snake-30', run.score >= 55 && 'snake-55',
+      run.golden >= 5 && 'snake-golden-5',
+    ].filter(Boolean),
+  });
+  window.__pauseSnake = () => { if (chrome.phase === 'running') { cancelAnimationFrame(raf); chrome.paused(); } };
+  function fresh() {
+    return {
+      body: [[10,10],[9,10],[8,10],[7,10]], dir: [1,0], queue: [],
+      apple: null, eaten: 0, golden: 0, tickMs: 160, grow: 0,
+    };
+  }
+  function placeApple() {
+    const taken = new Set(s.body.map((p) => p.join()));
+    const free = [];
+    for (let y = 0; y < N; y++) for (let x = 0; x < N; x++) if (!taken.has(x + ',' + y)) free.push([x, y]);
+    const pos = free[Math.floor(Math.random() * free.length)];
+    s.apple = { pos, golden: (s.eaten + 1) % 5 === 0 };
+  }
+  function step() {
+    if (!s.apple) placeApple();
+    if (s.queue.length) {
+      const d = s.queue.shift();
+      if (d[0] !== -s.dir[0] || d[1] !== -s.dir[1]) s.dir = d;
+    }
+    const head = [s.body[0][0] + s.dir[0], s.body[0][1] + s.dir[1]];
+    const tailWillMove = s.grow === 0;
+    const bodyCheck = tailWillMove ? s.body.slice(0, -1) : s.body;
+    if (head[0] < 0 || head[0] >= N || head[1] < 0 || head[1] >= N
+      || bodyCheck.some((p) => p[0] === head[0] && p[1] === head[1])) {
+      cancelAnimationFrame(raf);
+      const run = { score: s.body.length, golden: s.golden };
+      $('snakeLen').textContent = s.body.length;
+      chrome.result(run); s = null;
+      return;
+    }
+    s.body.unshift(head);
+    if (s.apple && head[0] === s.apple.pos[0] && head[1] === s.apple.pos[1]) {
+      s.eaten += 1; s.grow += s.apple.golden ? 2 : 1;
+      if (s.apple.golden) s.golden += 1;
+      s.tickMs = Math.max(80, s.tickMs - 4);
+      placeApple();
+    }
+    if (s.grow > 0) s.grow -= 1; else s.body.pop();
+    updateHud();
+  }
+  function updateHud() {
+    const len = s.body.length;
+    $('snakeLen').textContent = len; $('snakeGolden').textContent = s.golden;
+    const next = BALANCE.snake.grades.find(([, min]) => len < min);
+    $('snakeNextGradeLabel').textContent = next
+      ? `다음 등급(${next[0].toUpperCase()} ${next[1]})까지 ${next[1] - len}`
+      : '최고 등급 달성!';
+    $('snakeGradeFill').style.width = Math.min(100, (len / 55) * 100) + '%';
+    document.querySelectorAll('#snakeChips span').forEach((c) =>
+      c.classList.toggle('hit', len >= Number(c.dataset.min)));
+  }
+  function draw() {
+    ctx.fillStyle = '#12151d'; ctx.fillRect(0, 0, cv.width, cv.height);
+    ctx.strokeStyle = 'rgba(45,48,65,.35)';
+    for (let i = 1; i < N; i++) {
+      ctx.beginPath(); ctx.moveTo(i * CELL, 0); ctx.lineTo(i * CELL, cv.height); ctx.stroke();
+      ctx.beginPath(); ctx.moveTo(0, i * CELL); ctx.lineTo(cv.width, i * CELL); ctx.stroke();
+    }
+    if (!s) return;
+    if (s.apple) {
+      ctx.fillStyle = s.apple.golden ? '#fdcb6e' : '#ff7675';
+      ctx.shadowColor = s.apple.golden ? '#fdcb6e' : 'transparent';
+      ctx.shadowBlur = s.apple.golden ? 12 : 0;
+      const [ax, ay] = s.apple.pos;
+      ctx.beginPath(); ctx.arc(ax * CELL + CELL / 2, ay * CELL + CELL / 2, CELL * .34, 0, 7); ctx.fill();
+      ctx.shadowBlur = 0;
+    }
+    s.body.forEach(([x, y], i) => {
+      ctx.fillStyle = i === 0 ? '#c9c3ff' : '#a29bfe';
+      const pad = i === 0 ? 1.5 : 2.5;
+      roundRect(x * CELL + pad, y * CELL + pad, CELL - pad * 2, CELL - pad * 2, 5);
+    });
+  }
+  function roundRect(x, y, w, h, r) {
+    ctx.beginPath(); ctx.roundRect(x, y, w, h, r); ctx.fill();
+  }
+  function loop(ts) {
+    raf = requestAnimationFrame(loop);
+    if (!s) return;
+    if (!last) last = ts ?? performance.now();
+    const now = ts ?? performance.now();
+    acc += now - last; last = now;
+    while (s && acc >= s.tickMs) { acc -= s.tickMs; step(); }
+    draw();
+  }
+  draw();
+  window.addEventListener('keydown', (e) => {
+    if (chrome.phase !== 'running' && chrome.phase !== 'paused') return;
+    const map = { ArrowUp: [0,-1], ArrowDown: [0,1], ArrowLeft: [-1,0], ArrowRight: [1,0],
+      w: [0,-1], s: [0,1], a: [-1,0], d: [1,0], W: [0,-1], S: [0,1], A: [-1,0], D: [1,0] };
+    if (e.key === 'p' || e.key === 'P' || e.key === 'Escape') {
+      e.preventDefault();
+      if (chrome.phase === 'running') { cancelAnimationFrame(raf); chrome.paused(); }
+      return;
+    }
+    if (chrome.phase !== 'running' || !map[e.key] || !s) return;
+    e.preventDefault();
+    if (s.queue.length < 2) s.queue.push(map[e.key]);
+  });
+  chrome.ready();
+})();
+
+/* ══════════ 테트리스 (목업: 간이 킥 — 실구현은 SRS) ══════════ */
+(function tetrisGame() {
+  const cv = $('tetrisCanvas'), ctx = cv.getContext('2d');
+  const W = 10, H = 20, CELL = 21, OX = 8, OY = 8;
+  const SPEED = [1000, 850, 720, 600, 490, 390, 310, 240, 180, 140, 105, 80, 60, 45, 35];
+  const SHAPES = {
+    I: [[[0,1],[1,1],[2,1],[3,1]],[[2,0],[2,1],[2,2],[2,3]],[[0,2],[1,2],[2,2],[3,2]],[[1,0],[1,1],[1,2],[1,3]]],
+    O: [[[1,0],[2,0],[1,1],[2,1]],[[1,0],[2,0],[1,1],[2,1]],[[1,0],[2,0],[1,1],[2,1]],[[1,0],[2,0],[1,1],[2,1]]],
+    T: [[[1,0],[0,1],[1,1],[2,1]],[[1,0],[1,1],[2,1],[1,2]],[[0,1],[1,1],[2,1],[1,2]],[[1,0],[0,1],[1,1],[1,2]]],
+    S: [[[1,0],[2,0],[0,1],[1,1]],[[1,0],[1,1],[2,1],[2,2]],[[1,1],[2,1],[0,2],[1,2]],[[0,0],[0,1],[1,1],[1,2]]],
+    Z: [[[0,0],[1,0],[1,1],[2,1]],[[2,0],[1,1],[2,1],[1,2]],[[0,1],[1,1],[1,2],[2,2]],[[1,0],[0,1],[1,1],[0,2]]],
+    J: [[[0,0],[0,1],[1,1],[2,1]],[[1,0],[2,0],[1,1],[1,2]],[[0,1],[1,1],[2,1],[2,2]],[[1,0],[1,1],[0,2],[1,2]]],
+    L: [[[2,0],[0,1],[1,1],[2,1]],[[1,0],[1,1],[1,2],[2,2]],[[0,1],[1,1],[2,1],[0,2]],[[0,0],[1,0],[1,1],[1,2]]],
+  };
+  const COLORS = { I:'#45e0b5', O:'#fdcb6e', T:'#a29bfe', S:'#00b894', Z:'#8c7cf4', J:'#74b9ff', L:'#e8a2b8' };
+  let g = null, raf = 0, last = 0;
+  const chrome = makeChrome($('tetrisBox'), 'mint', {
+    id: 'tetris', title: '테트리스', unit: '점',
+    rules: '줄을 지워 점수를 모으세요. 한 번에 4줄이 최고 효율!',
+    status: (t) => { $('tetrisStatus').textContent = t; },
+    begin() { g = fresh(); last = 0; loop(); $('tetrisStatus').textContent = '진행 중'; },
+    resume() { last = 0; loop(); $('tetrisStatus').textContent = '진행 중'; },
+    abort() { cancelAnimationFrame(raf); g = null; },
+    pauseOthers: () => window.__pauseSnake?.(),
+    evaluate: (run) => [
+      run.maxClear >= 4 && 'tetris-tetris', run.level >= 10 && 'tetris-level-10',
+      run.score >= 30000 && 'tetris-30k',
+    ].filter(Boolean),
+  });
+  window.__pauseTetris = () => { if (chrome.phase === 'running') { cancelAnimationFrame(raf); chrome.paused(); } };
+  function bag() {
+    const b = ['I','O','T','S','Z','J','L'];
+    for (let i = b.length - 1; i > 0; i--) { const j = Math.floor(Math.random() * (i + 1)); [b[i], b[j]] = [b[j], b[i]]; }
+    return b;
+  }
+  function fresh() {
+    const q = bag().concat(bag());
+    const st = { board: Array.from({ length: H }, () => Array(W).fill(null)),
+      queue: q, hold: null, holdUsed: false, level: 1, lines: 0, score: 0, combo: -1,
+      maxClear: 0, levelReached: 1, gravAcc: 0, soft: false, over: false };
+    spawn(st); return st;
+  }
+  function spawn(st) {
+    if (st.queue.length < 7) st.queue.push(...bag());
+    st.active = { p: st.queue.shift(), r: 0, x: 3, y: 0 };
+    st.holdUsed = false;
+    if (collides(st, st.active)) st.over = true;
+  }
+  function cells(a) { return SHAPES[a.p][a.r].map(([cx, cy]) => [a.x + cx, a.y + cy]); }
+  function collides(st, a) {
+    return cells(a).some(([x, y]) => x < 0 || x >= W || y >= H || (y >= 0 && st.board[y][x]));
+  }
+  function tryMove(dx, dy) {
+    const n = { ...g.active, x: g.active.x + dx, y: g.active.y + dy };
+    if (!collides(g, n)) { g.active = n; return true; } return false;
+  }
+  function rotate(dir) {
+    const n = { ...g.active, r: (g.active.r + dir + 4) % 4 };
+    for (const [kx, ky] of [[0,0],[-1,0],[1,0],[0,-1],[-2,0],[2,0]]) {
+      const k = { ...n, x: n.x + kx, y: n.y + ky };
+      if (!collides(g, k)) { g.active = k; return; }
+    }
+  }
+  function hardDropY() {
+    const a = { ...g.active };
+    while (!collides(g, { ...a, y: a.y + 1 })) a.y += 1;
+    return a.y;
+  }
+  function lock() {
+    cells(g.active).forEach(([x, y]) => { if (y >= 0) g.board[y][x] = COLORS[g.active.p]; });
+    let cleared = 0;
+    g.board = g.board.filter((row) => { const full = row.every(Boolean); if (full) cleared += 1; return !full; });
+    while (g.board.length < H) g.board.unshift(Array(W).fill(null));
+    if (cleared > 0) {
+      g.combo += 1;
+      g.maxClear = Math.max(g.maxClear, cleared);
+      g.lines += cleared;
+      g.score += [0, 100, 300, 500, 800][cleared] * g.level + 50 * Math.max(0, g.combo) * g.level;
+      g.level = Math.min(15, Math.floor(g.lines / 10) + 1);
+      g.levelReached = Math.max(g.levelReached, g.level);
+    } else g.combo = -1;
+    spawn(g);
+    if (g.over) {
+      cancelAnimationFrame(raf);
+      const run = { score: g.score, maxClear: g.maxClear, level: g.levelReached };
+      chrome.result(run); g = null;
+    }
+  }
+  function updateHud() {
+    $('tScore').textContent = fmt(g.score); $('tLevel').textContent = g.level; $('tLines').textContent = g.lines;
+    const next = BALANCE.tetris.grades.find(([, min]) => g.score < min);
+    $('tNextGradeLabel').textContent = next
+      ? `다음 등급(${next[0].toUpperCase()} ${fmt(next[1])})까지 ${fmt(next[1] - g.score)}`
+      : '최고 등급 달성!';
+    $('tGradeFill').style.width = Math.min(100, (g.score / 50000) * 100) + '%';
+    document.querySelectorAll('#tChips span').forEach((c) =>
+      c.classList.toggle('hit', g.score >= Number(c.dataset.min)));
+  }
+  function draw() {
+    ctx.fillStyle = '#12151d'; ctx.fillRect(0, 0, cv.width, cv.height);
+    ctx.strokeStyle = 'rgba(45,48,65,.5)';
+    ctx.strokeRect(OX - .5, OY - .5, W * CELL + 1, H * CELL + 1);
+    for (let y = 0; y < H; y++) for (let x = 0; x < W; x++) {
+      if (g?.board[y][x]) block(x, y, g.board[y][x], 1);
+    }
+    if (g && !g.over) {
+      const gy = hardDropY();
+      cells({ ...g.active, y: gy }).forEach(([x, y]) => { if (y >= 0) block(x, y, COLORS[g.active.p], .18); });
+      cells(g.active).forEach(([x, y]) => { if (y >= 0) block(x, y, COLORS[g.active.p], 1); });
+    }
+    // side: hold + next
+    ctx.fillStyle = 'rgba(139,141,163,.9)'; ctx.font = '700 10px ui-monospace';
+    ctx.fillText('HOLD', OX + W * CELL + 16, 20);
+    if (g?.hold) mini(g.hold, OX + W * CELL + 16, 28);
+    ctx.fillStyle = 'rgba(139,141,163,.9)'; ctx.fillText('NEXT', OX + W * CELL + 16, 92);
+    g?.queue.slice(0, 5).forEach((p, i) => mini(p, OX + W * CELL + 16, 100 + i * 52));
+    function block(x, y, color, alpha) {
+      ctx.globalAlpha = alpha; ctx.fillStyle = color;
+      ctx.beginPath(); ctx.roundRect(OX + x * CELL + 1, OY + y * CELL + 1, CELL - 2, CELL - 2, 4); ctx.fill();
+      ctx.globalAlpha = 1;
+    }
+    function mini(p, px, py) {
+      SHAPES[p][0].forEach(([cx, cy]) => {
+        ctx.fillStyle = COLORS[p];
+        ctx.beginPath(); ctx.roundRect(px + cx * 11, py + cy * 11, 9, 9, 2); ctx.fill();
+      });
+    }
+  }
+  /* DAS/ARR */
+  const held = { left: null, right: null };
+  function repeatMoves(now) {
+    for (const [key, dir] of [['left', -1], ['right', 1]]) {
+      const h = held[key];
+      if (!h) continue;
+      if (!h.dasDone && now - h.since >= 160) { h.dasDone = true; h.lastRepeat = now; tryMove(dir, 0); }
+      else if (h.dasDone && now - h.lastRepeat >= 40) { h.lastRepeat = now; tryMove(dir, 0); }
+    }
+  }
+  function loop(ts) {
+    raf = requestAnimationFrame(loop);
+    if (!g || chrome.phase !== 'running') { draw(); return; }
+    const now = ts ?? performance.now();
+    if (!last) last = now;
+    const dt = now - last; last = now;
+    repeatMoves(now);
+    const interval = g.soft ? 50 : SPEED[g.level - 1];
+    g.gravAcc += dt;
+    while (g && g.gravAcc >= interval) {
+      g.gravAcc -= interval;
+      if (!tryMove(0, 1)) { lock(); if (!g) { draw(); return; } }
+      else if (g.soft) g.score += 1;
+    }
+    updateHud(); draw();
+  }
+  draw();
+  window.addEventListener('keydown', (e) => {
+    if (chrome.phase !== 'running' && chrome.phase !== 'paused') return;
+    if (e.key === 'p' || e.key === 'P' || e.key === 'Escape') {
+      e.preventDefault();
+      if (chrome.phase === 'running') { cancelAnimationFrame(raf); chrome.paused(); }
+      return;
+    }
+    if (chrome.phase !== 'running' || !g) return;
+    if (['ArrowLeft','ArrowRight','ArrowDown',' ','z','x','Z','X','c','C','ArrowUp'].includes(e.key)) e.preventDefault();
+    if (e.repeat) return;
+    const now = performance.now();
+    if (e.key === 'ArrowLeft') { held.left = { since: now, dasDone: false, lastRepeat: 0 }; tryMove(-1, 0); }
+    if (e.key === 'ArrowRight') { held.right = { since: now, dasDone: false, lastRepeat: 0 }; tryMove(1, 0); }
+    if (e.key === 'ArrowDown') g.soft = true;
+    if (e.key === 'z' || e.key === 'Z') rotate(-1);
+    if (e.key === 'x' || e.key === 'X' || e.key === 'ArrowUp') rotate(1);
+    if (e.key === ' ') {
+      const from = g.active.y, to = hardDropY();
+      g.score += (to - from) * 2; g.active = { ...g.active, y: to }; lock();
+    }
+    if ((e.key === 'c' || e.key === 'C') && !g.holdUsed) {
+      const cur = g.active.p;
+      if (g.hold) { g.active = { p: g.hold, r: 0, x: 3, y: 0 }; g.hold = cur; }
+      else { g.hold = cur; spawn(g); }
+      g.holdUsed = true;
+    }
+    updateHud();
+  });
+  window.addEventListener('keyup', (e) => {
+    if (e.key === 'ArrowLeft') held.left = null;
+    if (e.key === 'ArrowRight') held.right = null;
+    if (e.key === 'ArrowDown' && g) g.soft = false;
+  });
+  chrome.ready();
+})();
+
+/* 창 이탈 자동 일시정지 */
+document.addEventListener('visibilitychange', () => {
+  if (document.hidden) { window.__pauseSnake?.(); window.__pauseTetris?.(); }
+});
+</script>
+</body>
+</html>

--- a/docs/superpowers/plans/2026-07-13-baeplayground-arcade-points.md
+++ b/docs/superpowers/plans/2026-07-13-baeplayground-arcade-points.md
@@ -1,0 +1,649 @@
+# 배플레이그라운드 아케이드 · 포인트 제도 구현 계획
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (subagent 사용 가능 시) 또는 superpowers:executing-plans로 task 단위 구현. 단계는 checkbox(`- [ ]`)로 추적한다.
+
+**Goal:** 업무 활동·출석으로 포인트를 적립하고, 스네이크·테트리스를 플레이해 등급 보상을 받으며, 도전과제·게임별 랭킹·신기록 슬랙 알림·앱 우상단 포인트 배지가 동작하는 배플레이그라운드 v1 아케이드를 만든다.
+
+**Architecture:** 기존 모의투자 지갑(`playground_wallet_accounts`)과 멱등 원장(`playground_value_ledger`)을 확장하고, 신설 RPC 2개(`playground_arcade_read`/`playground_arcade_execute`)가 모든 포인트 변경을 원자·멱등 처리한다. 활동 적립은 Electron main의 기존 활동 로그 지점에 fire-and-forget 훅으로 붙이고, 렌더러에는 `arcade:wallet-updated` push로 전파한다. 게임 엔진은 시드 PRNG를 주입받는 순수 TS 모듈로 만들어 node:test로 결정론 검증하고, 렌더러는 모의투자와 동일한 domain → gateway(electron/localStorage) → zustand store → view 레이어링을 복제한다.
+
+**Tech Stack:** Electron 33, React 18, TypeScript 5.5, Tailwind(플레이그라운드는 자체 pg-* CSS), Zustand, framer-motion, sonner, Node `node:test`, Supabase(PostgreSQL, RPC only).
+
+**승인 원본:** `docs/superpowers/specs/2026-07-13-baeplayground-arcade-points-design.md`(설계), `docs/superpowers/mockups/2026-07-13-baeplayground-arcade-mockup.html`(인터랙션 목업 — 화면 구조·상태 전환·결과 연출의 시각 기준).
+
+---
+
+## Global Constraints
+
+- 모든 변경은 이 레포에서만 수행한다. 참고용 Bflow 원본(`/home/user/Bflow`)은 절대 수정하지 않는다.
+- `DEVLOG/migrations/2026-07-11-playground-market-v2.sql`과 `2026-07-12-...hotfix.sql`은 **수정 금지**(참조 전용). 스키마 변경은 전부 신규 마이그레이션 파일에서.
+- 렌더러에서 Supabase 직접 호출 금지. 반드시 preload 브릿지 → IPC → main → `electron/supabase.ts` → RPC.
+- 렌더러는 `p_user_id`를 위조할 수 없다: main의 `sessionManager`/`currentActivityUser`가 신원 정본이며, 아케이드 IPC 핸들러는 모의투자의 `ensureCanonicalMarketAccess()`와 같은 게이트를 거친다.
+- 지갑 변경은 예외 없이 원장(`playground_value_ledger`) insert와 같은 트랜잭션의 RPC 경유. 클라이언트 수치는 표시용 미러일 뿐 서버가 보상의 SSOT다.
+- 멱등성: 모든 execute는 `request_id`를 갖고, 서버는 v2와 동일한 probe 규약(`same` → `response_state` 재생, `conflict` → 오류, `missing` → 실행)을 따른다.
+- 게임 엔진·사과 배치 등 모든 랜덤은 주입식 시드 PRNG만 사용한다. `Math.random()`·`Date.now()` 직접 호출 금지(루프 시간은 rAF timestamp 사용, 시드는 `crypto.getRandomValues` 1회).
+- 게임 루프는 `requestAnimationFrame` + 고정 timestep 누적기. `document.hidden`/blur 시 자동 일시정지하며 멈춘 시간은 시뮬레이션하지 않는다.
+- 포인트·점수는 전부 정수. `Number.MAX_SAFE_INTEGER` 초과 금지(서버 CHECK 준수).
+- 활동 훅은 원래 mutation 성공 확정 후 `void ...catch(log)` — 원래 흐름을 절대 막거나 실패시키지 않는다. 행위자가 canonical 배한솔이 아니면 조용히 no-op.
+- 접근성: 모든 버튼 44px 이상 + `:focus-visible` 링(기존 playground.css 규칙 준수), 캔버스 옆 `aria-live="polite"` 상태 텍스트, `prefers-reduced-motion` 시 리빌/카운트업/플로팅 애니메이션은 즉시 표시로 대체.
+- UI 문구는 전부 한국어, 기존 플레이그라운드 톤(해요체) 유지. 메모/placeholder에 italic 금지.
+- 슬랙 웹훅 URL은 기존 패턴대로 main에 상수 하드코딩한다(서버 프록시 도입 금지 — 기존 결정). URL 빈 문자열이면 발송 스킵.
+- 각 PR 완료 기준: `npm run typecheck` + `npm run test:playground` + `npm run build:vite` 통과. `npm run build`(installer)와 G드라이브 배포는 한솔 명시 요청 시에만.
+- `DEVLOG/update-notes.json`과 PR 본문 "업데이트 요약"은 비개발자 톤 규칙(CLAUDE.md) 준수 — 기술 용어·식별자·파일경로 금지, 상황+영향+결과 시나리오로.
+- 버전: PR A=1.84.0, B=1.85.0, C=1.86.0, D=1.87.0 (머지 시점의 main 최신 버전에 따라 +1 마이너로 재조정 가능. 규칙: 기능 추가=마이너).
+- 커밋 메시지는 한글. task별로 명시된 파일만 정확히 stage한다(미추적 사용자 파일 금지).
+
+## File Structure
+
+**신규 (renderer):**
+- `src/features/playground/arcade/constants.ts` — `ARCADE_BALANCE`(입장료·등급·보상·상한), 도전과제 정의. 밸런스 수치의 단일 소스.
+- `src/features/playground/arcade/types.ts` — `ArcadeSnapshot`, `ArcadeExecuteCommand`, `ArcadeExecuteResult`, `ArcadeFinishResult`, `ArcadeGameId` 등 공용 타입.
+- `src/features/playground/arcade/domain.ts` — 순수 함수: 등급 계산(`gradeForScore`/`rewardForGrade`/`nextGradeInfo`), 도전과제 평가(`evaluateAchievements`).
+- `src/features/playground/arcade/gateway.ts` / `electronGateway.ts` / `localStorageGateway.ts` / `previewGateway.ts` / `seed.ts` — 모의투자 게이트웨이 5종과 같은 구조.
+- `src/features/playground/arcade/useArcadeStore.ts` — zustand 스토어(스냅샷/런 실행/도전과제/설정).
+- `src/features/playground/arcade/walletBridge.ts` — `arcade:wallet-updated` push 구독 → 아케이드/마켓 스토어 동기화.
+- `src/features/playground/arcade/badgeFloatQueue.ts` — 배지 "+N P" 플로팅 표시 큐 (순수 모듈, PR B).
+- `src/features/playground/arcade/games/prng.ts` — mulberry32 시드 PRNG.
+- `src/features/playground/arcade/games/loop.ts` — 고정 timestep rAF 루프 팩토리.
+- `src/features/playground/arcade/games/snake/engine.ts`, `snake/types.ts` — 순수 스네이크 엔진.
+- `src/features/playground/arcade/games/tetris/engine.ts`, `tetris/types.ts`, `tetris/pieces.ts`(4상태 셀 데이터), `tetris/srs.ts`(킥 테이블), `tetris/bag.ts` — 순수 테트리스 엔진.
+- `src/views/playground/arcade/GameHost.tsx` — `route.kind === 'game'` 진입점, 게임별 스테이지/ComingSoon 분기.
+- `src/views/playground/arcade/ArcadeStageChrome.tsx` — ready/countdown/running/paused/result 상태 셸(좌 HUD·우 스테이지, `pg-game-screen` 그리드 재사용).
+- `src/views/playground/arcade/SnakeStage.tsx` / `TetrisStage.tsx` — 캔버스 렌더 + 입력 바인딩.
+- `src/views/playground/arcade/RunResultOverlay.tsx` — 등급 리빌·보상 카운트업·신기록·도전과제 해금.
+- `src/views/playground/arcade/ArcadeRankingPanel.tsx` — 게임별 전체/주간 랭킹 탭.
+- `src/views/playground/arcade/arcade.css` — playground.css 토큰(`--pg-*`)만 사용.
+- `src/components/layout/HeaderPointsBadge.tsx` — 앱 헤더 우상단 포인트 배지.
+
+**신규 (electron/main):**
+- `electron/arcadeService.ts` — 사용자별 FIFO 큐, read/execute, awardActivity, grantDailyLogin, 신기록 슬랙 발송, `arcade:wallet-updated` broadcast.
+
+**신규 (DB/테스트):**
+- `DEVLOG/migrations/2026-07-13-playground-arcade-v1.sql`
+- `tests/playgroundArcadeDatabaseContract.test.ts`, `playgroundArcadeDomain.test.ts`, `playgroundArcadeGateway.test.ts`, `playgroundArcadeStore.test.ts`, `playgroundArcadeMainWiring.test.ts`, `playgroundSnakeEngine.test.ts`, `playgroundTetrisEngine.test.ts`, `playgroundArcadeUiWiring.test.ts`, `playgroundHeaderPointsBadge.test.ts`
+
+**수정:** 설계 문서 §12 표의 파일 전부 (routes/PlaygroundView/ranking/catalog/GameCard/Hero/JbbjHouse/useMarketPreviewStore/Header/main/preload/supabase/devElectronAPI/package.json/기존 playground 테스트).
+
+## PR 분할
+
+| PR | 버전 | 내용 | Tasks |
+|---|---|---|---|
+| **A. 아케이드 기반** | 1.84.0 | 마이그레이션+RPC, main 서비스+IPC, 게이트웨이+스토어, 헤더 배지, 출석 적립, 포인트 랭킹 실데이터 | 1–6 |
+| **B. 업무 활동 적립** | 1.85.0 | 씬/댓글/리테이크 훅 3종 + 배지 획득 연출 | 7 |
+| **C. 스네이크** | 1.86.0 | 스네이크 엔진, 공용 스테이지 셸, 결과/보상, 도전과제(공통4+스네이크3), 라우트 개명, 로비 기록 연동 | 8–10 |
+| **D. 테트리스 + 랭킹/슬랙** | 1.87.0 | 테트리스 엔진/스테이지, 테트리스 도전과제 3종, 게임별 랭킹 패널, 신기록 슬랙 알림 + 설정 토글 | 11–13 |
+
+각 PR 마지막 task에 버전·update-notes·ROADMAP/CONTEXT/AGENTS 갱신과 전체 검증이 포함된다. PR 생성 시 저장소의 `pr-creator` 스킬 형식(업데이트 요약/상세 기술 설명/테스트 가이드)을 따른다.
+
+---
+
+## Chunk 1: PR A — 아케이드 기반 (Tasks 1–6)
+
+### Task 1: DB 마이그레이션 + 계약 테스트
+
+**Files:**
+- Create: `DEVLOG/migrations/2026-07-13-playground-arcade-v1.sql`
+- Create: `tests/playgroundArcadeDatabaseContract.test.ts`
+- Modify: `package.json` (`test:playground`에 신규 테스트 추가 — 이후 task들도 생성 즉시 같은 방식으로 추가, 개별 언급 생략)
+
+**마이그레이션 필수 내용 (순서대로):**
+
+1. `BEGIN;` … `COMMIT;` 래핑, 파일 머리에 v2와 같은 형식으로 원칙·위협모델 주석(v2의 "ACCEPTED TEST-ONLY THREAT MODEL" 문단을 아케이드 문맥으로 요약 인용).
+2. 원장 kind 확장:
+
+```sql
+ALTER TABLE public.playground_value_ledger
+  DROP CONSTRAINT IF EXISTS playground_ledger_kind_valid;
+ALTER TABLE public.playground_value_ledger
+  ADD CONSTRAINT playground_ledger_kind_valid CHECK (
+    kind IN (
+      'initial-grant', 'favorite', 'read-reason', 'transfer', 'buy', 'sell',
+      'game-entry', 'game-reward', 'scene-progress', 'comment', 'retake-done',
+      'daily-login', 'achievement', 'arcade-grant'
+    )
+  );
+```
+
+3. 신규 테이블 3개 (v2와 동일한 스타일: `IF NOT EXISTS`, 정수 안전 CHECK, `user_id text REFERENCES public.users(id) ON DELETE CASCADE`):
+
+```sql
+CREATE TABLE IF NOT EXISTS public.playground_game_runs (
+  id uuid PRIMARY KEY,                     -- 클라이언트 발급 runId
+  user_id text NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  game_id text NOT NULL,
+  score bigint NOT NULL,
+  grade text NOT NULL,
+  duration_ms bigint NOT NULL,
+  meta jsonb NOT NULL DEFAULT '{}'::jsonb, -- lines/level/goldenEaten/maxLineClear 등
+  reward_points bigint NOT NULL DEFAULT 0,
+  was_alltime_best boolean NOT NULL DEFAULT false,
+  entry_request_id text NOT NULL UNIQUE,   -- 'game-entry:<runId>' 원장 행과 1:1
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT playground_run_game_valid CHECK (game_id IN ('snake', 'tetris', 'sudoku')),
+  CONSTRAINT playground_run_grade_valid CHECK (grade IN ('none', 'bronze', 'silver', 'gold', 'platinum')),
+  CONSTRAINT playground_run_score_range CHECK (score >= 0 AND score <= 9007199254740991),
+  CONSTRAINT playground_run_duration_range CHECK (duration_ms >= 1000 AND duration_ms <= 14400000),
+  CONSTRAINT playground_run_reward_range CHECK (reward_points >= 0 AND reward_points <= 9007199254740991)
+);
+CREATE INDEX IF NOT EXISTS playground_game_runs_leaderboard_idx
+  ON public.playground_game_runs(game_id, score DESC, created_at ASC);
+CREATE INDEX IF NOT EXISTS playground_game_runs_user_idx
+  ON public.playground_game_runs(user_id, game_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.playground_achievement_unlocks (
+  user_id text NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  achievement_id text NOT NULL,
+  reward_points bigint NOT NULL DEFAULT 0,
+  unlocked_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, achievement_id),
+  CONSTRAINT playground_achievement_id_valid CHECK (
+    char_length(achievement_id) BETWEEN 1 AND 80 AND achievement_id = btrim(achievement_id)
+  )
+);
+
+CREATE TABLE IF NOT EXISTS public.playground_arcade_config (
+  id smallint PRIMARY KEY DEFAULT 1,
+  slack_notify_enabled boolean NOT NULL DEFAULT false,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT playground_arcade_config_singleton CHECK (id = 1)
+);
+INSERT INTO public.playground_arcade_config (id) VALUES (1) ON CONFLICT (id) DO NOTHING;
+```
+
+4. RLS + 잠금 (v2 :147–162와 동일 패턴): 3개 테이블 `ENABLE ROW LEVEL SECURITY` + `REVOKE ALL PRIVILEGES ... FROM anon, authenticated` + `FROM PUBLIC`.
+5. RPC 2개. **v2의 `playground_market_read`/`playground_market_execute` 본문을 템플릿으로 복제**하되 아래 계약을 정확히 구현한다. 공통 하드닝(둘 다): `SECURITY DEFINER`, `SET search_path = ''`, canonical 배한솔 확인(v2 :172–180과 동일한 name+slack_id 단일 행 조회 후 `p_user_id::text` 일치 검증), execute는 `pg_advisory_xact_lock(hashtextextended(p_user_id::text, 0))` + 지갑 행 `SELECT ... FOR UPDATE`, 원장 probe(`same`이면 저장된 `response_state`에 **`replayed: true`를 덧붙여** 반환 — replayed는 저장하지 않고 재생 시점에만 추가, `conflict`면 예외 "같은 요청이 다른 내용으로 이미 처리되었어요", `missing`이면 실행), 성공 시 `response_state`를 채워 원장 insert. 마지막에 `REVOKE ALL ON FUNCTION ... FROM PUBLIC/anon/authenticated` 후 `GRANT EXECUTE ... TO anon` (v2 :975–990 패턴).
+
+**`playground_arcade_read(p_user_id uuid) RETURNS jsonb` 응답 계약 (camelCase 키):**
+
+```jsonc
+{
+  "wallet": { "walletPoints": 999985, "lifetimeEarnedPoints": 1000020 },
+  "attendance": { "streakDays": 3, "todayGranted": true },       // KST 기준, 원장 daily-login 행으로 계산
+  "todayActivityCounts": { "sceneProgress": 4, "comment": 2, "retakeDone": 0 },
+  "games": {
+    "snake":  { "myBestScore": 34, "myWeeklyBestScore": 34, "todayRewardedRuns": 2, "totalRuns": 11,
+                "leaderboardAll":    [{ "userId": "…", "name": "배한솔", "score": 34, "at": "2026-07-13T…" }],
+                "leaderboardWeekly": [ /* 같은 shape, top5 */ ] },
+    "tetris": { /* 동일 shape */ }
+  },
+  "achievements": [{ "achievementId": "arcade-first-run", "unlockedAt": "…" }],
+  "aggregates": { "totalRuns": 23, "arcadeEarnedPoints": 380 },  // arcadeEarnedPoints = 적립형 kind 합계(scene-progress·comment·retake-done·daily-login·game-reward·achievement)
+  "walletLeaderboard": [{ "userId": "…", "name": "배한솔", "lifetimeEarnedPoints": 1000020 }],
+  "config": { "slackNotifyEnabled": false }
+}
+```
+
+- KST 계산은 전부 `(now() AT TIME ZONE 'Asia/Seoul')::date`, 주간은 `date_trunc('week', now() AT TIME ZONE 'Asia/Seoul')` (월요일 시작)과 `created_at AT TIME ZONE 'Asia/Seoul'` 비교.
+- `streakDays`: 오늘(또는 어제)부터 역방향으로 연속된 `daily-login` 날짜 수. 오늘 미출석이면 어제까지의 연속을 반환.
+- 리더보드는 사용자별 최고 1행만(`DISTINCT ON (user_id)` 후 score DESC, 동점은 created_at ASC 우선) top5.
+
+**`playground_arcade_execute(p_user_id uuid, p_request_id text, p_kind text, p_payload jsonb) RETURNS jsonb` kind별 계약:**
+
+| kind | request_id 형식(서버가 형식 검증) | payload | 동작 | 응답 |
+|---|---|---|---|---|
+| `daily-login` | `daily-login:<KST today>` — 서버가 오늘 날짜로 재계산해 불일치 시 예외 | `{}` | +20P (wallet+lifetime), 원장 kind `daily-login` | `{granted, wallet, attendance}` |
+| `activity` | `scene-stage:<uuid>:<stage>` / `scene-phase-done:<uuid>` / `comment:<id>` / `retake-done:<id>` | `{ "activity": "scene-stage"\|"scene-phase-done"\|"comment"\|"retake-done" }` | 표(§spec 5-1) 포인트. 댓글은 `supabase:add-comment`를 지나는 모든 댓글(일반+리테이크+캐릭터 보드) 포함. **일일 상한 검사**: 같은 원장 kind의 오늘(KST) 행 수 ≥ 상한이면 지급 0으로 성공 응답(`capped: true`), 원장은 기록하지 않고 response도 저장하지 않음(멱등 키 소비 방지) — 단 이 경우 재시도에도 무해하므로 허용 | `{awarded, points, capped, wallet}` |
+| `game-start` | `game-entry:<runId>` | `{ "runId", "gameId" }` | 입장료 차감(부족 시 예외 "포인트가 부족해 게임을 시작할 수 없어요"), 원장 kind `game-entry`(wallet_delta 음수) | `{wallet}` |
+| `game-finish` | `game-finish:<runId>` | `{ "runId", "gameId", "score", "durationMs", "meta" }` | (1) `game-entry:<runId>` 원장 행 존재+본인 소유 확인 (2) runs PK 중복 없음 (3) score 상한(snake 441 / tetris 3,000,000)·duration 1s~4h 검증 — durationMs는 running 상태 고정 timestep 누적 합(카운트다운·일시정지 제외) (4) 등급=서버 CASE, 경계 **이상(>=)** 판정(§Task 2 표와 동일 수치·동일 비교연산) (5) 오늘 보상 판 수(`reward_points > 0`인 오늘 runs) < 5 이고 grade≠none이면 보상 지급, 아니면 0 (6) `was_alltime_best` = score가 이전 내 최고 **초과(>)**, 이전 기록 없으면 true — 계산 후 runs insert. `newWeeklyBest`도 같은 규칙을 주간 범위에 적용 (7) 원장 kind `game-reward`(보상 0이어도 insert — 멱등 키 유지) | `{grade, rewardPoints, rewardCapped, newAlltimeBest, newWeeklyBest, prevBestScore, myBestScore, todayRewardedRuns, wallet, slackNotifyEnabled}` — `slackNotifyEnabled`는 config 현재값, `prevBestScore`는 이전 최고(없으면 null, 슬랙 detail용) |
+| `achievement-unlock` | `ach:<achievementId>` | `{ "achievementId" }` | 서버 내 고정 맵(id→보너스, §Task 2 표와 동일 10종)에 없는 id는 예외. unlocks insert(이미 있으면 probe가 same 처리) + 보너스 원장 kind `achievement` | `{achievementId, rewardPoints, wallet}` |
+| `config-set` | `config:<uuid>` | `{ "slackNotifyEnabled": bool }` | config 행 UPDATE. **원장 미기록**(자연 멱등) | `{config}` |
+
+6. 시드: 없음 (지갑은 v2가 이미 시드). 마이그레이션은 재실행 안전해야 함(`IF NOT EXISTS`/`ON CONFLICT DO NOTHING`, CHECK 재생성은 DROP 후 ADD라 재실행 시 실패하지 않도록 `DROP CONSTRAINT IF EXISTS` 사용).
+
+**Steps:**
+
+- [ ] **Step 1: 계약 테스트 작성** — `tests/playgroundMarketDatabaseContract.test.ts`의 방식(마이그레이션 SQL 텍스트를 읽어 regex로 계약 단언)을 복제. 단언 목록: 3개 테이블 DDL 존재와 핵심 CHECK(duration 하한 1000 포함), kind CHECK가 신규 8종 포함, RPC 2개 시그니처(`uuid` / `uuid, text, text, jsonb`), `SECURITY DEFINER`·`search_path`·advisory lock·`FOR UPDATE`·`GRANT EXECUTE ... TO anon` 존재, KST 표현식(`Asia/Seoul`) 존재, `replayed` 재생 필드 존재, 밸런스 수치(입장료 10/15, 등급 경계 15/25/40/55와 3000/10000/25000/50000이 **`>= 15` 같은 이상-비교 패턴으로** 존재, 보상 8/18/30/45와 12/30/55/80, 상한 5, 활동 포인트 20/5/10/5/30, 도전과제 보너스 맵)가 SQL 본문에 존재.
+- [ ] **Step 2: RED 확인** — Run: `node --test ./tests/playgroundArcadeDatabaseContract.test.ts` → 파일 없음/단언 실패로 FAIL.
+- [ ] **Step 3: 마이그레이션 SQL 작성** — 위 1~6 전부. v2 파일을 열어 probe/lock/canonical 확인 블록을 그대로 이식하며 함수명·키만 교체.
+- [ ] **Step 4: GREEN 확인** — 같은 명령 PASS.
+- [ ] **Step 5: 커밋** — `git add DEVLOG/migrations/2026-07-13-playground-arcade-v1.sql tests/playgroundArcadeDatabaseContract.test.ts package.json` / 메시지: `아케이드 포인트 DB 스키마와 RPC 계약 추가`
+- [ ] **Step 6 (한솔 계정 라이브 적용은 별도)**: 마이그레이션은 PR 본문 "배포 후 할 일"에 기재만 하고 이 계획에서는 라이브 DB에 적용하지 않는다 (기존 관행: `DEVLOG/migrations/`에 기록 후 한솔/운영 세션에서 적용).
+
+### Task 2: 밸런스 상수 + 순수 도메인
+
+**Files:**
+- Create: `src/features/playground/arcade/constants.ts`, `src/features/playground/arcade/types.ts`, `src/features/playground/arcade/domain.ts`
+- Create: `tests/playgroundArcadeDomain.test.ts`
+
+**constants.ts 전문(수치는 이 코드가 정본, SQL과 계약 테스트로 동기화):**
+
+```ts
+export type ArcadeGameId = 'snake' | 'tetris';
+export type ArcadeGrade = 'none' | 'bronze' | 'silver' | 'gold' | 'platinum';
+
+export const ARCADE_BALANCE = {
+  dailyLoginPoints: 20,
+  activity: {
+    'scene-stage': { points: 5, dailyCap: 30, capKind: 'scene-progress' },
+    'scene-phase-done': { points: 10, dailyCap: 30, capKind: 'scene-progress' },
+    comment: { points: 5, dailyCap: 5, capKind: 'comment' },
+    'retake-done': { points: 30, dailyCap: 5, capKind: 'retake-done' },
+  },
+  games: {
+    snake: {
+      entryFee: 10,
+      scoreLabel: '길이',
+      maxScore: 441,
+      grades: [
+        { grade: 'bronze', min: 15, reward: 8 },
+        { grade: 'silver', min: 25, reward: 18 },
+        { grade: 'gold', min: 40, reward: 30 },
+        { grade: 'platinum', min: 55, reward: 45 },
+      ],
+    },
+    tetris: {
+      entryFee: 15,
+      scoreLabel: '점수',
+      maxScore: 3_000_000,
+      grades: [
+        { grade: 'bronze', min: 3_000, reward: 12 },
+        { grade: 'silver', min: 10_000, reward: 30 },
+        { grade: 'gold', min: 25_000, reward: 55 },
+        { grade: 'platinum', min: 50_000, reward: 80 },
+      ],
+    },
+  },
+  dailyRewardedRunsCap: 5,
+} as const;
+
+export interface ArcadeAchievementDefinition {
+  id: string;
+  name: string;
+  description: string;
+  bonusPoints: number;
+  game: ArcadeGameId | 'common';
+}
+
+export const ARCADE_ACHIEVEMENTS: readonly ArcadeAchievementDefinition[] = [
+  { id: 'arcade-first-run', name: '첫 판', description: '아케이드 게임을 처음 완주했어요', bonusPoints: 10, game: 'common' },
+  { id: 'arcade-runs-50', name: '단골 손님', description: '누적 50판을 플레이했어요', bonusPoints: 30, game: 'common' },
+  { id: 'arcade-earned-5k', name: '티끌 모아', description: '적립 포인트 누적 5,000P를 모았어요', bonusPoints: 50, game: 'common' },
+  { id: 'attend-7', name: '개근상', description: '7일 연속 출석했어요', bonusPoints: 50, game: 'common' },
+  { id: 'snake-30', name: '몸집 불리기', description: '스네이크 길이 30을 달성했어요', bonusPoints: 15, game: 'snake' },
+  { id: 'snake-55', name: '전설의 뱀', description: '스네이크 길이 55를 달성했어요', bonusPoints: 40, game: 'snake' },
+  { id: 'snake-golden-5', name: '황금 미식가', description: '한 판에 골든 사과 5개를 먹었어요', bonusPoints: 20, game: 'snake' },
+  { id: 'tetris-tetris', name: '테트리스!', description: '한 번에 4줄을 지웠어요', bonusPoints: 20, game: 'tetris' },
+  { id: 'tetris-level-10', name: '고속 낙하', description: '레벨 10에 도달했어요', bonusPoints: 30, game: 'tetris' },
+  { id: 'tetris-30k', name: '3만 클럽', description: '한 판에 30,000점을 넘겼어요', bonusPoints: 40, game: 'tetris' },
+] as const;
+```
+
+**types.ts 필수 정의**: `ArcadeGameId`/`ArcadeGrade`(constants에서 re-export), `ArcadeSnapshot`(read 응답 미러), `ArcadeExecuteCommand`(kind별 union), `ArcadeExecuteResult`(kind별 서버 응답 union — 공통 옵션 필드 `replayed?: true`), `ArcadeFinishResult`(finishRun 반환 뷰모델 = game-finish 응답 + `unlockedAchievements: ArcadeAchievementDefinition[]`).
+
+**domain.ts 시그니처:**
+
+```ts
+gradeForScore(gameId: ArcadeGameId, score: number): ArcadeGrade          // 경계 이상(>=) 판정 — SQL과 동일
+rewardForGrade(gameId: ArcadeGameId, grade: ArcadeGrade): number
+nextGradeInfo(gameId: ArcadeGameId, score: number): { grade: ArcadeGrade; remaining: number } | null // HUD "다음 등급까지 n"
+evaluateAchievements(input: {
+  gameId: ArcadeGameId | null;   // null = 게임 외 평가(스냅샷 load 후) — 공통 과제만 검사
+  runMeta: { score: number; goldenEaten?: number; maxLineClear?: number; levelReached?: number } | null;
+  runRewardPoints: number;       // 이번 런 지급 보상 (게임 외 평가면 0)
+  aggregates: { totalRuns: number; arcadeEarnedPoints: number };  // 서버 스냅샷 = 이번 런 미포함 값
+  attendanceStreakDays: number;
+  unlockedIds: ReadonlySet<string>;
+}): string[]                     // 새로 해금할 id 목록(정의 순서)
+// 누적형 판정 규칙(내부에서 이번 런 반영): runsAfter = totalRuns + (runMeta ? 1 : 0),
+// earnedAfter = arcadeEarnedPoints + runRewardPoints.
+// arcade-first-run: runsAfter >= 1 (로드-시 평가에서도 완주 이력이 있으면 해금 — finish 직후 unlock 실패의 회복 경로) / arcade-runs-50: runsAfter >= 50 /
+// arcade-earned-5k: earnedAfter >= 5000 / attend-7: attendanceStreakDays >= 7.
+```
+
+**Steps:**
+
+- [ ] **Step 1: 실패 테스트 작성** — 경계값 전수: `gradeForScore('snake', 14) === 'none'`, `15→bronze`, `54→gold`, `55→platinum`; tetris 동일; `nextGradeInfo('snake', 20) => { grade: 'silver', remaining: 5 }`, platinum 이후 `null`; evaluateAchievements: 첫 판(totalRuns 0 + runMeta 존재 → 'arcade-first-run' 포함), 누적 경계(totalRuns 49 + runMeta 존재 → 'arcade-runs-50' 해금, 48이면 미해금), earned 경계(arcadeEarnedPoints 4980 + runRewardPoints 20 → 'arcade-earned-5k' 해금), 게임 외 평가(gameId null → 게임 과제 제외·공통 과제만), 이미 해금된 id 제외, `goldenEaten: 5 → 'snake-golden-5'`, `maxLineClear: 4 → 'tetris-tetris'`, `attendanceStreakDays: 7 → 'attend-7'`, 복수 동시 해금 시 정의 순서 유지.
+- [ ] **Step 2: RED** — `node --test ./tests/playgroundArcadeDomain.test.ts`
+- [ ] **Step 3: 구현** — constants 전문 그대로 + domain 순수 함수.
+- [ ] **Step 4: GREEN + 커밋** — 메시지: `아케이드 밸런스 상수와 등급·도전과제 도메인 추가`
+
+### Task 3: 타입 + 게이트웨이 (electron/localStorage/preview)
+
+**Files:**
+- Create: `arcade/gateway.ts`, `electronGateway.ts`, `localStorageGateway.ts`, `previewGateway.ts`, `seed.ts` (모두 `src/features/playground/arcade/`)
+- Modify: `src/mocks/devElectronAPI.ts`
+- Create: `tests/playgroundArcadeGateway.test.ts` (주의: `tests/devPreviewElectronApi.test.ts`는 어떤 npm 스크립트/tsconfig에도 포함되지 않으므로 수정하지 않는다 — devElectronAPI 목 3종 존재 단언은 `playgroundArcadeGateway.test.ts`에 넣는다)
+
+모의투자 게이트웨이 5종(`src/features/playground/market/gateway.ts` 등)을 구조 그대로 복제한다. 인터페이스:
+
+```ts
+export interface ArcadePreviewGateway {
+  read(): Promise<ArcadeSnapshot>;
+  execute(command: ArcadeExecuteCommand): Promise<ArcadeExecuteResult>;
+}
+```
+
+- `electronGateway`: `window.electronAPI.arcadeRead()` / `arcadeExecute(command)` 위임.
+- `localStorageGateway`: 키 `bflow-arcade-preview-v1`. `seed.ts` 시드 — 지갑 12,500P/lifetime 48,200P, 팀원 리더보드(민지 4,920 / 도윤 3,860 / 서아 2,820 / 유진 2,115 — `ranking.ts`에서 제거되는 fixture를 여기로 이사), 스네이크/테트리스 가짜 상위 기록 각 3행, 해금 도전과제 `['arcade-first-run']`, streak 3. execute는 도메인 함수로 실제 규칙(입장료/등급/상한/멱등 request_id 중복 무시)을 로컬에서 재현 — 프리뷰 모드에서도 실제와 같은 흐름 검증 가능해야 한다.
+- `gateway.ts`: 모의투자와 같은 기준으로 electron/preview 선택.
+- `devElectronAPI.ts`: `arcadeRead`/`arcadeExecute`/`onArcadeWalletUpdated`(no-op unsubscribe 반환) 목 추가 — localStorage 게이트웨이로 위임.
+
+**Steps:**
+
+- [ ] **Step 1: 실패 테스트** — localStorage 게이트웨이: 시드 로드, `game-start` 잔액 차감, 같은 request_id 재실행 시 상태 불변 + 응답 `replayed: true`(멱등), 잔액 부족 예외 메시지, `game-finish` 등급·보상·`newAlltimeBest` 계산, 일일 보상 5회 초과 시 `rewardCapped: true`·보상 0. devElectronAPI 목에 arcade 3종 API 존재.
+- [ ] **Step 2: RED → Step 3: 구현 → Step 4: GREEN**
+- [ ] **Step 5: 커밋** — `아케이드 게이트웨이와 프리뷰 시드 추가`
+
+### Task 4: Electron main — supabase 함수, arcadeService, IPC, preload, 출석 훅
+
+**Files:**
+- Create: `electron/arcadeService.ts`
+- Modify: `electron/supabase.ts` (RPC 호출 함수 2개), `electron/main.ts` (서비스 초기화 + `ipcMain.handle('arcade:read'|'arcade:execute')` + `setCanonicalActivityUser`에 출석 훅), `electron/preload.ts` (`arcadeRead`/`arcadeExecute`/`onArcadeWalletUpdated`)
+- Create: `tests/playgroundArcadeMainWiring.test.ts`
+
+**계약:**
+
+- `electron/supabase.ts`: `sbReadPlaygroundArcadeState(userId)` → `supabase.rpc('playground_arcade_read', { p_user_id })`, `sbExecutePlaygroundArcade(userId, requestId, kind, payload)` → `supabase.rpc('playground_arcade_execute', …)`. 기존 `readPlaygroundMarketState`(≈:2856)와 같은 오류 래핑 스타일.
+- `arcadeService.ts` (모의투자 `marketAccountService.ts`의 축소 복제):
+  - 의존성 주입 생성자: `{ read, execute, resolveActor, broadcastWalletUpdate, sendSlackRecord, log }` — node:test에서 전부 목 주입 가능해야 한다.
+  - 사용자별 FIFO 큐(`createMarketMutationQueue` 패턴 복제)로 execute 직렬화.
+  - `read(userId)`, `execute(userId, command)` — 네트워크 오류 1회 재시도(같은 request_id, 서버 멱등에 의존).
+  - `awardActivity(input: { activity, refId, stage? })`: actor = `resolveActor()`(= main의 `currentActivityUser`). actor 없음/비-canonical이면 no-op. request_id를 §spec 5-1 표 규칙으로 조립해 `activity` execute 호출. **`!result.replayed` && `awarded && points > 0`일 때만** `broadcastWalletUpdate({ wallet, delta: points, reason: activity })` — 재생 응답(재체크·재시도)은 push하지 않는다(가짜 "+N P"·스테일 지갑 방지).
+  - `grantDailyLogin()`: KST 오늘 문자열로 request_id 조립 후 execute. 앱 세션당 사용자+날짜별 1회만 시도하되 **메모리 Set 등록은 성공 시에만**(자정 경계 등으로 예외가 나면 다음 트리거에서 재시도 가능). 서버 멱등이 최종 방어. 신규 지급(`!replayed`)일 때만 broadcast.
+  - game-finish execute 응답이 `newAlltimeBest && slackNotifyEnabled && !replayed`이면 `sendSlackRecord({ title, detail, player })` fire-and-forget — 둘 다 **응답 필드**라 config 캐시 불필요. detail은 `prevBestScore`로 조립(없으면 "첫 기록"). (Task 13에서 URL 연결, 여기서는 의존성 호출만.)
+- `main.ts`: `ensureCanonicalMarketAccess()`와 동일한 게이트를 재사용(또는 동일 로직의 `ensureCanonicalArcadeAccess()` — 기존 함수가 market 전용 네이밍이면 새 이름으로 복제)해 두 핸들러 보호. `arcade:wallet-updated`는 `BrowserWindow.getAllWindows().forEach(w => w.webContents.send(...))`.
+- `preload.ts`: 기존 market 브릿지(≈:299–307) 바로 아래에 동일 스타일로 3개 추가. `onArcadeWalletUpdated(cb)`는 구독 해제 함수를 반환.
+- KST 날짜 유틸: `new Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Seoul' }).format(new Date())` → `YYYY-MM-DD`.
+
+**Steps:**
+
+- [ ] **Step 1: 실패 테스트** — arcadeService를 목 의존성으로 생성해: 비-canonical actor의 awardActivity가 execute를 호출하지 않음 / request_id 조립 규칙 4종 정확 일치 / grantDailyLogin 같은 날 2회 호출 시 execute 1회·실패 후엔 재시도 허용(Set은 성공 시에만 등록) / execute 네트워크 오류 1회 재시도 후 성공 / awarded 응답 시 broadcastWalletUpdate 호출 payload 검증 / capped 응답 시 broadcast 미호출 / **`replayed: true` 응답 시 broadcast·슬랙 모두 미호출**.
+- [ ] **Step 2: RED → Step 3: 구현 → Step 4: GREEN**
+- [ ] **Step 5: typecheck** — `npm run typecheck` (electron tsconfig 포함 확인)
+- [ ] **Step 6: 커밋** — `아케이드 메인 서비스와 IPC 배선 추가`
+
+### Task 5: useArcadeStore + 지갑 브릿지 + 마켓 스토어 패치 액션
+
+**Files:**
+- Create: `src/features/playground/arcade/useArcadeStore.ts`, `src/features/playground/arcade/walletBridge.ts`
+- Modify: `src/features/playground/market/useMarketPreviewStore.ts` (`applyServerWallet` 액션)
+- Create: `tests/playgroundArcadeStore.test.ts`
+
+**스토어 계약 (모의투자 스토어 패턴 준수 — confirmed/visible 이중 스냅샷은 불필요, 아케이드는 단일 `snapshot` + mutation 중 `mutating` 플래그):**
+
+```ts
+interface ArcadeState {
+  snapshot: ArcadeSnapshot | null;
+  loading: boolean;
+  mutating: boolean;
+  error: string | null;
+  sessionKey: string | null;
+  load(sessionKey?: string): Promise<void>;
+  startRun(gameId: ArcadeGameId): Promise<{ runId: string } | null>;   // 실패 시 error 세팅 + null
+  finishRun(input: { runId: string; gameId: ArcadeGameId; score: number; durationMs: number; meta: Record<string, number> }):
+    Promise<ArcadeFinishResult | null>;                                 // 응답으로 snapshot 갱신 + 도전과제 평가·unlock 실행
+                                                                        // 평가 입력: aggregates는 갱신 "전" 스냅샷 값(이번 런 미포함), runRewardPoints = 응답 rewardPoints
+  setSlackNotify(enabled: boolean): Promise<boolean>;
+  applyWalletPush(update: { wallet: ArcadeWallet; delta: number; reason: string }): void;
+  clearError(): void;
+}
+```
+
+- `finishRun` 성공 후: (1) 갱신 **전** aggregates를 캡처해 `evaluateAchievements` 입력으로 사용 (2) snapshot의 wallet/기록/leaderboard/todayRewardedRuns/aggregates(totalRuns+1, arcadeEarnedPoints+rewardPoints) 갱신 (3) 신규 해금마다 `achievement-unlock` execute(실패는 무시하고 다음 로드에서 재평가) 후 해금 보너스를 wallet과 `aggregates.arcadeEarnedPoints`에 모두 반영 (4) 결과에 `unlockedAchievements: ArcadeAchievementDefinition[]` 포함해 반환 — RunResultOverlay가 그대로 표시.
+- `load()` 성공 후: `evaluateAchievements({ gameId: null, runMeta: null, runRewardPoints: 0, … })`로 공통 과제(attend-7, arcade-earned-5k 등)를 평가해 미해금분 unlock — 게임을 하지 않아도 출석·적립 과제가 해금되게.
+- 모든 execute 성공 응답의 wallet과 `applyWalletPush`는 `useMarketPreviewStore.getState().applyServerWallet(wallet)`도 함께 호출한다(플레이그라운드 헤더 잔액 동기화).
+- `applyServerWallet(wallet)`: confirmed/visible 각각 존재할 때 `account.walletPoints`/`lifetimeEarnedPoints`만 교체한 새 스냅샷으로 set.
+- `walletBridge.ts`: `initArcadeWalletBridge()` — `window.electronAPI.onArcadeWalletUpdated` 구독을 앱에서 1회 등록(중복 등록 가드), 콜백에서 두 스토어 갱신. 반환값으로 해제 함수.
+
+**Steps:**
+
+- [ ] **Step 1: 실패 테스트** — 목 게이트웨이 주입 스토어 팩토리(모의투자 `createMarketPreviewStore` 패턴): load 스냅샷 반영 / startRun 잔액 부족 오류 메시지 세팅·null 반환 / finishRun이 unlock execute를 신규 해금 수만큼 호출 / applyWalletPush가 market 스토어 `applyServerWallet`과 함께 동작(스파이) / 동일 세션키 재로드 시 중복 로딩 방지.
+- [ ] **Step 2: RED → Step 3: 구현 → Step 4: GREEN**
+- [ ] **Step 5: 커밋** — `아케이드 스토어와 지갑 동기화 브릿지 추가`
+
+### Task 6: 헤더 포인트 배지 + 포인트 랭킹 실데이터 + PR A 마무리
+
+**Files:**
+- Create: `src/components/layout/HeaderPointsBadge.tsx` / Create: `tests/playgroundHeaderPointsBadge.test.ts`
+- Modify: `src/components/layout/Header.tsx` (우상단 클러스터 ≈:51 — `NotificationBell`과 구분선 사이에 배지 삽입)
+- Modify: `src/features/playground/ranking.ts`, `src/views/PlaygroundView.tsx`
+- Modify: `package.json`(1.84.0), `DEVLOG/update-notes.json`, `ROADMAP.md`, `CONTEXT.md`, `AGENTS.md`
+
+**배지 스펙 (목업 §헤더 배지 참조):**
+
+- 노출 조건: `canAccessPlayground(currentUser)`(기존 `featureFlag.ts`). 미충족 시 렌더 안 함.
+- 마운트 시 arcade store `load(currentUser.id)`(이미 로드됐으면 no-op) + `initArcadeWalletBridge()` 1회.
+- 표시: `1,234,567 P` (ko-KR 천단위, `font-variant-numeric: tabular-nums`), 로딩/오류 시 `— P`. 클릭 → `useAppStore.getState().setView('playground')`. `aria-label="보유 포인트 …, 배플레이그라운드 열기"`.
+- 획득 연출(+N 플로팅·펄스)은 PR B(Task 7)에서 — 이 task는 정적 배지까지.
+- 스타일: Tailwind 다크 토큰(카드 #1A1D27, 보더 #2D3041, 액센트 #6C5CE7 계열) — 헤더의 기존 버튼들과 동일한 높이/radius.
+
+**랭킹 실데이터:**
+
+- `ranking.ts`: `TEAMMATES` 상수 삭제. `buildPointRanking(user, teammates: readonly { id, name, lifetimeEarnedPoints: number | null }[])`로 변경 — 정렬·동점·상태문구 로직 유지. **null 처리 규칙**: `lifetimeEarnedPoints === null`인 팀원은 항상 최하단에 이름순(ko-KR collator)으로 배치하고 rank/points는 null(표시 '—') — 기존 comparator에 null이 섞이면 NaN 정렬이 되므로 non-null 그룹 정렬 후 null 그룹을 이어 붙인다.
+- `PlaygroundView.tsx`: 아케이드 스냅샷 load(마운트 시) 후 `walletLeaderboard` + `useAuthStore.users`(지갑 없는 팀원 → `lifetimeEarnedPoints: null`)를 합성해 전달. 스냅샷 없으면 기존 '순위 계산 중' 경로.
+
+**Steps:**
+
+- [ ] **Step 1: 실패 테스트** — **테스트 방식 주의**: 이 레포에는 jsdom/@testing-library가 없다. 컴포넌트 배선은 기존 `playgroundV3UiWiring.test.ts`처럼 소스 파일 텍스트 정규식 단언으로(게이트 조건·setView('playground') 호출·`— P` 폴백·tabular-nums 존재), 로직(포인트 포맷 함수)은 순수 함수로 분리해 node:test로 직접 검증. 랭킹: teammates 주입 시그니처로 기존 케이스(1위/동점/차이 문구) 재검증 + null 팀원 최하단 이름순 배치 + fixture 상수 부재 확인.
+- [ ] **Step 2: RED → Step 3: 구현 → Step 4: GREEN**
+- [ ] **Step 5: PR A 전체 검증** — Run: `npm run typecheck && npm run test:playground && npm run build:vite` → 모두 PASS.
+- [ ] **Step 6: 문서·버전** — package.json 1.84.0, update-notes(예: "이제 화면 오른쪽 위에 내 포인트가 항상 보여요. 매일 처음 앱을 켜면 출석 포인트도 쌓여요" 톤), ROADMAP 배플레이그라운드 섹션 체크 갱신, CONTEXT/AGENTS의 파일 맵에 arcade 추가.
+- [ ] **Step 7: 커밋 + PR** — 메시지: `아케이드 포인트 기반과 우상단 포인트 배지 (v1.84.0)`. PR 본문은 pr-creator 형식, "배포 후 할 일: `2026-07-13-playground-arcade-v1.sql` 라이브 적용 필요" 명시.
+
+---
+
+## Chunk 2: PR B — 업무 활동 적립 (Task 7)
+
+### Task 7: 활동 훅 3종 + 배지 획득 연출
+
+**Files:**
+- Modify: `electron/main.ts` — 훅 4곳:
+  - `supabase:update-scene-stage` 핸들러(≈:1944, `logSceneActivity` 직후): `value === true`일 때 `void arcadeService.awardActivity({ activity: 'scene-stage', refId: sceneUuid, stage })`
+  - `supabase:update-scene-phase` 핸들러(≈:1956): `sceneState === 'done'`일 때 `scene-phase-done`
+  - `supabase:add-comment` 핸들러(≈:2277, 활동 로그 직후): `comment`(commentId 사용)
+  - 리비전 상태 핸들러(≈:2488–2492): actionType이 `revision_assignee_done`으로 매핑될 때 `retake-done`(revisionId 사용)
+  - **주의**: `supabase:bulk-update-scene-stages`(≈:1986)에는 훅을 넣지 않는다.
+- Create: `src/features/playground/arcade/badgeFloatQueue.ts` — 플로팅 표시 큐 **순수 모듈**(enqueue(delta) → 표시 항목 배열, 최대 3개 대기·초과분은 마지막 항목에 합산, pop 규칙 포함) — node:test로 직접 검증 가능해야 한다.
+- Modify: `src/components/layout/HeaderPointsBadge.tsx` — `applyWalletPush` 수신 시: 배지 펄스(scale 1→1.06→1) + `+{delta}P` 플로팅 라벨(framer-motion, 1.2s 상승 페이드)을 badgeFloatQueue로 순차 표시. `prefers-reduced-motion`이면 즉시 갱신만.
+- Modify: `tests/playgroundArcadeMainWiring.test.ts`(훅 조건 케이스 추가), `tests/playgroundHeaderPointsBadge.test.ts`(연출 상태 전이)
+- Modify: `package.json`(1.85.0), `DEVLOG/update-notes.json`, `ROADMAP.md`
+
+**Steps:**
+
+- [ ] **Step 1: 실패 테스트** — main wiring: stage=false(체크 해제)는 award 미호출 / phase='work'는 미호출·'done'만 호출 / bulk 경로 미호출 / revision_reassign 미호출·assignee_done만 호출. badgeFloatQueue(순수): push 3연속 시 큐 길이 3, 4번째는 마지막에 합산, pop 순서. 배지 JSX 배선은 정규식 단언.
+- [ ] **Step 2: RED → Step 3: 구현 → Step 4: GREEN**
+- [ ] **Step 5: 수동 검증(프리뷰 불가 영역)** — `npm run electron:dev`로 실제 실행 후 씬 체크 1회 → 배지 +5P 연출과 다음 read 반영 확인. 결과를 PR 본문 테스트 가이드에 기록.
+- [ ] **Step 6: PR B 검증·문서·커밋** — typecheck/test:playground/build:vite, 1.85.0, update-notes("씬을 완료하거나 댓글을 달면 포인트가 쌓이고, 오른쪽 위 배지가 살짝 반짝이며 알려줘요" 톤). 메시지: `업무 활동 포인트 적립 훅과 배지 연출 (v1.85.0)`
+
+---
+
+## Chunk 3: PR C — 스네이크 + 공용 스테이지 (Tasks 8–10)
+
+### Task 8: 스네이크 엔진 (순수)
+
+**Files:**
+- Create: `src/features/playground/arcade/games/prng.ts`, `games/snake/types.ts`, `games/snake/engine.ts`
+- Create: `tests/playgroundSnakeEngine.test.ts`
+
+**규칙 전문 (스펙 §8과 동일 — 구현은 이 표가 정본):**
+
+| 항목 | 값 |
+|---|---|
+| 그리드 | 21×21, x 0–20 좌→우, y 0–20 상→하 |
+| 시작 | 몸 `[(10,10),(9,10),(8,10),(7,10)]`(머리 첫 번째), 방향 동(+1,0), 길이 4 |
+| 틱 | 시작 160ms, 사과당 −4ms, 하한 80ms |
+| 입력 | 방향 큐 최대 2개. 큐가 가득이면 무시. 각 틱에 큐에서 1개 꺼내 적용하되 현재 진행 방향의 정반대면 버리고 다음 것도 보지 않는다(그 틱은 기존 방향 유지) |
+| 사과 | 빈 칸 중 균등 선택: `floor(random() * freeCells.length)` (freeCells는 y·x 오름차순 정렬). 먹은 개수가 5의 배수가 되는 사과(5,10,…번째로 먹히는 사과)는 스폰 시점부터 골든 |
+| 성장 | 일반 +1, 골든 +2 (꼬리 유지 방식: 성장 수만큼 틱에서 꼬리 제거 생략) |
+| 죽음 | 다음 머리 위치가 벽 밖 또는 몸(꼬리가 이번 틱에 빠지는 칸은 제외) |
+| score | 최종 길이. `goldenEaten` 카운트 meta 보고 |
+
+**엔진 인터페이스:**
+
+```ts
+createSnakeGame(seed: number): SnakeState
+enqueueDirection(state: SnakeState, dir: 'up' | 'down' | 'left' | 'right'): SnakeState
+stepSnake(state: SnakeState): SnakeState   // 1틱 진행. state.status: 'running' | 'dead'
+// SnakeState: { grid: 21, body: Point[], dir, queue, apple: { pos, golden }, eaten, goldenEaten,
+//               tickMs, status, length }  — 모두 불변 업데이트
+```
+
+**Steps:**
+
+- [ ] **Step 1: 실패 테스트** — 고정 시드로: 초기 상태 정확성 / 4틱 직진 후 머리 (14,10) / 반대방향 입력 무시 / 사과 취식 시 길이 +1·tickMs 156 / 5번째 사과 골든·길이 +2 / 벽 충돌 dead / 자기 몸 충돌 dead / 꼬리 빠지는 칸 진입은 생존 / 같은 시드 두 판 deep-equal(결정론).
+- [ ] **Step 2: RED → Step 3: 구현 → Step 4: GREEN → Step 5: 커밋** — `스네이크 순수 엔진 추가`
+
+### Task 9: 공용 스테이지 셸 + 게임 루프 + 결과 오버레이
+
+**Files:**
+- Create: `src/features/playground/arcade/games/loop.ts`
+- Create: `src/views/playground/arcade/ArcadeStageChrome.tsx`, `RunResultOverlay.tsx`, `arcade.css`
+- Create: `tests/playgroundArcadeUiWiring.test.ts`(시작)
+
+**계약 (목업의 화면 구조·상태 전환이 시각 기준):**
+
+- `loop.ts`: `createFixedStepLoop({ stepMs, onStep, onFrame })` — rAF 누적기, `start/pause/resume/stop`, hidden/blur 자동 pause 콜백 노출. stepMs는 매 스텝 후 변경 가능(스네이크 가속).
+- `ArcadeStageChrome`: props `{ game: PlaygroundGameDefinition; phase: 'ready'|'countdown'|'running'|'paused'|'finishing'|'result'; hud: ReactNode; stage: ReactNode; result?: ReactNode; onStart/onResume/onQuit; startDisabledReason?: string; todayRewardedRuns: number; entryFee: number; keyHints: readonly { key: string; label: string }[] }`.
+  - ready: 규칙 요약 + 키 안내 + "오늘 보상 가능 {5-n}/5" + `{fee}P 내고 시작` 버튼(잔액 부족 시 disabled + 사유). countdown: 3→2→1 오버레이(각 700ms). paused: 반투명 오버레이 + 재개/나가기. `aria-live="polite"` 상태 텍스트 1개 유지.
+  - 진행 중 뒤로가기: `PlaygroundBackProvider`의 인터셉터 스택(`src/features/playground/backInterception.ts` — JbbjHouse 쪽 사용례 참고)에 등록해 "게임을 종료할까요? 입장료는 돌려받지 못해요" 확인 모달. running/paused/countdown에서만 인터셉트, ready/result는 통과.
+- `RunResultOverlay`: props `{ gameId, result: ArcadeFinishResult, scoreLabel, onReplay, onExit, replayDisabledReason? }`. 연출 순서(모두 reduced-motion 대체 있음): 등급 게이지 채움(560ms) → 등급명 스탬프 → 보상 카운트업(0→n, 480ms) → `newAlltimeBest`면 "신기록!" 배너 → 해금 도전과제 카드 순차 등장(120ms 스태거). `rewardCapped`면 보상 자리에 "오늘 보상 한도에 도달했어요 (5/5)".
+- `arcade.css`: `--pg-*` 토큰만 사용, 클래스 접두 `pg-arcade-`.
+
+**Steps:**
+
+- [ ] **Step 1: 실패 테스트** — loop: 고정 스텝 누적(stepMs 160에서 33ms 프레임 4회 → step 0회, 5회째(누적 165ms) → 1회), pause 중 시간 미누적, stepMs 변경 반영. chrome: phase별 필수 요소 존재(테스트는 기존 `playgroundV3UiWiring.test.ts`의 JSX 문자열/구조 검사 방식을 따른다), 잔액 부족 disabled, back 인터셉터 등록/해제 시점.
+- [ ] **Step 2: RED → Step 3: 구현 → Step 4: GREEN → Step 5: 커밋** — `아케이드 공용 스테이지 셸과 결과 오버레이 추가`
+
+### Task 10: SnakeStage 통합 + 라우트 개명 + 로비 연동 + PR C 마무리
+
+**Files:**
+- Create: `src/views/playground/arcade/SnakeStage.tsx`, `GameHost.tsx`
+- Modify: `src/features/playground/routes.ts`(`'coming-soon'` → `'game'`), `src/views/PlaygroundView.tsx`(GameHost 렌더 + 스냅샷/도전과제 토스트 연결). 참고: 'coming-soon' 문자열 실참조는 routes.ts, PlaygroundView.tsx, tests/playgroundRoutes·playgroundTransition·playgroundV3UiWiring 5개 파일(2026-07-13 grep 기준)이며, `src/features/playground/history.ts`와 `transition/playgroundTransitionPolicy.ts`는 kind 문자열을 직접 참조하지 않지만 타입 추론으로 영향받을 수 있으니 typecheck로 확인. 추가 Modify: `src/features/playground/catalog.ts`(카피 갱신 — 스네이크 `heroMeta: '평균 3분 · 내 최고 기록은 카드에서 바로 보여요'` 류, `stageReward`를 확정 보상표 문구로), `PlaygroundGameCard.tsx`/`PlaygroundRecommendationHero.tsx`(`record?: string` prop — 내 최고 기록 오버레이, 없으면 "아직 기록이 없어요"), `JbbjHouse.tsx`(구현 게임 상태 문구 "바로 플레이")
+- Modify: 기존 테스트 — `grep -rn "coming-soon" src tests` 전수 치환 (2026-07-13 기준 실참조: `tests/playgroundRoutes.test.ts`, `tests/playgroundTransition.test.ts`, `tests/playgroundV3UiWiring.test.ts`)
+- Modify: `tests/playgroundArcadeUiWiring.test.ts`(SnakeStage/GameHost 케이스), `package.json`(1.86.0), update-notes, ROADMAP/CONTEXT/AGENTS
+
+**SnakeStage 계약:**
+
+- 캔버스 21×21(셀 20px 기준, DPR 스케일, 컨테이너에 맞춰 축소). 스네이크 몸은 라운드 사각형, 머리 밝게, 골든 사과는 `--pg-yellow` 발광. HUD: 길이(=score) / 다음 등급까지 / 골든 카운트 / 내 최고.
+- 키: 화살표+WASD(`keydown`에서 `preventDefault`) → `enqueueDirection`. P/Esc 일시정지.
+- 흐름: ready에서 시작 클릭 → `useArcadeStore.startRun('snake')` 성공 시 countdown → 엔진 생성(시드 발급) → 루프. dead → `finishRun({ score: length, meta: { goldenEaten } })` → result. 다시 하기 = 새 runId로 ready부터.
+- `GameHost`: `route.game`이 'snake'(PR D 이후 'tetris' 포함)면 해당 스테이지, 아니면(sudoku) 기존 `ComingSoonGame`.
+- 도전과제 토스트: `finishRun` 결과의 `unlockedAchievements`를 sonner 커스텀 토스트("도전과제 달성! {name} +{bonus}P")로 — PlaygroundView 레벨에서 표시.
+
+**Steps:**
+
+- [ ] **Step 1: 실패 테스트** — routes: `navigatePlayground(…, { kind: 'open-game', game: 'snake' })`가 `{ kind: 'game', … }` 반환 + 기존 route 테스트 전수 갱신. GameHost 분기(snake→스테이지, sudoku→ComingSoon). 카드 record prop 오버레이.
+- [ ] **Step 2: RED → Step 3: 구현 → Step 4: GREEN**
+- [ ] **Step 5: 프리뷰 실측** — `npm run dev:renderer` 후 `http://localhost:5190/?preview=1`(배한솔/1234 로그인) → 로비→스네이크 진입→한 판 완주→결과/보상/기록 반영을 실제 조작으로 확인. 콘솔 오류 0 확인.
+- [ ] **Step 6: PR C 검증·문서·커밋** — typecheck/test:playground/build:vite, 1.86.0, update-notes("이제 스네이크를 진짜로 플레이할 수 있어요. 포인트를 내고 시작해서 등급에 따라 더 크게 돌려받아요" 톤). 메시지: `스네이크 게임과 보상·도전과제 흐름 (v1.86.0)`
+
+---
+
+## Chunk 4: PR D — 테트리스 + 랭킹/슬랙 (Tasks 11–13)
+
+### Task 11: 테트리스 엔진 (순수)
+
+**Files:**
+- Create: `src/features/playground/arcade/games/tetris/types.ts`, `tetris/pieces.ts`, `tetris/srs.ts`, `tetris/bag.ts`, `tetris/engine.ts`
+- Create: `tests/playgroundTetrisEngine.test.ts`
+
+**규칙 전문 (이 표·데이터가 정본):**
+
+- 보드: 폭 10(x 0–9), 총 22행(y 0 상단, y 0–1 숨김, 가시 y 2–21). y는 아래로 증가.
+- 조각 셀 데이터(`pieces.ts`): 회전 상태 `0/R/2/L` 순. JLSTZ·T는 3×3 박스, I는 4×4, O는 고정. 박스 로컬 `(col,row)`:
+
+```
+T: 0=(1,0)(0,1)(1,1)(2,1)  R=(1,0)(1,1)(2,1)(1,2)  2=(0,1)(1,1)(2,1)(1,2)  L=(1,0)(0,1)(1,1)(1,2)
+J: 0=(0,0)(0,1)(1,1)(2,1)  R=(1,0)(2,0)(1,1)(1,2)  2=(0,1)(1,1)(2,1)(2,2)  L=(1,0)(1,1)(0,2)(1,2)
+L: 0=(2,0)(0,1)(1,1)(2,1)  R=(1,0)(1,1)(1,2)(2,2)  2=(0,1)(1,1)(2,1)(0,2)  L=(0,0)(1,0)(1,1)(1,2)
+S: 0=(1,0)(2,0)(0,1)(1,1)  R=(1,0)(1,1)(2,1)(2,2)  2=(1,1)(2,1)(0,2)(1,2)  L=(0,0)(0,1)(1,1)(1,2)
+Z: 0=(0,0)(1,0)(1,1)(2,1)  R=(2,0)(1,1)(2,1)(1,2)  2=(0,1)(1,1)(1,2)(2,2)  L=(1,0)(0,1)(1,1)(0,2)
+I: 0=(0,1)(1,1)(2,1)(3,1)  R=(2,0)(2,1)(2,2)(2,3)  2=(0,2)(1,2)(2,2)(3,2)  L=(1,0)(1,1)(1,2)(1,3)
+O: 전 상태 (1,0)(2,0)(1,1)(2,1) — 회전해도 불변, 킥 없음
+```
+
+- 스폰: 박스 원점 보드 `(3,0)` (I도 (3,0)). 스폰 셀이 기존 블록과 겹치면 즉시 게임 오버(block out).
+- SRS 킥(`srs.ts`): **아래 표는 y-down 좌표로 이미 변환된 값**(표준 SRS의 +y↑를 반전). 순서대로 5개 오프셋을 시도, 전부 실패면 회전 취소.
+
+```
+JLSTZ/T:
+0→R: (0,0) (-1,0) (-1,-1) (0,+2) (-1,+2)
+R→0: (0,0) (+1,0) (+1,+1) (0,-2) (+1,-2)
+R→2: (0,0) (+1,0) (+1,+1) (0,-2) (+1,-2)
+2→R: (0,0) (-1,0) (-1,-1) (0,+2) (-1,+2)
+2→L: (0,0) (+1,0) (+1,-1) (0,+2) (+1,+2)
+L→2: (0,0) (-1,0) (-1,+1) (0,-2) (-1,-2)
+L→0: (0,0) (-1,0) (-1,+1) (0,-2) (-1,-2)
+0→L: (0,0) (+1,0) (+1,-1) (0,+2) (+1,+2)
+I:
+0→R: (0,0) (-2,0) (+1,0) (-2,+1) (+1,-2)
+R→0: (0,0) (+2,0) (-1,0) (+2,-1) (-1,+2)
+R→2: (0,0) (-1,0) (+2,0) (-1,-2) (+2,+1)
+2→R: (0,0) (+1,0) (-2,0) (+1,+2) (-2,-1)
+2→L: (0,0) (+2,0) (-1,0) (+2,-1) (-1,+2)
+L→2: (0,0) (-2,0) (+1,0) (-2,+1) (+1,-2)
+L→0: (0,0) (+1,0) (-2,0) (+1,+2) (-2,-1)
+0→L: (0,0) (-1,0) (+2,0) (-1,-2) (+2,+1)
+```
+
+- `bag.ts`: 7-bag — 7종 셔플(Fisher–Yates, 주입 PRNG) 소진 후 재충전. Next 5 노출.
+- 중력(레벨 1–15 ms/행): `[1000, 850, 720, 600, 490, 390, 310, 240, 180, 140, 105, 80, 60, 45, 35]`, 레벨 = `min(15, floor(누적 라인/10)+1)`.
+- 소프트드롭 50ms/행(+1점/칸), 하드드롭 즉시(+2점/칸, 즉시 고정·락 딜레이 무시).
+- 락 딜레이: 접지 상태 500ms 후 고정. 이동/회전 성공 시 리셋, 피스당 최대 15회, 초과 시 접지 즉시 고정.
+- 점수: 1/2/3/4줄 = 100/300/500/800 × 레벨. 콤보: 라인을 지운 락이 연속되면 `50 × 콤보수 × 레벨`(첫 클리어 콤보수 0, 이후 1,2,…), 클리어 없는 락에서 리셋. T-spin/B2B 없음.
+- Hold: C키, 피스당 1회. 홀드 교체 피스는 스폰 위치에서 시작.
+- 게임 오버: block out. `meta` 보고: `{ lines, levelReached, maxLineClear }`.
+
+**엔진 인터페이스 (스네이크와 같은 불변 스타일):**
+
+```ts
+createTetrisGame(seed: number): TetrisState
+tickTetris(state: TetrisState, elapsedMs: number): TetrisState        // 중력·락딜레이 진행
+applyTetrisInput(state: TetrisState, input:
+  'left' | 'right' | 'softDropOn' | 'softDropOff' | 'rotateCw' | 'rotateCcw' | 'hardDrop' | 'hold'): TetrisState
+// TetrisState: { board, active: { piece, rotation, x, y }, hold, holdUsed, queue(next 5 보장),
+//               bag, level, lines, score, combo, lockElapsedMs, lockResets, status, stats: { maxLineClear, levelReached } }
+```
+
+**Steps:**
+
+- [ ] **Step 1: 실패 테스트** — 고정 시드: 7-bag 14개에 7종×2 / T 스폰 셀 (4,0)(3,1)(4,1)(5,1) / 벽에 붙은 T의 0→R 회전이 킥 2번째 (-1,0)로 성공하는 구체 배치 / I 킥 케이스 1개 / 4줄 클리어 800×레벨 + `maxLineClear: 4` / 콤보 점수 / 소프트·하드드롭 가산 / 락 리셋 15회 초과 강제 고정 / 레벨 10 진입 시 중력 140ms / block out 게임 오버 / 같은 시드 결정론.
+- [ ] **Step 2: RED → Step 3: 구현 → Step 4: GREEN → Step 5: 커밋** — `테트리스 순수 엔진 추가 (SRS·7백·콤보)`
+
+### Task 12: TetrisStage + DAS/ARR 입력
+
+**Files:**
+- Create: `src/views/playground/arcade/TetrisStage.tsx`, `src/features/playground/arcade/games/keymap.ts`
+- Modify: `src/views/playground/arcade/GameHost.tsx`(tetris 분기), `tests/playgroundArcadeUiWiring.test.ts`
+
+**계약:**
+
+- `keymap.ts`: DAS/ARR 상태기 — `keydown`(repeat 무시)으로 즉시 1회 이동, 160ms 유지 시 40ms 간격 반복. 좌우 동시엔 나중 키 우선. 프레임 루프에서 `advance(nowMs)` 호출로 반복 발생. 소프트드롭은 keydown/keyup을 `softDropOn/Off`로 전달.
+- 렌더: 캔버스 — 보드(가시 20행), 고스트 피스(현 위치에서 하드드롭 위치 반투명), Hold 박스, Next 5 세로 목록, HUD(점수/레벨/라인/콤보/다음 등급까지/내 최고). 셀 색은 `--pg-*` 토큰에서 조각별 매핑(I=mint, O=yellow, T=lavender, S=green, Z=accent, J=blue, L=muted 계열 — arcade.css에 변수로).
+- 키 안내: `← → 이동 · ↓ 소프트 · Space 하드 · Z/X 회전 · C 홀드 · P 일시정지`.
+- finish meta: `{ lines, levelReached, maxLineClear }`.
+
+**Steps:**
+
+- [ ] **Step 1: 실패 테스트** — keymap: DAS 전 1회 이동/160ms 후 40ms 간격 반복/keyup 리셋/repeat 이벤트 무시. GameHost tetris 분기.
+- [ ] **Step 2: RED → Step 3: 구현 → Step 4: GREEN**
+- [ ] **Step 5: 프리뷰 실측** — Task 10과 동일 방식으로 테트리스 한 판(하드드롭·홀드·4줄 시도) 완주 확인.
+- [ ] **Step 6: 커밋** — `테트리스 스테이지와 DAS·ARR 입력 추가`
+
+### Task 13: 게임별 랭킹 패널 + 신기록 슬랙 + 설정 토글 + PR D 마무리
+
+**Files:**
+- Create: `src/views/playground/arcade/ArcadeRankingPanel.tsx`
+- Modify: `src/views/playground/JbbjHouse.tsx`(랭킹 패널 배치 확정 — 하우스 그리드의 명예의 전당(podium) 아래에 게임별 랭킹 패널 추가. 로비는 변경하지 않음), `electron/main.ts`(`SLACK_ARCADE_WEBHOOK_URL = ''` 상수 + arcadeService에 주입되는 `sendSlackRecord` 구현 — 기존 `postSlackWebhook` 재사용, URL 빈 값이면 skip), `electron/arcadeService.ts`(game-finish 응답 후 조건 발송 로직 마감), `src/views/playground/market/MarketAdminPanel.tsx` 또는 신규 아케이드 설정 섹션(슬랙 토글 — `setSlackNotify`), 테스트들, `package.json`(1.87.0), update-notes, ROADMAP/CONTEXT/AGENTS
+
+**계약:**
+
+- 랭킹 패널: 게임 탭(스네이크/테트리스) × 기간 탭(전체/이번 주). 행: 순위/이름/score(게임별 라벨)/달성일. 내 행 강조(`is-me`). 5행 미만은 "—" 자리 표시. 데이터는 스냅샷의 leaderboard — 별도 fetch 없음, `finishRun` 후 자동 최신화.
+- 슬랙 발송 조건: 응답의 `newAlltimeBest && slackNotifyEnabled && !replayed` && URL 비어있지 않음. payload `{ title: '테트리스 신기록!', detail: '32,410점 — 이전 기록 18,420점', player: '배한솔' }` — detail은 응답의 `prevBestScore`로 조립(null이면 '32,410점 — 첫 기록'). 실패는 로그만.
+- 토글 UI: 배한솔 관리자 영역(모의투자 관리자 패널과 같은 게이트)에 "신기록 슬랙 알림" 스위치 + "슬랙 워크플로 URL이 설정된 뒤에 실제로 발송돼요" 안내문.
+
+**Steps:**
+
+- [ ] **Step 1: 실패 테스트** — arcadeService: newAlltimeBest+config on→send 호출, off→미호출, URL 빈 값→미호출, send 실패해도 finish 결과 반환. 랭킹 패널 wiring(탭 전환·빈 행) / 토글이 `config-set` execute 호출.
+- [ ] **Step 2: RED → Step 3: 구현 → Step 4: GREEN**
+- [ ] **Step 5: PR D 전체 검증** — typecheck/test:playground/build:vite + 프리뷰에서 랭킹 탭·토글 실측.
+- [ ] **Step 6: 문서·버전·커밋** — 1.87.0, update-notes("테트리스가 열렸어요. 게임마다 순위표가 생겼고, 최고 기록을 깨면 슬랙으로 자랑도 보낼 수 있어요(관리 설정에서 켤 수 있어요)" 톤), ROADMAP의 "게임 실행과 서버 저장"/"포인트·게임 점수 정책 확정" 체크. 메시지: `테트리스와 게임별 랭킹·신기록 슬랙 알림 (v1.87.0)`
+- [ ] **Step 7: 후속 메모** — PR 본문에 잔여 항목 기재: 스도쿠/슬롯머신, 주간 다이제스트, 팀 공개 시 위협모델 업그레이드(Supabase Auth)와 신규 유저 시드(`arcade-grant`), `SLACK_ARCADE_WEBHOOK_URL` 실값 주입.
+
+---
+
+## 완료 정의 (전체)
+
+1. 4개 PR 모두: `npm run typecheck` + `npm run test:playground` + `npm run build:vite` 통과, 프리뷰(`?preview=1`) 실측 증적.
+2. 포인트 순환 루프 시연 가능: 출석/씬 체크로 적립 → 우상단 배지 반영 → 스네이크·테트리스 입장료 지불 → 등급 보상·도전과제 → 랭킹 갱신 → (설정 on 시) 신기록 슬랙.
+3. 원장(`playground_value_ledger`)만 봐도 모든 포인트 증감이 재구성 가능(감사 가능성).
+4. 같은 이벤트 재발생(재체크·재시도·재실행)에 중복 지급 0건 — 멱등 키 테스트로 보증.

--- a/docs/superpowers/specs/2026-07-13-baeplayground-arcade-points-design.md
+++ b/docs/superpowers/specs/2026-07-13-baeplayground-arcade-points-design.md
@@ -1,0 +1,221 @@
+# 배플레이그라운드 아케이드 · 포인트 제도 설계 (스네이크 / 테트리스 / 도전과제 / 랭킹 / 슬랙)
+
+- **날짜**: 2026-07-13
+- **상태**: 한솔 리뷰 대기 초안 (자율 세션에서 코드베이스 근거로 결정을 내렸으며, 각 결정의 근거를 명시함. §14 "한솔 확인 항목"만 확정하면 구현 착수 가능)
+- **구현 계획**: `docs/superpowers/plans/2026-07-13-baeplayground-arcade-points.md`
+- **인터랙션 목업**: `docs/superpowers/mockups/2026-07-13-baeplayground-arcade-mockup.html` (브라우저로 열면 스네이크/테트리스가 실제로 조작되는 목업)
+
+---
+
+## 1. 목표
+
+업무 활동(씬 완료, 댓글, 리테이크 수정 완료, 매일 접속)으로 **포인트**를 벌고, 그 포인트로 배플레이그라운드에서 **게임(스네이크·테트리스)** 을 플레이해 포인트를 더 벌 수 있는 순환 구조를 만든다. 게임마다 **도전과제**와 **랭킹**이 있고, 신기록이 나오면 **슬랙 웹훅**으로 알린다. 보유 포인트는 **메인 화면 우상단**에 항상 보인다.
+
+한 줄 루프: `일해서 포인트 획득 → 우상단 배지에 쌓임 → 플레이그라운드에서 입장료 내고 게임 → 등급 보상/도전과제/신기록 → 슬랙 자랑 → 다시 일`
+
+## 2. 현재 상태 (이미 만들어져 있는 것)
+
+| 영역 | 상태 | 위치 |
+|---|---|---|
+| 플레이그라운드 로비/하우스/전환(dot-wipe)/뒤로가기 | ✅ 완성 | `src/views/PlaygroundView.tsx`, `src/views/playground/*`, `src/features/playground/*` |
+| 게임 3종 카탈로그(테트리스/스네이크/스도쿠) | ✅ 정의됨, 화면은 `ComingSoonGame` 플레이스홀더 | `src/features/playground/catalog.ts`, `routes.ts`(`kind: 'coming-soon'`) |
+| 포인트 지갑 (`walletPoints`, `lifetimeEarnedPoints`) | ✅ DB·RPC 존재. 단 **적립 경로가 없음** (최초 1,000,000P 시드뿐) | `playground_wallet_accounts` 테이블, `DEVLOG/migrations/2026-07-11-playground-market-v2.sql` |
+| 멱등 원장 (`UNIQUE(user_id, request_id)`) | ✅ 존재 | `playground_value_ledger` |
+| 모의투자(JBBJ 증권) | ✅ 별도 트랙에서 완성/운영 중 (이 설계에서 변경 최소화) | `src/features/playground/market/*`, `electron/marketAccountService.ts` |
+| 포인트 랭킹 UI | ⚠️ 내 지갑만 실데이터, 팀원 4명은 fixture | `src/features/playground/ranking.ts`(`TEAMMATES`) |
+| 로비 카드의 "최고 기록 18,420점" 등 | ⚠️ 전부 하드코딩 카피 | `catalog.ts`의 `heroMeta`/`quickRecord` |
+| 활동 로그 (씬/댓글/리테이크, 메인 프로세스 중앙집중) | ✅ 존재 — 포인트 훅을 끼울 지점 | `electron/main.ts` 각 IPC 핸들러 (§7) |
+| 슬랙 웹훅 (워크플로 트리거, 메인에서 fetch) | ✅ 패턴 존재 (멘션·리깅 공지) | `electron/main.ts:2923~2947`, `src/services/slackWebhookService.ts` |
+| 접근 게이트 | ✅ 배한솔 전용 (`canAccessPlayground`) | `src/features/playground/featureFlag.ts` |
+
+## 3. 비범위 (v1에서 하지 않는 것)
+
+- 슬롯머신, 스도쿠 **구현** (스도쿠는 카탈로그·ComingSoon 유지, 슬롯은 disabled 유지)
+- JBBJ 하우스의 팀 챌린지 실데이터화, "4명 접속 중" 실시간 presence
+- 주간 랭킹 다이제스트 슬랙 자동 발송 (신기록 단건 알림만 v1)
+- 테트리스 T-spin/Back-to-Back 보너스 판정
+- 팀 전체 공개 (배한솔 전용 게이트와 v2 위협 모델 유지 — `2026-07-11-playground-market-v2.sql` 주석의 "TEST-ONLY THREAT MODEL" 그대로)
+- Supabase Realtime 구독 (모의투자와 동일하게 미사용 — 단일 사용자라 불필요)
+- 포인트 차감형 패널티, 포인트 만료, 유저 간 포인트 선물
+
+## 4. 아키텍처 결정
+
+### 4-1. 지갑·원장은 신설하지 않고 모의투자 것을 확장한다 (결정)
+
+- 포인트 통화는 하나다. 게임/활동/모의투자 이체가 모두 같은 `playground_wallet_accounts.wallet_points`를 쓰고, 모든 증감은 `playground_value_ledger`에 남는다.
+- 원장의 `kind` CHECK 제약을 확장해 아케이드용 kind를 추가한다: `'game-entry' | 'game-reward' | 'scene-progress' | 'comment' | 'retake-done' | 'daily-login' | 'achievement' | 'arcade-grant'`.
+- **멱등성**: 기존 `UNIQUE(user_id, request_id)`를 그대로 활용. 활동 적립의 request_id는 결정론적 이벤트 키(§7 표)라서 "체크 해제 후 재체크" 같은 반복 행동에 재지급되지 않는다.
+- 대안(별도 아케이드 지갑/원장 신설)은 지갑 이원화·이체 UI 추가 부담 때문에 기각.
+
+### 4-2. RPC는 신설 2개, 기존 모의투자 RPC는 건드리지 않는다 (결정)
+
+- `playground_arcade_read(p_user_id uuid)` — 지갑/기록/랭킹/도전과제/출석/설정 스냅샷 1회 조회.
+- `playground_arcade_execute(p_user_id uuid, p_request_id text, p_kind text, p_payload jsonb)` — 모든 변경(출석/활동/게임 시작/게임 종료/도전과제/설정).
+- v2와 동일한 하드닝을 복제한다: `SECURITY DEFINER` + `SET search_path=''`, 테이블 REVOKE ALL + RPC만 `GRANT EXECUTE TO anon`, canonical 배한솔 재확인, `pg_advisory_xact_lock`(사용자 단위), 지갑 행 `FOR UPDATE`, 원장 멱등 probe(`same`/`conflict`/`missing`), `response_state` 재생 응답.
+- `playground_market_execute`를 확장하지 않는 이유: 이미 800줄 규모의 신중히 관리되는 함수라 게임 분기를 섞으면 회귀 위험이 크다.
+
+### 4-3. 활동 포인트는 렌더러가 아니라 **Electron 메인의 기존 활동 로그 지점**에서 지급한다 (결정)
+
+- 메인은 이미 씬/댓글/리테이크 mutation 성공 직후 활동 로그를 남기고(`logSceneActivity`/`sbRecordActivityLog`), 행위자 신원도 메인 소유의 `currentActivityUser`가 정본이다.
+- 이 지점에서 `arcadeService.awardActivity(...)`를 **fire-and-forget**으로 호출한다(await로 원래 mutation을 막지 않고, 실패는 로그만). 렌더러 UI에는 메인 → 렌더러 push(`arcade:wallet-updated`)로 잔액 변화를 알린다.
+- 프로토타입 게이트: `currentActivityUser`가 canonical 배한솔이 아니면 지급 시도 자체를 건너뛴다(조용히 no-op). 팀 공개 시 이 게이트만 제거하면 된다.
+
+### 4-4. 렌더러는 모의투자와 동일한 레이어링을 복제한다 (결정)
+
+`domain(순수) → gateway(electron/localStorage 이중) → zustand store → view`. 게임 엔진(스네이크/테트리스)은 **순수 TS 모듈 + 주입식 시드 PRNG**로 만들어 node:test로 결정론 테스트한다 (`Math.random()` 직접 사용 금지 — 모의투자 가격 모델과 같은 원칙).
+
+### 4-5. 지갑 표시의 단일 소스 (결정)
+
+- 지갑 UI 소스는 계속 `useMarketPreviewStore.visible.account`(플레이그라운드 헤더/랭킹)와 신규 `useArcadeStore.snapshot.wallet`(앱 헤더 배지) 두 군데가 되므로, **아케이드 mutation 성공 응답과 `arcade:wallet-updated` push가 올 때마다 두 스토어 모두에 반영**한다. `useMarketPreviewStore`에 외부 지갑 패치 액션(`applyServerWallet`)을 추가한다 (confirmed/visible 동시 패치; 모의투자 명령 진행 중이면 서버 응답이 곧 덮어쓰므로 충돌 무해).
+
+## 5. 포인트 경제 (v1 밸런스)
+
+> 모든 수치는 `src/features/playground/arcade/constants.ts`의 `ARCADE_BALANCE` 한 곳에 두고, SQL RPC의 수치와 계약 테스트로 동기화한다. 한솔이 나중에 조정할 때 이 파일 + 마이그레이션만 바꾸면 된다.
+
+### 5-1. 적립 (업무 활동 — 메인 프로세스 훅)
+
+| 활동 | 포인트 | request_id (멱등 키) | 1일 상한 (KST) |
+|---|---|---|---|
+| 매일 첫 실행(로그인·세션 복원 포함) | **+20** | `daily-login:<YYYY-MM-DD>` | 1회 |
+| BG 씬 단계 체크 (lo/done/review/png 각각, false→true 최초 1회) | **+5** | `scene-stage:<sceneUuid>:<stage>` | scene-progress 합산 30건 |
+| ACT 씬 phase가 done으로 최초 진입 | **+10** | `scene-phase-done:<sceneUuid>` | scene-progress 합산 30건 |
+| 댓글 작성 (일반 + 리테이크 + 캐릭터 보드 댓글 — `supabase:add-comment` 경유 전부) | **+5** | `comment:<commentId>` | 5건 |
+| 리테이크 담당자 수정 완료 (`revision_assignee_done`) | **+30** | `retake-done:<revisionId>` | 5건 |
+
+- 상한 판정은 **서버(RPC)** 가 원장에서 같은 kind의 오늘(KST) 행 수를 세어 강제한다. 상한 초과 시 지급 0으로 정상 응답(에러 아님).
+- 체크 해제해도 회수하지 않는다(원장 불변). 재체크 시 멱등 키 때문에 재지급 없음.
+- `supabase:bulk-update-scene-stages`(일괄 보정 경로)에서는 지급하지 않는다 — 대량 보정으로 오지급 방지.
+- `revision_resolve`(감독 최종 완료)는 v1에서 지급 없음. 수정 행위자 보상이 목적이므로 담당자 완료에만 지급.
+
+### 5-2. 소비·게임 보상
+
+| 게임 | 입장료 | 등급 기준 (score) | 등급별 보상 |
+|---|---|---|---|
+| 스네이크 (score = 최종 길이) | **10P** | BRONZE 15 / SILVER 25 / GOLD 40 / PLATINUM 55 | 8 / 18 / 30 / **45P** |
+| 테트리스 (score = 점수) | **15P** | BRONZE 3,000 / SILVER 10,000 / GOLD 25,000 / PLATINUM 50,000 | 12 / 30 / 55 / **80P** |
+
+- 보상은 **한 판에 최고 도달 등급 1개만** 지급. 미달(NONE)은 0P.
+- **보상 지급은 게임별 1일 5회(KST)**. NONE 판은 카운트하지 않음. 이후 판은 플레이·기록·랭킹은 되지만 보상 0 (시작 화면에 "오늘 보상 가능 3/5" 표시).
+- 입장료는 게임 시작 시 차감(잔액 부족이면 시작 불가), 중도 이탈·사망·앱 종료 시 환불 없음. 입장료에는 횟수 제한 없음 → 포인트 싱크 역할.
+- 최고 등급 보상(45/80)은 기존 카탈로그 카피의 수치(스네이크 45P, 테트리스 80P)를 계승. 등급 문구는 §12에 따라 카피 갱신.
+
+### 5-3. 밸런스 감각 (근거)
+
+활발한 하루: 출석 20 + 씬 체크 ~10건 50~100 + 댓글 25 + 리테이크 1~2건 30~60 ≈ **125~205P/일**. 게임 기대 수익은 실력에 따라 판당 -15 ~ +65P, 보상 상한(5회)까지 하루 최대 +400P(플래티넘 5연속, 사실상 불가). 초기 시드 1,000,000P(모의투자 자본)가 이미 있어 v1 수치는 "의미 있는 잔액 변화"보다 **루프 검증**이 목적. 팀 공개 시 신규 유저 시드는 `arcade-grant` kind로 별도 책정(예: 3,000P — v1 비범위).
+
+## 6. 게임 공통 플로우 (스테이지 상태 머신)
+
+```
+ready ──[입장료 지급 성공(game-start)]──▶ countdown(3→2→1, 각 700ms) ──▶ running
+running ──[P/Esc, 창 blur, document.hidden]──▶ paused ──[재개]──▶ running
+running ──[죽음/탑아웃]──▶ finishing(game-finish RPC) ──▶ result
+result ──[다시 하기]──▶ ready(새 runId)   result/ready ──[나가기]──▶ 로비/하우스
+```
+
+- `runId = crypto.randomUUID()` 를 시작 시 발급. `game-start`의 request_id는 `game-entry:<runId>`, 종료는 `game-finish:<runId>`.
+- **결과 검증(서버)**: finish는 (1) 같은 유저의 `game-entry:<runId>` 원장 행 존재, (2) 동일 runId 런 미존재, (3) score/duration 상식 범위(§8·§9의 상한, duration 1초~4시간)일 때만 접수. 등급·보상 계산은 서버가 SSOT(클라 상수는 표시용 미러). 등급 판정은 경계값 **이상(>=)**.
+- **durationMs 정의**: running 상태에서 고정 timestep으로 소비된 시뮬레이션 시간의 합(ms). 카운트다운·일시정지 시간은 포함하지 않는다. (정상 스네이크 최단 사망 ≈ 1.76초라 1초 하한은 조작 방어용으로만 작동)
+- **멱등 재생 표시**: execute가 원장 probe `same`으로 저장된 응답을 재생할 때는 응답에 `replayed: true`를 덧붙인다. 재생 응답으로는 지갑 push·획득 연출을 발생시키지 않는다 (재체크·재시도 시 가짜 "+N P" 방지).
+- **게임 중 뒤로가기/사이드바 이탈**: 기존 `PlaygroundBackProvider` 인터셉터 스택에 등록해 "게임을 종료할까요? 입장료는 돌려받지 못해요" 확인 모달을 띄운다.
+- **일시정지 자동화**: `document.hidden`·창 blur 시 자동 pause. 게임 루프는 `requestAnimationFrame` + 고정 timestep 누적기(멈춘 시간은 시뮬레이션하지 않음).
+- **RNG**: 판마다 `seed = crypto.getRandomValues` 기반 32bit 정수 1개 → mulberry32 계열 시드 PRNG. 엔진은 `random()`을 주입받는 순수 함수 집합.
+- **결과 화면**: 등급 리빌(게이지 채움) → 보상 카운트업 → 신기록 배너 → 새로 해금된 도전과제 목록. 목업 참조.
+- **접근성**: 캔버스 옆 `aria-live="polite"` 상태 텍스트(시작/일시정지/게임 오버/등급), 모든 버튼 44px 이상, `prefers-reduced-motion`이면 리빌·카운트업을 즉시 표시로 대체.
+
+## 7. 활동 훅 지점 (Electron 메인 — 정확한 위치)
+
+| 훅 | 위치 (현재 기준) | 조건 |
+|---|---|---|
+| 씬 단계(BG) | `electron/main.ts` `supabase:update-scene-stage` 핸들러 (≈:1944, `logSceneActivity` 호출부) | `value === true`인 체크만 |
+| 씬 phase(ACT) | 같은 파일 `supabase:update-scene-phase` 핸들러 (≈:1956) | `sceneState === 'done'`만 |
+| 댓글 | 같은 파일 `supabase:add-comment` 핸들러 (≈:2277) | 저장 성공 후 |
+| 리테이크 | 같은 파일 리비전 상태 핸들러의 actionType 매핑 (≈:2488–2492) | `revision_assignee_done`으로 매핑되는 경우만 |
+| 출석 | `electron/main.ts` `setCanonicalActivityUser` (≈:1470) — sessionManager.publish 경유로 로그인·세션 복원 모두 통과 | 사용자 확정 시 1회 시도(멱등) |
+
+공통 규칙: **원래 mutation의 성공이 확정된 뒤**에만 호출, `void arcadeService.awardActivity(...).catch(log)` 형태로 절대 원래 흐름을 막거나 실패시키지 않는다. 행위자는 `currentActivityUser`.
+
+## 8. 스네이크 스펙 (전체 규칙 — 구현 계획 Task에 상세 재기술)
+
+- 그리드 21×21. 시작: 머리 (10,10), 몸 (9,10)(8,10)(7,10), 길이 4, 동쪽 진행.
+- 틱 기반: 시작 160ms/틱, 사과 1개당 -4ms, 하한 80ms.
+- 입력: 화살표/WASD. 방향 큐 최대 2개 버퍼(가득이면 입력 무시). 각 틱에 큐에서 1개 꺼내 적용하되, 현재 진행 방향의 180° 반전이면 버리고 그 틱은 기존 방향을 유지한다(다음 큐 항목을 당겨 보지 않음).
+- 사과: 빈 칸에서 균등 랜덤(주입 PRNG). **5의 배수 번째(5, 10, 15…) 사과는 골든** — 성장 +2 (일반은 +1). 골든도 속도 증가는 1회분.
+- 죽음: 벽 또는 자기 몸 충돌 → finish.
+- score = 최종 길이 (이론 최대 441 — 서버 상한). 카탈로그 표기 "최고 길이"와 일치.
+
+## 9. 테트리스 스펙 (전체 규칙 — 구현 계획 Task에 상세 재기술)
+
+- 보드 10×20 (+숨김 2행). 7-bag 랜덤라이저, Next 5개, Hold 1개(피스당 1회), 고스트 피스 표시.
+- 회전: **SRS 표준 + 벽킥 테이블(JLSTZ·I 분리)** — 킥 테이블 전문을 구현 계획에 수록.
+- 중력(레벨→ms/행): `[1000, 850, 720, 600, 490, 390, 310, 240, 180, 140, 105, 80, 60, 45, 35]` (레벨 1~15, 15에서 고정).
+- 입력: ←→ 이동(DAS 160ms / ARR 40ms 자체 구현 — OS 키 반복 사용 금지), ↓ 소프트드롭(50ms/행, +1점/칸), Space 하드드롭(+2점/칸), Z=반시계, X 또는 ↑=시계, C=홀드, P/Esc=일시정지.
+- 락 딜레이 500ms, 이동/회전 성공 시 리셋(최대 15회, 초과 시 즉시 고정).
+- 점수: 1/2/3/4줄 = 100/300/500/800 × 레벨. 콤보(연속 클리어 락) = 50 × 콤보수 × 레벨. 레벨 = `floor(누적 라인/10)+1` (상한 15).
+- 게임 오버: 스폰 위치 충돌(block out). 서버 score 상한 3,000,000.
+
+## 10. 도전과제 (v1 — 10종)
+
+정의는 코드 상수(정의 파일은 `constants.ts`), 해금 상태만 DB(`playground_achievement_unlocks`). 평가 트리거는 두 곳: **① 게임 finish 직후**(게임 과제 + 공통 과제), **② 아케이드 스냅샷 load 직후**(공통 과제만 — attend-7, arcade-earned-5k처럼 게임 없이 달성되는 과제 커버). 새 해금마다 `achievement-unlock` execute(멱등 키 `ach:<id>`) → 보너스는 서버의 id→보너스 고정 맵으로 지급(클라 주장 금액을 믿지 않음). 조건 자체의 서버 재검증은 하지 않음(단일 사용자 프로토타입 한계로 수용, 스펙에 명시). 누적형 조건은 "이번 런 반영 후" 기준: 도메인 함수가 서버 스냅샷(런 미포함 값)에 이번 런(+1판, +보상 포인트)을 더해 판정한다.
+
+| id | 이름 | 조건 | 보너스 |
+|---|---|---|---|
+| `arcade-first-run` | 첫 판 | 아케이드 런 최초 완료 | +10P |
+| `arcade-runs-50` | 단골 손님 | 누적 런 50판 | +30P |
+| `arcade-earned-5k` | 티끌 모아 | 적립형 kind(활동+출석+게임보상+도전과제) 누적 +5,000P | +50P |
+| `attend-7` | 개근상 | 연속 출석 7일 (원장 `daily-login` 행으로 계산) | +50P |
+| `snake-30` | 몸집 불리기 | 스네이크 한 판 길이 30 | +15P |
+| `snake-55` | 전설의 뱀 | 스네이크 한 판 길이 55 | +40P |
+| `snake-golden-5` | 황금 미식가 | 한 판에 골든 사과 5개 | +20P |
+| `tetris-tetris` | 테트리스! | 한 번에 4줄 클리어 | +20P |
+| `tetris-level-10` | 고속 낙하 | 레벨 10 도달 | +30P |
+| `tetris-30k` | 3만 클럽 | 단판 30,000점 | +40P |
+
+## 11. 랭킹 · 슬랙 알림
+
+- **게임별 랭킹**: `playground_game_runs`에서 read RPC가 계산 — 전체 기간 top5 + 주간(KST 월요일 시작) top5 + 내 최고. 로비/하우스에서 게임별 탭 패널로 표시. (현재 실사용자는 한솔뿐이라 자리 표시 행 "—" 노출.)
+- **포인트 랭킹(기존 레일)**: `ranking.ts`의 `TEAMMATES` fixture 제거. read RPC가 모든 지갑 행(+`users` join 이름)을 반환하고, 지갑 없는 팀원은 `useAuthStore.users` 목록으로 "— P" 행 표시. 프리뷰 모드에서만 기존 fixture 4명을 시드로 유지.
+- **신기록 정의**: `newAlltimeBest` = 이번 score가 내 이전 전체 기간 최고를 **초과(>)** — 동점은 신기록 아님. 이전 기록이 없으면(첫 완주) 신기록으로 취급하고 슬랙 detail은 "첫 기록"으로 표기. `newWeeklyBest`도 같은 규칙을 주간 범위에 적용.
+- **슬랙 알림 (v1 = 전체 기간 신기록 단건)**: finish 응답의 `newAlltimeBest === true && slackNotifyEnabled === true`(둘 다 서버 응답 필드)일 때 **메인 프로세스가** 기존 `postSlackWebhook` 패턴으로 발송. 렌더러 왕복 없음. `replayed` 응답에는 발송하지 않음.
+  - 신규 워크플로 트리거 URL 상수 `SLACK_ARCADE_WEBHOOK_URL`(메인 하드코딩, 기존 패턴 유지 — `feedback_slack_hardcoded_webhook` 결정 준수). **한솔이 슬랙 워크플로를 새로 만들어 URL을 채워야 하며**, 빈 문자열이면 조용히 skip.
+  - payload 변수 3개 고정: `title`(예: "테트리스 신기록!"), `detail`(예: "32,410점 — 이전 기록 18,420점"), `player`(행위자 이름).
+  - 발송 여부는 DB 설정 `playground_arcade_config.slack_notify_enabled`(기본 **false**)로 제어. 플레이그라운드 내 관리자 설정 토글(모의투자 관리자 패널 패턴)로 변경.
+
+## 12. 현재 코드에서 수정해야 할 것 (신규 파일 제외 전체 목록)
+
+| 파일 | 수정 내용 |
+|---|---|
+| `DEVLOG/migrations/2026-07-11-playground-market-v2.sql` | 수정 금지(참조만). kind CHECK 확장은 **새 마이그레이션**에서 `ALTER TABLE ... DROP CONSTRAINT playground_ledger_kind_valid; ADD CONSTRAINT ...` |
+| `src/features/playground/routes.ts` | `{ kind: 'coming-soon' }` → `{ kind: 'game' }`로 개명 (게임 구현이 붙는 PR C에서). 액션은 `open-game` 그대로 |
+| `src/views/PlaygroundView.tsx` | `route.kind === 'game'` 분기에서 신규 `GameHost` 렌더 + 아케이드 스냅샷 load + 랭킹 빌드에 실데이터 전달 |
+| `src/features/playground/ranking.ts` | `TEAMMATES` fixture 제거, `buildPointRanking(user, teammates)` 시그니처로 실데이터 주입 |
+| `src/features/playground/catalog.ts` | `heroMeta`/`quickRecord`의 하드코딩 수치 제거(예: "평균 4분 · 최고 기록은 실제 기록으로 표시"), 보상 카피를 §5-2 확정 수치로 갱신 (예: 테트리스 "플래티넘 등급은 80 포인트") |
+| `src/views/playground/PlaygroundGameCard.tsx`, `PlaygroundRecommendationHero.tsx` | `record`/`reward` 표시용 옵션 prop 추가 — 아케이드 스토어의 내 최고 기록으로 오버레이, 없으면 "아직 기록이 없어요" |
+| `src/views/playground/JbbjHouse.tsx` | 도크 항목 상태 문구 "플레이 준비 중" → "바로 플레이" (구현된 게임만) |
+| `src/features/playground/market/useMarketPreviewStore.ts` | `applyServerWallet(wallet)` 액션 추가 (confirmed/visible의 `account.walletPoints`/`lifetimeEarnedPoints` 패치) |
+| `src/components/layout/Header.tsx` | 우상단 클러스터(≈:51, NotificationBell과 구분선 사이)에 `HeaderPointsBadge` 삽입 (canAccessPlayground 게이트) |
+| `electron/main.ts` | 아케이드 IPC 핸들러 2개 + 활동 훅 4곳 + 출석 훅 + `SLACK_ARCADE_WEBHOOK_URL` 상수 + arcadeService 초기화 |
+| `electron/preload.ts` | `arcadeRead`/`arcadeExecute`/`onArcadeWalletUpdated` 브릿지 |
+| `electron/supabase.ts` | `sbReadPlaygroundArcadeState`/`sbExecutePlaygroundArcade` |
+| `src/mocks/devElectronAPI.ts` | 아케이드 API 목 추가 (localStorage 게이트웨이로 위임) |
+| `package.json` | `test:playground`에 신규 테스트 파일 추가, 버전 상향 |
+| `tests/playgroundRoutes.test.ts` 등 route/전환/프레젠테이션 테스트 | `coming-soon` → `game` 개명 반영 (`grep -r "coming-soon" src tests`로 전수 확인) |
+| `ROADMAP.md`, `CONTEXT.md`, `AGENTS.md`, `DEVLOG/update-notes.json` | PR별 갱신 (update-notes는 비개발자 톤 규칙 준수) |
+
+## 13. 데이터 모델 · IPC 요약
+
+- **신규 테이블**: `playground_game_runs`(런 기록: id=runId, game_id, score, grade, duration_ms, meta jsonb, reward_points, was_alltime_best, entry_request_id UNIQUE), `playground_achievement_unlocks`(PK user_id+achievement_id), `playground_arcade_config`(단일 행, slack_notify_enabled).
+- **원장 kind 확장**: §4-1.
+- **IPC**: `arcade:read`, `arcade:execute` (invoke) / `arcade:wallet-updated` (메인→렌더러 push, payload `{ wallet, delta, reason }`). 네이밍은 기존 `도메인:동작` kebab-case 컨벤션.
+- **execute kind**: `daily-login` / `activity` / `game-start` / `game-finish` / `achievement-unlock` / `config-set` (config-set만 원장 미기록 — 자연 멱등이므로). 모든 execute 응답은 재생 시 `replayed: true`를 포함한다.
+- 전체 DDL·RPC 계약·응답 shape는 구현 계획 Task 1에 수록.
+
+## 14. 한솔 확인 항목 (구현 전 결정하면 좋은 것 — 기본값으로도 진행 가능)
+
+1. **입장료 유무**: 게임 시작에 입장료(스네이크 10P/테트리스 15P)를 받는 설계입니다. "포인트로 게임을 한다"는 컨셉 + 포인트 싱크 목적. 무료로 하려면 `ARCADE_BALANCE`에서 0으로.
+2. **보상 상한**: 게임별 1일 5회가 기본값. 조정 가능.
+3. **리테이크 완료의 정의**: 담당자 완료(`revision_assignee_done`)에만 +30P. 감독 최종 완료에도 줄지 여부.
+4. **슬랙 워크플로**: 신기록 알림용 워크플로(변수 `title`/`detail`/`player`)를 슬랙에서 새로 만들어 URL을 전달해야 발송 가능. 그 전까지는 토글 off + URL 빈 값으로 무해.
+5. **활동 포인트 수치** (§5-1 표) — 전부 상수 파일에서 일괄 조정 가능.
+
+---
+*작성: Claude (자율 세션) × 한솔 리뷰 대기 · Studio JBBJ*


### PR DESCRIPTION
> **문서 전용 PR** — 앱 코드/버전 변경 없음 (v1.83.0 유지). 배플레이그라운드 게임·포인트 제도의 **최종 계획 문서**이며, 실제 구현은 이 문서를 승인한 뒤 Codex/Opus가 별도 PR(A~D)로 진행합니다.

## 📋 업데이트 요약

> 이번 PR로 앱이 달라지는 건 없어요. "배플레이그라운드를 어떻게 완성할지" 설계도를 확정하는 단계입니다.

- 🗺️ 배플레이그라운드 게임 시대의 설계도가 완성됐어요. 씬을 완료하거나 댓글을 달고 매일 출석하면 포인트가 쌓이고, 그 포인트로 스네이크·테트리스를 플레이해서 등급 보상을 받는 순환 구조예요.
- 🕹️ **직접 만져볼 수 있는 목업**이 들어 있어요. 파일을 브라우저로 열면 스네이크와 테트리스가 진짜로 플레이되고, 포인트가 쌓이고 빠지는 흐름, 도전과제 달성, 랭킹 갱신, 슬랙 알림 미리보기까지 체험할 수 있어요.
- 🏅 게임마다 도전과제 10종과 순위표가 생기고, 최고 기록을 깨면 슬랙으로 자랑을 보낼 수 있게 설계했어요 (알림은 기본 꺼짐, 관리 설정에서 켜는 방식).
- 💰 포인트는 화면 오른쪽 위에 항상 보이게 되고, 획득할 때마다 "+5P"처럼 살짝 떠올라요.

**한솔 확인이 필요한 것 (스펙 §14):**
1. 게임 시작에 입장료를 받을지 (스네이크 10P / 테트리스 15P 제안)
2. 게임 보상 하루 5회 제한이 적당한지
3. "리테이크 수정 완료" 포인트는 담당자 완료 기준(+30P)으로 좋은지
4. 신기록 슬랙 알림용 워크플로(변수 3개: title/detail/player)를 슬랙에서 새로 만들어 URL 전달
5. 활동별 포인트 수치(씬 체크 +5, 액팅 완료 +10, 댓글 +5, 리테이크 +30, 출석 +20)

## 🔧 상세 기술 설명

### 문서 3종 (docs/superpowers/, 기존 컨벤션 준수)
- **설계 스펙** `specs/2026-07-13-baeplayground-arcade-points-design.md` — 아키텍처 결정 5개(지갑·원장 재사용 / 신설 RPC 2개 / 메인 프로세스 활동 훅 / 마켓 레이어링 복제 / 지갑 단일 소스), 포인트 경제 표, 게임 규칙, 도전과제 10종, 랭킹·슬랙 정책, **현재 코드 수정 필요 목록(§12, 16개 파일)**, 비범위 명시
- **구현 계획** `plans/2026-07-13-baeplayground-arcade-points.md` — PR A~D(v1.84~1.87) × TDD 태스크 13개. 핵심 계약 전문 수록:
  - DB: `2026-07-13-playground-arcade-v1.sql` 설계 — `playground_value_ledger.kind` CHECK 확장(8종), 신규 테이블 3개(`playground_game_runs`/`playground_achievement_unlocks`/`playground_arcade_config`), RPC `playground_arcade_read`/`playground_arcade_execute` (v2와 동일 하드닝: SECURITY DEFINER, advisory lock, FOR UPDATE, 원장 멱등 probe + **재생 응답 `replayed: true`**)
  - 활동 적립은 렌더러가 아닌 **electron main의 기존 활동 로그 지점** 훅(씬 stage/phase, 댓글, 리테이크 assignee_done, 출석) + `arcade:wallet-updated` push
  - 게임 엔진: 순수 TS + 주입식 시드 PRNG. 테트리스는 SRS 킥 테이블(y-down 변환본)·7-bag·중력표·락딜레이·콤보 전문, 스네이크는 틱·골든 사과·큐 규칙 전문
  - 멱등 키 체계: `scene-stage:<uuid>:<stage>`, `daily-login:<KST date>`, `game-entry/finish:<runId>`, `ach:<id>` — 재체크·재시도 중복 지급 0 보장
- **인터랙션 목업** `mockups/2026-07-13-baeplayground-arcade-mockup.html` — 의존성 없는 단일 HTML. 두 게임 플레이 가능, 스테이지 상태머신(ready→countdown→running→paused→result), 등급 게이지/카운트업/신기록 배너/도전과제 토스트, 랭킹 탭, 슬랙 메시지 미리보기 전부 동작
- **ROADMAP.md** — 배플레이그라운드 잔여 2항목에 계획 문서 참조 연결

### 품질 보증
- 적대적 리뷰 2회 실시: 1차에서 P1 1건(서버 duration 하한이 정상 스네이크 최단 사망 1.76초를 거부 → 1초로 완화), P2 4건(슬랙 조건이 응답에 없는 config 참조, 멱등 재생 응답의 가짜 "+N P" 연출, 도전과제 누적 집계 시점 미정의, 루프 테스트 산술 오류), P3 13건 발견 → 전부 반영. 2차 검증에서 잔재 3건 추가 수정 후 신규 P1·P2 0건 확인
- 목업은 브라우저 실측 완료: 적립/멱등(출석 2회차 +0), 입장료 차감, 사망→NONE 등급, 도전과제 해금(+10P 잔액 일치), 신기록→랭킹 행·슬랙 미리보기 갱신까지 시나리오 전수 통과

## 🚧 개발 난항

### 인앱 브라우저로 목업 검증이 안 되던 문제
- **문제**: 검증용 브라우저 탭이 항상 숨김(hidden) 상태라 `requestAnimationFrame`이 발화하지 않아 게임이 멈춘 것처럼 보이고 스크린샷도 타임아웃
- **시도**: file:// 직접 열기(거부) → 로컬 정적 서버 경유(로드는 성공, rAF는 여전히 정지)
- **해결**: rAF를 setTimeout 폴리필로 주입한 뒤 키 이벤트를 스크립트로 쏴서 전 시나리오 실측. 실사용 브라우저(가시 탭)에서는 정상
- **교훈**: rAF 기반 로직의 헤드리스 검증은 폴리필 주입으로 가능. 목업 자체 버그가 아님

## ✅ 테스트 가이드

### 사용자 테스트 (한솔)
> 이 PR은 문서라서 앱 테스트는 없어요. 목업만 열어보면 됩니다.

1. **목업 열어보기**
   - `docs/superpowers/mockups/2026-07-13-baeplayground-arcade-mockup.html` 파일을 더블클릭해 브라우저로 열기 (또는 아티팩트 링크: https://claude.ai/code/artifact/83bab227-0061-4a39-8c97-7ee09afff012 )
   - ① 활동 버튼들을 눌러 우상단 포인트가 "+N P" 뜨며 쌓이는지 (출석은 두 번째부터 +0)
   - ② 스네이크 "10P 내고 시작" → 화살표로 플레이 → 죽으면 등급/보상/도전과제 화면
   - ③ 테트리스도 동일 (Space 하드드롭, C 홀드)
   - ✅ 기대: 게임이 부드럽게 조작되고, 신기록을 내면 ⑤ 랭킹 표의 내 행과 슬랙 미리보기가 갱신됨
2. **스펙 §14 확인 항목 5개**에 답 주기 — 답에 따라 상수만 조정하고 구현 착수 가능

### 개발자 테스트 (구현 담당 모델용)
```bash
# 구현 시작 전 계획 문서 경로
docs/superpowers/plans/2026-07-13-baeplayground-arcade-points.md
# 각 PR 완료 게이트 (계획 Global Constraints 명시)
npm run typecheck && npm run test:playground && npm run build:vite
```
> 구현 PR A 머지 후 `DEVLOG/migrations/2026-07-13-playground-arcade-v1.sql` 라이브 DB 적용 필요 (계획 Task 1 Step 6 참조)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
