### PR TITLE
[v1.89.0] 릴리스 메타데이터 테스트 안정화

### DIFF
--- a/tests/playgroundMarketUiWiring.test.ts
+++ b/tests/playgroundMarketUiWiring.test.ts
@@ -9,18 +9,18 @@ test('playground market v3 release metadata stays aligned', () => {
   const packageLock = JSON.parse(readFileSync('package-lock.json', 'utf8'));
   const updateNotes = JSON.parse(readFileSync('DEVLOG/update-notes.json', 'utf8'));
 
-  assert.equal(packageJson.version, '1.88.3');
-  assert.equal(packageLock.version, '1.88.3');
-  assert.equal(packageLock.packages[''].version, '1.88.3');
+  const latestVersion = packageJson.version;
+  assert.equal(packageLock.version, latestVersion);
+  assert.equal(packageLock.packages[''].version, latestVersion);
   assert.equal(packageJson.dependencies['lightweight-charts'], '5.2.0');
   assert.equal(packageLock.packages[''].dependencies['lightweight-charts'], '5.2.0');
   assert.deepEqual(
-    updateNotes.slice(0, 4).map((note: { version: string }) => note.version),
-    ['1.88.3', '1.88.2', '1.88.1', '1.88.0'],
+    updateNotes.slice(0, 5).map((note: { version: string }) => note.version),
+    [latestVersion, '1.88.3', '1.88.2', '1.88.1', '1.88.0'],
   );
 
-  // 최신 릴리스(1.88.3)는 테트리스 홀드·다음 조각을 실제 블록 모양으로 표시.
-  assert.equal(updateNotes[0].version, '1.88.3');
+  // 최신 릴리스는 package 버전과 업데이트 내역의 맨 앞 항목이 항상 일치해야 한다.
+  assert.equal(updateNotes[0].version, latestVersion);
 
   // 모의투자 시장 v3 릴리스(1.82.0) 메타데이터는 그대로 유지돼야 한다.
   const marketNote = updateNotes.find((note: { version: string }) => note.version === '1.82.0');

--- a/tests/playgroundMarketUiWiring.test.ts
+++ b/tests/playgroundMarketUiWiring.test.ts
@@ -14,10 +14,12 @@ test('playground market v3 release metadata stays aligned', () => {
   assert.equal(packageLock.packages[''].version, latestVersion);
   assert.equal(packageJson.dependencies['lightweight-charts'], '5.2.0');
   assert.equal(packageLock.packages[''].dependencies['lightweight-charts'], '5.2.0');
-  assert.deepEqual(
-    updateNotes.slice(0, 5).map((note: { version: string }) => note.version),
-    [latestVersion, '1.88.3', '1.88.2', '1.88.1', '1.88.0'],
-  );
+  const historicalVersions = ['1.88.3', '1.88.2', '1.88.1', '1.88.0'];
+  const historicalIndexes = historicalVersions.map((version) => (
+    updateNotes.findIndex((note: { version: string }) => note.version === version)
+  ));
+  assert.ok(historicalIndexes.every((index) => index > 0));
+  assert.deepEqual([...historicalIndexes].sort((left, right) => left - right), historicalIndexes);
 
   // 최신 릴리스는 package 버전과 업데이트 내역의 맨 앞 항목이 항상 일치해야 한다.
   assert.equal(updateNotes[0].version, latestVersion);


### PR DESCRIPTION
## 📋 업데이트 요약

> 배포 빌드에서 새 버전이 나와도 기존 버전만 검사하던 테스트를 고쳤습니다.

- 🐛 v1.89.0처럼 새 릴리스가 추가되어도 버전 메타데이터 테스트가 현재 버전을 기준으로 확인합니다.
- ✅ 앱 기능이나 사용자 화면은 바뀌지 않고, 정식 빌드 검증이 막히지 않게 됩니다.

## 🔧 상세 기술 설명

- `tests/playgroundMarketUiWiring.test.ts`에서 package.json의 현재 버전을 `latestVersion`으로 읽습니다.
- package.json·package-lock.json·update-notes.json의 최신 항목이 서로 일치하는지 검증하고, 기존 1.88.x 릴리스 기록도 순서대로 보존되는지 함께 확인합니다.
- 버전을 하드코딩하던 회귀 검사를 새 릴리스마다 자동으로 따라가도록 바꿨습니다.

## 🚧 개발 난항

- **문제**: v1.89.0 릴리스 후 기존 테스트가 v1.88.3을 고정값으로 요구해 정식 빌드가 중단됐습니다.
- **해결**: 테스트가 현재 package 버전을 읽고 릴리스 노트 최신 항목과 비교하도록 변경했습니다.

## ✅ 테스트 가이드

### 사용자 테스트
- 사용자 화면에는 변경이 없으므로 별도 UI 확인 없이 기존 v1.89.0 배포 시나리오를 사용하면 됩니다.

### 개발자 테스트
```powershell
node --test tests/playgroundMarketUiWiring.test.ts
npm run typecheck
```