### PR TITLE
피드백 42~50 구현 기록 최종 갱신 (문서 전용)

### DIFF
--- a/DEVLOG/2026-08-06-피드백-42-50-구현.md
+++ b/DEVLOG/2026-08-06-피드백-42-50-구현.md
@@ -13,7 +13,9 @@
 | [#241](https://github.com/baehandoridori/Bflow-BGonly/pull/241) | v1.96.0 | 1~5 (45·44·46·43·50) | `25d5673` | 1라운드 클린 |
 | [#242](https://github.com/baehandoridori/Bflow-BGonly/pull/242) | v1.97.0 | 6~7 (42·47) | `eab537e` | 1라운드 클린 |
 | [#243](https://github.com/baehandoridori/Bflow-BGonly/pull/243) | v1.98.0 | 8 (48) | `c3f8945` | 2라운드 (P2 2건 반영) |
-| [#244](https://github.com/baehandoridori/Bflow-BGonly/pull/244) | v1.99.0 | 9 (49) | (본문 참조) | (본문 참조) |
+| [#244](https://github.com/baehandoridori/Bflow-BGonly/pull/244) | v1.99.0 | 9 (49) | `561d61e` | 7라운드 (P2 5건 반영 · 1건 근거 회신 후 미반영) |
+
+**배포**: v1.99.0 정식 빌드(`npm run build`) 후 G드라이브 `dist` 동기화 완료 — `manifest.json` 마지막 갱신, `BFLOW-Setup.exe`/`latest.yml`/`manifest.json` SHA-256 3종 일치 확인.
 
 ### 작업별 커밋
 
@@ -38,6 +40,11 @@
 **PR 4 (v1.99.0)**
 - `40a5752` 피드백 49: 댓글에 복장+버전 태그 (bcostume) 추가
 - `8ecf466` v1.99.0 버전 반영 + 업데이트 내역 추가
+- `a667529` 코덱스 1차 반영 — 모달 밖 복장 태그도 버전·삭제 안내
+- `906483e` 코덱스 2차 반영 — 복장 전환 요청을 nonce 당 1회만 소비
+- `bed393b` 코덱스 3차 반영 — 복장 태그 이동도 뒤로가기 스택 기록
+- `3305d30` 코덱스 5차 반영 — 재조회 대기 + 알림에 태그 원문 노출 차단
+- `cb08cf2` 코덱스 6차 반영 — 모달 안 복장 태그 클릭도 재조회 대기
 
 ---
 
@@ -65,16 +72,16 @@ PR 2 머지 **전에** Supabase 프로젝트 `Bflow`(`mpqifkpxalwxgcrddchv`)에 
 | 스위트 | 기준선 | 최종 | 증가분 |
 |---|---|---|---|
 | character | 130 | **144** | +14 |
-| entity | 239 | **244** | +5 |
+| entity | 239 | **248** | +9 |
 | ui | 14 | 14 | — |
 | notifications | 142 | 142 | — |
 | presence | 33 | 33 | — |
 | auto-update | 29 | 29 | — |
 | playground | 461 | 461 | — |
 
-전 스위트 fail 0. 증가분 내역:
+위 수치는 배포 빌드(`npm run build`) 로그 기준이며 전 스위트 fail 0. 증가분 내역:
 - character +14 — 피드백 45 배선 / 피드백 46 배선 / `buildRiggingContent` / `buildRiggingImageValue` / `rowToRealtimeMapping` 폴백 / 마이그레이션 앵커 2건 / `effectiveHeightPx` / 피드백 47 배선 / `characterStatusFilter.test.ts` 신규 6건
-- entity +5 — `costumeHashTag.test.ts` 신규 5건
+- entity +9 — `costumeHashTag.test.ts` 신규 9건(초기 5건 + 코덱스 리뷰 반영으로 추가된 4건: nonce 1회 소비 / 뒤로가기 스택 / 재조회 대기·알림 평문화 / 모달 안 클릭 게이트)
 
 신규 테스트 파일 2건은 `package.json` 에 등록했다(`tests/characterStatusFilter.test.ts` → `test:character`, `tests/costumeHashTag.test.ts` → `test:entity`).
 
@@ -91,20 +98,39 @@ PR 2 머지 **전에** Supabase 프로젝트 `Bflow`(`mpqifkpxalwxgcrddchv`)에 
 | `playgroundMarketUiWiring.test.ts` — release metadata | 버전을 올리면 `package.json`/`package-lock.json`(2곳)/`update-notes.json[0]` **3자 일치**를 강제. 계획서 부록 B 검증 목록에 `test:playground` 가 빠져 있었다 | 각 PR 의 버전 커밋에 `package-lock.json` 버전 2곳을 함께 갱신 |
 | `characterTier2.test.ts` T2-4 | `updateCostumeField` 의 `Pick` 목록 **끝**을 `\| 'dueDate'>>` 로 고정 — `heightPx` 추가로 끝이 바뀜 | 항목 존재만 고정하도록 `\| 'dueDate'` 로 완화 |
 | `characterBoardAssetWorkflow.test.ts` — my tasks widget | `parseAssigneeNames` 가 `characterStageMeta` 에 정의돼 있음을 고정 — 작업 8 (a-0) 의 분리로 깨짐 | '새 파일에 정의 + 기존 파일은 re-export' 두 사실을 각각 고정 |
-| `characterBoardAssetWorkflow.test.ts` — spotlight pending request | `pendingCharacterBoardRequest` 타입 리터럴 전체를 고정 — `costumeId?` 추가로 깨짐 | 확장된 타입으로 갱신 |
+| `characterBoardAssetWorkflow.test.ts` — spotlight pending request | `pendingCharacterBoardRequest` 타입 리터럴 전체를 고정 — `costumeId?`(이후 `costumeVersionNo?`) 추가로 깨짐 | 확장된 타입으로 갱신 |
+| `characterBoardAssetWorkflow.test.ts` — 딥링크 소비 조건 | 소비 게이트 식 전체를 고정 — 코덱스 5차 반영으로 `boardLoading` 이 추가돼 깨짐 | 확장된 식으로 갱신 |
 
 ### 4-2. 실코드 구조에 맞춘 구현 조정 1건
 
 작업 9 (h-2) 의 '다른 캐릭터 태그' 가드를 계획서는 `visibleCharacters`(그리드 필터 부분집합) 기준으로 기술했으나, 실코드에는 그 사이 도입된 `showAllList` 폴백이 있다 — 선택 캐릭터가 필터 밖이면 자동 보정 이펙트가 '전체 보기'로 전환해 **유지**한다. 그래서 `allVisibleCharacters` 기준으로 가드했다. 계획서의 의도(자동 보정에 스냅되는 오동작 방지)는 그대로 지키면서, 필터가 걸린 상태에서도 태그된 캐릭터가 정상적으로 열린다.
 
-### 4-3. 코덱스 리뷰로 계획서 설계가 수정된 지점 1건 (PR 3, P2 2건)
+### 4-3. 코덱스 리뷰로 계획서 설계가 수정된 지점 (PR 3 · PR 4)
+
+#### PR 3 (P2 2건)
 
 - **레거시 `assignee` 유니온 제거.** 계획서 작업 8 (a) 의 `tracksForAssignee`/`collectCharacterAssignees` 는 레거시 `assignee` 를 양 트랙 겸용으로 유니온했다. 그러나 `rowToCostume` 은 `design_assignee` **컬럼이 있으면 값이 null 이어도 그 값을** 쓰고, 컬럼이 없을 때만 `assignee` 로 승계한다. 즉 마이그레이션된 row 에서 트랙 담당자를 비운 것은 '해제'인데, 레거시 유니온이 예전 담당자를 되살려 필터·상태 판정을 틀리게 만든다. 트랙 필드만 보도록 수정하고 `StageLike` 에서 `assignee` 를 제거했다.
 - **커스텀 탭 그룹 뷰 드래그 게이트.** `CharacterTabGroupsView` 가 `dragEnabled = viewMode !== 'list'` 로 자체 판단해, 필터로 일부만 보이는 상태에서도 그룹 배치·순서를 바꿀 수 있었다(검색·태그 필터에서도 존재하던 기존 결함). 보드의 `cardDragEnabled` 를 prop 으로 넘겨 일반 그리드와 동일하게 잠갔다.
 
+#### PR 4 (7라운드 — P2 5건 반영, 1건 미반영)
+
+계획서 작업 9 는 '태그를 남긴다 → 누르면 열린다'는 정상 경로만 기술했고, 아래는 그 주변의 어긋난 경우들이다.
+
+1. **모달 밖 경로의 안내 누락** — 씬 댓글에서 태그를 누르면 `versionNo` 가 유실돼, 모달 안 클릭에는 있는 '태그는 vN 때 기록' 안내가 뜨지 않고 삭제된 복장은 조용히 첫 복장으로 떨어졌다. 딥링크 요청에 `costumeVersionNo` 를 실어 보드가 로드 후 검증하도록 했다.
+2. **stale 요청 재소비** — 복장 전환 요청 소비 이펙트가 `costumes` 변경마다 재실행돼, 태그로 복장 B 를 연 뒤 수동으로 A 로 바꾸고 아무 복장을 편집하거나 실시간 변경을 받으면 화면이 다시 B 로 돌아갔다. 마지막 소비 nonce 를 기록해 1회만 소비한다.
+3. **뒤로가기 스택 누락** — costume 분기가 `pushNavigationBackTarget()` 없이 뷰를 바꿔, 같은 태그 클릭인데 뒤로 가기가 원래 화면 대신 스택에 남은 옛 목적지로 갔다. 씬·파트·화 분기(`navigateToSceneView`)와 동일하게 `setView` 앞에서 기록한다.
+4. **조용한 재조회 중 판정** — 보드 재진입 시 도는 silent 재조회 동안에도 `loaded` 는 true 라, 딥링크·모달 클릭이 낡은 복장 목록으로 판정됐다(원격 삭제 복장이 잠깐 열리거나 올라간 버전 안내 누락). 외부 경로는 게이트를, 모달 안 클릭은 '보류 후 재조회 완료 시 판정'을 넣었다.
+5. **알림에 태그 원문 노출** — 멘션 슬랙 알림이 댓글 저장 원문을 그대로 실어 `[#라벨](b…:UUID…)` 가 노출됐다(기존 씬 태그도 동일했던 결함). 알림 경로 3곳을 `stripEntityTokens` 경유로 바꿔 `#라벨` 로 나가게 했다. 계획서 작업 9 '검증 방법 4' 가 확인을 지시했던 표면이다.
+
+**미반영 1건** — '스레드 답글 작성기에서 `#` 자동완성이 안 된다'는 지적. 확인 결과 `useHashtagAutocomplete` 인스턴스는 원래부터 메인 작성기 1곳뿐이고 답글 작성기는 멘션만 초기화한다 — 즉 **이번 PR 의 회귀가 아니라 기존 제약**이며 기존 #씬·#파트·#화 태그도 답글에서는 자동완성되지 않는다. 답글에 해시태그 파이프라인을 새로 붙이는 것은 계획서의 '명시 밖 기능 추가 금지' 범위를 벗어나 PR 코멘트에 근거를 남기고 후속 과제로 돌렸다(답글에서도 태그 붙여넣기 → 칩 렌더 → 클릭 이동은 정상 동작).
+
 ### 4-4. 건너뛴 작업
 
 **없음.** 계획서 작업 1~9 전부 구현했다. 부록 C(범위 외 후속 권장)는 계획대로 손대지 않았다.
+
+### 4-5. 이번 라운드에서 새로 생긴 후속 과제 (부록 C 추가분)
+
+- 스레드 답글 작성기에 `#` 자동완성 지원 (씬·파트·화·복장 공통) — 위 미반영 건.
 
 ---
 


### PR DESCRIPTION
## 📋 업데이트 요약

> 문서만 변경합니다 — 앱 동작에는 영향이 없습니다.

피드백 42~50 라운드(v1.96.0~v1.99.0)가 전부 머지·배포되어, 계획서가 요구한 구현 기록(`DEVLOG/2026-08-06-피드백-42-50-구현.md`)의 빈칸을 최종 결과로 채웠습니다.

## 🔧 상세 기술 설명

PR #244 에 초안이 머지된 뒤 확정된 내용을 반영:

- PR #244 머지 해시(`561d61e`)와 코덱스 7라운드 내역(P2 5건 반영 · 1건 근거 회신 후 미반영)
- PR 4 의 코덱스 반영 커밋 5개 목록
- 최종 테스트 수치 — 배포 빌드(`npm run build`) 로그 기준: character 144 / entity **248**(초안의 244 → 리뷰 반영으로 4건 추가) / ui 14 / notifications 142 / presence 33 / auto-update 29 / playground 461, 전부 fail 0
- v1.99.0 G드라이브 배포 검증 결과(manifest 마지막 갱신, SHA-256 3종 일치)
- 코덱스 리뷰로 계획서 설계가 수정된 지점에 PR 4 분(5건 + 미반영 1건 근거) 추가
- 새로 생긴 후속 과제: 스레드 답글 작성기의 `#` 자동완성(기존 제약 — 씬 태그 포함)

## 🚧 개발 난항

특이사항 없음 (문서 전용).

## ✅ 테스트 가이드

코드 변경이 없어 별도 테스트가 필요하지 않습니다. 문서 내용이 실제 머지 해시·배포 결과와 일치하는지만 확인하면 됩니다.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)